### PR TITLE
Array literals

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4329,7 +4329,7 @@ class String(Basic):
         return self.arg
 
 
-class Concatinate(Basic):
+class Concatenate(Basic):
 
     """Represents the String concatination operation.
 
@@ -4341,11 +4341,11 @@ class Concatinate(Basic):
     Examples
 
     >>> from sympy import symbols
-    >>> from pyccel.ast.core import Concatinate
+    >>> from pyccel.ast.core import Concatenate
     >>> x = symbols('x')
-    >>> Concatinate('some_string',x)
+    >>> Concatenate('some_string',x)
     some_string+x
-    >>> Concatinate('some_string','another_string')
+    >>> Concatenate('some_string','another_string')
     'some_string' + 'another_string'
     """
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -131,7 +131,7 @@ class Array(Application):
             import functools
             import operator
             arg = functools.reduce(operator.concat, arg)
-            init_value = 'reshape(' + printer(arg) + ',' + printer(shape) + ')'
+            init_value = 'reshape(' + printer(arg) + ', ' + printer(shape) + ')'
         else:
             init_value = printer(arg)
 
@@ -358,7 +358,7 @@ class Shape(Array):
             alloc = 'allocate({}(0:{}))'.format(lhs_code, self.arg.rank-1)
             if self.index is None:
 
-                code_init = '{0} = (/ {1} /)'.format(lhs_code, init_value)
+                code_init = '{0} = [{1}]'.format(lhs_code, init_value)
 
             else:
                 index = printer(self.index)
@@ -367,7 +367,7 @@ class Shape(Array):
             code_init = alloc+ '\n'+ code_init
         else:
             if self.index is None:
-                code_init = '(/ {0} /)'.format(init_value)
+                code_init = '[{0}]'.format(init_value)
 
             else:
                 index = printer(self.index)
@@ -663,7 +663,7 @@ class Linspace(Application):
     def fprint(self, printer, lhs=None):
         """Fortran print."""
 
-        init_value = '(/ ({0} + {1}*{2},{1} = 0,{3}-1) /)'
+        init_value = '[({0} + {1}*{2},{1} = 0,{3}-1)]'
 
         start = printer(self.start)
         step  = printer(self.step)
@@ -881,7 +881,7 @@ class Cross(Application):
 
             if order == 'C':
 
-                code = 'reshape({}, shape({}), order=[2,1])'.format(cross_product, first)
+                code = 'reshape({}, shape({}), order=[2, 1])'.format(cross_product, first)
             else:
 
                 code = 'reshape({}, shape({})'.format(cross_product, first)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -535,10 +535,10 @@ class FCodePrinter(CodePrinter):
         shape = numpy.shape(expr)
         if len(shape)>1:
             arg = functools.reduce(operator.concat, expr)
-            elements = ','.join(self._print(i) for i in arg)
-            return 'reshape((/ '+ elements + ' /), '+ self._print(Tuple(*shape)) + ')'
+            elements = ', '.join(self._print(i) for i in arg)
+            return 'reshape(['+ elements + '], '+ self._print(Tuple(*shape)) + ')'
         fs = ', '.join(self._print(f) for f in expr)
-        return '(/ {0} /)'.format(fs)
+        return '[{0}]'.format(fs)
 
     def _print_Variable(self, expr):
         return self._print(expr.name)
@@ -576,7 +576,7 @@ class FCodePrinter(CodePrinter):
     def _print_Concatinate(self, expr):
          args = expr.args
          if expr.is_list:
-             code = ','.join(self._print(a) for a in expr.args)
+             code = ', '.join(self._print(a) for a in expr.args)
              return '[' + code + ']'
          else:
              code = '//'.join('trim('+self._print(a)+')' for a in expr.args)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -573,7 +573,7 @@ class FCodePrinter(CodePrinter):
     def _print_DottedName(self, expr):
         return ' % '.join(self._print(n) for n in expr.name)
 
-    def _print_Concatinate(self, expr):
+    def _print_Concatenate(self, expr):
          args = expr.args
          if expr.is_list:
              code = ', '.join(self._print(a) for a in expr.args)

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -101,7 +101,7 @@ from pyccel.ast import FunctionHeader, ClassHeader, MethodHeader
 from pyccel.ast import VariableHeader, InterfaceHeader
 from pyccel.ast import MetaVariable
 from pyccel.ast import MacroFunction, MacroVariable
-from pyccel.ast import Concatinate
+from pyccel.ast import Concatenate
 from pyccel.ast import ValuedVariable
 from pyccel.ast import Argument, ValuedArgument
 from pyccel.ast import Is

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -49,7 +49,7 @@ from pyccel.ast import FunctionHeader, ClassHeader, MethodHeader
 from pyccel.ast import VariableHeader, InterfaceHeader
 from pyccel.ast import MetaVariable
 from pyccel.ast import MacroFunction, MacroVariable
-from pyccel.ast import Concatinate
+from pyccel.ast import Concatenate
 from pyccel.ast import ValuedVariable
 from pyccel.ast import Argument, ValuedArgument
 from pyccel.ast import Is, IsNot
@@ -1061,7 +1061,7 @@ class SemanticParser(BasicParser):
                 else:
                     raise NotImplementedError('TODO')
             return d_var
-        elif isinstance(expr, Concatinate):
+        elif isinstance(expr, Concatenate):
             import operator
             d_vars = [self._infere_type(a, **settings) for a in expr.args]
             ls = any(d['is_pointer'] or d['is_target'] for d in d_vars)
@@ -1390,9 +1390,9 @@ class SemanticParser(BasicParser):
 
 
         if any(atoms) or atoms_ls:
-            return Concatinate(args, True)
+            return Concatenate(args, True)
         elif atoms_str:
-            return Concatinate(args, False)
+            return Concatenate(args, False)
 
 
         expr_new = Add(*args, evaluate=False)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -101,7 +101,7 @@ from pyccel.ast import FunctionHeader, ClassHeader, MethodHeader
 from pyccel.ast import VariableHeader, InterfaceHeader
 from pyccel.ast import MetaVariable
 from pyccel.ast import MacroFunction, MacroVariable
-from pyccel.ast import Concatinate
+from pyccel.ast import Concatenate
 from pyccel.ast import ValuedVariable
 from pyccel.ast import Argument, ValuedArgument
 from pyccel.ast import Is, IsNot


### PR DESCRIPTION
Circumvent issues with Pyccel breaking lines at wrong location in array literals by using brackets `[x]` instead of `(/x/)` (Fortran 2003 feature). This also improves readability and closes issue #236.