### PR TITLE
Raise an error in Ternary Operator When ranks and shapes are different

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5203,8 +5203,13 @@ class IfTernaryOperator(Basic, PyccelAstNode):
         self._args = [cond, first, second]
         if self.stage == 'syntactic':
             return
+
+        if isinstance(first , Nil) or isinstance(second, Nil):
+            raise TypeError('None is not implemeted for Ternary Operator')
+        if first.shape != second.shape :
+            raise TypeError('results in Ternary Operator should be the same shape')
         if isinstance(first.dtype, NativeString) ^ isinstance(second.dtype, NativeString):
-             raise TypeError('Only one of the condition results is type string')
+            raise TypeError('Only one of the Ternary Operator results is type string')
         _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
         if first.dtype not in _tmp_list :
             raise TypeError('cannot determine the type of {}'.format(first.dtype))

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5192,8 +5192,8 @@ class IfTernaryOperator(Basic, PyccelAstNode):
     >>> from pyccel.ast.core import Assign, IfTernaryOperator
     >>> n = Symbol('n')
     >>> x = 5 if n > 1 else 2
-    >>> IfTernaryOperator([PyccelGt(n > 1),  5,  2])
-    IfTernaryOperator([PyccelGt(n > 1),  5,  2])
+    >>> IfTernaryOperator(PyccelGt(n > 1),  5,  2)
+    IfTernaryOperator(PyccelGt(n > 1),  5,  2)
     """
     def __init__(self, *args):
         self._args = []

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5178,9 +5178,6 @@ class If(Basic):
 
 
 class IfTernaryOperator(Basic, PyccelAstNode):
-    _rank  = 0
-    _shape = ()
-
     """Represents a IfTernaryOperator statement in the code.
 
     Parameters
@@ -5195,8 +5192,8 @@ class IfTernaryOperator(Basic, PyccelAstNode):
     >>> from pyccel.ast.core import Assign, IfTernaryOperator
     >>> n = Symbol('n')
     >>> x = 5 if n > 1 else 2
-    >>> IfTernaryOperator([PyccelGt(n > 1),  CodeBlock([5]),  CodeBlock([2])])
-    IfTernaryOperator([PyccelGt(n > 1),  CodeBlock([5]),  CodeBlock([2])])
+    >>> IfTernaryOperator([PyccelGt(n > 1),  5,  2])
+    IfTernaryOperator([PyccelGt(n > 1),  5,  2])
     """
     def __init__(self, *args):
         self._args = []

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5208,10 +5208,13 @@ class IfTernaryOperator(Basic, PyccelAstNode):
             return
         if isinstance(first.dtype, NativeString) ^ isinstance(second.dtype, NativeString):
              raise TypeError('Only one of the condition results is type string')
-        _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
-        _tmp_elem = max([first, second], key = lambda x : _tmp_list.index(x.dtype))
-        self._dtype = _tmp_elem.dtype
-        self._precision = _tmp_elem.precision
+        _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex()]
+        if first.dtype not in _tmp_list :
+            raise TypeError('cannot determine the type of {}'.format(first.dtype))
+        if second.dtype not in _tmp_list :
+            raise TypeError('cannot determine the type of {}'.format(second.dtype))
+        self._dtype = max([first.dtype, second.dtype], key = lambda x : _tmp_list.index(x))
+        self._precision = max([first.precision, second.precision])
 
 
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5205,7 +5205,7 @@ class IfTernaryOperator(Basic, PyccelAstNode):
             return
 
         if isinstance(first , Nil) or isinstance(second, Nil):
-            raise TypeError('None is not implemeted for Ternary Operator')
+            raise NotImplementedError('None is not implemeted for Ternary Operator')
         if first.shape != second.shape :
             raise TypeError('results in Ternary Operator should be the same shape')
         if isinstance(first.dtype, NativeString) ^ isinstance(second.dtype, NativeString):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5203,11 +5203,8 @@ class IfTernaryOperator(Basic, PyccelAstNode):
         self._args = [cond, first, second]
         if self.stage == 'syntactic':
             return
-
         if isinstance(first , Nil) or isinstance(second, Nil):
             raise NotImplementedError('None is not implemeted for Ternary Operator')
-        if first.shape != second.shape :
-            raise TypeError('results in Ternary Operator should be the same shape')
         if isinstance(first.dtype, NativeString) ^ isinstance(second.dtype, NativeString):
             raise TypeError('Only one of the Ternary Operator results is type string')
         _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5178,6 +5178,8 @@ class If(Basic):
 
 
 class IfTernaryOperator(Basic, PyccelAstNode):
+    _rank  = 0
+    _shape = ()
 
     """class for the Ternery operator"""
     def __init__(self, *args):
@@ -5196,6 +5198,15 @@ class IfTernaryOperator(Basic, PyccelAstNode):
         else:
             raise TypeError('body is not CodeBlock')
         self._args = [cond, first, second]
+        if isinstance(first.body[0].dtype, NativeString) ^ isinstance(second.body[0].dtype, NativeString):
+             raise TypeError('Only one of the condition results is type string')
+        _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
+        _tmp_elem = max([first, second], key = lambda x : _tmp_list.index(x.body[0].dtype))
+        self._dtype = _tmp_elem.body[0].dtype
+        self._precision = _tmp_elem.body[0].precision
+
+
+
 
     @property
     def body(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5177,15 +5177,29 @@ class If(Basic):
         return b
 
 
-class IfTernaryOperator(If):
+class IfTernaryOperator(Basic, PyccelAstNode):
 
     """class for the Ternery operator"""
     def __init__(self, *args):
-        for arg in self.args:
-            if len(arg[1].body)!=1:
-                raise TypeError('IfTernary body must be of length 1')
+        self._args = []
+        cond = args[0]
+        if isinstance(args[1], (list, Tuple, tuple)):
+            first = CodeBlock(args[1])
+        elif isinstance(args[1], CodeBlock):
+            first = args[1]
+        else:
+            raise TypeError('body is not CodeBlock')
+        if isinstance(args[2], (list, Tuple, tuple)):
+            second = CodeBlock(args[2])
+        elif isinstance(args[2], CodeBlock):
+            second = args[2]
+        else:
+            raise TypeError('body is not CodeBlock')
+        self._args = [cond, first, second]
 
-    pass
+    @property
+    def body(self):
+        return self._args
 
 class StarredArguments(Basic):
     def __new__(cls, args):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5201,27 +5201,17 @@ class IfTernaryOperator(Basic, PyccelAstNode):
     def __init__(self, *args):
         self._args = []
         cond = args[0]
-        if isinstance(args[1], (list, Tuple, tuple)):
-            first = CodeBlock(args[1])
-        elif isinstance(args[1], CodeBlock):
-            first = args[1]
-        else:
-            raise TypeError('body is not CodeBlock')
-        if isinstance(args[2], (list, Tuple, tuple)):
-            second = CodeBlock(args[2])
-        elif isinstance(args[2], CodeBlock):
-            second = args[2]
-        else:
-            raise TypeError('body is not CodeBlock')
+        first = args[1]
+        second = args[2]
         self._args = [cond, first, second]
         if self.stage == 'syntactic':
             return
-        if isinstance(first.body[0].dtype, NativeString) ^ isinstance(second.body[0].dtype, NativeString):
+        if isinstance(first.dtype, NativeString) ^ isinstance(second.dtype, NativeString):
              raise TypeError('Only one of the condition results is type string')
         _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
-        _tmp_elem = max([first, second], key = lambda x : _tmp_list.index(x.body[0].dtype))
-        self._dtype = _tmp_elem.body[0].dtype
-        self._precision = _tmp_elem.body[0].precision
+        _tmp_elem = max([first, second], key = lambda x : _tmp_list.index(x.dtype))
+        self._dtype = _tmp_elem.dtype
+        self._precision = _tmp_elem.precision
 
 
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5208,9 +5208,9 @@ class IfTernaryOperator(Basic, PyccelAstNode):
             raise TypeError('Only one of the Ternary Operator results is type string')
         _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
         if value_true.dtype not in _tmp_list :
-            raise TypeError('cannot determine the type of {}'.format(value_true.dtype))
+            raise NotImplementedError('cannot determine the type of {}'.format(value_true.dtype))
         if value_false.dtype not in _tmp_list :
-            raise TypeError('cannot determine the type of {}'.format(value_false.dtype))
+            raise NotImplementedError('cannot determine the type of {}'.format(value_false.dtype))
         self._dtype = max([value_true.dtype, value_false.dtype], key = lambda x : _tmp_list.index(x))
         self._precision = max([value_true.precision, value_false.precision])
         if None in [value_true.rank, value_false.rank]:

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5184,7 +5184,7 @@ class IfTernaryOperator(Basic, PyccelAstNode):
     ----------
     args :
         args : type list
-        format : [condition , value_if_true, value_if_false]
+        format : condition , value_if_true, value_if_false
 
     Examples
     --------
@@ -5195,35 +5195,43 @@ class IfTernaryOperator(Basic, PyccelAstNode):
     >>> IfTernaryOperator(PyccelGt(n > 1),  5,  2)
     IfTernaryOperator(PyccelGt(n > 1),  5,  2)
     """
-    def __init__(self, *args):
-        self._args = []
-        cond = args[0]
-        first = args[1]
-        second = args[2]
-        self._args = [cond, first, second]
+    def __init__(self, cond, value_true, value_false):
+        self._cond = cond
+        self._value_true = value_true
+        self._value_false = value_false
+
         if self.stage == 'syntactic':
             return
-        if isinstance(first , Nil) or isinstance(second, Nil):
+        if isinstance(value_true , Nil) or isinstance(value_false, Nil):
             raise NotImplementedError('None is not implemeted for Ternary Operator')
-        if isinstance(first.dtype, NativeString) ^ isinstance(second.dtype, NativeString):
+        if isinstance(value_true.dtype, NativeString) ^ isinstance(value_false.dtype, NativeString):
             raise TypeError('Only one of the Ternary Operator results is type string')
         _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
-        if first.dtype not in _tmp_list :
-            raise TypeError('cannot determine the type of {}'.format(first.dtype))
-        if second.dtype not in _tmp_list :
-            raise TypeError('cannot determine the type of {}'.format(second.dtype))
-        self._dtype = max([first.dtype, second.dtype], key = lambda x : _tmp_list.index(x))
-        self._precision = max([first.precision, second.precision])
-        if None in [first.rank, second.rank]:
+        if value_true.dtype not in _tmp_list :
+            raise TypeError('cannot determine the type of {}'.format(value_true.dtype))
+        if value_false.dtype not in _tmp_list :
+            raise TypeError('cannot determine the type of {}'.format(value_false.dtype))
+        self._dtype = max([value_true.dtype, value_false.dtype], key = lambda x : _tmp_list.index(x))
+        self._precision = max([value_true.precision, value_false.precision])
+        if None in [value_true.rank, value_false.rank]:
             self._rank = None
             self.shape = None
         else :
-            self._shape = broadcast(first.shape, second.shape)
+            self._shape = broadcast(value_true.shape, value_false.shape)
             self._rank = len(self._shape)
 
     @property
-    def body(self):
-        return self._args
+    def cond(self):
+        return self._cond
+
+    @property
+    def value_true(self):
+        return self._value_true
+
+    @property
+    def value_false(self):
+        return self._value_false
+
 
 class StarredArguments(Basic):
     def __new__(cls, args):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5205,15 +5205,19 @@ class IfTernaryOperator(Basic, PyccelAstNode):
             return
         if isinstance(first.dtype, NativeString) ^ isinstance(second.dtype, NativeString):
              raise TypeError('Only one of the condition results is type string')
-        _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex()]
+        _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
         if first.dtype not in _tmp_list :
             raise TypeError('cannot determine the type of {}'.format(first.dtype))
         if second.dtype not in _tmp_list :
             raise TypeError('cannot determine the type of {}'.format(second.dtype))
         self._dtype = max([first.dtype, second.dtype], key = lambda x : _tmp_list.index(x))
         self._precision = max([first.precision, second.precision])
-        self._shape = broadcast(first.shape, second.shape)
-        self._rank = len(self._shape)
+        if None in [first.rank, second.rank]:
+            self._rank = None
+            self.shape = None
+        else :
+            self._shape = broadcast(first.shape, second.shape)
+            self._rank = len(self._shape)
 
     @property
     def body(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5181,7 +5181,23 @@ class IfTernaryOperator(Basic, PyccelAstNode):
     _rank  = 0
     _shape = ()
 
-    """class for the Ternery operator"""
+    """Represents a IfTernaryOperator statement in the code.
+
+    Parameters
+    ----------
+    args :
+        args : type list
+        format : [condition , value_if_true, value_if_false]
+
+    Examples
+    --------
+    >>> from sympy import Symbol
+    >>> from pyccel.ast.core import Assign, IfTernaryOperator
+    >>> n = Symbol('n')
+    >>> x = 5 if n > 1 else 2
+    >>> IfTernaryOperator([PyccelGt(n > 1),  CodeBlock([5]),  CodeBlock([2])])
+    IfTernaryOperator([PyccelGt(n > 1),  CodeBlock([5]),  CodeBlock([2])])
+    """
     def __init__(self, *args):
         self._args = []
         cond = args[0]

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5203,9 +5203,9 @@ class IfTernaryOperator(Basic, PyccelAstNode):
         if self.stage == 'syntactic':
             return
         if isinstance(value_true , Nil) or isinstance(value_false, Nil):
-            errors.report('None is not implemeted for Ternary Operator', severity='fatal')
+            errors.report('None is not implemented for Ternary Operator', severity='fatal')
         if isinstance(value_true.dtype, NativeString) or isinstance(value_false.dtype, NativeString):
-            raise TypeError('Strings are not supported by Ternary Operator')
+            errors.report('Strings are not supported by Ternary Operator', severity='fatal')
         _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
         if value_true.dtype not in _tmp_list :
             raise NotImplementedError('cannot determine the type of {}'.format(value_true.dtype))

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5214,6 +5214,8 @@ class IfTernaryOperator(Basic, PyccelAstNode):
         else:
             raise TypeError('body is not CodeBlock')
         self._args = [cond, first, second]
+        if self.stage == 'syntactic':
+            return
         if isinstance(first.body[0].dtype, NativeString) ^ isinstance(second.body[0].dtype, NativeString):
              raise TypeError('Only one of the condition results is type string')
         _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5211,14 +5211,15 @@ class IfTernaryOperator(Basic, PyccelAstNode):
             raise NotImplementedError('cannot determine the type of {}'.format(value_true.dtype))
         if value_false.dtype not in _tmp_list :
             raise NotImplementedError('cannot determine the type of {}'.format(value_false.dtype))
+        if value_false.rank != value_true.rank :
+            errors.report('Ternary operator results should have the same rank', severity='fatal')
+        if value_false.shape != value_true.shape :
+            errors.report('Ternary operator results should have the same shape', severity='fatal')
         self._dtype = max([value_true.dtype, value_false.dtype], key = lambda x : _tmp_list.index(x))
         self._precision = max([value_true.precision, value_false.precision])
-        if None in [value_true.rank, value_false.rank]:
-            self._rank = None
-            self.shape = None
-        else :
-            self._shape = broadcast(value_true.shape, value_false.shape)
-            self._rank = len(self._shape)
+        self._shape = value_true.shape
+        self._rank = value_true.rank
+
 
     @property
     def cond(self):
@@ -5231,7 +5232,6 @@ class IfTernaryOperator(Basic, PyccelAstNode):
     @property
     def value_false(self):
         return self._value_false
-
 
 class StarredArguments(Basic):
     def __new__(cls, args):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5203,9 +5203,9 @@ class IfTernaryOperator(Basic, PyccelAstNode):
         if self.stage == 'syntactic':
             return
         if isinstance(value_true , Nil) or isinstance(value_false, Nil):
-            raise NotImplementedError('None is not implemeted for Ternary Operator')
-        if isinstance(value_true.dtype, NativeString) ^ isinstance(value_false.dtype, NativeString):
-            raise TypeError('Only one of the Ternary Operator results is type string')
+            errors.report('None is not implemeted for Ternary Operator', severity='fatal')
+        if isinstance(value_true.dtype, NativeString) or isinstance(value_false.dtype, NativeString):
+            raise TypeError('Strings are not supported by Ternary Operator')
         _tmp_list = [NativeBool(), NativeInteger(), NativeReal(), NativeComplex(), NativeString()]
         if value_true.dtype not in _tmp_list :
             raise NotImplementedError('cannot determine the type of {}'.format(value_true.dtype))

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5215,9 +5215,8 @@ class IfTernaryOperator(Basic, PyccelAstNode):
             raise TypeError('cannot determine the type of {}'.format(second.dtype))
         self._dtype = max([first.dtype, second.dtype], key = lambda x : _tmp_list.index(x))
         self._precision = max([first.precision, second.precision])
-
-
-
+        self._shape = broadcast(first.shape, second.shape)
+        self._rank = len(self._shape)
 
     @property
     def body(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5178,7 +5178,7 @@ class If(Basic):
 
 
 class IfTernaryOperator(Basic, PyccelAstNode):
-    """Represents a IfTernaryOperator statement in the code.
+    """Represent a ternary conditional operator in the code, of the form (a if cond else b)
 
     Parameters
     ----------

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -10,7 +10,7 @@ from .datatypes import NativeInteger, NativeReal, NativeComplex, NativeBool, Nat
 
 from .core      import FunctionCall, FunctionDef, Variable, ValuedVariable, VariableAddress
 from .core      import AliasAssign, Assign, Return
-from .core      import IfTernaryOperator, PyccelEq
+from .core      import PyccelEq, If
 
 from .numpyext  import Real as NumpyReal, Imag as NumpyImag
 
@@ -265,7 +265,7 @@ def pyint_to_bool(cast_function_name):
 def bool_to_pyobj(cast_function_name):
     cast_function_argument = Variable(dtype=NativeBool(), name = 'b')
     cast_function_result   = Variable(dtype=PyccelPyObject(), name='o', is_pointer=True)
-    cast_function_body = [IfTernaryOperator(
+    cast_function_body = [If(
                             (PythonBool(cast_function_argument),
                                 [AliasAssign(cast_function_result, Py_True)]),
                             (BooleanTrue(),

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -312,6 +312,14 @@ class CCodePrinter(CodePrinter):
             lines.append("%s\n}" % var)
         return "\n".join(lines)
 
+    def _print_IfTernaryOperator(self, expr):
+        print('in print if ternary')
+        body = expr.body
+        cond = self._print(body[0])
+        first = self._print(body[1])
+        second = self._print(body[2])
+        return '({cond}) ? {true} : {false}'.format(cond = cond, true =first , false =second )
+
     def _print_BooleanTrue(self, expr):
         return '1'
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -313,11 +313,10 @@ class CCodePrinter(CodePrinter):
         return "\n".join(lines)
 
     def _print_IfTernaryOperator(self, expr):
-        body = expr.body
-        cond = self._print(body[0])
-        first = self._print(body[1])
-        second = self._print(body[2])
-        return '({cond}) ? {true} : {false}'.format(cond = cond, true =first , false =second )
+        cond = self._print(expr.cond)
+        value_true = self._print(expr.value_true)
+        value_false = self._print(expr.value_false)
+        return '({cond}) ? {true} : {false}'.format(cond = cond, true =value_true, false = value_false)
 
     def _print_BooleanTrue(self, expr):
         return '1'

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -313,7 +313,6 @@ class CCodePrinter(CodePrinter):
         return "\n".join(lines)
 
     def _print_IfTernaryOperator(self, expr):
-        print('in print if ternary')
         body = expr.body
         cond = self._print(body[0])
         first = self._print(body[1])

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2068,9 +2068,9 @@ class FCodePrinter(CodePrinter):
 
     def _print_IfTernaryOperator(self, expr):
         args = expr.body
-        cond = self._print(args[0])
-        first = args[1].body[0]
-        second = args[2].body[0]
+        cond = self._print(PythonBool(args[0]))
+        first = args[1]
+        second = args[2]
         try :
             cast_func = python_builtin_datatypes[str_dtype(expr.dtype)]
         except KeyError:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2068,7 +2068,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_IfTernaryOperator(self, expr):
         args = expr.body
-        cond = self._print(PythonBool(args[0]))
+        cond = self._print(PythonBool(args[0])) if not isinstance(args[0].dtype, NativeBool) else self._print(args[0])
         first = args[1]
         second = args[2]
         try :

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -44,7 +44,7 @@ from pyccel.ast.core      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus
 from pyccel.ast.core      import FunctionCall
 
 from pyccel.ast.builtins  import Enumerate, PythonInt, Len, Map, Print, Range, Zip, PythonTuple, PythonFloat
-
+from pyccel.ast.builtins  import PythonComplex, PythonBool
 from pyccel.ast.datatypes import is_pyccel_datatype
 from pyccel.ast.datatypes import is_iterable_datatype, is_with_construct_datatype
 from pyccel.ast.datatypes import NativeSymbol, NativeString
@@ -55,6 +55,7 @@ from pyccel.ast.numbers   import Integer, Float
 from pyccel.ast.numbers   import BooleanTrue
 
 from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
+from pyccel.ast.type_inference import str_dtype
 
 from pyccel.ast.numpyext import Full, Array, Linspace, Diag, Cross
 from pyccel.ast.numpyext import Real, Where
@@ -153,6 +154,13 @@ math_function_to_fortran = {
 _default_methods = {
     '__init__': 'create',
     '__del__' : 'free',
+}
+
+python_builtin_datatypes = {
+    'integer' : PythonInt,
+    'real'    : PythonFloat,
+    'bool'    : PythonBool,
+    'complex' : PythonComplex
 }
 
 errors = Errors()

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2067,14 +2067,17 @@ class FCodePrinter(CodePrinter):
         return ''.join(lines)
 
     def _print_IfTernaryOperator(self, expr):
-        body = expr.body
+        args = expr.body
+        cond = self._print(args[0])
+        first = args[1].body[0]
+        second = args[2].body[0]
         try :
             cast_func = python_builtin_datatypes[str_dtype(expr.dtype)]
         except KeyError:
             errors.report(PYCCEL_RESTRICTION_TODO, severity='fatal')
-        cond = self._print(body[0])
-        first = self._print(cast_func(body[1].body[0]))
-        second = self._print(cast_func(body[2].body[0]))
+
+        first = self._print(cast_func(first) if first.dtype != expr.dtype else first)
+        second = self._print(cast_func(second) if second.dtype != expr.dtype else second)
         return 'merge({true}, {false}, {cond})'.format(cond = cond, true =first , false =second)
 
     def _print_MatrixElement(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2066,6 +2066,17 @@ class FCodePrinter(CodePrinter):
 
         return ''.join(lines)
 
+    def _print_IfTernaryOperator(self, expr):
+        body = expr.body
+        try :
+            cast_func = python_builtin_datatypes[str_dtype(expr.dtype)]
+        except KeyError:
+            errors.report(PYCCEL_RESTRICTION_TODO, severity='fatal')
+        cond = self._print(body[0])
+        first = self._print(cast_func(body[1].body[0]))
+        second = self._print(cast_func(body[2].body[0]))
+        return 'merge({true}, {false}, {cond})'.format(cond = cond, true =first , false =second)
+
     def _print_MatrixElement(self, expr):
         return "{0}({1}, {2})".format(expr.parent, expr.i + 1, expr.j + 1)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2200,7 +2200,6 @@ class SemanticParser(BasicParser):
         return expr.func(*args)
 
     def _visit_IfTernaryOperator(self, expr, **settings):
-        print('semantic stage for IfTernaryOperator')
         args = [self._visit(i, **settings) for i in expr.args]
         return expr.func(*args)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2213,6 +2213,11 @@ class SemanticParser(BasicParser):
         args = [self._visit(i, **settings) for i in expr.args]
         return expr.func(*args)
 
+    def _visit_IfTernaryOperator(self, expr, **settings):
+        print('semantic stage for IfTernaryOperator')
+        args = [self._visit(i, **settings) for i in expr.args]
+        return expr.func(*args)
+
     def _visit_VariableHeader(self, expr, **settings):
 
         # TODO improve

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1595,21 +1595,7 @@ class SemanticParser(BasicParser):
         else:
             rhs = self._visit(rhs, **settings)
 
-        if isinstance(rhs, IfTernaryOperator):
-            args = rhs.args
-            new_args = []
-            for arg in args:
-                result = arg[1].body[0]
-                if isinstance(expr, Assign):
-                    body = Assign(lhs, result)
-                else:
-                    body = AugAssign(lhs, expr.op, result)
-                body.set_fst(fst)
-                new_args.append([arg[0], [body]])
-            expr = IfTernaryOperator(*new_args)
-            return self._visit_If(expr, **settings)
-
-        elif isinstance(rhs, FunctionDef):
+        if isinstance(rhs, FunctionDef):
 
             # case of lambdify
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -981,8 +981,7 @@ class SyntaxParser(BasicParser):
         test1 = self._visit(stmt.test)
         first = self._visit(stmt.body)
         second = self._visit(stmt.orelse)
-        args = [Tuple(test1, [first], sympify=False),
-                Tuple(BooleanTrue(), [second], sympify=False)]
+        args = [test1, [first], [second]]
         expr = IfTernaryOperator(*args)
         expr.set_fst(stmt)
         return expr

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -968,7 +968,7 @@ class SyntaxParser(BasicParser):
         test = self._visit(stmt.test)
         body = self._visit(stmt.body)
         orelse = self._visit(stmt.orelse)
-
+        print('body', type(body))
         if len(orelse)==1 and isinstance(orelse[0],If):
             orelse = orelse[0]._args
             return If(Tuple(test, body, sympify=False), *orelse)
@@ -981,7 +981,8 @@ class SyntaxParser(BasicParser):
         test1 = self._visit(stmt.test)
         first = self._visit(stmt.body)
         second = self._visit(stmt.orelse)
-        args = [test1, [first], [second]]
+        print('type :' ,type(first))
+        args = [test1, first, second]
         expr = IfTernaryOperator(*args)
         expr.set_fst(stmt)
         return expr

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -968,7 +968,6 @@ class SyntaxParser(BasicParser):
         test = self._visit(stmt.test)
         body = self._visit(stmt.body)
         orelse = self._visit(stmt.orelse)
-        print('body', type(body))
         if len(orelse)==1 and isinstance(orelse[0],If):
             orelse = orelse[0]._args
             return If(Tuple(test, body, sympify=False), *orelse)
@@ -981,7 +980,6 @@ class SyntaxParser(BasicParser):
         test1 = self._visit(stmt.test)
         first = self._visit(stmt.body)
         second = self._visit(stmt.orelse)
-        print('type :' ,type(first))
         args = [test1, first, second]
         expr = IfTernaryOperator(*args)
         expr.set_fst(stmt)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -980,8 +980,7 @@ class SyntaxParser(BasicParser):
         test1 = self._visit(stmt.test)
         first = self._visit(stmt.body)
         second = self._visit(stmt.orelse)
-        args = [test1, first, second]
-        expr = IfTernaryOperator(*args)
+        expr = IfTernaryOperator(test1, first, second)
         expr.set_fst(stmt)
         return expr
 

--- a/tests/epyccel/test_epyccel_IfTernaryOperator.py
+++ b/tests/epyccel/test_epyccel_IfTernaryOperator.py
@@ -4,7 +4,7 @@ import pytest
 
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
-
+'''
 #------------------------------------------------------------------------------
 def test_f1(language):
     @types('int')
@@ -106,5 +106,47 @@ def test_f7(language):
     # ...
     assert f(6).decode("utf-8").strip() == f7(6)
     assert f(4).decode("utf-8").strip() == f7(4)
+    # ...
+#------------------------------------------------------------------------------
+'''
+@pytest.mark.parametrize( 'language', [
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="Arrays are not yet implemented for C language"),
+            pytest.mark.c]),
+        pytest.param("fortran", marks = pytest.mark.fortran)
+    ]
+)
+def test_f8(language):
+    @types('int')
+    def f8(x):
+        a = [1,2,3] if x < 5 else [1.5,6.5,7.5]
+        return a[0]
+
+    f = epyccel(f8, language = language)
+
+    # ...
+    assert f(6) == f8(6)
+    assert f(4) == f8(4)
+    # ...
+#------------------------------------------------------------------------------
+
+@pytest.mark.parametrize( 'language', [
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="Tuples are not yet implemented for C language"),
+            pytest.mark.c]),
+        pytest.param("fortran", marks = pytest.mark.fortran)
+    ]
+)
+def test_f9(language):
+    @types('int')
+    def f9(x):
+        a = (1, 2) if x < 5 else (complex(5, 1), complex(2, 2))
+        return a[0]
+
+    f = epyccel(f9, language = language)
+
+    # ...
+    assert f(6) == f9(6)
+    assert f(4) == f9(4)
     # ...
 #------------------------------------------------------------------------------

--- a/tests/epyccel/test_epyccel_IfTernaryOperator.py
+++ b/tests/epyccel/test_epyccel_IfTernaryOperator.py
@@ -77,6 +77,7 @@ def test_f5(language):
 def test_f6(language):
     @types('int')
     def f6(x):
+        # a = x if x < 0 else (1 if x < 5 else (complex(0, 1) if x == 5 else 6.5))
         a = x if x < 0 else 1 if x < 5 else complex(0, 1) if x == 5 else 6.5
         return a
 

--- a/tests/epyccel/test_epyccel_IfTernaryOperator.py
+++ b/tests/epyccel/test_epyccel_IfTernaryOperator.py
@@ -1,10 +1,11 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 
+import pytest
+
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
 
 #------------------------------------------------------------------------------
-
 def test_f1(language):
     @types('int')
     def f1(x):
@@ -85,5 +86,25 @@ def test_f6(language):
     assert f(6) == f6(6)
     assert f(4) == f6(4)
     assert f(5) == f6(5)
+    # ...
+#------------------------------------------------------------------------------
+@pytest.mark.parametrize( 'language', [
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="Strings are not yet implemented for C language"),
+            pytest.mark.c]),
+        pytest.param("fortran", marks = pytest.mark.fortran)
+    ]
+)
+def test_f7(language):
+    @types('int')
+    def f7(x):
+        a = 'Hello' if x < 5 else 'Olleh'
+        return a
+
+    f = epyccel(f7, language = language)
+
+    # ...
+    assert f(6).decode("utf-8").strip() == f7(6)
+    assert f(4).decode("utf-8").strip() == f7(4)
     # ...
 #------------------------------------------------------------------------------

--- a/tests/epyccel/test_epyccel_IfTernaryOperator.py
+++ b/tests/epyccel/test_epyccel_IfTernaryOperator.py
@@ -88,26 +88,6 @@ def test_f6(language):
     assert f(5) == f6(5)
     # ...
 #------------------------------------------------------------------------------
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="Strings are not yet implemented for C language"),
-            pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
-    ]
-)
-def test_f7(language):
-    @types('int')
-    def f7(x):
-        a = 'Hello' if x < 5 else 'Olleh'
-        return a
-
-    f = epyccel(f7, language = language)
-
-    # ...
-    assert f(6).decode("utf-8").strip() == f7(6)
-    assert f(4).decode("utf-8").strip() == f7(4)
-    # ...
-#------------------------------------------------------------------------------
 
 @pytest.mark.parametrize( 'language', [
         pytest.param("c", marks = [
@@ -116,17 +96,17 @@ def test_f7(language):
         pytest.param("fortran", marks = pytest.mark.fortran)
     ]
 )
-def test_f8(language):
+def test_f7(language):
     @types('int')
-    def f8(x):
+    def f7(x):
         a = [1,2,3] if x < 5 else [1.5,6.5,7.5]
         return a[0]
 
-    f = epyccel(f8, language = language)
+    f = epyccel(f7, language = language)
 
     # ...
-    assert f(6) == f8(6)
-    assert f(4) == f8(4)
+    assert f(6) == f7(6)
+    assert f(4) == f7(4)
     # ...
 #------------------------------------------------------------------------------
 
@@ -137,16 +117,16 @@ def test_f8(language):
         pytest.param("fortran", marks = pytest.mark.fortran)
     ]
 )
-def test_f9(language):
+def test_f8(language):
     @types('int')
-    def f9(x):
+    def f8(x):
         a = (1, 2) if x < 5 else (complex(5, 1), complex(2, 2))
         return a[0]
 
-    f = epyccel(f9, language = language)
+    f = epyccel(f8, language = language)
 
     # ...
-    assert f(6) == f9(6)
-    assert f(4) == f9(4)
+    assert f(6) == f8(6)
+    assert f(4) == f8(4)
     # ...
 #------------------------------------------------------------------------------

--- a/tests/epyccel/test_epyccel_IfTernaryOperator.py
+++ b/tests/epyccel/test_epyccel_IfTernaryOperator.py
@@ -87,17 +87,3 @@ def test_f6(language):
     assert f(5) == f6(5)
     # ...
 #------------------------------------------------------------------------------
-def test_f6(language):
-    @types('int')
-    def f6(x):
-        a = x if x < 0 else 1 if x < 5 else complex(0, 1) if x == 5 else 6.5
-        return a
-
-    f = epyccel(f6, language = language)
-
-    # ...
-    assert f(6) == f6(6)
-    assert f(4) == f6(4)
-    assert f(5) == f6(5)
-    # ...
-#------------------------------------------------------------------------------

--- a/tests/epyccel/test_epyccel_IfTernaryOperator.py
+++ b/tests/epyccel/test_epyccel_IfTernaryOperator.py
@@ -1,7 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 
-import pytest
-
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
 
@@ -73,6 +71,20 @@ def test_f5(language):
     assert f(6) == f5(6)
     assert f(4) == f5(4)
     assert f(5) == f5(5)
+    # ...
+#------------------------------------------------------------------------------
+def test_f6(language):
+    @types('int')
+    def f6(x):
+        a = x if x < 0 else 1 if x < 5 else complex(0, 1) if x == 5 else 6.5
+        return a
+
+    f = epyccel(f6, language = language)
+
+    # ...
+    assert f(6) == f6(6)
+    assert f(4) == f6(4)
+    assert f(5) == f6(5)
     # ...
 #------------------------------------------------------------------------------
 def test_f6(language):

--- a/tests/epyccel/test_epyccel_IfTernaryOperator.py
+++ b/tests/epyccel/test_epyccel_IfTernaryOperator.py
@@ -1,0 +1,91 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+
+import pytest
+
+from pyccel.epyccel import epyccel
+from pyccel.decorators import types
+
+#------------------------------------------------------------------------------
+
+def test_f1(language):
+    @types('int')
+    def f1(x):
+        a = 5 if x < 5 else x
+        return a
+
+    f = epyccel(f1, language = language)
+
+    # ...
+    assert f(6) == f1(6)
+    assert f(4) == f1(4)
+    # ...
+#------------------------------------------------------------------------------
+
+def test_f2(language):
+    @types('int')
+    def f2(x):
+        a = 5.5 if x < 5 else x
+        return a
+
+    f = epyccel(f2, language = language)
+
+    # ...
+    assert f(6) == f2(6)
+    assert f(4) == f2(4)
+    # ...
+#------------------------------------------------------------------------------
+def test_f3(language):
+    @types('int')
+    def f3(x):
+        a = x if x < 5 else 5 + 2
+        return a
+
+    f = epyccel(f3, language = language)
+
+    # ...
+    assert f(6) == f3(6)
+    assert f(4) == f3(4)
+    # ...
+#------------------------------------------------------------------------------
+
+def test_f4(language):
+    @types('int')
+    def f4(x):
+        a = x if x < 5 else 5 >> 2
+        return a
+
+    f = epyccel(f4, language = language)
+
+    # ...
+    assert f(6) == f4(6)
+    assert f(4) == f4(4)
+    # ...
+#------------------------------------------------------------------------------
+def test_f5(language):
+    @types('int')
+    def f5(x):
+        a = x if x < 5 else 5 if x == 5 else 5.5
+        return a
+
+    f = epyccel(f5, language = language)
+
+    # ...
+    assert f(6) == f5(6)
+    assert f(4) == f5(4)
+    assert f(5) == f5(5)
+    # ...
+#------------------------------------------------------------------------------
+def test_f6(language):
+    @types('int')
+    def f6(x):
+        a = x if x < 0 else 1 if x < 5 else complex(0, 1) if x == 5 else 6.5
+        return a
+
+    f = epyccel(f6, language = language)
+
+    # ...
+    assert f(6) == f6(6)
+    assert f(4) == f6(4)
+    assert f(5) == f6(5)
+    # ...
+#------------------------------------------------------------------------------

--- a/tests/epyccel/test_epyccel_IfTernaryOperator.py
+++ b/tests/epyccel/test_epyccel_IfTernaryOperator.py
@@ -4,7 +4,7 @@ import pytest
 
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
-'''
+
 #------------------------------------------------------------------------------
 def test_f1(language):
     @types('int')
@@ -108,7 +108,7 @@ def test_f7(language):
     assert f(4).decode("utf-8").strip() == f7(4)
     # ...
 #------------------------------------------------------------------------------
-'''
+
 @pytest.mark.parametrize( 'language', [
         pytest.param("c", marks = [
             pytest.mark.xfail(reason="Arrays are not yet implemented for C language"),


### PR DESCRIPTION
Ternary Operator should raise an error when ranks are different until issue  #359  is solved it should be converted to an if / else block.

Ternary Operator should raise an error when shapes are different because we don't know what size we are going to allocate if they are different, same as above it should be converted to an if / else block.