### PR TITLE
Allow casting to bool within an if statement

### DIFF
--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -73,6 +73,7 @@ PYCCEL_RESTRICTION_UNARY_OPERATOR = 'Invert unary operator is not covered by Pyc
 PYCCEL_RESTRICTION_TRY_EXCEPT_FINALLY = 'Uncovered try/except/finally statements by Pyccel'
 PYCCEL_RESTRICTION_RAISE = 'Uncovered raise statement by Pyccel'
 PYCCEL_RESTRICTION_YIELD = 'Uncovered yield statement by Pyccel'
+PYCCEL_RESTRICTION_IS_LHS = 'Only variables are allowed as lhs for is statement'
 PYCCEL_RESTRICTION_IS_RHS = 'Only booleans and None are allowed as rhs for is statement'
 PYCCEL_RESTRICTION_IMPORT = 'Import must be inside a def statement or a module'
 PYCCEL_RESTRICTION_IMPORT_IN_DEF = 'Only From Import is allowed inside a def statement'

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -73,7 +73,6 @@ PYCCEL_RESTRICTION_UNARY_OPERATOR = 'Invert unary operator is not covered by Pyc
 PYCCEL_RESTRICTION_TRY_EXCEPT_FINALLY = 'Uncovered try/except/finally statements by Pyccel'
 PYCCEL_RESTRICTION_RAISE = 'Uncovered raise statement by Pyccel'
 PYCCEL_RESTRICTION_YIELD = 'Uncovered yield statement by Pyccel'
-PYCCEL_RESTRICTION_IS_LHS = 'Only variables are allowed as lhs for is statement'
 PYCCEL_RESTRICTION_IS_RHS = 'Only booleans and None are allowed as rhs for is statement'
 PYCCEL_RESTRICTION_IMPORT = 'Import must be inside a def statement or a module'
 PYCCEL_RESTRICTION_IMPORT_IN_DEF = 'Only From Import is allowed inside a def statement'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2715,10 +2715,10 @@ class SemanticParser(BasicParser):
         return IsClass(var1, var2)
 
     def _visit_Is(self, expr, **settings):
-        return self._handle_is_operator(Is, expr, settings)
+        return self._handle_is_operator(Is, expr, **settings)
 
     def _visit_IsNot(self, expr, **settings):
-        return self._handle_is_operator(IsNot, expr, settings)
+        return self._handle_is_operator(IsNot, expr, **settings)
 
     def _visit_Import(self, expr, **settings):
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2685,7 +2685,7 @@ class SemanticParser(BasicParser):
         ls = [self._visit(i, **settings) for i in expr.variables]
         return Del(ls)
 
-    def _handle_is_operator(self, IsClass, expr, **settings)
+    def _handle_is_operator(self, IsClass, expr, **settings):
 
         # TODO ERROR wrong position ??
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2698,16 +2698,16 @@ class SemanticParser(BasicParser):
                 bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                 severity='error', blocker=self.blocking)
 
-        if ((var1.is_Boolean or isinstance(var1.dtype, NativeBool)) and
-            (var2.is_Boolean or isinstance(var2.dtype, NativeBool))):
-            return Is(var1, var2)
-
         if isinstance(var2, Nil):
             if not var1.is_optional:
                 errors.report(PYCCEL_RESTRICTION_OPTIONAL_NONE,
                         bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                         severity='error', blocker=self.blocking)
             return Is(var1, expr.rhs)
+
+        if ((var1.is_Boolean or isinstance(var1.dtype, NativeBool)) and
+            (var2.is_Boolean or isinstance(var2.dtype, NativeBool))):
+            return Is(var1, var2)
 
         errors.report(PYCCEL_RESTRICTION_IS_RHS,
             bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2693,10 +2693,8 @@ class SemanticParser(BasicParser):
         var1 = self._visit(expr.lhs)
         var2 = self._visit(expr.rhs)
 
-        if not isinstance(var1, Variable):
-            errors.report(PYCCEL_RESTRICTION_IS_LHS,
-                bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
-                severity='error', blocker=self.blocking)
+        if isinstance(var1, Nil):
+            var1, var2 = var2, var1
 
         if isinstance(var2, Nil):
             if not var1.is_optional:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2685,7 +2685,7 @@ class SemanticParser(BasicParser):
         ls = [self._visit(i, **settings) for i in expr.variables]
         return Del(ls)
 
-    def _visit_Is(self, expr, **settings):
+    def _handle_is_operator(self, IsClass, expr, **settings)
 
         # TODO ERROR wrong position ??
 
@@ -2703,40 +2703,22 @@ class SemanticParser(BasicParser):
                 errors.report(PYCCEL_RESTRICTION_OPTIONAL_NONE,
                         bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                         severity='error', blocker=self.blocking)
-            return Is(var1, expr.rhs)
+            return IsClass(var1, expr.rhs)
 
         if ((var1.is_Boolean or isinstance(var1.dtype, NativeBool)) and
             (var2.is_Boolean or isinstance(var2.dtype, NativeBool))):
-            return Is(var1, var2)
+            return IsClass(var1, var2)
 
         errors.report(PYCCEL_RESTRICTION_IS_RHS,
             bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
             severity='error', blocker=self.blocking)
-        return Is(var1, expr.rhs)
+        return IsClass(var1, var2)
+
+    def _visit_Is(self, expr, **settings):
+        return self._handle_is_operator(Is, expr, settings)
 
     def _visit_IsNot(self, expr, **settings):
-
-        # TODO ERROR wrong position ??
-
-        name = expr.lhs
-        var1 = self.get_variable(str(expr.lhs))
-
-        var2 = self.check_for_variable(str(expr.rhs))
-        if var2 is None:
-            if (isinstance(expr.rhs, Nil) and not var1.is_optional):
-                errors.report(PYCCEL_RESTRICTION_OPTIONAL_NONE,
-                        bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
-                        severity='error', blocker=self.blocking)
-            return IsNot(var1, expr.rhs)
-
-        if ((var1.is_Boolean or isinstance(var1.dtype, NativeBool)) and
-            (var2.is_Boolean or isinstance(var2.dtype, NativeBool))):
-            return IsNot(var1, var2)
-
-        errors.report(PYCCEL_RESTRICTION_IS_RHS,
-            bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
-            severity='error', blocker=self.blocking)
-        return IsNot(var1, expr.rhs)
+        return self._handle_is_operator(IsNot, expr, settings)
 
     def _visit_Import(self, expr, **settings):
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2690,19 +2690,24 @@ class SemanticParser(BasicParser):
         # TODO ERROR wrong position ??
 
         name = expr.lhs
-        var1 = self.get_variable(str(expr.lhs))
+        var1 = self._visit(expr.lhs)
+        var2 = self._visit(expr.rhs)
 
-        var2 = self.check_for_variable(str(expr.rhs))
-        if var2 is None:
-            if (isinstance(expr.rhs, Nil) and not var1.is_optional):
-                errors.report(PYCCEL_RESTRICTION_OPTIONAL_NONE,
-                        bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
-                        severity='error', blocker=self.blocking)
-            return Is(var1, expr.rhs)
+        if not isinstance(var1, Variable):
+            errors.report(PYCCEL_RESTRICTION_IS_LHS,
+                bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
+                severity='error', blocker=self.blocking)
 
         if ((var1.is_Boolean or isinstance(var1.dtype, NativeBool)) and
             (var2.is_Boolean or isinstance(var2.dtype, NativeBool))):
             return Is(var1, var2)
+
+        if isinstance(var2, Nil):
+            if not var1.is_optional:
+                errors.report(PYCCEL_RESTRICTION_OPTIONAL_NONE,
+                        bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
+                        severity='error', blocker=self.blocking)
+            return Is(var1, expr.rhs)
 
         errors.report(PYCCEL_RESTRICTION_IS_RHS,
             bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),

--- a/tests/epyccel/modules/base.py
+++ b/tests/epyccel/modules/base.py
@@ -28,6 +28,20 @@ def compare_is_not(a, b):
         c = True
     return c
 
+@types('bool', 'int')
+def compare_is_int(a, b):
+    c = False
+    if a is bool(b):
+        c = True
+    return c
+
+@types('bool', 'int')
+def compare_is_not_int(a, b):
+    c = False
+    if a is not bool(b):
+        c = True
+    return c
+
 @types('bool')
 def not_false(a):
     c = False

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -31,6 +31,18 @@ def test_compare_is_not():
     compare_epyccel(base.compare_is_not, False, True)
     compare_epyccel(base.compare_is_not, False, False)
 
+def test_compare_is_int():
+    compare_epyccel(base.compare_is_int, True, 1)
+    compare_epyccel(base.compare_is_int, True, 0)
+    compare_epyccel(base.compare_is_int, False, 1)
+    compare_epyccel(base.compare_is_int, False, 0)
+
+def test_compare_is_not_int():
+    compare_epyccel(base.compare_is_not_int, True, 1)
+    compare_epyccel(base.compare_is_not_int, True, 0)
+    compare_epyccel(base.compare_is_not_int, False, 1)
+    compare_epyccel(base.compare_is_not_int, False, 0)
+
 def test_not_false():
     compare_epyccel(base.not_false, True)
     compare_epyccel(base.not_false, False)


### PR DESCRIPTION
Allow casting to bool within an if statement. Fixes #418 

- Ensure members of Is statement are visited.
- Ensure error messages clearly explain restrictions
- Create _handle_is_operator function to remove Is/IsNot duplication