### PR TITLE
[WIP]: Try to locate cause of occasional travis failures

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -821,6 +821,7 @@ def float2int(expr):
 
 def create_random_string(expr):
     import numpy as np
+    return str(np.random.randint(10))
     try:
         randstr = str(abs(hash(expr)
                                   + np.random.randint(500)))[-4:]

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -263,6 +263,7 @@ class Codegen(object):
             for line in code:
                 f.write(line)
 
+        import sys
         for line in code:
             sys.stdout.write(line)
 

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -263,6 +263,9 @@ class Codegen(object):
             for line in code:
                 f.write(line)
 
+        for line in code:
+            print(line)
+
         return filename
 
 

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -264,7 +264,7 @@ class Codegen(object):
                 f.write(line)
 
         for line in code:
-            print(line)
+            sys.stdout.write(line)
 
         return filename
 

--- a/pyccel/epyccel.py
+++ b/pyccel/epyccel.py
@@ -18,10 +18,10 @@ __all__ = ['random_string', 'get_source_function', 'epyccel_seq', 'epyccel']
 #==============================================================================
 random_selector = random.SystemRandom()
 
-def random_string( n ):
+def random_string( n, prefix = '' ):
     # we remove uppercase letters because of f2py
     chars    = string.ascii_lowercase + string.digits
-    return ''.join( random_selector.choice( chars ) for _ in range(n) )
+    return prefix + ''.join( random_selector.choice( chars ) for _ in range(n) )
 
 #==============================================================================
 def get_source_function(func):
@@ -63,8 +63,11 @@ def epyccel_seq(function_or_module,
     if isinstance(function_or_module, FunctionType):
         pyfunc = function_or_module
         code = get_source_function(pyfunc)
-        tag = random_string(8)
-        module_name = 'mod_{}'.format(tag)
+
+        module_name = random_string(prefix='mod_', n=8)
+        while module_name in sys.modules.keys():
+            module_name = random_string(prefix='mod_', n=8)
+
         pymod_filename = '{}.py'.format(module_name)
         pymod_filepath = os.path.abspath(pymod_filename)
 
@@ -74,7 +77,12 @@ def epyccel_seq(function_or_module,
         pymod_filename = os.path.basename(pymod_filepath)
         lines = inspect.getsourcelines(pymod)[0]
         code = ''.join(lines)
-        tag = random_string(8)
+
+        tag = random_string(n=8)
+        module_import_prefix = pymod.__name__ + '_'
+        while module_import_prefix + tag in sys.modules.keys():
+            tag = random_string(n=8)
+
         module_name = pymod.__name__.split('.')[-1] + '_' + tag
 
     else:


### PR DESCRIPTION
Travis occasionally fails but will succeed if the test is rerun. Tests that fail in this manner usually have similar outputs to the expected result. Often 1 of the output values is missing or one or two of the output values is wrong.

The original hypothesis for the cause of this problem was that collisions in the module name caused the wrong function to be called. As many of these tests are similar it would not be surprising if the output was similar to the expected output.
This theory is now disproved as this branch prevents module name collisions. In addition it is simple to show we cannot call a function from an unexpected module as we would not be using the correct function name.

To find this bug we can try to document which tests fail and try to find similarities in how they fail