### PR TITLE
Avoid name collisions for temporary variables and modules

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -819,9 +819,12 @@ def int2float(expr):
 def float2int(expr):
     return expr
 
-def create_random_string(forbidden_exprs : set, prefix = 'Dummy', nDigits : int = 2):
+def create_random_string(forbidden_exprs : set, prefix = None, nDigits : int = 2):
     assert(isinstance(forbidden_exprs, set))
     import numpy as np
+
+    if prefix is None:
+        prefix = 'Dummy'
 
     max_val = 10**nDigits
 
@@ -832,10 +835,10 @@ def create_random_string(forbidden_exprs : set, prefix = 'Dummy', nDigits : int 
         name = prefix + str(np.random.randint(max_val))
     return name
 
-def create_variable(forbidden_names):
+def create_variable(forbidden_names, prefix = None):
     """."""
 
-    name = create_random_string(forbidden_names)
+    name = create_random_string(forbidden_names, prefix)
 
     return Symbol(name)
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -819,11 +819,13 @@ def int2float(expr):
 def float2int(expr):
     return expr
 
-def create_random_string(forbidden_exprs : set, prefix = 'Dummy_', nDigits : int = 1):
+def create_random_string(forbidden_exprs : set, prefix = 'Dummy', nDigits : int = 1):
     assert(isinstance(forbidden_exprs, set))
     import numpy as np
 
     max_val = 10**nDigits
+
+    prefix += '_'
 
     name = prefix + str(np.random.randint(max_val))
     while name in forbidden_exprs:

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -882,7 +882,7 @@ def create_variable(forbidden_names, prefix = None, counter = 1):
 
       Returns
       ----------
-      name            : Symbol
+      name            : sympy.Symbol
                         A sympy Symbol with the incremented string name
       counter         : int
                         The expected value of the next name

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -156,7 +156,7 @@ __all__ = (
     '_atomic',
 #    'allocatable_like',
     'create_variable',
-    'create_random_string',
+    'create_incremented_string',
     'extract_subexpressions',
 #    'float2int',
     'get_assigned_symbols',
@@ -819,7 +819,7 @@ def int2float(expr):
 def float2int(expr):
     return expr
 
-def create_random_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
+def create_incremented_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
     assert(isinstance(forbidden_exprs, set))
     import numpy as np
     nDigits = 4
@@ -841,7 +841,7 @@ def create_random_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
 def create_variable(forbidden_names, prefix = None, counter = 1):
     """."""
 
-    name, counter = create_random_string(forbidden_names, prefix, counter = counter)
+    name, counter = create_incremented_string(forbidden_names, prefix, counter = counter)
 
     return Symbol(name), counter
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -822,7 +822,7 @@ def float2int(expr):
 def create_random_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
     assert(isinstance(forbidden_exprs, set))
     import numpy as np
-    nDigits = 2
+    nDigits = 4
 
     if prefix is None:
         prefix = 'Dummy'
@@ -842,7 +842,6 @@ def create_variable(forbidden_names, prefix = None, counter = 1):
     """."""
 
     name, counter = create_random_string(forbidden_names, prefix, counter = counter)
-    print(counter)
 
     return Symbol(name), counter
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -819,7 +819,7 @@ def int2float(expr):
 def float2int(expr):
     return expr
 
-def create_random_string(forbidden_exprs : set, prefix = '', nDigits : int = 1):
+def create_random_string(forbidden_exprs : set, prefix = 'Dummy_', nDigits : int = 1):
     assert(isinstance(forbidden_exprs, set))
     import numpy as np
 
@@ -833,7 +833,7 @@ def create_random_string(forbidden_exprs : set, prefix = '', nDigits : int = 1):
 def create_variable(forbidden_names):
     """."""
 
-    name = create_random_string(forbidden_names, 'Dummy_')
+    name = create_random_string(forbidden_names)
 
     return Symbol(name)
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -819,22 +819,21 @@ def int2float(expr):
 def float2int(expr):
     return expr
 
-def create_random_string(expr):
+def create_random_string(forbidden_exprs : set, prefix = '', nDigits : int = 1):
+    assert(isinstance(forbidden_exprs, set))
     import numpy as np
-    return str(np.random.randint(10))
-    try:
-        randstr = str(abs(hash(expr)
-                                  + np.random.randint(500)))[-4:]
-    except TypeError:
-        # Catch unhashable type (e.g. list, FunctionalSum)
-        randstr = str(abs(np.random.randint(10000)))[-4:]
-    return randstr
 
-def create_variable(expr):
+    max_val = 10**nDigits
+
+    name = prefix + str(np.random.randint(max_val))
+    while name in forbidden_exprs:
+        name = prefix + str(np.random.randint(max_val))
+    return name
+
+def create_variable(forbidden_names):
     """."""
 
-    import numpy as np
-    name = 'Dummy_' + create_random_string(expr)
+    name = create_random_string(forbidden_names, 'Dummy_')
 
     return Symbol(name)
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -819,7 +819,7 @@ def int2float(expr):
 def float2int(expr):
     return expr
 
-def create_random_string(forbidden_exprs, prefix = None):
+def create_random_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
     assert(isinstance(forbidden_exprs, set))
     import numpy as np
     nDigits = 2
@@ -827,21 +827,24 @@ def create_random_string(forbidden_exprs, prefix = None):
     if prefix is None:
         prefix = 'Dummy'
 
-    max_val = 10**nDigits
-
-    prefix += '_'
-
-    name = prefix + str(np.random.randint(max_val))
+    name_format = "{prefix}_{counter:0="+str(nDigits)+"d}"
+    name = name_format.format(prefix=prefix, counter = counter)
+    counter += 1
     while name in forbidden_exprs:
-        name = prefix + str(np.random.randint(max_val))
-    return name
+        name = name_format.format(prefix=prefix, counter = counter)
+        counter += 1
 
-def create_variable(forbidden_names, prefix = None):
+    forbidden_exprs.add(name)
+
+    return name, counter
+
+def create_variable(forbidden_names, prefix = None, counter = 1):
     """."""
 
-    name = create_random_string(forbidden_names, prefix)
+    name, counter = create_random_string(forbidden_names, prefix, counter = counter)
+    print(counter)
 
-    return Symbol(name)
+    return Symbol(name), counter
 
 class DottedName(Basic):
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -820,6 +820,31 @@ def float2int(expr):
     return expr
 
 def create_incremented_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
+    """This function takes a prefix and a counter and uses them to construct
+    a new name of the form:
+            prefix_counter
+    Where counter is formatted to fill 4 characters
+    The new name is checked against a list of forbidden expressions. If the
+    constructed name is forbidden then the counter is incremented until a valid
+    name is found
+
+      Parameters
+      ----------
+      forbidden_exprs : Set
+                        A set of all the values which are not valid solutions to this problem
+      prefix          : str
+                        The prefix used to begin the string
+      counter         : int
+                        The expected value of the next name
+
+      Returns
+      ----------
+      name            : str
+                        The incremented string name
+      counter         : int
+                        The expected value of the next name
+
+    """
     assert(isinstance(forbidden_exprs, set))
     nDigits = 4
 
@@ -838,7 +863,31 @@ def create_incremented_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
     return name, counter
 
 def create_variable(forbidden_names, prefix = None, counter = 1):
-    """."""
+    """This function takes a prefix and a counter and uses them to construct
+    a Symbol with a name of the form:
+            prefix_counter
+    Where counter is formatted to fill 4 characters
+    The new name is checked against a list of forbidden expressions. If the
+    constructed name is forbidden then the counter is incremented until a valid
+    name is found
+
+      Parameters
+      ----------
+      forbidden_exprs : Set
+                        A set of all the values which are not valid solutions to this problem
+      prefix          : str
+                        The prefix used to begin the string
+      counter         : int
+                        The expected value of the next name
+
+      Returns
+      ----------
+      name            : Symbol
+                        A sympy Symbol with the incremented string name
+      counter         : int
+                        The expected value of the next name
+
+    """
 
     name, counter = create_incremented_string(forbidden_names, prefix, counter = counter)
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -819,9 +819,10 @@ def int2float(expr):
 def float2int(expr):
     return expr
 
-def create_random_string(forbidden_exprs : set, prefix = None, nDigits : int = 2):
+def create_random_string(forbidden_exprs, prefix = None):
     assert(isinstance(forbidden_exprs, set))
     import numpy as np
+    nDigits = 2
 
     if prefix is None:
         prefix = 'Dummy'

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -821,7 +821,6 @@ def float2int(expr):
 
 def create_incremented_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
     assert(isinstance(forbidden_exprs, set))
-    import numpy as np
     nDigits = 4
 
     if prefix is None:

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -819,7 +819,7 @@ def int2float(expr):
 def float2int(expr):
     return expr
 
-def create_random_string(forbidden_exprs : set, prefix = 'Dummy', nDigits : int = 1):
+def create_random_string(forbidden_exprs : set, prefix = 'Dummy', nDigits : int = 2):
     assert(isinstance(forbidden_exprs, set))
     import numpy as np
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -821,6 +821,7 @@ def float2int(expr):
 
 def create_random_string(expr):
     import numpy as np
+    return str(np.random.randint(10))
     try:
         randstr = str(abs(hash(expr)
                                   + np.random.randint(500)))[-4:]

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -86,7 +86,7 @@ def sympy_to_pyccel(expr, symbol_map):
         raise TypeError(str(type(expr)))
 
 #==============================================================================
-def pyccel_to_sympy(expr, symbol_map):
+def pyccel_to_sympy(expr, symbol_map, used_names):
     """
     Convert a sympy expression to a pyccel expression replacing sympy symbols with
     pyccel expressions provided in a symbol_map
@@ -101,30 +101,30 @@ def pyccel_to_sympy(expr, symbol_map):
 
     #Operators
     elif isinstance(expr, PyccelDiv):
-        args = [pyccel_to_sympy(e, symbol_map) for e in expr.args]
+        args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
         return args[0] / args[1]
 
     elif isinstance(expr, PyccelMul):
-        args = [pyccel_to_sympy(e, symbol_map) for e in expr.args]
+        args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
         return sp.Mul(*args)
 
     elif isinstance(expr, PyccelMinus):
-        args = [pyccel_to_sympy(e, symbol_map) for e in expr.args]
+        args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
         return args[0] - args[1]
 
     elif isinstance(expr, PyccelAdd):
-        args = [pyccel_to_sympy(e, symbol_map) for e in expr.args]
+        args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
         return sp.Add(*args)
 
     elif isinstance(expr, PyccelPow):
-        args = [pyccel_to_sympy(e, symbol_map) for e in expr.args]
+        args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
         return sp.Pow(*args)
 
     elif isinstance(expr, PyccelAssociativeParenthesis):
-        return pyccel_to_sympy(expr.args[0], symbol_map)
+        return pyccel_to_sympy(expr.args[0], symbol_map, used_names)
 
     elif isinstance(expr, MathCeil):
-        return sp.ceiling(pyccel_to_sympy(expr.args[0], symbol_map))
+        return sp.ceiling(pyccel_to_sympy(expr.args[0], symbol_map, used_names))
 
     elif expr in symbol_map.values():
         return list(symbol_map.keys())[list(symbol_map.values()).index(expr)]
@@ -135,7 +135,7 @@ def pyccel_to_sympy(expr, symbol_map):
         return sym
 
     elif isinstance(expr, PyccelArraySize):
-        sym = sp.Symbol(create_random_string(expr, prefix = 'tmp_size_'))
+        sym = sp.Symbol(create_random_string(used_names, prefix = 'tmp_size_'))
         symbol_map[sym] = expr
         return sym
 

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -135,7 +135,7 @@ def pyccel_to_sympy(expr, symbol_map):
         return sym
 
     elif isinstance(expr, PyccelArraySize):
-        sym = sp.Symbol('tmp_size_' + create_random_string(expr))
+        sym = sp.Symbol(create_random_string(expr, prefix = 'tmp_size_'))
         symbol_map[sym] = expr
         return sym
 

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -135,7 +135,8 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
         return sym
 
     elif isinstance(expr, PyccelArraySize):
-        sym = sp.Symbol(create_random_string(used_names, prefix = 'tmp_size_'))
+        sym_name,_ = create_random_string(used_names, prefix = 'tmp_size')
+        sym = sp.Symbol(sym_name)
         symbol_map[sym] = expr
         return sym
 

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -16,6 +16,17 @@ def sympy_to_pyccel(expr, symbol_map):
     """
     Convert a sympy expression to a pyccel expression replacing sympy symbols with
     pyccel expressions provided in a symbol_map
+
+      Parameters
+      ----------
+      expr       : PyccelAstNode
+                   The pyccel node to be translated
+      symbol_map : dict
+                   Dictionary mapping sympy symbols to pyccel objects
+
+      Returns
+      ----------
+      expr       : pyccel Object
     """
 
     #Constants
@@ -88,8 +99,23 @@ def sympy_to_pyccel(expr, symbol_map):
 #==============================================================================
 def pyccel_to_sympy(expr, symbol_map, used_names):
     """
-    Convert a sympy expression to a pyccel expression replacing sympy symbols with
-    pyccel expressions provided in a symbol_map
+    Convert a pyccel expression to a sympy expression saving any pyccel objects
+    converted to sympy symbols in a dictionary to allow the reverse conversion
+    to be carried out later
+
+      Parameters
+      ----------
+      expr       : PyccelAstNode
+                   The pyccel node to be translated
+      symbol_map : dict
+                   Dictionary containing any pyccel objects converted to sympy symbols
+      used_names : Set
+                   A set of all the names which already exist and therefore cannot
+                   be used to create new symbols
+
+      Returns
+      ----------
+      expr       : sympy Object
     """
 
     #Constants

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -3,7 +3,7 @@ from sympy.core.numbers import One, NegativeOne, Zero, Half
 
 from .core      import PyccelAdd, PyccelMul, PyccelPow
 from .core      import PyccelDiv, PyccelMinus, PyccelAssociativeParenthesis
-from .core      import Variable, create_random_string, PyccelArraySize
+from .core      import Variable, create_incremented_string, PyccelArraySize
 
 from .mathext   import MathCeil
 
@@ -135,7 +135,7 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
         return sym
 
     elif isinstance(expr, PyccelArraySize):
-        sym_name,_ = create_random_string(used_names, prefix = 'tmp_size')
+        sym_name,_ = create_incremented_string(used_names, prefix = 'tmp_size')
         sym = sp.Symbol(sym_name)
         symbol_map[sym] = expr
         return sym

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -263,6 +263,7 @@ class Codegen(object):
             for line in code:
                 f.write(line)
 
+        import sys
         for line in code:
             sys.stdout.write(line)
 

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -263,6 +263,9 @@ class Codegen(object):
             for line in code:
                 f.write(line)
 
+        for line in code:
+            print(line)
+
         return filename
 
 

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -264,7 +264,7 @@ class Codegen(object):
                 f.write(line)
 
         for line in code:
-            print(line)
+            sys.stdout.write(line)
 
         return filename
 

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -263,10 +263,6 @@ class Codegen(object):
             for line in code:
                 f.write(line)
 
-        import sys
-        for line in code:
-            sys.stdout.write(line)
-
         return filename
 
 

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -119,7 +119,7 @@ def execute_pyccel(fname, *,
 
     # Parse Python file
     try:
-        parser = Parser(pymod_filepath, output_folder=pyccel_dirpath.replace('/','.'), show_traceback=verbose)
+        parser = Parser(pymod_filepath, show_traceback=verbose)
         parser.parse(verbose=verbose)
     except NotImplementedError as error:
         msg = str(error)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -640,7 +640,7 @@ class FCodePrinter(CodePrinter):
 
         if (not self._additional_code):
             self._additional_code = ''
-        var_name = parser.get_new_name()
+        var_name = self.parser.get_new_name()
         var = Variable(expr.dtype, var_name, is_stack_array = all([s.is_constant for s in expr.shape]),
                 shape = expr.shape, precision = expr.precision,
                 order = expr.order, rank = expr.rank)
@@ -2256,7 +2256,7 @@ class FCodePrinter(CodePrinter):
             else:
                 if (not self._additional_code):
                     self._additional_code = ''
-                var_name = parser.get_new_name()
+                var_name = self.parser.get_new_name()
                 var = Variable(base.dtype, var_name, is_stack_array = True,
                         shape=base.shape,precision=base.precision,
                         order=base.order,rank=base.rank)
@@ -2295,7 +2295,7 @@ class FCodePrinter(CodePrinter):
             else:
                 if (not self._additional_code):
                     self._additional_code = ''
-                var_name = parser.get_new_name()
+                var_name = self.parser.get_new_name()
                 var = Variable(base.dtype, var_name, is_stack_array = True,
                         shape=base.shape,precision=base.precision,
                         order=base.order,rank=base.rank)
@@ -2372,7 +2372,7 @@ class FCodePrinter(CodePrinter):
                 self._additional_code = ''
             out_vars = []
             for r in func.results:
-                var_name = parser.get_new_name()
+                var_name = self.parser.get_new_name()
                 var =  r.clone(name = var_name)
 
                 if self._current_function:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -43,7 +43,7 @@ from pyccel.ast.core import (Assign, AliasAssign, Variable,
 
 
 from pyccel.ast.core      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus
-from pyccel.ast.core      import create_random_string, create_variable, FunctionCall
+from pyccel.ast.core      import create_random_string, FunctionCall
 from pyccel.ast.builtins  import Enumerate, Int, Len, Map, Print, Range, Zip, PythonTuple
 from pyccel.ast.datatypes import is_pyccel_datatype
 from pyccel.ast.datatypes import is_iterable_datatype, is_with_construct_datatype
@@ -199,6 +199,7 @@ class FCodePrinter(CodePrinter):
         userfuncs = settings.get('user_functions', {})
         self.known_functions.update(userfuncs)
         self._current_function = None
+        self._used_names = parser.used_names
 
         self._additional_code = None
 
@@ -640,8 +641,8 @@ class FCodePrinter(CodePrinter):
 
         if (not self._additional_code):
             self._additional_code = ''
-        var = create_variable(expr)
-        var = Variable(expr.dtype, var.name, is_stack_array = all([s.is_constant for s in expr.shape]),
+        var_name = create_random_string(self._used_names, prefix = 'Dummy_')
+        var = Variable(expr.dtype, var_name, is_stack_array = all([s.is_constant for s in expr.shape]),
                 shape = expr.shape, precision = expr.precision,
                 order = expr.order, rank = expr.rank)
 
@@ -2227,7 +2228,7 @@ class FCodePrinter(CodePrinter):
                 self._additional_code = ''
             out_vars = []
             for r in func.results:
-                var_name = 'Dummy_' + create_random_string(r)
+                var_name = create_random_string(self._used_names, prefix='Dummy_')
                 var =  r.clone(name = var_name)
 
                 if self._current_function:
@@ -2297,8 +2298,8 @@ class FCodePrinter(CodePrinter):
             else:
                 if (not self._additional_code):
                     self._additional_code = ''
-                var = create_variable(base)
-                var = Variable(base.dtype, var.name, is_stack_array = True,
+                var_name = create_random_string(self._used_names)
+                var = Variable(base.dtype, var_name, is_stack_array = True,
                         shape=base.shape,precision=base.precision,
                         order=base.order,rank=base.rank)
 
@@ -2336,8 +2337,8 @@ class FCodePrinter(CodePrinter):
             else:
                 if (not self._additional_code):
                     self._additional_code = ''
-                var = create_variable(base)
-                var = Variable(base.dtype, var.name, is_stack_array = True,
+                var_name = create_random_string(self._used_names)
+                var = Variable(base.dtype, var_name, is_stack_array = True,
                         shape=base.shape,precision=base.precision,
                         order=base.order,rank=base.rank)
 
@@ -2413,7 +2414,7 @@ class FCodePrinter(CodePrinter):
                 self._additional_code = ''
             out_vars = []
             for r in func.results:
-                var_name = 'Dummy_' + create_random_string(r)
+                var_name = create_random_string(self._used_names, prefix='Dummy_')
                 var =  r.clone(name = var_name)
 
                 if self._current_function:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1613,7 +1613,7 @@ class FCodePrinter(CodePrinter):
         body = self._print(expr.body)
 
         return ('{prolog}'
-                '{body}\n'
+                '{body}'
                 '{epilog}').format(prolog=prolog, body=body, epilog=epilog)
 
     # .....................................................

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -43,7 +43,7 @@ from pyccel.ast.core import (Assign, AliasAssign, Variable,
 
 
 from pyccel.ast.core      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus
-from pyccel.ast.core      import create_random_string, FunctionCall
+from pyccel.ast.core      import FunctionCall
 from pyccel.ast.builtins  import Enumerate, Int, Len, Map, Print, Range, Zip, PythonTuple
 from pyccel.ast.datatypes import is_pyccel_datatype
 from pyccel.ast.datatypes import is_iterable_datatype, is_with_construct_datatype
@@ -199,7 +199,6 @@ class FCodePrinter(CodePrinter):
         userfuncs = settings.get('user_functions', {})
         self.known_functions.update(userfuncs)
         self._current_function = None
-        self._used_names = parser.used_names
 
         self._additional_code = None
 
@@ -641,7 +640,7 @@ class FCodePrinter(CodePrinter):
 
         if (not self._additional_code):
             self._additional_code = ''
-        var_name = create_random_string(self._used_names)
+        var_name = parser.get_new_name()
         var = Variable(expr.dtype, var_name, is_stack_array = all([s.is_constant for s in expr.shape]),
                 shape = expr.shape, precision = expr.precision,
                 order = expr.order, rank = expr.rank)
@@ -2257,7 +2256,7 @@ class FCodePrinter(CodePrinter):
             else:
                 if (not self._additional_code):
                     self._additional_code = ''
-                var_name = create_random_string(self._used_names)
+                var_name = parser.get_new_name()
                 var = Variable(base.dtype, var_name, is_stack_array = True,
                         shape=base.shape,precision=base.precision,
                         order=base.order,rank=base.rank)
@@ -2296,7 +2295,7 @@ class FCodePrinter(CodePrinter):
             else:
                 if (not self._additional_code):
                     self._additional_code = ''
-                var_name = create_random_string(self._used_names)
+                var_name = parser.get_new_name()
                 var = Variable(base.dtype, var_name, is_stack_array = True,
                         shape=base.shape,precision=base.precision,
                         order=base.order,rank=base.rank)
@@ -2373,7 +2372,7 @@ class FCodePrinter(CodePrinter):
                 self._additional_code = ''
             out_vars = []
             for r in func.results:
-                var_name = create_random_string(self._used_names)
+                var_name = parser.get_new_name()
                 var =  r.clone(name = var_name)
 
                 if self._current_function:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2209,47 +2209,6 @@ class FCodePrinter(CodePrinter):
             code_args = 'Real({})'.format(code_args)
         code = 'sqrt({})'.format(code_args)
         return self._get_statement(code)
-        
-    def _print_Function(self, expr):
-
-        args = expr.args
-        name = type(expr).__name__
-
-        # Get function without raising an error for None
-        func = None
-        container = self._namespace
-        while container:
-            if name in container.functions:
-                func = container.functions[name]
-            container = container.parent_scope
-
-        if isinstance(func,FunctionDef) and len(func.results)>1:
-            if (not self._additional_code):
-                self._additional_code = ''
-            out_vars = []
-            for r in func.results:
-                var_name = create_random_string(self._used_names)
-                var =  r.clone(name = var_name)
-
-                if self._current_function:
-                    name = self._current_function
-                    func = self.get_function(name)
-                    func.local_vars.append(var)
-                else:
-                    self._namespace.variables[var.name] = var
-
-                out_vars.append(var)
-            self._additional_code = self._additional_code + self._print(Assign(Tuple(*out_vars),expr)) + '\n'
-            return self._print(Tuple(*out_vars))
-        else:
-
-            code_args = ', '.join(self._print(i) for i in args if not isinstance(i,Nil))
-
-            code = '{0}({1})'.format(name, code_args)
-            if isinstance(expr.func, Subroutine):
-                code = 'call ' + code
-
-            return self._get_statement(code) + '\n'
 
     def _print_ImaginaryUnit(self, expr):
         # purpose: print complex numbers nicely in Fortran.

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -641,7 +641,7 @@ class FCodePrinter(CodePrinter):
 
         if (not self._additional_code):
             self._additional_code = ''
-        var_name = create_random_string(self._used_names, prefix = 'Dummy_')
+        var_name = create_random_string(self._used_names)
         var = Variable(expr.dtype, var_name, is_stack_array = all([s.is_constant for s in expr.shape]),
                 shape = expr.shape, precision = expr.precision,
                 order = expr.order, rank = expr.rank)
@@ -2228,7 +2228,7 @@ class FCodePrinter(CodePrinter):
                 self._additional_code = ''
             out_vars = []
             for r in func.results:
-                var_name = create_random_string(self._used_names, prefix='Dummy_')
+                var_name = create_random_string(self._used_names)
                 var =  r.clone(name = var_name)
 
                 if self._current_function:
@@ -2414,7 +2414,7 @@ class FCodePrinter(CodePrinter):
                 self._additional_code = ''
             out_vars = []
             for r in func.results:
-                var_name = create_random_string(self._used_names, prefix='Dummy_')
+                var_name = create_random_string(self._used_names)
                 var =  r.clone(name = var_name)
 
                 if self._current_function:

--- a/pyccel/epyccel.py
+++ b/pyccel/epyccel.py
@@ -18,10 +18,10 @@ __all__ = ['random_string', 'get_source_function', 'epyccel_seq', 'epyccel']
 #==============================================================================
 random_selector = random.SystemRandom()
 
-def random_string( n ):
+def random_string( n, prefix = '' ):
     # we remove uppercase letters because of f2py
     chars    = string.ascii_lowercase + string.digits
-    return ''.join( random_selector.choice( chars ) for _ in range(n) )
+    return prefix + ''.join( random_selector.choice( chars ) for _ in range(n) )
 
 #==============================================================================
 def get_source_function(func):
@@ -63,8 +63,11 @@ def epyccel_seq(function_or_module,
     if isinstance(function_or_module, FunctionType):
         pyfunc = function_or_module
         code = get_source_function(pyfunc)
-        tag = random_string(8)
-        module_name = 'mod_{}'.format(tag)
+
+        module_name = random_string(prefix='mod_', n=8)
+        while module_name in sys.modules.keys():
+            module_name = random_string(prefix='mod_', n=8)
+
         pymod_filename = '{}.py'.format(module_name)
         pymod_filepath = os.path.abspath(pymod_filename)
 
@@ -74,7 +77,12 @@ def epyccel_seq(function_or_module,
         pymod_filename = os.path.basename(pymod_filepath)
         lines = inspect.getsourcelines(pymod)[0]
         code = ''.join(lines)
-        tag = random_string(8)
+
+        tag = random_string(n=8)
+        module_import_prefix = pymod.__name__ + '_'
+        while module_import_prefix + tag in sys.modules.keys():
+            tag = random_string(n=8)
+
         module_name = pymod.__name__.split('.')[-1] + '_' + tag
 
     else:

--- a/pyccel/epyccel.py
+++ b/pyccel/epyccel.py
@@ -18,10 +18,10 @@ __all__ = ['random_string', 'get_source_function', 'epyccel_seq', 'epyccel']
 #==============================================================================
 random_selector = random.SystemRandom()
 
-def random_string( n, prefix = '' ):
+def random_string( n ):
     # we remove uppercase letters because of f2py
     chars    = string.ascii_lowercase + string.digits
-    return prefix + ''.join( random_selector.choice( chars ) for _ in range(n) )
+    return ''.join( random_selector.choice( chars ) for _ in range(n) )
 
 #==============================================================================
 def get_source_function(func):
@@ -64,9 +64,12 @@ def epyccel_seq(function_or_module,
         pyfunc = function_or_module
         code = get_source_function(pyfunc)
 
-        module_name = random_string(prefix='mod_', n=8)
+        tag = random_string(8)
+        module_name = 'mod_{}'.format(tag)
+
         while module_name in sys.modules.keys():
-            module_name = random_string(prefix='mod_', n=8)
+            tag = random_string(8)
+            module_name = 'mod_{}'.format(tag)
 
         pymod_filename = '{}.py'.format(module_name)
         pymod_filepath = os.path.abspath(pymod_filename)
@@ -78,7 +81,7 @@ def epyccel_seq(function_or_module,
         lines = inspect.getsourcelines(pymod)[0]
         code = ''.join(lines)
 
-        tag = random_string(n=8)
+        tag = random_string(8)
         module_import_prefix = pymod.__name__ + '_'
         while module_import_prefix + tag in sys.modules.keys():
             tag = random_string(n=8)

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -12,6 +12,7 @@ from pyccel.ast.core import SymbolicAssign
 from pyccel.ast.core import FunctionDef, Interface
 from pyccel.ast.core import PythonFunction, SympyFunction
 from pyccel.ast.core import Import, AsName
+from pyccel.ast.core import create_random_string, create_variable
 from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
 
 from pyccel.parser.utilities import is_valid_filename_pyh, is_valid_filename_py
@@ -231,6 +232,7 @@ class BasicParser(object):
         self._metavars  = OrderedDict()
         self._namespace = Scope()
 
+        self._used_names = None
 
         self._output_folder    = output_folder
 
@@ -333,6 +335,28 @@ class BasicParser(object):
     @property
     def show_traceback(self):
         return self._show_traceback
+
+    @property
+    def used_names(self):
+        return self._used_names
+
+    def get_new_name(self, current_name = None):
+        if current_name is None:
+            current_name = 'Dummy_'
+        elif current_name not in self._used_names:
+            self._used_names.add(current_name)
+            return current_name
+        else:
+            current_name += '_'
+
+        new_name = create_random_string(self._used_names, prefix = current_name+'_')
+        self._used_names.add(new_name)
+        return new_name
+
+    def get_new_variable(self):
+        var = create_variable(self._used_names)
+        self._used_names.add(var.name)
+        return var
 
     # TODO shall we need to export the Parser too?
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -349,8 +349,8 @@ class BasicParser(object):
         self._used_names.add(new_name)
         return new_name
 
-    def get_new_variable(self):
-        var = create_variable(self._used_names)
+    def get_new_variable(self, prefix = None):
+        var = create_variable(self._used_names, prefix)
         self._used_names.add(var.name)
         return var
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -12,7 +12,7 @@ from pyccel.ast.core import SymbolicAssign
 from pyccel.ast.core import FunctionDef, Interface
 from pyccel.ast.core import PythonFunction, SympyFunction
 from pyccel.ast.core import Import, AsName
-from pyccel.ast.core import create_random_string, create_variable
+from pyccel.ast.core import create_incremented_string, create_variable
 from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
 
 from pyccel.parser.utilities import is_valid_filename_pyh, is_valid_filename_py
@@ -348,9 +348,9 @@ class BasicParser(object):
             return current_name
 
         if current_name is not None:
-            new_name, self._dummy_counter = create_random_string(self._used_names, prefix = current_name, counter = self._dummy_counter)
+            new_name, self._dummy_counter = create_incremented_string(self._used_names, prefix = current_name, counter = self._dummy_counter)
         else:
-            new_name,_ = create_random_string(self._used_names, prefix = current_name)
+            new_name,_ = create_incremented_string(self._used_names, prefix = current_name)
         return new_name
 
     def get_new_variable(self, prefix = None):

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -245,6 +245,8 @@ class BasicParser(object):
         self._syntax_done   = False
         self._semantic_done = False
 
+        self._dummy_counter = 1
+
         # current position for errors
 
         self._current_fst_node = None
@@ -345,13 +347,17 @@ class BasicParser(object):
             self._used_names.add(current_name)
             return current_name
 
-        new_name = create_random_string(self._used_names, prefix = current_name)
-        self._used_names.add(new_name)
+        if current_name is not None:
+            new_name, self._dummy_counter = create_random_string(self._used_names, prefix = current_name, counter = self._dummy_counter)
+        else:
+            new_name,_ = create_random_string(self._used_names, prefix = current_name)
         return new_name
 
     def get_new_variable(self, prefix = None):
-        var = create_variable(self._used_names, prefix)
-        self._used_names.add(var.name)
+        if prefix is not None:
+            var,_ = create_variable(self._used_names, prefix)
+        else:
+            var, self._dummy_counter = create_variable(self._used_names, prefix, counter = self._dummy_counter)
         return var
 
     # TODO shall we need to export the Parser too?

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -353,6 +353,14 @@ class BasicParser(object):
         If no current_name is provided, then the standard prefix is used, and the
         dummy counter is used and updated to facilitate finding the next value of
         this common case
+
+          Parameters
+          ----------
+          current_name : str
+
+          Returns
+          -------
+          new_name     : str
         """
         if current_name is not None and current_name not in self.used_names:
             self.used_names.add(current_name)
@@ -369,6 +377,14 @@ class BasicParser(object):
         Creates a new sympy Symbol using the prefix provided. If this prefix is None,
         then the standard prefix is used, and the dummy counter is used and updated
         to facilitate finding the next value of this common case
+
+          Parameters
+          ----------
+          prefix   : str
+
+          Returns
+          -------
+          variable : sympy.Symbol
         """
         if prefix is not None:
             var,_ = create_variable(self._used_names, prefix)

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -341,7 +341,7 @@ class BasicParser(object):
         return self._used_names
 
     def get_new_name(self, current_name = None):
-        if current_name not in self._used_names:
+        if current_name is not None and current_name not in self._used_names:
             self._used_names.add(current_name)
             return current_name
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -341,15 +341,11 @@ class BasicParser(object):
         return self._used_names
 
     def get_new_name(self, current_name = None):
-        if current_name is None:
-            current_name = 'Dummy_'
-        elif current_name not in self._used_names:
+        if current_name not in self._used_names:
             self._used_names.add(current_name)
             return current_name
-        else:
-            current_name += '_'
 
-        new_name = create_random_string(self._used_names, prefix = current_name+'_')
+        new_name = create_random_string(self._used_names, prefix = current_name)
         self._used_names.add(new_name)
         return new_name
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -202,7 +202,9 @@ class Scope(object):
 
 class BasicParser(object):
 
-    """ Class for a base Parser."""
+    """ Class for a base Parser.
+    This class contains functions and properties which are common to SyntacticParser and SemanticParser
+    """
 
     def __init__(self,
                  debug=False,
@@ -222,7 +224,7 @@ class BasicParser(object):
             a list of 'static' functions as strings
 
         show_traceback: bool
-            prints Tracebacke exception if True
+            prints Traceback exception if True
 
         """
         self._fst = None
@@ -245,6 +247,7 @@ class BasicParser(object):
         self._syntax_done   = False
         self._semantic_done = False
 
+        # the next expected Dummy variable
         self._dummy_counter = 1
 
         # current position for errors
@@ -340,20 +343,36 @@ class BasicParser(object):
 
     @property
     def used_names(self):
+        """Returns a set of all names used in the current file.
+        The set is used to prevent name collisions when creating new variables
+        """
         return self._used_names
 
     def get_new_name(self, current_name = None):
-        if current_name is not None and current_name not in self._used_names:
-            self._used_names.add(current_name)
+        """
+        Creates a new name. A current_name can be provided indicating the name the
+        user would like to use if possible. If this name is not available then it
+        will be used as a prefix for the new name.
+        If no current_name is provided, then the standard prefix is used, and the
+        dummy counter is used and updated to facilitate finding the next value of
+        this common case
+        """
+        if current_name is not None and current_name not in self.used_names:
+            self.used_names.add(current_name)
             return current_name
 
         if current_name is not None:
-            new_name, self._dummy_counter = create_incremented_string(self._used_names, prefix = current_name, counter = self._dummy_counter)
+            new_name, self._dummy_counter = create_incremented_string(self.used_names, prefix = current_name, counter = self._dummy_counter)
         else:
-            new_name,_ = create_incremented_string(self._used_names, prefix = current_name)
+            new_name,_ = create_incremented_string(self.used_names, prefix = current_name)
         return new_name
 
     def get_new_variable(self, prefix = None):
+        """
+        Creates a new sympy Symbol using the prefix provided. If this prefix is None,
+        then the standard prefix is used, and the dummy counter is used and updated
+        to facilitate finding the next value of this common case
+        """
         if prefix is not None:
             var,_ = create_variable(self._used_names, prefix)
         else:

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -205,7 +205,8 @@ class BasicParser(object):
     """ Class for a base Parser.
     This class contains functions and properties which are common to SyntacticParser and SemanticParser
 
-    Parser constructor:
+    Parameters
+    ----------
 
         debug: bool
             True if in debug mode.
@@ -219,7 +220,7 @@ class BasicParser(object):
         show_traceback: bool
             prints Traceback exception if True
 
-        """
+    """
 
     def __init__(self,
                  debug=False,

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -204,15 +204,8 @@ class BasicParser(object):
 
     """ Class for a base Parser.
     This class contains functions and properties which are common to SyntacticParser and SemanticParser
-    """
 
-    def __init__(self,
-                 debug=False,
-                 headers=None,
-                 static=None,
-                 show_traceback=False,
-                 output_folder=''):
-        """Parser constructor.
+    Parser constructor:
 
         debug: bool
             True if in debug mode.
@@ -227,6 +220,12 @@ class BasicParser(object):
             prints Traceback exception if True
 
         """
+
+    def __init__(self,
+                 debug=False,
+                 headers=None,
+                 static=None,
+                 show_traceback=False):
         self._fst = None
         self._ast = None
 
@@ -235,8 +234,6 @@ class BasicParser(object):
         self._namespace = Scope()
 
         self._used_names = None
-
-        self._output_folder    = output_folder
 
         # represent the namespace of a function
 

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -27,7 +27,6 @@ class Parser(object):
         self._syntax_parser = None
         self._semantic_parser = None
 
-        self._output_folder = kwargs.pop('output_folder', '')
         self._input_folder = os.path.dirname(filename)
 
     @property

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -174,6 +174,7 @@ class SemanticParser(BasicParser):
         self._namespace = parser._namespace
         self._namespace.imports['imports'] = OrderedDict()
         self._used_names = parser.used_names
+        self._dummy_counter = parser._dummy_counter
 
         # we use it to detect the current method or function
 
@@ -2044,6 +2045,8 @@ class SemanticParser(BasicParser):
 
         idx_subs = dict()
 
+        # The symbols created to represent unknown valued objects are temporary
+        tmp_used_names = self.used_names.copy()
         while isinstance(body, For):
 
             stop  = None
@@ -2083,9 +2086,9 @@ class SemanticParser(BasicParser):
                               severity='fatal')
             self.insert_variable(var)
 
-            step  = pyccel_to_sympy(step , idx_subs, self.used_names)
-            start = pyccel_to_sympy(start, idx_subs, self.used_names)
-            stop  = pyccel_to_sympy(stop , idx_subs, self.used_names)
+            step  = pyccel_to_sympy(step , idx_subs, tmp_used_names)
+            start = pyccel_to_sympy(start, idx_subs, tmp_used_names)
+            stop  = pyccel_to_sympy(stop , idx_subs, tmp_used_names)
             size = (stop - start) / step
             if (step != 1):
                 size = ceiling(size)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1901,14 +1901,14 @@ class SemanticParser(BasicParser):
         iterator = expr.target
 
         if isinstance(iterable, Variable):
-            indx   = self.get_new_variable(iterable)
+            indx   = self.get_new_variable()
             assign = Assign(iterator, IndexedBase(iterable)[indx])
             assign.set_fst(expr.fst)
             iterator = indx
             body     = [assign] + body
 
         elif isinstance(iterable, Map):
-            indx   = self.get_new_variable(iterable)
+            indx   = self.get_new_variable()
             func   = iterable.args[0]
             args   = [IndexedBase(arg)[indx] for arg in iterable.args[1:]]
             assing = assign = Assign(iterator, func(*args))
@@ -1918,7 +1918,7 @@ class SemanticParser(BasicParser):
 
         elif isinstance(iterable, Zip):
             args = iterable.args
-            indx = self.get_new_variable(args)
+            indx = self.get_new_variable()
             for i in range(len(args)):
                 assign = Assign(iterator[i], IndexedBase(args[i])[indx])
                 assign.set_fst(expr.fst)
@@ -1938,7 +1938,7 @@ class SemanticParser(BasicParser):
             iterator = list(iterator)
             for i in range(len(args)):
                 if not isinstance(args[i], Range):
-                    indx   = self.get_new_variable(i)
+                    indx   = self.get_new_variable()
                     assign = Assign(iterator[i], IndexedBase(args[i])[indx])
 
                     assign.set_fst(expr.fst)
@@ -2083,9 +2083,9 @@ class SemanticParser(BasicParser):
                               severity='fatal')
             self.insert_variable(var)
 
-            step  = pyccel_to_sympy(step , idx_subs)
-            start = pyccel_to_sympy(start, idx_subs)
-            stop  = pyccel_to_sympy(stop , idx_subs)
+            step  = pyccel_to_sympy(step , idx_subs, self.used_names)
+            start = pyccel_to_sympy(start, idx_subs, self.used_names)
+            stop  = pyccel_to_sympy(stop , idx_subs, self.used_names)
             size = (stop - start) / step
             if (step != 1):
                 size = ceiling(size)
@@ -2327,7 +2327,7 @@ class SemanticParser(BasicParser):
 #            index_arg = args.index(arg)
 #            arg       = Symbol(arg)
 #            vec_arg   = IndexedBase(arg)
-#            index     = self.get_new_variable(expr.body)
+#            index     = self.get_new_variable()
 #            range_    = Function('range')(Function('len')(arg))
 #            args      = symbols(args)
 #            args[index_arg] = vec_arg[index]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3,7 +3,6 @@
 
 from collections import OrderedDict
 import traceback
-from ast import Name as ast_Name, walk as ast_walk
 
 from sympy.core.function       import Application, UndefinedFunction
 from sympy.core.numbers        import ImaginaryUnit
@@ -53,7 +52,7 @@ from pyccel.ast.core import AsName
 from pyccel.ast.core import With, Block
 from pyccel.ast.core import List, Dlist, Len
 from pyccel.ast.core import StarredArguments
-from pyccel.ast.core import inline, subs, create_random_string, create_variable, extract_subexpressions
+from pyccel.ast.core import inline, subs, extract_subexpressions
 from pyccel.ast.core import get_assigned_symbols
 from pyccel.ast.core import _atomic
 from pyccel.ast.core import PyccelPow, PyccelAdd, PyccelMinus, PyccelMul, PyccelDiv, PyccelMod, PyccelFloorDiv
@@ -170,12 +169,11 @@ class SemanticParser(BasicParser):
         self._fst = parser._fst
         self._ast = parser._ast
 
-        self._possible_names = set([str(a.id) for a in ast_walk(self._fst) if isinstance(a, ast_Name)])
-
         self._filename  = parser._filename
         self._metavars  = parser._metavars
         self._namespace = parser._namespace
         self._namespace.imports['imports'] = OrderedDict()
+        self._used_names = parser.used_names
 
         # we use it to detect the current method or function
 
@@ -256,29 +254,6 @@ class SemanticParser(BasicParser):
         self._semantic_done = True
 
         return ast
-
-    def _get_new_name(self, current_name):
-        if current_name not in self._possible_names:
-            self._possible_names.add(current_name)
-            return current_name
-        current_name = current_name + '_' + create_random_string(current_name)
-        while current_name in self._possible_names:
-            # Generate random name based on the original name
-            current_name = current_name + create_random_string(current_name)
-        self._possible_names.add(current_name)
-        return current_name
-
-    def _get_new_variable(self, obj):
-        var = create_variable(obj)
-        name = var.name
-        while name in self._possible_names:
-            var = create_variable(obj)
-            name = var.name
-        self._possible_names.add(name)
-        return var
-
-    def _get_new_variable_name(self, obj, start_name = None):
-        return self._get_new_variable(obj) if start_name is None else self._get_new_name(start_name)
 
     def get_variable_from_scope(self, name):
         """."""
@@ -1015,7 +990,7 @@ class SemanticParser(BasicParser):
                 if imp is not None:
                     new_name = imp.find_module_target(rhs_name)
                     if new_name is None:
-                        new_name = self._get_new_name(rhs_name)
+                        new_name = self.get_new_name(rhs_name)
 
                         # Save the import target that has been used
                         if new_name == rhs_name:
@@ -1379,7 +1354,7 @@ class SemanticParser(BasicParser):
         if isinstance(rhs, (TupleVariable, PythonTuple, List)):
             elem_vars = []
             for i,r in enumerate(rhs):
-                elem_name = self._get_new_variable_name( r, name + '_' + str(i) )
+                elem_name = self.get_new_name( name + '_' + str(i) )
                 elem_d_lhs = self._infere_type( r )
 
                 self._ensure_target( r, elem_d_lhs )
@@ -1839,8 +1814,8 @@ class SemanticParser(BasicParser):
             func  = UndefinedFunction(func)
             alloc = Assign(lhs, Zeros(lhs.shape, lhs.dtype))
             alloc.set_fst(fst)
-            index = self._get_new_variable(expr)
-            index = Variable('int',index.name)
+            index_name = self.get_new_name(expr)
+            index = Variable('int',index_name)
             range_ = UndefinedFunction('range')(UndefinedFunction('len')(lhs))
             name  = _get_name(lhs)
             var   = IndexedBase(name)[index]
@@ -1926,14 +1901,14 @@ class SemanticParser(BasicParser):
         iterator = expr.target
 
         if isinstance(iterable, Variable):
-            indx   = self._get_new_variable(iterable)
+            indx   = self.get_new_variable(iterable)
             assign = Assign(iterator, IndexedBase(iterable)[indx])
             assign.set_fst(expr.fst)
             iterator = indx
             body     = [assign] + body
 
         elif isinstance(iterable, Map):
-            indx   = self._get_new_variable(iterable)
+            indx   = self.get_new_variable(iterable)
             func   = iterable.args[0]
             args   = [IndexedBase(arg)[indx] for arg in iterable.args[1:]]
             assing = assign = Assign(iterator, func(*args))
@@ -1943,7 +1918,7 @@ class SemanticParser(BasicParser):
 
         elif isinstance(iterable, Zip):
             args = iterable.args
-            indx = self._get_new_variable(args)
+            indx = self.get_new_variable(args)
             for i in range(len(args)):
                 assign = Assign(iterator[i], IndexedBase(args[i])[indx])
                 assign.set_fst(expr.fst)
@@ -1963,7 +1938,7 @@ class SemanticParser(BasicParser):
             iterator = list(iterator)
             for i in range(len(args)):
                 if not isinstance(args[i], Range):
-                    indx   = self._get_new_variable(i)
+                    indx   = self.get_new_variable(i)
                     assign = Assign(iterator[i], IndexedBase(args[i])[indx])
 
                     assign.set_fst(expr.fst)
@@ -2352,7 +2327,7 @@ class SemanticParser(BasicParser):
 #            index_arg = args.index(arg)
 #            arg       = Symbol(arg)
 #            vec_arg   = IndexedBase(arg)
-#            index     = self._get_new_variable(expr.body)
+#            index     = self.get_new_variable(expr.body)
 #            range_    = Function('range')(Function('len')(arg))
 #            args      = symbols(args)
 #            args[index_arg] = vec_arg[index]

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -51,6 +51,7 @@ from pyccel.ast.core import List
 from pyccel.ast.core import StarredArguments
 from pyccel.ast.core import CodeBlock
 from pyccel.ast.core import _atomic
+from pyccel.ast.core import create_variable
 
 from pyccel.ast.core import PyccelPow, PyccelAdd, PyccelMul, PyccelDiv, PyccelMod, PyccelFloorDiv
 from pyccel.ast.core import PyccelEq,  PyccelNe,  PyccelLt,  PyccelLe,  PyccelGt,  PyccelGe
@@ -124,6 +125,7 @@ class SyntaxParser(BasicParser):
         self._fst = tree
 
         self._used_names = set([str(a.id) for a in ast.walk(self._fst) if isinstance(a, ast.Name)])
+        self._dummy_counter = 1
 
         self.parse(verbose=True)
 
@@ -709,11 +711,18 @@ class SyntaxParser(BasicParser):
         returns = [i.expr for i in _atomic(body, cls=Return)]
         assert all(len(i) == len(returns[0]) for i in returns)
         results = []
+        result_counter = 1
         for i in zip(*returns):
             if not all(i[0]==j for j in i) or not isinstance(i[0], Symbol):
-                results.append(self.get_new_variable())
+                result_name, result_counter = create_variable(self._used_names,
+                                                              prefix = 'Out',
+                                                              counter = result_counter)
+                results.append(result_name)
             elif isinstance(i[0], Symbol) and any(i[0].name==x.name for x in arguments):
-                results.append(self.get_new_variable())
+                result_name, result_counter = create_variable(self._used_names,
+                                                              prefix = 'Out',
+                                                              counter = result_counter)
+                results.append(result_name)
             else:
                 results.append(i[0])
 

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -22,7 +22,7 @@ def test_functional_for_1d_var():
 def test_functional_for_2d_range():
     compare_epyccel(functionals.functional_for_2d_range)
 
-def test_functional_for_2d_var_var_range():
+def test_functional_for_2d_var_range():
     y = randint(99, size = 3)
     compare_epyccel(functionals.functional_for_2d_var_range, y)
 


### PR DESCRIPTION
**Fix #403: Variable name collisions not always handled causing travis problems.**

Rewrite `create_random_string` and `create_variable` functions to generate deterministic names following an incrementing pattern. Ensure that the SyntacticParser, the `SemanticParser` and the `Codegen` all use the same function to access these functions to handle counter simply

- If epyccel generated import name is in the list of imported modules, find a new name
- Remove _print_Function function. There is no Function class
- Move name and variable creation functions to BaseParser : `get_new_name`, `get_new_variable`
- Rewrite `create_random_string` and `create_variable` functions to generate deterministic names following an incrementing pattern
These functions take a prefix and a counter. The prefix defaults to 'Dummy'
- Ensure that the SyntacticParser, the `SemanticParser` and the `Codegen` all use  `get_new_name` and `get_new_variable` to create names and variables
- Create a counter for Dummy Variables. Pass this information from `SyntaxParser` to `SemanticParser`
- Save list of used names in BaseParser. Pass this information from `SyntaxParser` to `SemanticParser`
- Update `pyccel_to_sympy` function to pass arguments that are now necessary
- Create a temporary copy of the set of used names to pass to pyccel_to_sympy as it creates temporary variables which do not need to be avoided later
- Use `create_variable` to create output variables in `SyntaxParser`. Use a different prefix `Out` and a separate counter
- Correct function name `test_functional_for_2d_var_var_range` -> `test_functional_for_2d_var_range`
- Rename `create_random_string` ->  `create_incremented_string`