### PR TITLE
Map Python imports to C imports

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -411,8 +411,11 @@ class CCodePrinter(CodePrinter):
         else:
             source = self._print(expr.source)
 
+        # Get with a default value is not used here as it is
+        # slower and on most occasions the import will not be in the
+        # dictionary
         if source in import_dict:
-            source = import_dict[source]
+            source = import_dict[source] # pylint: disable=consider-using-get
 
         if source is None:
             return ''

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -189,6 +189,8 @@ dtype_registry = {('real',8)    : 'double',
                   ('int',1)     : 'char',
                   ('bool',4)    : 'bool'}
 
+import_dict = {'numpy'   : None,
+               'omp_lib' : 'omp' }
 
 class CCodePrinter(CodePrinter):
     """A printer to convert python expressions to strings of c code"""
@@ -409,7 +411,13 @@ class CCodePrinter(CodePrinter):
         else:
             source = self._print(expr.source)
 
-        return '#include <{0}.h>'.format(source)
+        if source in import_dict:
+            source = import_dict[source]
+
+        if source is None:
+            return ''
+        else:
+            return '#include <{0}.h>'.format(source)
 
     def _print_String(self, expr):
         format_str = format(expr.arg)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -189,8 +189,7 @@ dtype_registry = {('real',8)    : 'double',
                   ('int',1)     : 'char',
                   ('bool',4)    : 'bool'}
 
-import_dict = {'numpy'   : None,
-               'omp_lib' : 'omp' }
+import_dict = {'omp_lib' : 'omp' }
 
 class CCodePrinter(CodePrinter):
     """A printer to convert python expressions to strings of c code"""

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -414,8 +414,8 @@ class CCodePrinter(CodePrinter):
         # Get with a default value is not used here as it is
         # slower and on most occasions the import will not be in the
         # dictionary
-        if source in import_dict:
-            source = import_dict[source] # pylint: disable=consider-using-get
+        if source in import_dict: # pylint: disable=consider-using-get
+            source = import_dict[source]
 
         if source is None:
             return ''


### PR DESCRIPTION
Create a dictionary which maps known module names (eg numpy, omp_lib, etc) onto their c equivalent (eg. None, omp, etc). Fixes #503