### PR TITLE
Only run tests w/ Python 3.5 on Linux on non-master branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ jobs:
   - os: linux
     python: 3.5
 
+# Test: see if this works on a non-draft PR
   - os: linux
     python: 3.6
     if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ jobs:
   - os: linux
     python: 3.5
 
-# Test: see if this works on a non-draft PR
   - os: linux
     python: 3.6
     if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,15 @@ jobs:
 
   - os: linux
     python: 3.6
+    branches: {only: master}
 
   - os: linux
     python: 3.7
+    branches: {only: master}
 
   - os: linux
     python: 3.8
+    branches: {only: master}
 
   - os: osx
     language: c  #'language: python' is an error on Travis CI macOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,15 +61,15 @@ jobs:
 
   - os: linux
     python: 3.6
-    branches: {only: master}
+    if: branch = master
 
   - os: linux
     python: 3.7
-    branches: {only: master}
+    if: branch = master
 
   - os: linux
     python: 3.8
-    branches: {only: master}
+    if: branch = master
 
   - os: osx
     language: c  #'language: python' is an error on Travis CI macOS


### PR DESCRIPTION
This speeds up our builds on Travis-CI and solves #496 