### PR TITLE
Include additional files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,14 @@
+include AUTHORS
+include CHANGES
+include LICENSE
 include README.rst
+include TODO.rst
 
 recursive-include pyccel *.tx
 recursive-include pyccel *.txt
 recursive-include pyccel *.cmake
 recursive-include pyccel *.pyh
+
+graft doc
+graft samples
+graft tests


### PR DESCRIPTION
Include other files in sdists.  In particular, include the license file, which the license requires.  Also include documentation and tests.