### PR TITLE
Fix broken codegen tests

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -206,6 +206,10 @@ def broadcast(shape_1, shape_2):
             new_shape.append(e1)
         elif isinstance(e1, PyccelArraySize) and isinstance(e2, PyccelArraySize):
             new_shape.append(e1)
+        elif isinstance(e1, PyccelArraySize):
+            new_shape.append(e2)
+        elif isinstance(e2, PyccelArraySize):
+            new_shape.append(e1)
         else:
             msg = 'operands could not be broadcast together with shapes {} {}'
             msg = msg.format(shape_1, shape_2)

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -204,6 +204,8 @@ def broadcast(shape_1, shape_2):
             new_shape.append(e2)
         elif e2 == 1:
             new_shape.append(e1)
+        elif isinstance(e1, PyccelArraySize) and isinstance(e2, PyccelArraySize):
+            new_shape.append(e1)
         else:
             msg = 'operands could not be broadcast together with shapes {} {}'
             msg = msg.format(shape_1, shape_2)

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -262,7 +262,7 @@ class PyccelOperator(Expr, PyccelAstNode):
             if None in ranks:
                 self._rank  = None
                 self._shape = None
-            elif all(not (sh is None or isinstance(sh, PyccelArraySize)) for tup in shapes for sh in tup):
+            elif all(sh is not None for tup in shapes for sh in tup):
                 if len(args) == 1:
                     shape = args[0].shape
                 else:
@@ -317,7 +317,7 @@ class PyccelDiv(PyccelOperator):
             self._rank  = None
             self._shape = None
 
-        elif all(not (sh is None or isinstance(sh, PyccelArraySize)) for tup in shapes for sh in tup):
+        elif all(sh is not None for tup in shapes for sh in tup):
             shape = broadcast(args[0].shape, args[1].shape)
 
             for a in args[2:]:
@@ -353,7 +353,7 @@ class PyccelBooleanOperator(Expr, PyccelAstNode):
             self._rank  = None
             self._shape = None
 
-        elif all(not (sh is None or isinstance(sh, PyccelArraySize)) for tup in shapes for sh in tup):
+        elif all(sh is not None for tup in shapes for sh in tup):
             shape = broadcast(args[0].shape, args[1].shape)
             for a in args[2:]:
                 shape = broadcast(shape, a.shape)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -830,7 +830,7 @@ class Rand(Function, NumpyNewArray):
         code_init = 'call random_number({0})'.format(lhs_code)
         stmts.append(code_init)
 
-        return '\n'.join(stmts)
+        return '\n'.join(stmts) + '\n'
 
 #==============================================================================
 class NumpyRandint(Function, NumpyNewArray):
@@ -963,7 +963,10 @@ class Full(Application, NumpyNewArray):
             code_init = '{0} = {1}'.format(lhs_code, init_value)
             stmts.append(code_init)
 
-        return '\n'.join(stmts)
+        if len(stmts) == 0:
+            return ''
+        else:
+            return '\n'.join(stmts) + '\n'
 
 #==============================================================================
 class Empty(Full):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1071,7 +1071,7 @@ class FCodePrinter(CodePrinter):
                 if lhs_name in vars_dict:
                     stack_array = vars_dict[lhs_name].is_stack_array
 
-            return rhs.fprint(self._print, expr.lhs, stack_array) + '\n'
+            return rhs.fprint(self._print, expr.lhs, stack_array)
 
         if isinstance(rhs, NumpyMod):
             lhs = self._print(expr.lhs)

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -57,11 +57,11 @@ def construct_flags(compiler,
     flags = str(fflags)
     if compiler == "gfortran":
         if debug:
-            flags += " -fbounds-check"
+            flags += " -fcheck=bounds"
 
     if compiler == "mpif90":
         if debug:
-            flags += " -fbounds-check"
+            flags += " -fcheck=bounds"
         if sys.platform == "win32":
             mpiinc = os.environ["MSMPI_INC"].rstrip('\\')
             mpilib = os.environ["MSMPI_LIB64"].rstrip('\\')

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from os.path import basename
 
 # ...
 #ERROR = 'error'
@@ -70,7 +71,7 @@ class ErrorInfo:
                  symbol=None,
                  blocker=False):
         # The source file that was the source of this error.
-        self.filename = filename
+        self.filename = basename(filename)
         # The line number related to this error within file.
         self.line = line
         # The column number related to this error with file.
@@ -93,10 +94,12 @@ class ErrorInfo:
 
         if self.line:
             if not self.column:
-                text = '{text}: {line}'.format(text=text, line=self.line)
+                text = '{text}: {filename} [{line}]'.format(text=text,
+                        filename = self.filename, line=self.line)
             else:
-                text = '{text}: [{line},{column}]'.format(text=text, line=self.line,
-                                                     column=self.column)
+                text = '{text}: {filename} [{line},{column}]'.format(text=text,
+                        filename = self.filename, line=self.line,
+                        column=self.column)
 
         text = '{text}| {msg}'.format(text=text, msg=self.message)
 

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -88,6 +88,7 @@ PYCCEL_RESTRICTION_LIST_COMPREHENSION_LIMITS = 'Pyccel cannot handle this list c
 # Fortran limitation
 FORTRAN_ALLOCATABLE_IN_EXPRESSION = 'An allocatable function cannot be used in an expression'
 FORTRAN_RANDINT_ALLOCATABLE_IN_EXPRESSION = "Numpy's randint function does not have a fortran equivalent. It can be expressed as '(high-low)*rand(size)+low' using numpy's rand, however allocatable function cannot be used in an expression"
+FORTRAN_ELEMENTAL_SINGLE_ARGUMENT = 'Elemental functions are defined as scalar operators, with a single dummy argument'
 
 # other Pyccel messages
 PYCCEL_INVALID_HEADER = 'Annotated comments must start with omp, acc or header'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1431,7 +1431,7 @@ class SemanticParser(BasicParser):
                             symbol = '|{name}| <module> -> {rhs}'.format(name=name, rhs=rhs),
                             bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                             severity='fatal', blocker=False)
-                elif str(dtype) != str(getattr(var, 'dtype', 'None')):
+                elif not is_augassign and str(dtype) != str(getattr(var, 'dtype', 'None')):
                     txt = '|{name}| {old} <-> {new}'
                     txt = txt.format(name=name, old=var.dtype, new=dtype)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1419,8 +1419,7 @@ class SemanticParser(BasicParser):
                     errors.report(PYCCEL_RESTRICTION_TODO+'\n'+msg,
                         bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                         severity='fatal', blocker=self.blocking)
-                elif lhs.rank>0 and ( isinstance(rhs, (PyccelOperator)) or
-                                     (isinstance(rhs, FunctionCall) and rhs.funcdef and rhs.funcdef.is_elemental)):
+                elif lhs.rank>0 and not isinstance(rhs, NumpyNewArray):
                     #TODO: Provide order once issue #335 is fixed
                     #new_expressions.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, lhs.order)))
                     new_expressions.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, 'C')))

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1419,7 +1419,7 @@ class SemanticParser(BasicParser):
                     errors.report(PYCCEL_RESTRICTION_TODO+'\n'+msg,
                         bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                         severity='fatal', blocker=self.blocking)
-                elif lhs.rank>0 and not isinstance(rhs, NumpyNewArray):
+                elif lhs.rank>0 and not isinstance(rhs, NumpyNewArray) and rhs.dtype is not NativeGeneric():
                     #TODO: Provide order once issue #335 is fixed
                     #new_expressions.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, lhs.order)))
                     new_expressions.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, 'C')))

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1686,6 +1686,11 @@ class SemanticParser(BasicParser):
                     if not all(same_ranks):
                         _name = _get_name(lhs)
                         var = self.get_variable(_name)
+                        c_shape = [x.shape for x in call_args]
+                        assert(len(c_shape) == 1)
+                        for d in d_var:
+                            d['shape'] = c_shape[0]
+                            d['rank' ] = c_ranks[0]
 
             elif isinstance(func, Interface):
                 d_var = [self._infere_type(i, **settings) for i in

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1419,7 +1419,7 @@ class SemanticParser(BasicParser):
                     errors.report(PYCCEL_RESTRICTION_TODO+'\n'+msg,
                         bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                         severity='fatal', blocker=self.blocking)
-                elif lhs.rank>0 and not isinstance(rhs, NumpyNewArray) and rhs.dtype is not NativeGeneric():
+                elif lhs.rank>0 and not isinstance(rhs, (NumpyNewArray, TupleVariable, PythonTuple)):
                     #TODO: Provide order once issue #335 is fixed
                     #new_expressions.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, lhs.order)))
                     new_expressions.append(Assign(lhs, Empty(lhs.alloc_shape, dtype, 'C')))

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -698,6 +698,11 @@ class SyntaxParser(BasicParser):
 
         if 'elemental' in decorators.keys():
             is_elemental = True
+            if len(arguments) > 1:
+                errors.report(FORTRAN_ELEMENTAL_SINGLE_ARGUMENT,
+                              symbol=decorators['elemental'],
+                              bounding_box=(stmt.lineno, stmt.col_offset),
+                              severity='error')
 
         if 'private' in decorators.keys():
             is_private = True

--- a/tests/codegen/ccode/test_ccode_codegen.py
+++ b/tests/codegen/ccode/test_ccode_codegen.py
@@ -25,11 +25,21 @@ files = [os.path.join(path_dir,f) \
 @pytest.mark.parametrize("f", files)
 def test_codegen(f):
 
+    # reset Errors singleton
+    errors = Errors()
+    errors.reset()
+
     pyccel = Parser(f)
     ast = pyccel.parse()
 
+    # Assert syntactic success
+    assert(not errors.has_errors())
+
     settings = {}
     ast = pyccel.annotate(**settings)
+
+    # Assert semantic success
+    assert(not errors.has_errors())
 
     name = os.path.basename(f)
     name = os.path.splitext(name)[0]
@@ -37,9 +47,8 @@ def test_codegen(f):
     codegen = Codegen(ast, name)
     code = codegen.doprint(language='c')
 
-    # reset Errors singleton
-    errors = Errors()
-    errors.reset()
+    # Assert codegen success
+    assert(not errors.has_errors())
 
 ######################
 if __name__ == '__main__':

--- a/tests/codegen/fcode/test_fcode_codegen.py
+++ b/tests/codegen/fcode/test_fcode_codegen.py
@@ -24,6 +24,7 @@ files = [os.path.join(path_dir,f) \
 @pytest.mark.parametrize("f", files)
 def test_codegen(f):
 
+    # reset Errors singleton
     errors = Errors()
     errors.reset()
 

--- a/tests/codegen/fcode/test_fcode_codegen.py
+++ b/tests/codegen/fcode/test_fcode_codegen.py
@@ -24,11 +24,20 @@ files = [os.path.join(path_dir,f) \
 @pytest.mark.parametrize("f", files)
 def test_codegen(f):
 
+    errors = Errors()
+    errors.reset()
+
     pyccel = Parser(f)
     ast = pyccel.parse()
 
+    # Assert syntactic success
+    assert(not errors.has_errors())
+
     settings = {}
     ast = pyccel.annotate(**settings)
+
+    # Assert semantic success
+    assert(not errors.has_errors())
 
     name = os.path.basename(f)
     name = os.path.splitext(name)[0]
@@ -36,9 +45,8 @@ def test_codegen(f):
     codegen = Codegen(ast, name)
     codegen.doprint()
 
-    # reset Errors singleton
-    errors = Errors()
-    errors.reset()
+    # Assert codegen success
+    assert(not errors.has_errors())
 
 ######################
 if __name__ == '__main__':

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1456,8 +1456,6 @@ def test_array_real_2d_2d_matmul_mixorder():
     f2(A2, B2, C2)
     assert np.array_equal(C1, C2)
 
-# TODO: Fix #245
-@pytest.mark.xfail(reason="Needs fixing, see #245")
 def test_array_real_loopdiff():
     f1 = arrays.array_real_loopdiff
     f2 = epyccel( f1 )

--- a/tests/errors/semantic/blocking/ARRAY_FROM_EXPRESSION.py
+++ b/tests/errors/semantic/blocking/ARRAY_FROM_EXPRESSION.py
@@ -1,5 +1,0 @@
-from pyccel.decorators import types
-
-@types('int[:,:]','int[:,:]')
-def f(x,y):
-    z = x + y # pylint: disable=unused-variable

--- a/tests/pyccel/scripts/decorators_elemental.py
+++ b/tests/pyccel/scripts/decorators_elemental.py
@@ -13,6 +13,5 @@ b = square(a)
 print(b)
 
 xs = array([1., 2., 3.])
-ys = zeros_like(xs)
 ys = square(xs)
 print(ys)

--- a/tests/pyccel/scripts/decorators_elemental.py
+++ b/tests/pyccel/scripts/decorators_elemental.py
@@ -1,0 +1,18 @@
+from pyccel.decorators import types, elemental
+from numpy import array
+from numpy import zeros_like
+
+@elemental
+@types(float)
+def square(x):
+    s = x*x
+    return s
+
+a = 2.0
+b = square(a)
+print(b)
+
+xs = array([1., 2., 3.])
+ys = zeros_like(xs)
+ys = square(xs)
+print(ys)

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -437,3 +437,7 @@ def test_multiple_results():
                 int,bool,float,float,float,float,float,float,
                 float,float,float,float,float,float,
                 float,float,float,float,float,float])
+
+#------------------------------------------------------------------------------
+def test_elemental():
+    pyccel_test("scripts/decorators_elemental.py")


### PR DESCRIPTION
Ensure that codegen tests fail if there is a problem during their treatment, even if the problem creates a neat error (fixes #436 ). Fix broken tests. Improve `broadcast` function by supposing that mathematical expressions are valid. As a result when both shapes are unknown in a dimension they are supposed to be the same, when only one shape is unknown then it is supposed that it is the same as the known shape (fixes #245).

- Stop codegen tests passing when errors have been raised
- Print filename with error (useful for errors in imported files)
- Allow broadcast function to handle PyccelArraySize
- Correct handling of elemental functions
- Add end to end test for elemental
- Do not complain about dtype differences in an AugAssign
- Assume that unknown sizes on the same axis are the same size
- When one of the sizes is unknown, prefer the known size