### PR TITLE
Improve formatting of generated Fortran code

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1796,52 +1796,20 @@ class Program(Basic):
     declarations: list
         list of declarations of the variables that appear in the block.
 
-    funcs: list
-        a list of FunctionDef instances
-
-    classes: list
-        a list of ClassDef instances
-
     body: list
         a list of statements
 
     imports: list, tuple
         list of needed imports
 
-    modules: list, tuple
-        list of needed modules
-
-    Examples
-    --------
-    >>> from pyccel.ast.core import Variable, Assign
-    >>> from pyccel.ast.core import ClassDef, FunctionDef, Module
-    >>> x = Variable('real', 'x')
-    >>> y = Variable('real', 'y')
-    >>> z = Variable('real', 'z')
-    >>> t = Variable('real', 't')
-    >>> a = Variable('real', 'a')
-    >>> b = Variable('real', 'b')
-    >>> body = [Assign(y,x+a)]
-    >>> translate = FunctionDef('translate', [x,y,a,b], [z,t], body)
-    >>> attributs   = [x,y]
-    >>> methods     = [translate]
-    >>> Point = ClassDef('Point', attributs, methods)
-    >>> incr = FunctionDef('incr', [x], [y], [Assign(y,x+1)])
-    >>> decr = FunctionDef('decr', [x], [y], [Assign(y,x-1)])
-    >>> Module('my_module', [], [incr, decr], [Point])
-    Module(my_module, [], [FunctionDef(incr, (x,), (y,), [y := 1 + x], [], [], None, False, function), FunctionDef(decr, (x,), (y,), [y := -1 + x], [], [], None, False, function)], [ClassDef(Point, (x, y), (FunctionDef(translate, (x, y, a, b), (z, t), [y := a + x], [], [], None, False, function),), [public])])
     """
 
     def __new__(
         cls,
         name,
         variables,
-        funcs,
-        interfaces,
-        classes,
         body,
         imports=[],
-        modules=[],
         ):
 
         if not isinstance(name, str):
@@ -1854,57 +1822,22 @@ class Program(Basic):
             if not isinstance(i, Variable):
                 raise TypeError('Only a Variable instance is allowed.')
 
-        if not iterable(funcs):
-            raise TypeError('funcs must be an iterable')
-        for i in funcs:
-            if not isinstance(i, FunctionDef):
-                raise TypeError('Only a FunctionDef instance is allowed.'
-                                )
-
-        if not iterable(interfaces):
-            raise TypeError('interfaces must be an iterable')
-        for i in interfaces:
-            if not isinstance(i, Interface):
-                raise TypeError('Only a Interface instance is allowed.')
-
         if not iterable(body):
             raise TypeError('body must be an iterable')
         body = CodeBlock(body)
 
-        if not iterable(classes):
-            raise TypeError('classes must be an iterable')
-        for i in classes:
-            if not isinstance(i, ClassDef):
-                raise TypeError('Only a ClassDef instance is allowed.')
-
         if not iterable(imports):
             raise TypeError('imports must be an iterable')
 
-        for i in funcs:
-            imports += i.imports
-        for i in classes:
-            imports += i.imports
         imports = set(imports)  # for unicity
         imports = Tuple(*imports, sympify=False)
-
-        if not iterable(modules):
-            raise TypeError('modules must be an iterable')
-
-        # TODO
-#        elif isinstance(stmt, list):
-#            for s in stmt:
-#                body += printer(s) + "\n"
 
         return Basic.__new__(
             cls,
             name,
             variables,
-            funcs,
-            interfaces,
-            classes,
             body,
             imports,
-            modules,
             )
 
     @property
@@ -1916,28 +1849,12 @@ class Program(Basic):
         return self._args[1]
 
     @property
-    def funcs(self):
+    def body(self):
         return self._args[2]
 
     @property
-    def interfaces(self):
-        return self._args[3]
-
-    @property
-    def classes(self):
-        return self._args[4]
-
-    @property
-    def body(self):
-        return self._args[5]
-
-    @property
     def imports(self):
-        return self._args[6]
-
-    @property
-    def modules(self):
-        return self._args[7]
+        return self._args[3]
 
     @property
     def declarations(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -96,7 +96,7 @@ __all__ = (
     'DoConcurrent',
     'DottedName',
     'DottedVariable',
-    'EmptyLine',
+    'EmptyNode',
     'ErrorExit',
     'Eval',
     'Exit',
@@ -4292,9 +4292,13 @@ class Del(Basic):
         return self._args[0]
 
 
-class EmptyLine(Basic):
-
-    """Represents a EmptyLine in the code.
+class EmptyNode(Basic):
+    """
+    Represents an empty node in the abstract syntax tree (AST).
+    When a subtree is removed from the AST, we replace it with an EmptyNode
+    object that acts as a placeholder. Using an EmptyNode instead of None
+    is more explicit and avoids confusion. Further, finding a None in the AST
+    is signal of an internal bug.
 
     Parameters
     ----------
@@ -4303,8 +4307,8 @@ class EmptyLine(Basic):
 
     Examples
     --------
-    >>> from pyccel.ast.core import EmptyLine
-    >>> EmptyLine()
+    >>> from pyccel.ast.core import EmptyNode
+    >>> EmptyNode()
 
     """
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -681,7 +681,7 @@ def extract_subexpressions(expr):
             return args
 
         else:
-            raise TypeError('statment {} not supported yet'.format(type(expr)))
+            raise TypeError('statement {} not supported yet'.format(type(expr)))
 
 
     new_expr  = substitute(expr)

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -6,7 +6,7 @@ from pyccel.codegen.printing.ccode  import ccode
 from pyccel.codegen.printing.pycode import pycode
 
 from pyccel.ast.core      import FunctionDef, Module, Program, Interface
-from pyccel.ast.core      import EmptyLine, NewLine, Comment, CommentBlock
+from pyccel.ast.core      import EmptyNode, NewLine, Comment, CommentBlock
 from pyccel.ast.headers   import Header
 from pyccel.errors.errors import Errors
 
@@ -181,7 +181,7 @@ class Codegen(object):
         """Finds the source code kind."""
 
 
-        cls = (Header, EmptyLine, NewLine, Comment, CommentBlock, Module)
+        cls = (Header, EmptyNode, NewLine, Comment, CommentBlock, Module)
         is_module = all(isinstance(i,cls) for i in self.ast.body)
 
 

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -209,8 +209,7 @@ class Codegen(object):
                 self.name,
                 self.variables,
                 self.body.body,
-                imports=self.imports,
-                modules=self.modules)
+                imports=self.imports)
 
         else:
             raise NotImplementedError('TODO')

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -208,9 +208,6 @@ class Codegen(object):
             expr = Program(
                 self.name,
                 self.variables,
-                self.routines,
-                self.interfaces,
-                self.classes,
                 self.body.body,
                 imports=self.imports,
                 modules=self.modules)

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -168,7 +168,7 @@ class Codegen(object):
                 interfaces.append(i)
 
         self._stmts['imports'   ] = list(namespace.imports['imports'].values())
-        self._stmts['variables' ] = list(set(self.parser.get_variables(namespace)))
+        self._stmts['variables' ] = list(self.parser.get_variables(namespace))
         self._stmts['routines'  ] = funcs
         self._stmts['classes'   ] = list(namespace.classes.values())
         self._stmts['interfaces'] = interfaces

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -53,7 +53,7 @@ class Codegen(object):
         for key in _structs:
             self._stmts[key] = []
 
-        self._collect_statments()
+        self._collect_statements()
         self._set_kind()
 
 
@@ -151,8 +151,8 @@ class Codegen(object):
 
         return self._code
 
-    def _collect_statments(self):
-        """Collects statments and split them into routines, classes, etc."""
+    def _collect_statements(self):
+        """Collects statements and split them into routines, classes, etc."""
 
         namespace  = self.parser.namespace
 
@@ -173,8 +173,6 @@ class Codegen(object):
         self._stmts['classes'   ] = list(namespace.classes.values())
         self._stmts['interfaces'] = interfaces
         self._stmts['body']       = self.ast
-
-
 
 
     def _set_kind(self):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -325,7 +325,7 @@ class CCodePrinter(CodePrinter):
                 '{1}\n'
                 '{2}').format(top, body, bottom)
 
-    def _print_EmptyLine(self, expr):
+    def _print_EmptyNode(self, expr):
         return ''
 
     def _print_NewLine(self, expr):

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -57,10 +57,10 @@ class CodePrinter(StrPrinter):
             expr = _sympify(expr)
 
         # Do the actual printing
-        lines = self._print(expr).splitlines()
+        lines = self._print(expr).splitlines(True)
 
         # Format the output
-        return "\n".join(self._format_code(lines))
+        return ''.join(self._format_code(lines))
 
 
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1427,7 +1427,7 @@ class FCodePrinter(CodePrinter):
         args_decs = OrderedDict()
         # ... local variables declarations
         func_end  = ''
-        rec = 'recursive ' if expr.is_recursive else ''
+        rec = 'recursive' if expr.is_recursive else ''
         if is_procedure:
             func_type = 'subroutine'
             out_args = list(expr.results)
@@ -1491,22 +1491,24 @@ class FCodePrinter(CodePrinter):
         for v in vars_to_print:
             if (v not in expr.local_vars) and (v not in expr.results) and (v not in expr.arguments):
                 args_decs[str(v)] = Declare(v.dtype,v)
+        prelude = '\n'.join(self._print(i) for i in args_decs.values())
 
-        prelude   = '\n'.join(self._print(i) for i in args_decs.values())
         if len(functions)>0:
             functions_code = '\n'.join(self._print(i) for  i in functions)
-            body_code = body_code +'\ncontains \n' +functions_code
-        body_code = prelude + '\n\n' + body_code
+            body_code = body_code +'\ncontains\n' + functions_code
+
         imports = '\n'.join(self._print(i) for i in expr.imports)
 
         self.set_current_function(None)
-        func = ('{0}({1}) {2}\n'
-                '{3}\n'
-                'implicit none\n'
-                '{4}\n'
-                'end {5}').format(sig, arg_code, func_end, imports, body_code, func_type)
 
-        return func
+        parts = ['{0}({1}) {2}'.format(sig, arg_code, func_end),
+                 imports,
+                'implicit none',
+                 prelude,
+                 body_code,
+                 'end {}'.format(func_type)]
+
+        return '\n\n'.join(a for a in parts if a)
 
     def _print_Pass(self, expr):
         return ''

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -551,7 +551,7 @@ class FCodePrinter(CodePrinter):
                 '{1}\n'
                 '{2}').format(top, body, bottom)
 
-    def _print_EmptyLine(self, expr):
+    def _print_EmptyNode(self, expr):
         return ''
 
     def _print_NewLine(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -308,7 +308,7 @@ class FCodePrinter(CodePrinter):
                  interfaces,
                  contains,
                  body,
-                 'end module\n']
+                 'end module {}\n'.format(name)]
 
         return '\n\n'.join([a for a in parts if a])
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1385,7 +1385,7 @@ class FCodePrinter(CodePrinter):
                 'implicit none\n',
                  prelude,
                  body_code,
-                 'end {}\n'.format(func_type)]
+                 'end {} {}\n'.format(func_type, name)]
 
         return '\n'.join(parts)
 
@@ -1501,7 +1501,7 @@ class FCodePrinter(CodePrinter):
                 'implicit none\n',
                  prelude,
                  body_code,
-                 'end {}\n'.format(func_type)]
+                 'end {} {}\n'.format(func_type, name)]
 
         return '\n'.join(a for a in parts if a)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2114,18 +2114,18 @@ class FCodePrinter(CodePrinter):
         lines = []
         for i, (c, e) in enumerate(expr.args):
             if i == 0:
-                lines.append("if (%s) then" % self._print(c))
+                lines.append("if (%s) then\n" % self._print(c))
             elif i == len(expr.args) - 1 and c is BooleanTrue():
-                lines.append("else")
+                lines.append("else\n")
             else:
-                lines.append("else if (%s) then" % self._print(c))
+                lines.append("else if (%s) then\n" % self._print(c))
             if isinstance(e, (list, tuple, Tuple, PythonTuple)):
                 for ee in e:
                     lines.append(self._print(ee))
             else:
                 lines.append(self._print(e))
-        lines.append("end if")
-        return "\n".join(lines)
+        lines.append("end if\n")
+        return ''.join(lines)
 
     def _print_MatrixElement(self, expr):
         return "{0}({1}, {2})".format(expr.parent, expr.i + 1, expr.j + 1)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -476,30 +476,6 @@ class FCodePrinter(CodePrinter):
         code = '\n'.join(self._print(i) for i in expr.imports)
         return self._get_statement(code) + '\n'
 
-
-    # TODO
-    def _print_FromImport(self, expr):
-        fil = self._print(expr.fil)
-        if isinstance(expr.fil, DottedName):
-            # pyccel-extension case
-            if expr.fil.name[0] == 'pyccelext':
-                fil = '_'.join(self._print(i) for i in expr.fil.name)
-                fil = 'mod_{0}'.format(fil)
-            else:
-                fil = '_'.join(self._print(i) for i in expr.fil.name)
-                fil = 'mod_{0}'.format(fil)
-
-        if not expr.funcs:
-            return 'use {0}\n'.format(fil)
-        elif isinstance(expr.funcs, str):
-            funcs = self._print(expr.funcs)
-            return 'use {0}, only: {1}\n'.format(fil, funcs)
-        elif isinstance(expr.funcs, (tuple, list, Tuple)):
-            funcs = ', '.join(self._print(f) for f in expr.funcs)
-            return 'use {0}, only: {1}\n'.format(fil, funcs)
-        else:
-            raise TypeError('Wrong type for funcs')
-
     def _print_Print(self, expr):
         args = []
         for f in expr.expr:
@@ -522,11 +498,9 @@ class FCodePrinter(CodePrinter):
         code = '\n'.join("print *, 'sympy> {}'".format(a) for a in expr.expr)
         return self._get_statement(code) + '\n'
 
-
     def _print_Comment(self, expr):
         comments = self._print(expr.text)
         return '!' + comments + '\n'
-
 
     def _print_CommentBlock(self, expr):
         txts = expr.comments

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -325,17 +325,13 @@ class FCodePrinter(CodePrinter):
         variables = self.parser.get_variables(self._namespace)
         decs = ''.join(self._print_Declare(Declare(v.dtype, v)) for v in variables)
 
-        mpi = False
-        #we use this to detect of we are using so that we can add
-        # mpi_init and mpi_finalize in the code instruction
+        # Detect if we are using mpi4py
         # TODO should we find a better way to do this?
-        for i in expr.imports:
-            if 'mpi4py' == str(getattr(i.source,'name',i.source)):
-                mpi = True
+        mpi = any('mpi4py' == str(getattr(i.source, 'name', i.source)) for i in expr.imports)
 
         # Additional code and variable declarations for MPI usage
+        # TODO: check if we should really add them like this
         if mpi:
-            #TODO shuold we add them like this ?
             body = 'call mpi_init(ierr)\n'+\
                    '\nallocate(status(0:-1 + mpi_status_size)) '+\
                    '\nstatus = 0\n'+\

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2553,7 +2553,7 @@ class FCodePrinter(CodePrinter):
         """Wrap long Fortran lines
 
            Argument:
-             lines  --  a list of lines (without \\n character)
+             lines  --  a list of lines (ending with a \\n character)
 
            A comment line is split at white space. Code lines are split with a more
            complex rule to give nice results.
@@ -2576,6 +2576,7 @@ class FCodePrinter(CodePrinter):
                 if pos == 0:
                     return endpos
             return pos
+
         # split line by line and add the splitted lines to result
         result = []
         trailing = ' &'
@@ -2601,7 +2602,9 @@ class FCodePrinter(CodePrinter):
                     result.append("%s%s"%("      " , hunk))
             else:
                 result.append(line)
-        return result
+
+        # make sure that all lines end with a carriage return
+        return [l if l.endswith('\n') else l+'\n' for l in result]
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -918,7 +918,7 @@ class FCodePrinter(CodePrinter):
         # ...
 
         if isinstance(expr.variable, TupleVariable) and not expr.variable.is_homogeneous:
-            return ''.join(self._print_Declare(Declare(v.dtype,v,intent=expr.intent, static=expr.static)) for v in expr.variable) + '\n'
+            return ''.join(self._print_Declare(Declare(v.dtype,v,intent=expr.intent, static=expr.static)) for v in expr.variable)
 
         # ... TODO improve
         # Group the variables by intent

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2112,19 +2112,26 @@ class FCodePrinter(CodePrinter):
         # ...
 
         lines = []
+
         for i, (c, e) in enumerate(expr.args):
+
+            if (not e) or (isinstance(e, CodeBlock) and not e.body):
+                continue
+
             if i == 0:
                 lines.append("if (%s) then\n" % self._print(c))
             elif i == len(expr.args) - 1 and c is BooleanTrue():
                 lines.append("else\n")
             else:
                 lines.append("else if (%s) then\n" % self._print(c))
+
             if isinstance(e, (list, tuple, Tuple, PythonTuple)):
-                for ee in e:
-                    lines.append(self._print(ee))
+                lines.extend(self._print(e) for e in ee)
             else:
                 lines.append(self._print(e))
+
         lines.append("end if\n")
+
         return ''.join(lines)
 
     def _print_MatrixElement(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2496,7 +2496,7 @@ class FCodePrinter(CodePrinter):
             else:
                 args = ['{}'.format(self._print(a)) for a in args]
 
-            args = ','.join(args)
+            args = ', '.join(args)
             code = '{name}({args})'.format( name = str(func.name),
                                             args = args)
 
@@ -2528,7 +2528,7 @@ class FCodePrinter(CodePrinter):
                 args    = ['{}'.format(self._print(a)) for a in args]
                 results = ['{}'.format(self._print(a)) for a in results]
 
-            newargs = ','.join(args+results)
+            newargs = ', '.join(args+results)
 
             code = 'call {name}({args})'.format( name = str(func.name),
                                                  args = newargs )

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2219,7 +2219,7 @@ class FCodePrinter(CodePrinter):
 
         if a is NativeBool() and b is NativeBool():
             return '{} .eqv. {}'.format(lhs, rhs)
-        return '{0} == {1} '.format(lhs, rhs)
+        return '{0} == {1}'.format(lhs, rhs)
 
     def _print_PyccelNe(self, expr):
         lhs = self._print(expr.args[0])
@@ -2229,7 +2229,7 @@ class FCodePrinter(CodePrinter):
 
         if a is NativeBool() and b is NativeBool():
             return '{} .neqv. {}'.format(lhs, rhs)
-        return '{0} /= {1} '.format(lhs, rhs)
+        return '{0} /= {1}'.format(lhs, rhs)
 
     def _print_PyccelLt(self, expr):
         lhs = self._print(expr.args[0])

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -284,18 +284,10 @@ class FCodePrinter(CodePrinter):
             interfaces = '\n'.join(self._print(i) for i in expr.interfaces if not i.hide)
             for interface in expr.interfaces:
                 if not interface.hide:
-                    for i in interface.functions:
-                        body = ('{body}\n'
-                                '{sep}\n'
-                                '{f}\n'
-                                '{sep}\n').format(body=body, sep=sep, f=self._print(i))
+                    body += '\n\n'.join('\n'.join([sep, self._print(i), sep]) for i in interface.functions)
 
         if expr.funcs:
-            for i in expr.funcs:
-                body = ('{body}\n'
-                         '{sep}\n'
-                         '{f}\n'
-                         '{sep}\n').format(body=body, sep=sep, f=self._print(i))
+            body += '\n\n'.join('\n'.join([sep, self._print(i), sep]) for i in expr.funcs)
         # ...
 
         # ...
@@ -306,23 +298,19 @@ class FCodePrinter(CodePrinter):
             body = '{0}\n{1}\n'.format(body, c_funcs)
         # ...
 
+        contains = 'contains' if (expr.funcs or expr.classes or expr.interfaces) else ''
 
-        if expr.funcs or expr.classes or expr.interfaces:
-            body = '\n contains\n{0}'.format(body)
+        parts = ['module {}'.format(name),
+                 imports,
+                 'implicit none',
+                 private,
+                 decs,
+                 interfaces,
+                 contains,
+                 body,
+                 'end module\n']
 
-        return ('module {name}\n'
-                '{imports}\n'
-                'implicit none\n'
-                '{private}\n'
-                '{decs}\n'
-                '{interfaces}\n'
-                '{body}\n'
-                'end module\n').format(name=name,
-                                       imports=imports,
-                                       decs=decs,
-                                       private=private,
-                                       interfaces=interfaces,
-                                       body=body)
+        return '\n\n'.join([a for a in parts if a])
 
     def _print_Program(self, expr):
         self._handle_fortran_specific_a_prioris(self.parser.get_variables(self._namespace))

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1374,19 +1374,20 @@ class FCodePrinter(CodePrinter):
             dec = Declare(result.dtype, result, static=True)
             args_decs[str(result.name)] = dec
         # ...
+
         arg_code  = ', '.join(self._print(i) for i in chain( arguments, results ))
+        imports   = ''.join(self._print(i) for i in expr.imports)
+        prelude   = ''.join(self._print(i) for i in args_decs.values())
         body_code = self._print(expr.body)
-        prelude   = '\n'.join(self._print(i) for i in args_decs.values())
-        body_code = prelude + '\n\n' + body_code
-        imports = '\n'.join(self._print(i) for i in expr.imports)
 
-        func = ('{0} {1} ({2}) {3}\n'
-                '{4}\n'
-                'implicit none\n'
-                '{5}\n'
-                'end {6}').format(func_type, name, arg_code, func_end, imports, body_code, func_type)
+        parts = ['{0} {1}({2}) {3}\n'.format(func_type, name, arg_code, func_end),
+                 imports,
+                'implicit none\n',
+                 prelude,
+                 body_code,
+                 'end {}\n'.format(func_type)]
 
-        return func
+        return '\n'.join(parts)
 
     def _print_FunctionDef(self, expr):
         self._handle_fortran_specific_a_prioris(list(expr.local_vars) +

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -469,9 +469,7 @@ class FCodePrinter(CodePrinter):
                 raise TypeError('Expecting str, Symbol, DottedName or AsName, '
                                 'given {}'.format(type(i)))
 
-            # TODO keep `\n` ?
-#            code = '{code}{line}'.format(code=code, line=line)
-            code = '{code}\n{line}'.format(code=code, line=line)
+            code = (code + '\n' + line) if code else line
 
         # in some cases, the source is given as a string (when using metavar)
         code = code.replace("'", '')

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -106,7 +106,7 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         txt = self._print(expr.text)
         return '# {0} '.format(txt)
 
-    def _print_EmptyLine(self, expr):
+    def _print_EmptyNode(self, expr):
         return ''
 
     def _print_NewLine(self, expr):

--- a/pyccel/codegen/python_wrapper.py
+++ b/pyccel/codegen/python_wrapper.py
@@ -6,6 +6,7 @@ import os
 import glob
 
 from pyccel.ast.f2py                import as_static_function_call
+from pyccel.ast.core                import SeparatorComment
 from pyccel.codegen.printing.fcode  import fcode
 from .utilities import language_extension
 from .cwrapper import create_c_wrapper, create_c_setup
@@ -196,8 +197,9 @@ def create_shared_library(codegen,
         # Construct f2py interface for assembly and write it to file f2py_MOD.f90
         # be careful: because of f2py we must use lower case
         funcs = codegen.routines + codegen.interfaces
+        sep = fcode(SeparatorComment(40), codegen.parser)
         f2py_funcs = [as_static_function_call(f, module_name, name=f.name) for f in funcs]
-        f2py_code = '\n\n'.join([fcode(f, codegen.parser) for f in f2py_funcs])
+        f2py_code = '\n'.join([sep + fcode(f, codegen.parser) + sep for f in f2py_funcs])
         f2py_filename = 'f2py_{}.f90'.format(module_name)
 
         with open(f2py_filename, 'w') as f:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -42,7 +42,7 @@ from pyccel.ast.core import If, IfTernaryOperator
 from pyccel.ast.core import While
 from pyccel.ast.core import SymbolicPrint
 from pyccel.ast.core import Del
-from pyccel.ast.core import EmptyLine
+from pyccel.ast.core import EmptyNode
 from pyccel.ast.core import Slice, IndexedVariable, IndexedElement
 from pyccel.ast.core import Concatenate
 from pyccel.ast.core import ValuedVariable
@@ -786,7 +786,7 @@ class SemanticParser(BasicParser):
 
     def _visit_Nil(self, expr, **settings):
         return expr
-    def _visit_EmptyLine(self, expr, **settings):
+    def _visit_EmptyNode(self, expr, **settings):
         return expr
     def _visit_NewLine(self, expr, **settings):
         return expr
@@ -1648,7 +1648,7 @@ class SemanticParser(BasicParser):
         elif isinstance(rhs, Block):
             #case of inline
             results = _atomic(rhs.body,Return)
-            sub = list(zip(results,[EmptyLine()]*len(results)))
+            sub = list(zip(results,[EmptyNode()]*len(results)))
             body = rhs.body
             body = subs(body,sub)
             results = [i.expr for i in results]
@@ -2608,7 +2608,7 @@ class SemanticParser(BasicParser):
 #               funcs = [funcs, vec_func]
 #           funcs = Interface(name, funcs)
 #           self.insert_function(funcs)
-        return EmptyLine()
+        return EmptyNode()
 
     def _visit_Print(self, expr, **settings):
         args = [self._visit(i, **settings) for i in expr.expr]
@@ -2700,7 +2700,7 @@ class SemanticParser(BasicParser):
               interfaces=interfaces, parent=parent)
         self.insert_class(cls)
 
-        return EmptyLine()
+        return EmptyNode()
 
     def _visit_Del(self, expr, **settings):
 
@@ -2867,7 +2867,7 @@ class SemanticParser(BasicParser):
             elif not __ignore_at_import__:
                 container['imports'][source_target] = expr
 
-        return EmptyLine()
+        return EmptyNode()
 
 
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -38,7 +38,7 @@ from pyccel.ast.core import While
 from pyccel.ast.core import Del
 from pyccel.ast.core import Assert
 from pyccel.ast.core import PythonTuple
-from pyccel.ast.core import Comment, EmptyLine, NewLine
+from pyccel.ast.core import Comment, EmptyNode, NewLine
 from pyccel.ast.core import Break, Continue
 from pyccel.ast.core import Slice
 from pyccel.ast.core import Argument, ValuedArgument
@@ -243,8 +243,8 @@ class SyntaxParser(BasicParser):
                 n_empty_lines = 0
                 current_file = start
                 current_file.append(v)
-            elif isinstance(v, (NewLine, EmptyLine)):
-                # EmptyLines are defined in the same block as the previous line
+            elif isinstance(v, (NewLine, EmptyNode)):
+                # EmptyNodes are defined in the same block as the previous line
                 current_file.append(v)
                 n_empty_lines += 1
             elif isinstance(v, Import):
@@ -669,7 +669,7 @@ class SyntaxParser(BasicParser):
                             for d in self._visit(stmt.decorator_list)}
 
         if 'bypass' in decorators:
-            return EmptyLine()
+            return EmptyNode()
 
         if 'stack_array' in decorators:
             args = list(decorators['stack_array'].args)
@@ -732,7 +732,7 @@ class SyntaxParser(BasicParser):
                     [stmt.__str__()])
             func.set_fst(stmt)
             self.insert_function(func)
-            return EmptyLine()
+            return EmptyNode()
 
         elif 'python' in decorators.keys():
 
@@ -743,7 +743,7 @@ class SyntaxParser(BasicParser):
                     [stmt.__str__()])
             func.set_fst(stmt)
             self.insert_function(func)
-            return EmptyLine()
+            return EmptyNode()
 
         else:
             body = self._visit(body)
@@ -1051,7 +1051,7 @@ class SyntaxParser(BasicParser):
                         # but can be used to modify the ast
 
                         self._metavars[str(expr.name)] = str(expr.value)
-                        expr = EmptyLine()
+                        expr = EmptyNode()
                     else:
                         expr.set_fst(stmt)
 
@@ -1088,7 +1088,7 @@ class SyntaxParser(BasicParser):
                     # but can be used to modify the ast
 
                     self._metavars[str(expr.name)] = str(expr.value)
-                    expr = EmptyLine()
+                    expr = EmptyNode()
                 else:
                     expr.set_fst(stmt)
 


### PR DESCRIPTION
Improve formatting of Fortran code in:

* modules
* programs
* variable declarations
* function definitions
* function calls
* comparisons
* use statements
* f2py interfaces

Other changes to Fortran printer:

* Print variable declarations in original order given by user
* Add module name to 'end module' statement
* Add procedure name to 'end function/subroutine' statement
* Throughout printer, end strings with '\n' where appropriate
* Add \n to end of lines in _wrap_fortran function
* Print 'else' in if/then/else block only if necessary
* Remove obsolete '_print_FromImport' 

Moreover:

* Fix typo: statment >> statement
* Rename empty AST node: EmptyLine >> EmptyNode
* Remove obsolete arguments from Program constructor:
   - Since PR #345 (merged with commit 33c17c1) functions, interfaces
     and classes are moved to a separate Fortran module during the
     syntactic stage, so they are not part of the Fortran program anymore
   - Argument 'modules' was neither populated at instance creation, nor
      used by other methods (dead code)
   - Fortran printer was cleaned up accordingly