### PR TITLE
Create a ClassDef instance for Numpy objects and use it to access numpy properties

### DIFF
--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -21,6 +21,7 @@ from .core           import PyccelMul, PyccelAdd
 from .core           import broadcast
 from .core           import create_variable
 from .core           import CodeBlock
+from .core           import ClassDef, FunctionDef
 
 from .builtins       import Int as PythonInt, Bool as PythonBool
 from .builtins       import PythonFloat, PythonTuple, PythonComplex
@@ -34,6 +35,7 @@ from .type_inference import str_dtype
 
 
 __all__ = (
+    'NumpyArrayClass',
     'NumpyAbs',
     'NumpyFloor',
     # ---
@@ -105,7 +107,6 @@ def process_dtype(dtype):
     dtype            = datatype(dtype)
 
     return dtype, precision
-
 
 class NumpyNewArray(PyccelAstNode):
 
@@ -1301,3 +1302,20 @@ class Int64(NumpyInt):
     _precision = dtype_registry['int64'][1]
 
 
+
+NumpyArrayClass = ClassDef('numpy.ndarray',
+        methods=[
+            FunctionDef('shape',[],[],body=[],
+                decorators={'property':'property', 'numpy_wrapper':Shape}),
+            FunctionDef('sum',[],[],body=[],
+                decorators={'numpy_wrapper':NumpySum}),
+            FunctionDef('min',[],[],body=[],
+                decorators={'numpy_wrapper':NumpyMin}),
+            FunctionDef('max',[],[],body=[],
+                decorators={'numpy_wrapper':NumpyMax}),
+            FunctionDef('imag',[],[],body=[],
+                decorators={'property':'property', 'numpy_wrapper':Imag}),
+            FunctionDef('real',[],[],body=[],
+                decorators={'property':'property', 'numpy_wrapper':Real}),
+            FunctionDef('diagonal',[],[],body=[],
+                decorators={'numpy_wrapper':Diag})])

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -81,6 +81,8 @@ numpy_functions = {
     'complex64' : Complex64,
     'matmul'    : Matmul,
     'sum'       : NumpySum,
+    'max'      : NumpyMax,
+    'min'      : NumpyMin,
     'prod'      : Prod,
     'product'   : Prod,
     'linspace'  : Linspace,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2349,6 +2349,8 @@ class SemanticParser(BasicParser):
                     d_var = self._infere_type(ah, **settings)
                     d_var['shape'] = ah.alloc_shape
                     dtype = d_var.pop('datatype')
+                    if d_var['rank']>0:
+                        d_var['cls_base'] = NumpyArrayClass
 
                     # this is needed for the static case
 

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -27,7 +27,6 @@ from conftest import *
 #    complex128
 #    complex64
 #    matmul
-#    sum
 #    prod
 #    product
 #    linspace
@@ -473,6 +472,27 @@ def test_shape_indexed():
     def test_shape_2d(f):
         from numpy import shape
         a = shape(f)
+        return a[0], a[1]
+
+    from numpy import empty
+    f1 = epyccel(test_shape_1d)
+    f2 = epyccel(test_shape_2d)
+    n1 = randint(20)
+    n2 = randint(20)
+    n3 = randint(20)
+    x1 = empty(n1,dtype = int)
+    x2 = empty((n2,n3), dtype = int)
+    assert(f1(x1) == test_shape_1d(x1))
+    assert(all(isclose(f2(x2), test_shape_2d(x2))))
+
+def test_shape_property():
+    @types('int[:]')
+    def test_shape_1d(f):
+        return f.shape[0]
+
+    @types('int[:,:]')
+    def test_shape_2d(f):
+        a = f.shape
         return a[0], a[1]
 
     from numpy import empty
@@ -1503,3 +1523,127 @@ def test_randint_expr():
     assert(all([yi >= 42 for yi in y]))
     assert(all([isinstance(yi,int) for yi in y]))
     assert(len(set(y))>1)
+
+def test_sum_int():
+    @types('int[:]')
+    def sum_call(x):
+        from numpy import sum as np_sum
+        return np_sum(x)
+
+    f1 = epyccel(sum_call)
+    x = randint(99,size=10)
+    assert(f1(x) == sum_call(x))
+
+def test_sum_real():
+    @types('real[:]')
+    def sum_call(x):
+        from numpy import sum as np_sum
+        return np_sum(x)
+
+    f1 = epyccel(sum_call)
+    x = rand(10)
+    assert(isclose(f1(x), sum_call(x), rtol=1e-15, atol=1e-15))
+
+def test_sum_phrase():
+    @types('real[:]','real[:]')
+    def sum_phrase(x,y):
+        from numpy import sum as np_sum
+        a = np_sum(x)*np_sum(y)
+        return a
+
+    f2 = epyccel(sum_phrase)
+    x = rand(10)
+    y = rand(15)
+    assert(isclose(f2(x,y), sum_phrase(x,y), rtol=1e-15, atol=1e-15))
+
+def test_sum_property():
+    @types('int[:]')
+    def sum_call(x):
+        return x.sum()
+
+    f1 = epyccel(sum_call)
+    x = randint(99,size=10)
+    assert(f1(x) == sum_call(x))
+
+def test_min_int():
+    @types('int[:]')
+    def min_call(x):
+        from numpy import min as np_min
+        return np_min(x)
+
+    f1 = epyccel(min_call)
+    x = randint(99,size=10)
+    assert(f1(x) == min_call(x))
+
+def test_min_real():
+    @types('real[:]')
+    def min_call(x):
+        from numpy import min as np_min
+        return np_min(x)
+
+    f1 = epyccel(min_call)
+    x = rand(10)
+    assert(isclose(f1(x), min_call(x), rtol=1e-15, atol=1e-15))
+
+def test_min_phrase():
+    @types('real[:]','real[:]')
+    def min_phrase(x,y):
+        from numpy import min as np_min
+        a = np_min(x)*np_min(y)
+        return a
+
+    f2 = epyccel(min_phrase)
+    x = rand(10)
+    y = rand(15)
+    assert(isclose(f2(x,y), min_phrase(x,y), rtol=1e-15, atol=1e-15))
+
+def test_min_property():
+    @types('int[:]')
+    def min_call(x):
+        return x.min()
+
+    f1 = epyccel(min_call)
+    x = randint(99,size=10)
+    assert(f1(x) == min_call(x))
+
+def test_max_int():
+    @types('int[:]')
+    def max_call(x):
+        from numpy import max as np_max
+        return np_max(x)
+
+    f1 = epyccel(max_call)
+    x = randint(99,size=10)
+    assert(f1(x) == max_call(x))
+
+def test_max_real():
+    @types('real[:]')
+    def max_call(x):
+        from numpy import max as np_max
+        return np_max(x)
+
+    f1 = epyccel(max_call)
+    x = rand(10)
+    assert(isclose(f1(x), max_call(x), rtol=1e-15, atol=1e-15))
+
+def test_max_phrase():
+    @types('real[:]','real[:]')
+    def max_phrase(x,y):
+        from numpy import max as np_max
+        a = np_max(x)*np_max(y)
+        return a
+
+    f2 = epyccel(max_phrase)
+    x = rand(10)
+    y = rand(15)
+    assert(isclose(f2(x,y), max_phrase(x,y), rtol=1e-15, atol=1e-15))
+
+def test_max_property():
+    @types('int[:]')
+    def max_call(x):
+        return x.max()
+
+    f1 = epyccel(max_call)
+    x = randint(99,size=10)
+    assert(f1(x) == max_call(x))
+

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -483,7 +483,7 @@ def test_shape_indexed():
     x1 = empty(n1,dtype = int)
     x2 = empty((n2,n3), dtype = int)
     assert(f1(x1) == test_shape_1d(x1))
-    assert(all(isclose(f2(x2), test_shape_2d(x2))))
+    assert(f2(x2) == test_shape_2d(x2))
 
 def test_shape_property():
     @types('int[:]')


### PR DESCRIPTION
Create a ClassDef instance for Numpy objects. Use it to stock numpy properties. These are detected thanks to an internal `numpy_wrapper` decorator which provides the function being wrapped. Fixes #239

- Create `NumpyArrayClass ` which is a ClassDef object containing all functions accessible via array properties
- Add `numpy_wrapper` decorator to numpy methods to mark these methods as being accessed by passing the class instance as an argument rather than calling the class instance directly
- Handle `numpy_wrapper` decorator in `_visit_DottedVariable` class
- Add tests for Numpy functions: np.sum(x), np.min(x), np.max(x)
- Add tests for Numpy array methods: x.sum(), x.min(), x.max()
- Add tests for Numpy array properties: x.shape