### PR TITLE
Check the return code of the compiler and raise Error

### DIFF
--- a/pyccel/codegen/python_wrapper.py
+++ b/pyccel/codegen/python_wrapper.py
@@ -189,7 +189,8 @@ def create_shared_library(codegen,
             print(out)
         if len(err)>0:
             print(err)
-            raise RuntimeError("Failed to build module")
+            if p.returncode != 0:
+                raise RuntimeError("Failed to build module")
 
         sharedlib_folder += 'build/lib*/'
 


### PR DESCRIPTION
This PR is about avoiding the cancelation of the build. This closes #416 

- check the result code of the command, if its a non-zero exit status then raise error.