### PR TITLE
Raise warning for undefined decorators

### DIFF
--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -218,7 +218,8 @@ def builtin_import(expr):
     if source == 'pyccel.decorators':
         funcs = [f[0] for f in inspect.getmembers(pyccel_decorators, inspect.isfunction)]
         for target in expr.target:
-            if str(target) not in funcs:
+            tmp = str(target).split()
+            if tmp[0] not in funcs:
                 errors = Errors()
                 errors.report("{} does not exist in pyccel.decorators".format(target),
                         symbol = expr, severity='error')

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -218,8 +218,8 @@ def builtin_import(expr):
     if source == 'pyccel.decorators':
         funcs = [f[0] for f in inspect.getmembers(pyccel_decorators, inspect.isfunction)]
         for target in expr.target:
-            tmp = str(target).split()
-            if tmp[0] not in funcs:
+            search_target = target.name if isinstance(target, AsName) else target
+            if search_target not in funcs:
                 errors = Errors()
                 errors.report("{} does not exist in pyccel.decorators".format(target),
                         symbol = expr, severity='error')

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -218,7 +218,7 @@ def builtin_import(expr):
     if source == 'pyccel.decorators':
         funcs = [f[0] for f in inspect.getmembers(pyccel_decorators, inspect.isfunction)]
         for target in expr.target:
-            search_target = target.name if isinstance(target, AsName) else target
+            search_target = target.name if isinstance(target, AsName) else str(target)
             if search_target not in funcs:
                 errors = Errors()
                 errors.report("{} does not exist in pyccel.decorators".format(target),

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -9,7 +9,8 @@ __all__ = (
     'pure',
     'private',
     'elemental',
-    'stack_array'
+    'stack_array',
+    'allow_negative_index'
 )
 
 def lambdify(f):

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -1,5 +1,17 @@
 #TODO use pycode and call exec after that in lambdify
 
+__all__ = (
+    'lambdify',
+    'python',
+    'sympy',
+    'bypass',
+    'types',
+    'pure',
+    'private',
+    'elemental',
+    'stack_array'
+)
+
 def lambdify(f):
 
     args = f.__code__.co_varnames

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -60,6 +60,9 @@ WRONG_NUMBER_OUTPUT_ARGS = 'Number of output arguments does not match number of 
 INDEXED_TUPLE = 'Tuples must be indexed with constant integers for the type inference to work'
 LIST_OF_TUPLES = 'Cannot create list of non-homogeneous tuples'
 
+UNDEFINED_DECORATOR = 'Decorator not used'
+UNDEFINED_DECORATORS = 'Decorators not used'
+
 UNDEFINED_LAMBDA_VARIABLE = 'Unknown variable(s) in lambda function'
 UNDEFINED_LAMBDA_FUNCTION = 'Unknown function in lambda function'
 

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -60,8 +60,7 @@ WRONG_NUMBER_OUTPUT_ARGS = 'Number of output arguments does not match number of 
 INDEXED_TUPLE = 'Tuples must be indexed with constant integers for the type inference to work'
 LIST_OF_TUPLES = 'Cannot create list of non-homogeneous tuples'
 
-UNDEFINED_DECORATOR = 'Decorator not used'
-UNDEFINED_DECORATORS = 'Decorators not used'
+UNDEFINED_DECORATORS = 'Decorator(s) not used'
 
 UNDEFINED_LAMBDA_VARIABLE = 'Unknown variable(s) in lambda function'
 UNDEFINED_LAMBDA_FUNCTION = 'Unknown function in lambda function'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2472,7 +2472,7 @@ class SemanticParser(BasicParser):
             # get the imports
             imports   = self.namespace.imports['imports'].values()
             imports   = list(set(imports))
-            print(imports)
+
             # remove the FunctionDef from the function scope
             # TODO improve func_ is None in the case of an interface
             func_     = self.namespace.functions.pop(name, None)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2304,7 +2304,7 @@ class SemanticParser(BasicParser):
                 not_used.append(value)
 
         if len(not_used) == 1:
-            errors.report(UNDEFINED_DECORATOR, symbol=''.join(not_used), severity='warning')
+            errors.report(UNDEFINED_DECORATORS, symbol=''.join(not_used), severity='warning')
         elif len(not_used) > 1:
             errors.report(UNDEFINED_DECORATORS, symbol=', '.join(not_used), severity='warning')
 
@@ -2472,6 +2472,7 @@ class SemanticParser(BasicParser):
             # get the imports
             imports   = self.namespace.imports['imports'].values()
             imports   = list(set(imports))
+            print(imports)
             # remove the FunctionDef from the function scope
             # TODO improve func_ is None in the case of an interface
             func_     = self.namespace.functions.pop(name, None)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2303,9 +2303,7 @@ class SemanticParser(BasicParser):
             if value not in def_decorators.__all__:
                 not_used.append(value)
 
-        if len(not_used) == 1:
-            errors.report(UNDEFINED_DECORATORS, symbol=''.join(not_used), severity='warning')
-        elif len(not_used) > 1:
+        if len(not_used) >= 1:
             errors.report(UNDEFINED_DECORATORS, symbol=', '.join(not_used), severity='warning')
 
         args_number = len(expr.arguments)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -104,6 +104,7 @@ from pyccel.parser.base      import BasicParser, Scope
 from pyccel.parser.base      import get_filename_from_import
 from pyccel.parser.syntactic import SyntaxParser
 
+import pyccel.decorators as def_decorators
 #==============================================================================
 
 errors = Errors()
@@ -2295,6 +2296,18 @@ class SemanticParser(BasicParser):
         is_private   = expr.is_private
 
         header = expr.header
+
+        keys = decorators.keys()
+        not_used = []
+        for value in keys:
+            if value not in def_decorators.__all__:
+                not_used.append(value)
+
+        if len(not_used) == 1:
+            errors.report(UNDEFINED_DECORATOR, symbol=''.join(not_used), severity='warning')
+        elif len(not_used) > 1:
+            errors.report(UNDEFINED_DECORATORS, symbol=', '.join(not_used), severity='warning')
+
         args_number = len(expr.arguments)
         if header is None:
             if cls_name:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2297,11 +2297,7 @@ class SemanticParser(BasicParser):
 
         header = expr.header
 
-        keys = decorators.keys()
-        not_used = []
-        for value in keys:
-            if value not in def_decorators.__all__:
-                not_used.append(value)
+        not_used = [d for d in decorators if d not in def_decorators.__all__]
 
         if len(not_used) >= 1:
             errors.report(UNDEFINED_DECORATORS, symbol=', '.join(not_used), severity='warning')

--- a/tests/warnings/semantic/UNDEFINED_DECORATOR.py
+++ b/tests/warnings/semantic/UNDEFINED_DECORATOR.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 
-@toto
+@toto # pylint: disable=undefined-variable
 def f():
     pass

--- a/tests/warnings/semantic/UNDEFINED_DECORATOR.py
+++ b/tests/warnings/semantic/UNDEFINED_DECORATOR.py
@@ -1,0 +1,4 @@
+
+@toto
+def f():
+    pass

--- a/tests/warnings/semantic/UNDEFINED_DECORATOR.py
+++ b/tests/warnings/semantic/UNDEFINED_DECORATOR.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
 
 @toto
 def f():

--- a/tests/warnings/semantic/UNDEFINED_DECORATORS.py
+++ b/tests/warnings/semantic/UNDEFINED_DECORATORS.py
@@ -1,0 +1,5 @@
+
+@toto
+@type()
+def f():
+    pass

--- a/tests/warnings/semantic/UNDEFINED_DECORATORS.py
+++ b/tests/warnings/semantic/UNDEFINED_DECORATORS.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 
-@toto
+@toto # pylint: disable=undefined-variable
 @type()
 def f():
     pass

--- a/tests/warnings/semantic/UNDEFINED_DECORATORS.py
+++ b/tests/warnings/semantic/UNDEFINED_DECORATORS.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
 
 @toto
 @type()


### PR DESCRIPTION
Raise a warning if Pyccel encounters an unknown decorator (not defined in `pyccel.decorators`) and hence ignores it. Fixes #348 