### PR TITLE
Fixes to PR 364 with failing tests + assorted issues

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -280,7 +280,8 @@ class List(Tuple, PyccelAstNode):
     def __init__(self, *args, **kwargs):
         if self.stage == 'syntactic':
             return
-        integers  = [a for a in args if a.dtype is NativeInteger() or a.dtype is NativeBool()]
+        bools     = [a for a in args if a.dtype is NativeBool()]
+        integers  = [a for a in args if a.dtype is NativeInteger()]
         reals     = [a for a in args if a.dtype is NativeReal()]
         complexes = [a for a in args if a.dtype is NativeComplex()]
         strs      = [a for a in args if a.dtype is NativeString()]
@@ -299,6 +300,9 @@ class List(Tuple, PyccelAstNode):
             elif integers:
                 self._dtype     = NativeInteger()
                 self._precision = max(a.precision for a in integers)
+            elif bools:
+                self._dtype     = NativeBool()
+                self._precision  = max(a.precision for a in bools)
             else:
                 raise TypeError('cannot determine the type of {}'.format(self))
             

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -70,7 +70,10 @@ class Bool(Expr, PyccelAstNode):
 
     def fprint(self, printer):
         """ Fortran printer. """
-        return 'merge(.true., .false., ({}) /= 0)'.format(printer(self.arg))
+        if isinstance(self.arg.dtype, NativeBool):
+            return 'logical({}, kind = {prec})'.format(printer(self.arg), prec = self.precision)
+        else:
+            return 'merge(.true., .false., ({}) /= 0)'.format(printer(self.arg))
 
 #==============================================================================
 class PythonComplex(Expr, PyccelAstNode):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2354,7 +2354,7 @@ class Variable(Symbol, PyccelAstNode):
 
         new_shape = []
         for i,s in enumerate(shape):
-            if isinstance(s,Py_Integer):
+            if isinstance(s,(Py_Integer, PyccelArraySize)):
                 new_shape.append(s)
             elif isinstance(s, sp_Integer):
                 new_shape.append(Py_Integer(s.p))

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -240,7 +240,7 @@ class PyccelOperator(Expr, PyccelAstNode):
             
             shapes = [a.shape for a in args]
 
-            if all(not isinstance(sh, PyccelArraySize) for tup in shapes for sh in tup):
+            if all(not (sh is None or isinstance(sh, PyccelArraySize)) for tup in shapes for sh in tup):
                 if len(args) == 1:
                     shape = args[0].shape
                 else:
@@ -284,7 +284,7 @@ class PyccelDiv(PyccelOperator):
 
         shapes = [a.shape for a in args]
         
-        if all(not isinstance(sh, PyccelArraySize) for tup in shapes for sh in tup):
+        if all(not (sh is None or isinstance(sh, PyccelArraySize)) for tup in shapes for sh in tup):
             shape = broadcast(args[0].shape, args[1].shape)
             
             for a in args[2:]:
@@ -310,7 +310,7 @@ class PyccelBooleanOperator(Expr, PyccelAstNode):
         self._precision = default_precision['bool']
         
         shapes = [a.shape for a in args]
-        if all(sh is not None for sh in shapes):
+        if all(not (sh is None or isinstance(sh, PyccelArraySize)) for tup in shapes for sh in tup):
             shape = broadcast(args[0].shape, args[1].shape)
             for a in args[2:]:
                 shape = broadcast(shape, a.shape)
@@ -319,6 +319,7 @@ class PyccelBooleanOperator(Expr, PyccelAstNode):
             self._rank  = len(shape)
         else:
             self._rank = max(a.rank for a in args)
+            self._shape = [None]*self._rank
 
 class PyccelEq(PyccelBooleanOperator):
     pass

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -139,22 +139,10 @@ class Array(Application, NumpyNewArray):
         if not isinstance(arg, (Tuple, PythonTuple, List)):
             raise TypeError('Uknown type of  %s.' % type(arg))
 
-        # Determine dtype and (if possible) precision
-        if dtype is not None:
-            if isinstance(dtype, ValuedArgument):
-                dtype = dtype.value
-            dtype = str(dtype).replace('\'', '')
-            dtype, prec = dtype_registry[dtype]
-        else:
+        # Verify dtype and get precision
+        if dtype is None:
             dtype = arg.dtype
-            prec  = arg.precision
-
-        # If necessary, use default precision
-        if not prec:
-            prec = default_precision[dtype]
-
-        # Convert dtype from string to Singleton
-        dtype = datatype(dtype)
+        dtype, prec = process_dtype(dtype)
 
         # ... Determine ordering
         if isinstance(order, ValuedArgument):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2266,6 +2266,7 @@ class SemanticParser(BasicParser):
             if arguments:
                 for (a, ah) in zip(arguments, m.arguments):
                     d_var = self._infere_type(ah, **settings)
+                    d_var['shape'] = ah.alloc_shape
                     dtype = d_var.pop('datatype')
 
                     # this is needed for the static case

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1392,7 +1392,7 @@ class SemanticParser(BasicParser):
                         severity='fatal', blocker=self.blocking)
                 elif lhs.rank>0 and isinstance(rhs, PyccelOperator):
                     #TODO: Provide order once issue #335 is fixed
-                    #stmts.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, lhs.order)))
+                    #new_expressions.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, lhs.order)))
                     new_expressions.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, 'C')))
             else:
 

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -365,6 +365,65 @@ def array_real_2d_F_initialization(a):
 
 
 #==============================================================================
+# COMPLEX EXPRESSIONS IN 3D : TEST CONSTANT AND UNKNOWN SHAPES
+#==============================================================================
+
+
+@types( 'int32[:]', 'int32[:]' )
+def array_int32_1d_complex_3d_expr( x, y ):
+    from numpy import full
+    z = full(3,5, dtype=np.int32)
+    x[:] = (x // y) * x + z
+
+@types( 'int32[:,:]', 'int32[:,:]' )
+def array_int32_2d_C_complex_3d_expr( x, y ):
+    from numpy import full
+    z = full((2,3),5, dtype=np.int32)
+    x[:] = (x // y) * x + z
+
+@types( 'int32[:,:](order=F)', 'int32[:,:](order=F)' )
+def array_int32_2d_F_complex_3d_expr( x, y ):
+    from numpy import full
+    z = full((2,3),5,order='F', dtype=np.int32)
+    x[:] = (x // y) * x + z
+
+@types( 'real[:]', 'real[:]' )
+def array_real_1d_complex_3d_expr( x, y ):
+    from numpy import full
+    z = full(3,5)
+    x[:] = (x // y) * x + z
+
+@types( 'real[:,:]', 'real[:,:]' )
+def array_real_2d_C_complex_3d_expr( x, y ):
+    from numpy import full
+    z = full((2,3),5)
+    x[:] = (x // y) * x + z
+
+@types( 'real[:,:](order=F)', 'real[:,:](order=F)' )
+def array_real_2d_F_complex_3d_expr( x, y ):
+    from numpy import full
+    z = full((2,3),5,order='F')
+    x[:] = (x // y) * x + z
+
+@types( 'int32[:]', 'int32[:]', 'bool[:]' )
+def array_int32_in_bool_out_1d_complex_3d_expr( x, y, r ):
+    from numpy import full, int32
+    z = full(3,5, dtype=int32)
+    r[:] = (x // y) * x > z
+
+@types( 'int32[:,:]', 'int32[:,:]', 'bool[:,:]' )
+def array_int32_in_bool_out_2d_C_complex_3d_expr( x, y, r ):
+    from numpy import full, int32
+    z = full((2,3),5, dtype=int32)
+    r[:] = (x // y) * x > z
+
+@types( 'int32[:,:](order=F)', 'int32[:,:](order=F)', 'bool[:,:](order=F)' )
+def array_int32_in_bool_out_2d_F_complex_3d_expr( x, y, r ):
+    from numpy import full, int32
+    z = full((2,3),5,order='F', dtype=int32)
+    r[:] = (x // y) * x > z
+
+#==============================================================================
 # 1D STACK ARRAYS OF REAL
 #==============================================================================
 

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -405,23 +405,29 @@ def array_real_2d_F_complex_3d_expr( x, y ):
     z = full((2,3),5,order='F')
     x[:] = (x // y) * x + z
 
-@types( 'int32[:]', 'int32[:]', 'bool[:]' )
-def array_int32_in_bool_out_1d_complex_3d_expr( x, y, r ):
-    from numpy import full, int32
+@types( 'int32[:]', 'int32[:]', 'int32[:]' )
+def array_int32_in_bool_out_1d_complex_3d_expr( x, y, ri ):
+    from numpy import full, int32, empty
     z = full(3,5, dtype=int32)
-    r[:] = (x // y) * x > z
+    r = empty(3, dtype=bool)
+    r = (x // y) * x > z
+    ri[:] = r
 
-@types( 'int32[:,:]', 'int32[:,:]', 'bool[:,:]' )
-def array_int32_in_bool_out_2d_C_complex_3d_expr( x, y, r ):
+@types( 'int32[:,:]', 'int32[:,:]', 'int32[:,:]' )
+def array_int32_in_bool_out_2d_C_complex_3d_expr( x, y, ri ):
     from numpy import full, int32
     z = full((2,3),5, dtype=int32)
+    r = full((2,3),5,order='F', dtype=bool)
     r[:] = (x // y) * x > z
+    ri[:] = r
 
-@types( 'int32[:,:](order=F)', 'int32[:,:](order=F)', 'bool[:,:](order=F)' )
-def array_int32_in_bool_out_2d_F_complex_3d_expr( x, y, r ):
+@types( 'int32[:,:](order=F)', 'int32[:,:](order=F)', 'int32[:,:](order=F)' )
+def array_int32_in_bool_out_2d_F_complex_3d_expr( x, y, ri ):
     from numpy import full, int32
     z = full((2,3),5,order='F', dtype=int32)
+    r = full((2,3),5,order='F', dtype=bool)
     r[:] = (x // y) * x > z
+    ri[:] = r
 
 #==============================================================================
 # 1D STACK ARRAYS OF REAL

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -371,20 +371,20 @@ def array_real_2d_F_initialization(a):
 
 @types( 'int32[:]', 'int32[:]' )
 def array_int32_1d_complex_3d_expr( x, y ):
-    from numpy import full
-    z = full(3,5, dtype=np.int32)
+    from numpy import full, int32
+    z = full(3,5, dtype=int32)
     x[:] = (x // y) * x + z
 
 @types( 'int32[:,:]', 'int32[:,:]' )
 def array_int32_2d_C_complex_3d_expr( x, y ):
-    from numpy import full
-    z = full((2,3),5, dtype=np.int32)
+    from numpy import full, int32
+    z = full((2,3),5, dtype=int32)
     x[:] = (x // y) * x + z
 
 @types( 'int32[:,:](order=F)', 'int32[:,:](order=F)' )
 def array_int32_2d_F_complex_3d_expr( x, y ):
-    from numpy import full
-    z = full((2,3),5,order='F', dtype=np.int32)
+    from numpy import full, int32
+    z = full((2,3),5,order='F', dtype=int32)
     x[:] = (x // y) * x + z
 
 @types( 'real[:]', 'real[:]' )

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -410,7 +410,7 @@ def array_int32_in_bool_out_1d_complex_3d_expr( x, y, ri ):
     from numpy import full, int32, empty
     z = full(3,5, dtype=int32)
     r = empty(3, dtype=bool)
-    r = (x // y) * x > z
+    r[:] = (x // y) * x > z
     ri[:] = r
 
 @types( 'int32[:,:]', 'int32[:,:]', 'int32[:,:]' )

--- a/tests/epyccel/modules/base.py
+++ b/tests/epyccel/modules/base.py
@@ -90,3 +90,13 @@ def is_not_nil(a):
     if a is not None:
         c = True
     return c
+
+@types('int')
+def cast_int(a):
+    b = bool(a)
+    return b
+
+@types('bool')
+def cast_bool(a):
+    b = bool(a)
+    return b

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1201,7 +1201,7 @@ def test_array_int32_in_bool_out_1d_complex_3d_expr():
 
     x  = np.array( [1,2,3], dtype=np.int32 )
     a  = np.array( [-1,-2,-3], dtype=np.int32 )
-    r1 = np.empty( 3 , dtype=np.bool )
+    r1 = np.empty( 3 , dtype=np.int32 )
     r2 = np.copy(r1)
 
     f1(x, a, r1)
@@ -1216,7 +1216,7 @@ def test_array_int32_in_bool_out_2d_C_complex_3d_expr():
 
     x  = np.array( [[1,2,3], [4,5,6]], dtype=np.int32 )
     a  = np.array( [[-1,-2,-3], [-4,-5,-6]], dtype=np.int32 )
-    r1 = np.empty( (2,3) , dtype=np.bool )
+    r1 = np.empty( (2,3) , dtype=np.int32 )
     r2 = np.copy(r1)
 
     f1(x, a, r1)
@@ -1231,7 +1231,7 @@ def test_array_int32_in_bool_out_2d_F_complex_3d_expr():
 
     x  = np.array( [[1,2,3], [4,5,6]], dtype=np.int32, order='F' )
     a  = np.array( [[-1,-2,-3], [-4,-5,-6]], dtype=np.int32, order='F' )
-    r1 = np.empty( (2,3) , dtype=np.bool, order='F' )
+    r1 = np.empty( (2,3) , dtype=np.int32, order='F' )
     r2 = np.copy(r1)
 
     f1(x, a, r1)

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1145,6 +1145,142 @@ def test_array_real_2d_F_initialization():
 
     assert np.array_equal(x1, x2)
 
+
+
+#==============================================================================
+# TEST: COMPLEX EXPRESSIONS IN 3D : TEST CONSTANT AND UNKNOWN SHAPES
+#==============================================================================
+
+
+def test_array_int32_1d_complex_3d_expr():
+
+    f1 = arrays.array_int32_1d_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x1 = np.array( [1,2,3], dtype=np.int32 )
+    x2 = np.copy(x1)
+    a  = np.array( [-1,-2,-3], dtype=np.int32 )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
+def test_array_int32_2d_C_complex_3d_expr():
+
+    f1 = arrays.array_int32_2d_C_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x1 = np.array( [[1,2,3], [4,5,6]], dtype=np.int32 )
+    x2 = np.copy(x1)
+    a  = np.array( [[-1,-2,-3], [-4,-5,-6]], dtype=np.int32 )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
+def test_array_int32_2d_F_complex_3d_expr():
+
+    f1 = arrays.array_int32_2d_F_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x1 = np.array( [[1,2,3], [4,5,6]], dtype=np.int32, order='F' )
+    x2 = np.copy(x1)
+    a  = np.array( [[-1,-2,-3], [-4,-5,-6]], dtype=np.int32, order='F' )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
+def test_array_int32_in_bool_out_1d_complex_3d_expr():
+
+    f1 = arrays.array_int32_in_bool_out_1d_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x  = np.array( [1,2,3], dtype=np.int32 )
+    a  = np.array( [-1,-2,-3], dtype=np.int32 )
+    r1 = np.empty( 3 , dtype=np.bool )
+    r2 = np.copy(r1)
+
+    f1(x, a, r1)
+    f2(x, a, r2)
+
+    assert np.array_equal( r1, r2 )
+
+def test_array_int32_in_bool_out_2d_C_complex_3d_expr():
+
+    f1 = arrays.array_int32_in_bool_out_2d_C_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x  = np.array( [[1,2,3], [4,5,6]], dtype=np.int32 )
+    a  = np.array( [[-1,-2,-3], [-4,-5,-6]], dtype=np.int32 )
+    r1 = np.empty( (2,3) , dtype=np.bool )
+    r2 = np.copy(r1)
+
+    f1(x, a, r1)
+    f2(x, a, r2)
+
+    assert np.array_equal( r1, r2 )
+
+def test_array_int32_in_bool_out_2d_F_complex_3d_expr():
+
+    f1 = arrays.array_int32_in_bool_out_2d_F_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x  = np.array( [[1,2,3], [4,5,6]], dtype=np.int32, order='F' )
+    a  = np.array( [[-1,-2,-3], [-4,-5,-6]], dtype=np.int32, order='F' )
+    r1 = np.empty( (2,3) , dtype=np.bool, order='F' )
+    r2 = np.copy(r1)
+
+    f1(x, a, r1)
+    f2(x, a, r2)
+
+    assert np.array_equal( r1, r2 )
+
+def test_array_real_1d_complex_3d_expr():
+
+    f1 = arrays.array_real_1d_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x1 = np.array( [1.,2.,3.] )
+    x2 = np.copy(x1)
+    a  = np.array( [-1.,-2.,-3.] )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
+def test_array_real_2d_C_complex_3d_expr():
+
+    f1 = arrays.array_real_2d_C_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x1 = np.array( [[1.,2.,3.], [4.,5.,6.]] )
+    x2 = np.copy(x1)
+    a  = np.array( [[-1.,-2.,-3.], [-4.,-5.,-6.]] )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
+def test_array_real_2d_F_complex_3d_expr():
+
+    f1 = arrays.array_real_2d_F_complex_3d_expr
+    f2 = epyccel( f1 )
+
+    x1 = np.array( [[ 1., 2., 3.], [4.,5.,6.]], order='F' )
+    x2 = np.copy(x1)
+    a  = np.array( [[-1.,-2.,-3.], [-4.,-5.,-6.]], order='F' )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
 #==============================================================================
 # TEST: 1D Stack ARRAYS OF REAL
 #==============================================================================

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -66,3 +66,9 @@ def test_compare_is_nil():
 @pytest.mark.xfail(reason="f2py does not support optional arguments https://github.com/numpy/numpy/issues/4013")
 def test_compare_is_not_nil():
     compare_epyccel(base.is_not_nil, True, None)
+
+def test_cast_int():
+    compare_epyccel(base.cast_int, 4)
+
+def test_cast_bool():
+    compare_epyccel(base.cast_bool, True)

--- a/tests/errors/semantic/blocking/ARRAY_FROM_EXPRESSION.py
+++ b/tests/errors/semantic/blocking/ARRAY_FROM_EXPRESSION.py
@@ -1,0 +1,5 @@
+from pyccel.decorators import types
+
+@types('int[:,:]','int[:,:]')
+def f(x,y):
+    z = x + y

--- a/tests/errors/semantic/blocking/ARRAY_FROM_EXPRESSION.py
+++ b/tests/errors/semantic/blocking/ARRAY_FROM_EXPRESSION.py
@@ -2,4 +2,4 @@ from pyccel.decorators import types
 
 @types('int[:,:]','int[:,:]')
 def f(x,y):
-    z = x + y
+    z = x + y # pylint: disable=unused-variable


### PR DESCRIPTION
- Provide the allocated size to function arguments. Keep the same size if the size is a PyccelArraySize
- An unknown shape is a PyccelArraySize or None. Add this logic to PyccelBooleanOperator too
- Add tests that would have been failing before corrections
- Add error test to ensure that error is raised when an array is created from an expression with unknown size (see issue #352)
- Add tests for issue #369
- If an array is created from an expression and the size is known then allocate the memory with an empty expression. Fixes issue #352
- Use the process_dtype function to find Array's dtype and precision. Fixes issue #367 
- Check for Boolean type for List. This mimmicks what is done in the Tuple class. Fixes issue #368
- Fix issue #369. When casting a boolean to a boolean change the precision. When casting something else to a boolean use a merge statement