### PR TITLE
Allow modifications to an instance of the class Variable

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2348,6 +2348,12 @@ class Variable(Symbol, PyccelAstNode):
     def allocatable(self):
         return self._allocatable
 
+    @allocatable.setter
+    def allocatable(self, allocatable):
+        if not isinstance(allocatable, bool):
+            raise TypeError('allocatable must be a boolean.')
+        self._allocatable = allocatable
+
     @property
     def cls_base(self):
         return self._cls_base
@@ -2360,9 +2366,21 @@ class Variable(Symbol, PyccelAstNode):
     def is_pointer(self):
         return self._is_pointer
 
+    @is_pointer.setter
+    def is_pointer(self, is_pointer):
+        if not isinstance(is_pointer, bool):
+            raise TypeError('is_pointer must be a boolean.')
+        self._is_pointer = is_pointer
+
     @property
     def is_target(self):
         return self._is_target
+
+    @is_target.setter
+    def is_target(self, is_target):
+        if not isinstance(is_target, bool):
+            raise TypeError('is_target must be a boolean.')
+        self._is_target = is_target
 
     @property
     def is_polymorphic(self):
@@ -2530,13 +2548,25 @@ class DottedVariable(AtomicExpr, sp_Boolean, PyccelAstNode):
     def allocatable(self):
         return self._args[1].allocatable
 
+    @allocatable.setter
+    def allocatable(self, allocatable):
+        self._args[1].allocatable = allocatable
+
     @property
     def is_pointer(self):
         return self._args[1].is_pointer
 
+    @is_pointer.setter
+    def is_pointer(self, is_pointer):
+        self._args[1].is_pointer = is_pointer
+
     @property
     def is_target(self):
         return self._args[1].is_target
+
+    @is_target.setter
+    def is_target(self, is_target):
+        self._args[1].is_target = is_target
 
     @property
     def name(self):
@@ -2681,6 +2711,29 @@ class TupleVariable(Variable):
     def is_homogeneous(self):
         return self._is_homogeneous
 
+    @Variable.allocatable.setter
+    def allocatable(self, allocatable):
+        if not isinstance(allocatable, bool):
+            raise TypeError('allocatable must be a boolean.')
+        self._allocatable = allocatable
+        for var in self._vars:
+            var.allocatable = allocatable
+
+    @Variable.is_pointer.setter
+    def is_pointer(self, is_pointer):
+        if not isinstance(is_pointer, bool):
+            raise TypeError('is_pointer must be a boolean.')
+        self._is_pointer = is_pointer
+        for var in self._vars:
+            var.is_pointer = is_pointer
+
+    @Variable.is_target.setter
+    def is_target(self, is_target):
+        if not isinstance(is_target, bool):
+            raise TypeError('is_target must be a boolean.')
+        self._is_target = is_target
+        for var in self._vars:
+            var.is_target = is_target
 
 class Constant(ValuedVariable, PyccelAstNode):
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2231,59 +2231,33 @@ class Variable(Symbol, PyccelAstNode):
         precision=0,
         is_argument=False
         ):
+        return Basic.__new__(cls)
+
+    def __init__(
+        self,
+        dtype,
+        name,
+        rank=0,
+        allocatable=False,
+        is_stack_array = False,
+        is_pointer=False,
+        is_target=False,
+        is_polymorphic=None,
+        is_optional=None,
+        shape=None,
+        cls_base=None,
+        cls_parameters=None,
+        order='C',
+        precision=0,
+        is_argument=False
+        ):
+
+        # ------------ PyccelAstNode Properties ---------------
         if isinstance(dtype, str) or str(dtype) == '*':
 
             dtype = datatype(str(dtype))
         elif not isinstance(dtype, DataType):
             raise TypeError('datatype must be an instance of DataType.')
-
-        if allocatable is None:
-            allocatable = False
-        elif not isinstance(allocatable, bool):
-            raise TypeError('allocatable must be a boolean.')
-
-        if is_pointer is None:
-            is_pointer = False
-        elif not isinstance(is_pointer, bool):
-            raise TypeError('is_pointer must be a boolean.')
-
-        if is_target is None:
-            is_target = False
-        elif not isinstance(is_target, bool):
-            raise TypeError('is_target must be a boolean.')
-
-        if is_stack_array is None:
-            is_stack_array = False
-        elif not isinstance(is_stack_array, bool):
-            raise TypeError('is_stack_array must be a boolean.')
-
-        if is_polymorphic is None:
-            if isinstance(dtype, CustomDataType):
-                is_polymorphic = dtype.is_polymorphic
-            else:
-                is_polymorphic = False
-        elif not isinstance(is_polymorphic, bool):
-            raise TypeError('is_polymorphic must be a boolean.')
-
-        if is_optional is None:
-            is_optional = False
-        elif not isinstance(is_optional, bool):
-            raise TypeError('is_optional must be a boolean.')
-
-        if not isinstance(precision,int):
-            raise TypeError('precision must be an integer.')
-
-        # if class attribut
-
-        if isinstance(name, str):
-            name = name.split(""".""")
-            if len(name) == 1:
-                name = name[0]
-            else:
-                name = DottedName(*name)
-
-        if not isinstance(name, (str, DottedName)):
-            raise TypeError('Expecting a string or DottedName, given {0}'.format(type(name)))
 
         if not isinstance(rank, int):
             raise TypeError('rank must be an instance of int.')
@@ -2300,89 +2274,115 @@ class Variable(Symbol, PyccelAstNode):
                 precision = default_precision['complex']
             elif isinstance(dtype, NativeBool):
                 precision = default_precision['bool']
+        if not isinstance(precision,int):
+            raise TypeError('precision must be an integer.')
 
-        shape = process_shape(shape)
+        self._dtype = dtype
+        self._shape = process_shape(shape)
+        self._rank  = rank
+        self._precision = precision
 
-        # TODO improve order of arguments
+        # ------------ Variable Properties ---------------
+        # if class attribute
+        if isinstance(name, str):
+            name = name.split(""".""")
+            if len(name) == 1:
+                name = name[0]
+            else:
+                name = DottedName(*name)
 
-        return Basic.__new__(
-            cls,
-            dtype,
-            name,
-            rank,
-            allocatable,
-            shape,
-            cls_base,
-            cls_parameters,
-            is_pointer,
-            is_target,
-            is_polymorphic,
-            is_optional,
-            order,
-            precision,
-            is_stack_array,
-            is_argument
-            )
+        if not isinstance(name, (str, DottedName)):
+            raise TypeError('Expecting a string or DottedName, given {0}'.format(type(name)))
+        self._name = name
 
-    @property
-    def dtype(self):
-        return self._args[0]
+        if allocatable is None:
+            allocatable = False
+        elif not isinstance(allocatable, bool):
+            raise TypeError('allocatable must be a boolean.')
+        self._allocatable = allocatable
+
+        if is_stack_array is None:
+            is_stack_array = False
+        elif not isinstance(is_stack_array, bool):
+            raise TypeError('is_stack_array must be a boolean.')
+        self._is_stack_array = is_stack_array
+
+        if is_pointer is None:
+            is_pointer = False
+        elif not isinstance(is_pointer, bool):
+            raise TypeError('is_pointer must be a boolean.')
+        self._is_pointer = is_pointer
+
+        if is_target is None:
+            is_target = False
+        elif not isinstance(is_target, bool):
+            raise TypeError('is_target must be a boolean.')
+        self._is_target = is_target
+
+        if is_polymorphic is None:
+            if isinstance(dtype, CustomDataType):
+                is_polymorphic = dtype.is_polymorphic
+            else:
+                is_polymorphic = False
+        elif not isinstance(is_polymorphic, bool):
+            raise TypeError('is_polymorphic must be a boolean.')
+        self._is_polymorphic = is_polymorphic
+
+        if is_optional is None:
+            is_optional = False
+        elif not isinstance(is_optional, bool):
+            raise TypeError('is_optional must be a boolean.')
+        self._is_optional = is_optional
+
+        self._cls_base       = cls_base
+        self._cls_parameters = cls_parameters
+        self._order          = order
+        self._is_argument    = is_argument
+
 
     @property
     def name(self):
-        return self._args[1]
-
-    @property
-    def rank(self):
-        return self._args[2]
+        return self._name
 
     @property
     def allocatable(self):
-        return self._args[3]
-
-    @property
-    def shape(self):
-        return self._args[4]
+        return self._allocatable
 
     @property
     def cls_base(self):
-        return self._args[5]
+        return self._cls_base
 
     @property
     def cls_parameters(self):
-        return self._args[6]
+        return self._cls_parameters
 
     @property
     def is_pointer(self):
-        return self._args[7]
+        return self._is_pointer
 
     @property
     def is_target(self):
-        return self._args[8]
+        return self._is_target
 
     @property
     def is_polymorphic(self):
-        return self._args[9]
+        return self._is_polymorphic
 
     @property
     def is_optional(self):
-        return self._args[10]
+        return self._is_optional
 
     @property
     def order(self):
-        return self._args[11]
-
-    @property
-    def precision(self):
-        return self._args[12]
+        return self._order
 
     @property
     def is_stack_array(self):
-        return self._args[13]
+        return self._is_stack_array
 
     @property
     def is_argument(self):
-        return self._args[14]
+        return self._is_argument
 
     @property
     def is_ndarray(self):
@@ -2527,14 +2527,6 @@ class DottedVariable(AtomicExpr, sp_Boolean, PyccelAstNode):
         return self._args[1]
 
     @property
-    def rank(self):
-        return self._args[1].rank
-
-    @property
-    def dtype(self):
-        return self._args[1].dtype
-
-    @property
     def allocatable(self):
         return self._args[1].allocatable
 
@@ -2622,6 +2614,7 @@ class ValuedVariable(Variable):
 
         # if value is not given, we set it to Nil
         self._value = kwargs.pop('value', Nil())
+        Variable.__init__(self, *args, **kwargs)
 
     @property
     def value(self):
@@ -2653,17 +2646,18 @@ class TupleVariable(Variable):
     n
     """
 
-    def __new__(cls, arg_vars, dtype, name, **kwargs):
+    def __new__(cls, arg_vars, dtype, name, *args, **kwargs):
 
         # if value is not given, we set it to Nil
         # we also remove value from kwargs,
         # since it is not a valid argument for Variable
         
-        return Variable.__new__(cls, dtype, name, **kwargs)
+        return Variable.__new__(cls, dtype, name, *args, **kwargs)
 
-    def __init__(self, arg_vars, dtype, *args, **kwargs):
+    def __init__(self, arg_vars, dtype, name, *args, **kwargs):
         self._vars = tuple(arg_vars)
         self._is_homogeneous = not dtype is NativeGeneric()
+        Variable.__init__(self, dtype, name, *args, **kwargs)
 
     def get_vars(self):
         return self._vars

--- a/pyccel/parser/messages.py
+++ b/pyccel/parser/messages.py
@@ -68,6 +68,7 @@ PYCCEL_RESTRICTION_IS_RHS = 'Only booleans and None are allowed as rhs for is st
 PYCCEL_RESTRICTION_IMPORT = 'Import must be inside a def statement or a module'
 PYCCEL_RESTRICTION_IMPORT_IN_DEF = 'Only From Import is allowed inside a def statement'
 PYCCEL_RESTRICTION_IMPORT_STAR = 'import * not allowed'
+PYCCEL_RESTRICTION_OPTIONAL_NONE = 'Variables cannot be equal to None unless they are optional arguments and None is the default value'
 
 # other Pyccel messages
 PYCCEL_INVALID_HEADER = 'Annotated comments must start with omp, acc or header'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -234,6 +234,8 @@ class SemanticParser(BasicParser):
                                 symbol=name, blocker=True,
                                 severity='fatal')
 
+        if errors.is_errors():
+            raise PyccelSemanticError('Semantic step failed')
         errors.check()
         self._semantic_done = True
 
@@ -311,51 +313,6 @@ class SemanticParser(BasicParser):
             severity='fatal', blocker=True)
         else:
             return var
-
-    def replace_variable_from_scope(self, name, new_var):
-        """."""
-        container = self.namespace
-        while container.is_loop:
-            container = container.parent_scope
-
-        return self._replace_variable_from_scope(name, container, new_var)
-
-    def _replace_variable_from_scope(self, name, container, new_var):
-
-        if name in container.variables:
-            container.variables[name] = new_var
-            return True
-
-        for container in container.loops:
-            res = self._replace_variable_from_scope(name, container,new_var)
-            if res:
-                return res
-
-        return False
-
-    def replace_variable(self, name, new_var):
-        """."""
-
-        if self.current_class:
-            for i,v in enumerate(self._current_class.attributes):
-                if str(v.name) == name:
-                    self._current_class.attributes[i] = new_var
-                    return True
-
-        container = self.namespace
-        while container.is_loop:
-            container = container.parent_scope
-
-
-        imports   = container.imports
-        while container:
-            res = self._replace_variable_from_scope(name, container, new_var)
-            if res:
-                return res
-            elif name in container.imports['variables']:
-                container.imports['variables'][name] = new_var
-                return True
-            container = container.parent_scope
 
     def get_variables(self, container):
         # this only works one called the function scope
@@ -2822,9 +2779,9 @@ class SemanticParser(BasicParser):
         var2 = self.check_for_variable(str(expr.rhs))
         if var2 is None:
             if (not var1.is_optional):
-                new_var = var1.clone(str(name),new_class=ValuedVariable,is_optional = True)
-                self.replace_variable(str(name),new_var)
-                var1=new_var
+                errors.report(PYCCEL_RESTRICTION_OPTIONAL_NONE,
+                        bounding_box=self._current_fst_node.absolute_bounding_box,
+                        severity='error', blocker=self.blocking)
             return Is(var1, expr.rhs)
 
         if ((var1.is_Boolean or isinstance(var1.dtype, NativeBool)) and
@@ -2832,8 +2789,8 @@ class SemanticParser(BasicParser):
             return Is(var1, var2)
 
         errors.report(PYCCEL_RESTRICTION_IS_RHS,
-        bounding_box=self._current_fst_node.absolute_bounding_box,
-        severity='error', blocker=self.blocking)
+            bounding_box=self._current_fst_node.absolute_bounding_box,
+            severity='error', blocker=self.blocking)
         return Is(var1, expr.rhs)
 
     def _visit_IsNot(self, expr, **settings):
@@ -2846,9 +2803,9 @@ class SemanticParser(BasicParser):
         var2 = self.check_for_variable(str(expr.rhs))
         if var2 is None:
             if (not var1.is_optional):
-                new_var = var1.clone(str(name),new_class=ValuedVariable,is_optional = True)
-                self.replace_variable(str(name),new_var)
-                var1=new_var
+                errors.report(PYCCEL_RESTRICTION_OPTIONAL_NONE,
+                        bounding_box=self._current_fst_node.absolute_bounding_box,
+                        severity='error', blocker=self.blocking)
             return IsNot(var1, expr.rhs)
 
         if ((var1.is_Boolean or isinstance(var1.dtype, NativeBool)) and

--- a/tests/errors/semantic/var_is_none.py
+++ b/tests/errors/semantic/var_is_none.py
@@ -1,0 +1,8 @@
+from pyccel.decorators import types
+
+@types('int')
+def f(a):
+    b = 0
+    if a is not None:
+        b = b + a
+    return b


### PR DESCRIPTION
Modify the instance of Variable directly rather than creating a new instance and inserting it into the scope. This avoids references to Variables potentially becoming invalidated.

Thus the functions `update_variable` and `replace_variable` are removed from `parser/semantic.py`