### PR TITLE
Handle negative indexes for arrays in fortran

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2525,7 +2525,8 @@ class Variable(Symbol, PyccelAstNode):
         order='C',
         precision=0,
         is_argument=False,
-        is_kwonly=False
+        is_kwonly=False,
+        allows_negative_indexes=False
         ):
 
         # ------------ PyccelAstNode Properties ---------------
@@ -2607,6 +2608,12 @@ class Variable(Symbol, PyccelAstNode):
         elif not isinstance(is_optional, bool):
             raise TypeError('is_optional must be a boolean.')
         self._is_optional = is_optional
+
+        if allows_negative_indexes is None:
+            allows_negative_indexes = False
+        elif not isinstance(allows_negative_indexes, bool):
+            raise TypeError('allows_negative_indexes must be a boolean.')
+        self._allows_negative_indexes = allows_negative_indexes
 
         self._cls_base       = cls_base
         self._order          = order
@@ -2692,6 +2699,14 @@ class Variable(Symbol, PyccelAstNode):
     @is_stack_array.setter
     def is_stack_array(self, is_stack_array):
         self._is_stack_array = is_stack_array
+
+    @property
+    def allows_negative_indexes(self):
+        return self._allows_negative_indexes
+
+    @allows_negative_indexes.setter
+    def allows_negative_indexes(self, allows_negative_indexes):
+        self._allows_negative_indexes = allows_negative_indexes
 
     @property
     def is_argument(self):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -40,7 +40,7 @@ from pyccel.ast.core import (Assign, AliasAssign, Variable,
                              If, PyccelArraySize)
 
 
-from pyccel.ast.core      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus
+from pyccel.ast.core      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus, PyccelUnarySub
 from pyccel.ast.core      import FunctionCall
 
 from pyccel.ast.builtins  import Enumerate, PythonInt, Len, Map, Print, Range, Zip, PythonTuple, PythonFloat
@@ -62,6 +62,7 @@ from pyccel.ast.numpyext import NumpyComplex, NumpyMod
 from pyccel.ast.numpyext import FullLike, EmptyLike, ZerosLike, OnesLike
 from pyccel.ast.numpyext import Rand, NumpyRandint
 from pyccel.ast.numpyext import NumpyNewArray
+from pyccel.ast.numpyext import Shape
 
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import *
@@ -2342,6 +2343,8 @@ class FCodePrinter(CodePrinter):
         for i, ind in enumerate(inds):
             if isinstance(ind, Tuple) and len(ind) == 1:
                 inds[i] = ind[0]
+            if isinstance(ind, PyccelUnarySub) and isinstance(ind.args[0], Integer):
+                inds[i] = PyccelMinus(Shape(expr.base)[i], ind.args[0])
 
         inds = [self._print(i) for i in inds]
 

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -34,7 +34,18 @@ def private(f):
 def elemental(f):
     return f
 
-def stack_array(*args, **kw):
+def stack_array(f, *args):
+    """
+    Decorator indicates that all arrays mentioned as args should be stored
+    on the stack.
+
+    Parameters
+    ----------
+    f : Function
+        The function to which the decorator is applied
+    args : list of str
+        A list containing the names of all arrays which should be stored on the stack
+    """
     def identity(f):
         return f
     return identity

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -38,3 +38,8 @@ def stack_array(*args, **kw):
     def identity(f):
         return f
     return identity
+
+def allow_negative_index(*args, **kw):
+    def identity(f):
+        return f
+    return identity

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -39,7 +39,20 @@ def stack_array(*args, **kw):
         return f
     return identity
 
-def allow_negative_index(*args, **kw):
+def allow_negative_index(f,*args):
+    """
+    Decorator indicates that all arrays mentioned as args can be accessed with
+    negative indexes. As a result all non-constant indexing uses a modulo
+    function. This can have negative results on the performance
+
+    Parameters
+    ----------
+    f : Function
+        The function to which the decorator is applied
+    args : list of str
+        A list containing the names of all arrays which can be accessed
+        with non-constant negative indexes
+    """
     def identity(f):
         return f
     return identity

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2444,11 +2444,17 @@ class SemanticParser(BasicParser):
                 for var in local_vars:
                     var_name = var.name
                     if var_name in decorators['stack_array']:
-                        d_var = self._infere_type(var, **settings)
                         var.is_stack_array = True
                         var.allocatable    = False
                         var.is_pointer     = False
                         var.is_target      = False
+
+            if 'allow_negative_index' in decorators:
+
+                for var in local_vars:
+                    var_name = var.name
+                    if var_name in decorators['allow_negative_index']:
+                        var.allows_negative_indexes = True
 
             # TODO should we add all the variables or only the ones used in the function
             container = self._namespace.parent_scope

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -632,6 +632,13 @@ class SyntaxParser(BasicParser):
             for i, arg in enumerate(args):
                 args[i] = str(arg).replace("'", '')
             decorators['stack_array'] = tuple(args)
+
+        if 'allow_negative_index' in decorators:
+            args = list(decorators['allow_negative_index'].args)
+            for i, arg in enumerate(args):
+                args[i] = str(arg).replace("'", '')
+            decorators['allow_negative_index'] = tuple(args)
+
         # extract the types to construct a header
         if 'types' in decorators:
             types = []

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -630,13 +630,13 @@ class SyntaxParser(BasicParser):
         if 'stack_array' in decorators:
             args = list(decorators['stack_array'].args)
             for i, arg in enumerate(args):
-                args[i] = str(arg).replace("'", '')
+                args[i] = str(arg)
             decorators['stack_array'] = tuple(args)
 
         if 'allow_negative_index' in decorators:
             args = list(decorators['allow_negative_index'].args)
             for i, arg in enumerate(args):
-                args[i] = str(arg).replace("'", '')
+                args[i] = str(arg)
             decorators['allow_negative_index'] = tuple(args)
 
         # extract the types to construct a header

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -628,16 +628,10 @@ class SyntaxParser(BasicParser):
             return EmptyNode()
 
         if 'stack_array' in decorators:
-            args = list(decorators['stack_array'].args)
-            for i, arg in enumerate(args):
-                args[i] = str(arg)
-            decorators['stack_array'] = tuple(args)
+            decorators['stack_array'] = tuple(str(a) for a in decorators['stack_array'].args)
 
         if 'allow_negative_index' in decorators:
-            args = list(decorators['allow_negative_index'].args)
-            for i, arg in enumerate(args):
-                args[i] = str(arg)
-            decorators['allow_negative_index'] = tuple(args)
+            decorators['allow_negative_index'] = tuple(str(a) for a in decorators['allow_negative_index'].args)
 
         # extract the types to construct a header
         if 'types' in decorators:

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -539,6 +539,32 @@ def array_kwargs_ones():
 
 
 #==============================================================================
+# NEGATIVE INDEXES
+#==============================================================================
+
+@types('int')
+def constant_negative_index(n):
+    import numpy as np
+    a = np.empty(n, dtype=int)
+
+    for i in range(n):
+        a[i] = i
+
+    return a[-1], a[-2]
+
+@types('int')
+def almost_negative_index(n):
+    import numpy as np
+    a = np.empty(n, dtype=int)
+
+    for i in range(n):
+        a[i] = i
+    j = -1
+
+    return a[-j]
+
+
+#==============================================================================
 # SHAPE INITIALISATION
 #==============================================================================
 

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
-from pyccel.decorators import types, stack_array
+from pyccel.decorators import types, stack_array, allow_negative_index
 
 #==============================================================================
 # 1D ARRAYS OF INT-32
@@ -562,6 +562,28 @@ def almost_negative_index(n):
     j = -1
 
     return a[-j]
+
+@allow_negative_index('a')
+@types('int', 'int')
+def var_negative_index(n, idx):
+    import numpy as np
+    a = np.empty(n, dtype=int)
+
+    for i in range(n):
+        a[i] = i
+
+    return a[idx]
+
+@allow_negative_index('a')
+@types('int', 'int', 'int')
+def expr_negative_index(n, idx_1, idx_2):
+    import numpy as np
+    a = np.empty(n, dtype=int)
+
+    for i in range(n):
+        a[i] = i
+
+    return a[idx_1-idx_2]
 
 
 #==============================================================================

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1499,6 +1499,23 @@ def test_almost_negative_index():
     f2 = epyccel( f1 )
     assert f1(n) == f2(n)
 
+def test_var_negative_index():
+    from numpy.random import randint
+    n = randint(2, 10)
+    idx = randint(-n,0)
+    f1 = arrays.var_negative_index
+    f2 = epyccel( f1 )
+    assert f1(n,idx) == f2(n,idx)
+
+def test_expr_negative_index():
+    from numpy.random import randint
+    n = randint(2, 10)
+    idx1 = randint(-n,2*n)
+    idx2 = randint(idx1,idx1+n+1)
+    f1 = arrays.expr_negative_index
+    f2 = epyccel( f1 )
+    assert f1(n,idx1,idx2) == f2(n,idx1,idx2)
+
 #==============================================================================
 # TEST: shape initialisation
 #==============================================================================

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1482,6 +1482,24 @@ def test_array_kwargs_ones():
     assert f1() == f2()
 
 #==============================================================================
+# TEST: Negative indexes
+#==============================================================================
+
+def test_constant_negative_index():
+    from numpy.random import randint
+    n = randint(2, 10)
+    f1 = arrays.constant_negative_index
+    f2 = epyccel( f1 )
+    assert f1(n) == f2(n)
+
+def test_almost_negative_index():
+    from numpy.random import randint
+    n = randint(2, 10)
+    f1 = arrays.constant_negative_index
+    f2 = epyccel( f1 )
+    assert f1(n) == f2(n)
+
+#==============================================================================
 # TEST: shape initialisation
 #==============================================================================
 


### PR DESCRIPTION
Handle negative constants as indexes for arrays. Also handle other indexes that could be negative if the new `allow_negative_index` decorator is specified. This fixes #248 

- Handle indexes which are negative constants by subtracting them from the shape
- Add `allow_negative_index` decorator and save property to `Variable`
- Add modulo operator when the index is not an integer and the user has added the `allow_negative_index` decorator for this variable
- Add tests