### PR TITLE
Raise an error when results type is missing for recursive function

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -45,6 +45,7 @@ from .functionalexpr import GeneratorComprehension as GC
 from .functionalexpr import FunctionalFor
 
 from pyccel.errors.errors import Errors
+from pyccel.errors.messages import *
 
 errors = Errors()
 
@@ -3060,6 +3061,10 @@ class FunctionCall(Basic, PyccelAstNode):
 
     def __init__(self, func, args, current_function=None):
 
+        if str(current_function) == str(func.name):
+            if len(func.results)>0 and not isinstance(func.results[0], PyccelAstNode):
+                errors.report(RECURSIVE_RESULTS_REQUIRED, symbol=func, severity="fatal")
+
         self._funcdef     = func
         self._dtype       = func.results[0].dtype if len(func.results) == 1 else NativeTuple()
         self._rank        = func.results[0].rank if len(func.results) == 1 else None
@@ -3620,6 +3625,14 @@ class FunctionDef(Basic):
     # TODO
     def check_elemental(self):
         raise NotImplementedError('')
+
+    def __str__(self):
+        result = 'None' if len(self.results) == 0 else \
+                    ', '.join(str(r) for r in self.results)
+        return '{name}({args}) -> {result}'.format(
+                name   = self.name,
+                args   = ', '.join(self.args),
+                result = result)
 
 
 class SympyFunction(FunctionDef):

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from ast import stmt as ast_stmt, dump as ast_dump
+from ast import dump as ast_dump
 
 # ...
 #ERROR = 'error'
@@ -223,7 +223,7 @@ class Errors:
             column = bounding_box[1]
 
         if symbol is not None:
-            if isinstance(symbol, ast_stmt):
+            if symbol.__module__ == '_ast':
                 line   = symbol.lineno
                 column = symbol.col_offset
                 symbol = ast_dump(symbol)

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from ast import stmt as ast_stmt, dump as ast_dump
 
 # ...
 #ERROR = 'error'
@@ -220,6 +221,17 @@ class Errors:
         if bounding_box:
             line   = bounding_box[0]
             column = bounding_box[1]
+
+        if symbol is not None:
+            if isinstance(symbol, ast_stmt):
+                line   = fst.lineno
+                column = fst.col_offset
+                symbol = ast_dump(symbol)
+            else:
+                fst = getattr(symbol, 'fst', None)
+                if fst is not None:
+                    line   = fst.lineno
+                    column = fst.col_offset
 
         info = ErrorInfo(filename,
                          line=line,

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -224,8 +224,8 @@ class Errors:
 
         if symbol is not None:
             if isinstance(symbol, ast_stmt):
-                line   = fst.lineno
-                column = fst.col_offset
+                line   = symbol.lineno
+                column = symbol.col_offset
                 symbol = ast_dump(symbol)
             else:
                 fst = getattr(symbol, 'fst', None)

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -223,7 +223,7 @@ class Errors:
             column = bounding_box[1]
 
         if symbol is not None:
-            if symbol.__module__ == '_ast':
+            if getattr(symbol, '__module__', '') == '_ast':
                 line   = symbol.lineno
                 column = symbol.col_offset
                 symbol = ast_dump(symbol)

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -7,6 +7,9 @@ INVALID_IMPLICIT_RETURN = 'Implicit return in function which does not return'
 INCOMPATIBLE_RETURN_VALUE_TYPE = 'Incompatible return value type'
 RETURN_VALUE_EXPECTED = 'Return value expected'
 NO_RETURN_EXPECTED = 'Return statement in function which does not return'
+RECURSIVE_RESULTS_REQUIRED = ("A results type must be provided for recursive functions with one of the following two syntaxes:\n"
+    "@types('ARG_TYPES', results='RESULT_TYPES')\n"
+    "#$ header function FUNC_NAME(ARG_TYPES) results(RESULT_TYPES)\n")
 INCOMPATIBLE_TYPES = 'Incompatible types'
 INCOMPATIBLE_TYPES_IN_ASSIGNMENT = 'Incompatible types in assignment'
 INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -637,7 +637,7 @@ class SyntaxParser(BasicParser):
                     if not arg_name == 'results':
                         msg = 'Argument "{}" provided to the types decorator is not valid'.format(arg_name)
                         errors.report(msg,
-                                      symbol = decorators[types],
+                                      symbol = decorators['types'],
                                       severity='error')
                     else:
                         ls = arg if isinstance(arg, PythonTuple) else [arg]
@@ -645,7 +645,7 @@ class SyntaxParser(BasicParser):
                 else:
                     msg = 'Invalid argument of type {} passed to types decorator'.format(type(arg))
                     errors.report(msg,
-                                  symbol = decorators[types],
+                                  symbol = decorators['types'],
                                   severity='error')
 
                 i = i+1

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -166,12 +166,7 @@ class SyntaxParser(BasicParser):
             return result
 
         # Unknown object, we raise an error.
-        if hasattr(stmt, 'lineno'):
-            bounding_box = (stmt.lineno, stmt.col_offset)
-        else:
-            bounding_box = None
-        errors.report(PYCCEL_RESTRICTION_UNSUPPORTED_SYNTAX, symbol=ast.dump(stmt),
-                      bounding_box=bounding_box,
+        errors.report(PYCCEL_RESTRICTION_UNSUPPORTED_SYNTAX, symbol=stmt,
                       severity='fatal')
 
     def _visit_Module(self, stmt):
@@ -358,7 +353,6 @@ class SyntaxParser(BasicParser):
             expr = AugAssign(lhs, '%', rhs)
         else:
             errors.report(PYCCEL_RESTRICTION_TODO, symbol = stmt,
-                      bounding_box=(stmt.lineno, stmt.col_offset),
                       severity='fatal')
 
         # we set the fst to keep track of needed information for errors
@@ -370,7 +364,6 @@ class SyntaxParser(BasicParser):
         arguments = []
         if stmt.vararg or stmt.kwarg:
             errors.report(VARARGS, symbol = stmt,
-                    bounding_box=(stmt.lineno, stmt.col_offset),
                     severity='fatal')
 
         if stmt.args:
@@ -498,7 +491,7 @@ class SyntaxParser(BasicParser):
                           severity='fatal')
         else:
             errors.report(PYCCEL_RESTRICTION_UNSUPPORTED_SYNTAX,
-                          bounding_box=(stmt.lineno, stmt.col_offset),
+                          symbol = stmt,
                           severity='fatal')
 
         return Func(PyccelUnary(target))
@@ -530,7 +523,7 @@ class SyntaxParser(BasicParser):
             return PyccelMod(first, second)
         else:
             errors.report(PYCCEL_RESTRICTION_UNSUPPORTED_SYNTAX,
-                          bounding_box=(stmt.lineno, stmt.col_offset),
+                          symbol = stmt,
                           severity='fatal')
 
     def _visit_BoolOp(self, stmt):
@@ -544,14 +537,13 @@ class SyntaxParser(BasicParser):
             return PyccelOr(*args)
 
         errors.report(PYCCEL_RESTRICTION_UNSUPPORTED_SYNTAX,
-                      symbol = ast.dump(stmt.op),
-                      bounding_box=(stmt.lineno, stmt.col_offset),
+                      symbol = stmt.op,
                       severity='fatal')
 
     def _visit_Compare(self, stmt):
         if len(stmt.ops)>1:
             errors.report(PYCCEL_RESTRICTION_MULTIPLE_COMPARISONS,
-                      bounding_box=(stmt.lineno, stmt.col_offset),
+                      symbol = stmt,
                       severity='fatal')
 
         first = self._visit(stmt.left)
@@ -576,7 +568,7 @@ class SyntaxParser(BasicParser):
             return IsNot(first, second)
 
         errors.report(PYCCEL_RESTRICTION_UNSUPPORTED_SYNTAX,
-                      bounding_box=(stmt.lineno, stmt.col_offset),
+                      symbol = stmt,
                       severity='fatal')
 
     def _visit_Return(self, stmt):
@@ -645,7 +637,7 @@ class SyntaxParser(BasicParser):
                     if not arg_name == 'results':
                         msg = 'Argument "{}" provided to the types decorator is not valid'.format(arg_name)
                         errors.report(msg,
-                                      bounding_box=(stmt.lineno, stmt.col_offset),
+                                      symbol = decorators[types],
                                       severity='error')
                     else:
                         ls = arg if isinstance(arg, PythonTuple) else [arg]
@@ -653,7 +645,7 @@ class SyntaxParser(BasicParser):
                 else:
                     msg = 'Invalid argument of type {} passed to types decorator'.format(type(arg))
                     errors.report(msg,
-                                  bounding_box=(stmt.lineno, stmt.col_offset),
+                                  symbol = decorators[types],
                                   severity='error')
 
                 i = i+1
@@ -864,8 +856,7 @@ class SyntaxParser(BasicParser):
 
         if not isinstance(self._scope[-2],ast.Assign):
             errors.report(PYCCEL_RESTRICTION_LIST_COMPREHENSION_ASSIGN,
-                          symbol = ast.dump(stmt),
-                          bounding_box=(stmt.lineno, stmt.col_offset),
+                          symbol = stmt,
                           severity='error')
             lhs = self.get_new_variable()
         else:
@@ -1010,7 +1001,7 @@ class SyntaxParser(BasicParser):
                     exprs.append(expr)
                 else:
                     errors.report(PYCCEL_INVALID_HEADER,
-                                 bounding_box=(stmt.lineno, stmt.col_offset),
+                                  symbol = stmt,
                                   severity='error')
             else:
 
@@ -1048,7 +1039,7 @@ class SyntaxParser(BasicParser):
             else:
 
                 errors.report(PYCCEL_INVALID_HEADER,
-                              bounding_box=(stmt.lineno, stmt.col_offset),
+                              symbol = stmt,
                               severity='error')
 
         else:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -638,6 +638,7 @@ class SyntaxParser(BasicParser):
                         msg = 'Argument "{}" provided to the types decorator is not valid'.format(arg_name)
                         errors.report(msg,
                                       symbol = decorators['types'],
+                                      bounding_box = (stmt.lineno, stmt.col_offset),
                                       severity='error')
                     else:
                         ls = arg if isinstance(arg, PythonTuple) else [arg]
@@ -646,6 +647,7 @@ class SyntaxParser(BasicParser):
                     msg = 'Invalid argument of type {} passed to types decorator'.format(type(arg))
                     errors.report(msg,
                                   symbol = decorators['types'],
+                                  bounding_box = (stmt.lineno, stmt.col_offset),
                                   severity='error')
 
                 i = i+1

--- a/tests/errors/semantic/blocking/RECURSIVE_RESULTS_REQUIRED_decorator.py
+++ b/tests/errors/semantic/blocking/RECURSIVE_RESULTS_REQUIRED_decorator.py
@@ -1,0 +1,11 @@
+from pyccel.decorators import types
+
+@types('int')
+def fib(n) :
+    if n < 2:
+        result = n
+        return result
+    result = fib (n - 1) + fib (n - 2)
+    return result
+
+print(fib(20))

--- a/tests/errors/semantic/blocking/RECURSIVE_RESULTS_REQUIRED_header.py
+++ b/tests/errors/semantic/blocking/RECURSIVE_RESULTS_REQUIRED_header.py
@@ -1,0 +1,10 @@
+
+#$ header function fib(int)
+def fib(n) :
+    if n < 2:
+        result = n
+        return result
+    result = fib (n - 1) + fib (n - 2)
+    return result
+
+print(fib(20))


### PR DESCRIPTION
Raise a pedagogical error when results type is missing for recursive function (fixes #429). Reduce duplication in parser/syntactic.py by allowing the errors class to handle the line and column information of an ast node

- Fix issue #429. Raise error when calling recursive function with missing results descriptor
- Use ast object to collect line information in errors class to reduce duplication in parser/syntactic.py
- Add tests for issue #429