### PR TITLE
Clean up code to reduce generated warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ jobs:
     if: branch = master
 
   - os: osx
+    python: 3.8
     language: c  #'language: python' is an error on Travis CI macOS
     env: PYTHON=python3 MPI_OPTS="--oversubscribe"
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 install:
   - ${PYTHON} -m pip install .
-  - ${PYTHON} -m pip install scipy
+  - ${PYTHON} -m pip install scipy -v
   - ${PYTHON} -m pip install mpi4py
   - ${PYTHON} -m pip install tblib
   - ${PYTHON} -m pip install "pytest>=4.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 install:
   - ${PYTHON} -m pip install .
-  - ${PYTHON} -m pip install scipy -v
+  - ${PYTHON} -m pip install scipy
   - ${PYTHON} -m pip install mpi4py
   - ${PYTHON} -m pip install tblib
   - ${PYTHON} -m pip install "pytest>=4.5"
@@ -73,7 +73,6 @@ jobs:
     if: branch = master
 
   - os: osx
-    python: 3.8
     language: c  #'language: python' is an error on Travis CI macOS
     env: PYTHON=python3 MPI_OPTS="--oversubscribe"
     before_install:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -113,8 +113,7 @@ def execute_pyccel(fname, *,
                                  fflags=None,
                                  debug=debug,
                                  accelerator=accelerator,
-                                 includes=(),
-                                 libdirs=())
+                                 includes=())
 
     # Build position-independent code, suited for use in shared library
     fflags = ' {} -fPIC '.format(fflags)
@@ -236,8 +235,7 @@ def execute_pyccel(fname, *,
                                 fflags=fflags,
                                 debug=debug,
                                 accelerator=accelerator,
-                                includes=includes,
-                                libdirs=libdirs)
+                                includes=includes)
 
         # Compile Fortran code
         #
@@ -252,6 +250,7 @@ def execute_pyccel(fname, *,
                             is_module=codegen.is_module,
                             output=pyccel_dirpath,
                             libs=libs,
+                            libdirs=libdirs,
                             language=language)
         except Exception:
             handle_error('Fortran compilation')

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -251,7 +251,8 @@ def execute_pyccel(fname, *,
                             modules=modules,
                             is_module=codegen.is_module,
                             output=pyccel_dirpath,
-                            libs=libs)
+                            libs=libs,
+                            language=language)
         except Exception:
             handle_error('Fortran compilation')
             raise

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -488,7 +488,10 @@ class CCodePrinter(CodePrinter):
         rank  = expr.rank
         dtype = self.find_in_dtype_registry(dtype, prec)
 
-        if rank > 0 or self.stored_in_c_pointer(expr):
+        if rank > 0:
+            errors.report(PYCCEL_RESTRICTION_TODO, symbol="rank > 0",severity='fatal')
+
+        if self.stored_in_c_pointer(expr):
             return '{0} *'.format(dtype)
         else:
             return '{0} '.format(dtype)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -25,7 +25,8 @@ from pyccel.ast.core import Declare, ValuedVariable
 from pyccel.codegen.printing.codeprinter import CodePrinter
 
 from pyccel.errors.errors import Errors
-from pyccel.errors.messages import *
+from pyccel.errors.messages import (PYCCEL_RESTRICTION_TODO, INCOMPATIBLE_TYPEVAR_TO_FUNC,
+                                    PYCCEL_RESTRICTION_IS_ISNOT )
 
 errors = Errors()
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -108,7 +108,6 @@ def compile_files(filename, compiler, flags,
 
     o_code = '-o'
     j_code = ''
-    mod_file = ''
     if is_module:
         flags += ' -c '
         if (len(output)>0) and language == "fortran":

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -23,8 +23,7 @@ def construct_flags(compiler,
                     fflags=None,
                     debug=False,
                     accelerator=None,
-                    includes=(),
-                    libdirs=()):
+                    includes=()):
     """
     Constructs compiling flags for a given compiler.
 
@@ -78,7 +77,6 @@ def construct_flags(compiler,
 
     # Construct flags
     flags += ''.join(' -I"{0}"'.format(i) for i in includes)
-    flags += ''.join(' -L"{0}"'.format(i) for i in libdirs)
 
     return flags
 
@@ -89,6 +87,7 @@ def compile_files(filename, compiler, flags,
                     modules=[],
                     is_module=False,
                     libs=(),
+                    libdirs=(),
                     language="fortran",
                     output=''):
     """
@@ -120,6 +119,7 @@ def compile_files(filename, compiler, flags,
     if is_module:
         libs_flags = ''
     else:
+        flags += ''.join(' -L"{0}"'.format(i) for i in libdirs)
         libs_flags = ' '.join('-l{}'.format(i) for i in libs)
 
     filename = '"{}"'.format(filename)  # in case of spaces in path

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -117,7 +117,10 @@ def compile_files(filename, compiler, flags,
             j_code = '-J'
 
     m_code = ' '.join('{}.o'.format(m) for m in modules)
-    libs_flags = ' '.join('-l{}'.format(i) for i in libs)
+    if is_module:
+        libs_flags = ''
+    else:
+        libs_flags = ' '.join('-l{}'.format(i) for i in libs)
 
     filename = '"{}"'.format(filename)  # in case of spaces in path
     binary = '"{}"'.format(binary)

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -100,20 +100,19 @@ def compile_files(filename, compiler, flags,
     if binary is None:
         if not is_module:
             binary = os.path.splitext(os.path.basename(filename))[0]
-            mod_file = ''
         else:
             f = os.path.join(output, os.path.splitext(os.path.basename(filename))[0])
             binary = '{}.o'.format(f)
 #            binary = "{folder}{binary}.o".format(folder=output,
 #                                binary=os.path.splitext(os.path.basename(filename))[0])
-            mod_file = '"{folder}"'.format(folder=output)
 
     o_code = '-o'
     j_code = ''
+    mod_file = ''
     if is_module:
         flags += ' -c '
         if (len(output)>0) and language == "fortran":
-            j_code = '-J'
+            j_code = '-J"{folder}"'.format(folder=output)
 
     m_code = ' '.join('{}.o'.format(m) for m in modules)
     if is_module:
@@ -129,8 +128,8 @@ def compile_files(filename, compiler, flags,
         compiler = "gfortran"
         filename += ' "{}"'.format(os.path.join(os.environ["MSMPI_LIB64"], 'libmsmpi.a'))
 
-    cmd = '{0} {1} {2} {3} {4} {5} {6} {7} {8}'.format( \
-        compiler, flags, m_code, filename, o_code, binary, libs_flags, j_code, mod_file)
+    cmd = '{0} {1} {2} {3} {4} {5} {6} {7}'.format( \
+        compiler, flags, m_code, filename, o_code, binary, libs_flags, j_code)
 
     if verbose:
         print(cmd)

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -6,71 +6,88 @@ from pyccel.epyccel import epyccel
 from modules import base
 
 
-def compare_epyccel(f, *args, language='fortran'):
-    f2 = epyccel(f, language=language)
-    out1 = f(*args)
-    out2 = f2(*args)
-    assert np.equal(out1, out2)
+class epyccel_test:
+    def __init__(self, f, lang='fortran'):
+        self._f  = f
+        self._f2 = epyccel(f, language=lang)
+
+    def compare_epyccel(self, *args):
+        out1 = self._f(*args)
+        out2 = self._f2(*args)
+        assert np.equal(out1, out2 )
 
 def test_is_false(language):
-    compare_epyccel(base.is_false, True, language=language)
-    compare_epyccel(base.is_false, False, language=language)
+    test = epyccel_test(base.is_false, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 def test_is_true(language):
-    compare_epyccel(base.is_true, True, language=language)
-    compare_epyccel(base.is_true, False, language=language)
+    test = epyccel_test(base.is_true, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 def test_compare_is(language):
-    compare_epyccel(base.compare_is, True, True, language=language)
-    compare_epyccel(base.compare_is, True, False, language=language)
-    compare_epyccel(base.compare_is, False, True, language=language)
-    compare_epyccel(base.compare_is, False, False, language=language)
+    test = epyccel_test(base.compare_is, lang=language)
+    test.compare_epyccel( True, True )
+    test.compare_epyccel( True, False )
+    test.compare_epyccel( False, True )
+    test.compare_epyccel( False, False )
 
 def test_compare_is_not(language):
-    compare_epyccel(base.compare_is_not, True, True, language=language)
-    compare_epyccel(base.compare_is_not, True, False, language=language)
-    compare_epyccel(base.compare_is_not, False, True, language=language)
-    compare_epyccel(base.compare_is_not, False, False, language=language)
+    test = epyccel_test(base.compare_is_not, lang=language)
+    test.compare_epyccel( True, True )
+    test.compare_epyccel( True, False )
+    test.compare_epyccel( False, True )
+    test.compare_epyccel( False, False )
 
 def test_compare_is_int(language):
-    compare_epyccel(base.compare_is_int, True, 1, language=language)
-    compare_epyccel(base.compare_is_int, True, 0, language=language)
-    compare_epyccel(base.compare_is_int, False, 1, language=language)
-    compare_epyccel(base.compare_is_int, False, 0, language=language)
+    test = epyccel_test(base.compare_is_int, lang=language)
+    test.compare_epyccel( True, 1 )
+    test.compare_epyccel( True, 0 )
+    test.compare_epyccel( False, 1 )
+    test.compare_epyccel( False, 0 )
 
 def test_compare_is_not_int(language):
-    compare_epyccel(base.compare_is_not_int, True, 1, language=language)
-    compare_epyccel(base.compare_is_not_int, True, 0, language=language)
-    compare_epyccel(base.compare_is_not_int, False, 1, language=language)
-    compare_epyccel(base.compare_is_not_int, False, 0, language=language)
+    test = epyccel_test(base.compare_is_not_int, lang=language)
+    test.compare_epyccel( True, 1 )
+    test.compare_epyccel( True, 0 )
+    test.compare_epyccel( False, 1 )
+    test.compare_epyccel( False, 0 )
 
 def test_not_false(language):
-    compare_epyccel(base.not_false, True, language=language)
-    compare_epyccel(base.not_false, False, language=language)
+    test = epyccel_test(base.not_false, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 def test_not_true(language):
-    compare_epyccel(base.not_true, True, language=language)
-    compare_epyccel(base.not_true, False, language=language)
+    test = epyccel_test(base.not_true, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 def test_eq_false(language):
-    compare_epyccel(base.eq_false, True, language=language)
-    compare_epyccel(base.eq_false, False, language=language)
+    test = epyccel_test(base.eq_false, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 def test_eq_true(language):
-    compare_epyccel(base.eq_true, True, language=language)
-    compare_epyccel(base.eq_true, False, language=language)
+    test = epyccel_test(base.eq_true, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 def test_neq_false(language):
-    compare_epyccel(base.eq_false, True, language=language)
-    compare_epyccel(base.eq_false, False, language=language)
+    test = epyccel_test(base.eq_false, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 def test_neq_true(language):
-    compare_epyccel(base.eq_true, True, language=language)
-    compare_epyccel(base.eq_true, False, language=language)
+    test = epyccel_test(base.eq_true, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 def test_not(language):
-    compare_epyccel(base.not_val, True, language=language)
-    compare_epyccel(base.not_val, False, language=language)
+    test = epyccel_test(base.not_val, lang=language)
+    test.compare_epyccel( True )
+    test.compare_epyccel( False )
 
 @pytest.mark.parametrize( 'language', [
         pytest.param("fortran", marks = [
@@ -80,7 +97,8 @@ def test_not(language):
     ]
 )
 def test_compare_is_nil(language):
-    compare_epyccel(base.is_nil, None, language=language)
+    test = epyccel_test(base.is_nil, lang=language)
+    test.compare_epyccel( None )
 
 @pytest.mark.parametrize( 'language', [
         pytest.param("fortran", marks = [
@@ -90,34 +108,46 @@ def test_compare_is_nil(language):
     ]
 )
 def test_compare_is_not_nil(language):
-    compare_epyccel(base.is_not_nil, None, language=language)
+    test = epyccel_test(base.is_not_nil, lang=language)
+    test.compare_epyccel( None )
 
 def test_cast_int(language):
-    compare_epyccel(base.cast_int, 4, language=language)
-    compare_epyccel(base.cast_float_to_int, 4.5, language=language)
+    test = epyccel_test(base.cast_int, lang=language)
+    test.compare_epyccel( 4 )
+    test = epyccel_test(base.cast_float_to_int, lang=language)
+    test.compare_epyccel( 4.5 )
 
 def test_cast_bool(language):
-    compare_epyccel(base.cast_bool, True, language=language)
+    test = epyccel_test(base.cast_bool, lang=language)
+    test.compare_epyccel( True )
 
 def test_cast_float(language):
-    compare_epyccel(base.cast_float, 4.5, language=language)
-    compare_epyccel(base.cast_int_to_float, 4, language=language)
+    test = epyccel_test(base.cast_float, lang=language)
+    test.compare_epyccel( 4.5 )
+    test = epyccel_test(base.cast_int_to_float, lang=language)
+    test.compare_epyccel( 4 )
 
 def test_if_0_int(language):
-    compare_epyccel(base.if_0_int, 22, language=language)
-    compare_epyccel(base.if_0_int, 0, language=language)
+    test = epyccel_test(base.if_0_int, lang=language)
+    test.compare_epyccel( 22 )
+    test.compare_epyccel( 0 )
 
 def test_if_0_real(language):
-    compare_epyccel(base.if_0_real, 22.3, language=language)
-    compare_epyccel(base.if_0_real, 0.0, language=language)
+    test = epyccel_test(base.if_0_real, lang=language)
+    test.compare_epyccel( 22.3 )
+    test.compare_epyccel( 0.0 )
 
 def test_same_int(language):
-    compare_epyccel(base.is_same_int, 22, language=language)
-    compare_epyccel(base.isnot_same_int, 22, language=language)
+    test = epyccel_test(base.is_same_int, lang=language)
+    test.compare_epyccel( 22 )
+    test = epyccel_test(base.isnot_same_int, lang=language)
+    test.compare_epyccel( 22 )
 
 def test_same_float(language):
-    compare_epyccel(base.is_same_float, 22.2, language=language)
-    compare_epyccel(base.isnot_same_float, 22.2, language=language)
+    test = epyccel_test(base.is_same_float, lang=language)
+    test.compare_epyccel( 22.2 )
+    test = epyccel_test(base.isnot_same_float, lang=language)
+    test.compare_epyccel( 22.2 )
 
 @pytest.mark.parametrize( 'language', [
         pytest.param("c", marks = [
@@ -127,21 +157,29 @@ def test_same_float(language):
     ]
 )
 def test_same_string(language):
-    compare_epyccel(base.is_same_string, language=language)
-    compare_epyccel(base.isnot_same_string, language=language)
+    test = epyccel_test(base.is_same_string, lang=language)
+    test.compare_epyccel()
+    test = epyccel_test(base.isnot_same_string, lang=language)
+    test.compare_epyccel()
 
 def test_same_complex(language):
-    compare_epyccel(base.is_same_complex, complex(2,3), language=language)
-    compare_epyccel(base.isnot_same_complex, complex(2,3), language=language)
+    test = epyccel_test(base.is_same_complex, lang=language)
+    test.compare_epyccel( complex(2,3) )
+    test = epyccel_test(base.isnot_same_complex, lang=language)
+    test.compare_epyccel( complex(2,3) )
 
 def test_is_types(language):
-    compare_epyccel(base.is_types, 1, 1.0, language=language)
+    test = epyccel_test(base.is_types, lang=language)
+    test.compare_epyccel( 1, 1.0 )
 
 def test_isnot_types(language):
-    compare_epyccel(base.isnot_types, 1, 1.0, language=language)
+    test = epyccel_test(base.isnot_types, lang=language)
+    test.compare_epyccel( 1, 1.0 )
 
 def test_none_is_none(language):
-    compare_epyccel(base.none_is_none, language=language)
+    test = epyccel_test(base.none_is_none, lang=language)
+    test.compare_epyccel()
 
 def test_none_isnot_none(language):
-    compare_epyccel(base.none_isnot_none, language=language)
+    test = epyccel_test(base.none_isnot_none, lang=language)
+    test.compare_epyccel()

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -7,6 +7,11 @@ from modules import base
 
 
 class epyccel_test:
+    """
+    Class to pyccelize module then compare different results
+    This avoids the need to pyccelize the file multiple times
+    or write the arguments multiple times
+    """
     def __init__(self, f, lang='fortran'):
         self._f  = f
         self._f2 = epyccel(f, language=lang)

--- a/tests/epyccel/test_bitwise.py
+++ b/tests/epyccel/test_bitwise.py
@@ -7,42 +7,42 @@ from modules import bitwise
 @pytest.mark.parametrize("a, b",[(True, False),(True, True)])
 def test_right_shift_b_b(language, a, b):
     f1 = bitwise.right_shift_b_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(1, 1),(1, 2)])
 def test_right_shift_i_i(language, a, b):
     f1 = bitwise.right_shift_i_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(True, 2),(True, 1)])
 def test_right_shift_b_i(language, a, b):
     f1 = bitwise.right_shift_b_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(True, 1),(True, 2)])
 def test_left_shift_b_i(language, a, b):
     f1 = bitwise.right_shift_b_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(1, 1),(1, 2)])
 def test_left_shift_i_i(language, a, b):
     f1 = bitwise.right_shift_i_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(True, False),(True, True)])
 def test_left_shift_b_b(language, a, b):
     f1 = bitwise.right_shift_b_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
@@ -56,41 +56,41 @@ def test_left_shift_b_b(language, a, b):
 )
 def test_bit_xor_b_b(language):
     f1 = bitwise.bit_xor_b_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(True, False) == f2(True, False)
     assert(type(f1(True, False)) == type(f2(True, False))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b, c",[(True, False, False),(True, True, True)])
 def test_bit_xor_b_b_b(language, a, b, c):
     f1 = bitwise.bit_xor_b_b_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b, c) == f2(a, b, c)
 
 @pytest.mark.parametrize("a, b",[(1, 1),(1, 2)])
 def test_bit_xor_i_i(language, a, b):
     f1 = bitwise.bit_xor_i_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(False, 2), (True, 1)])
 def test_bit_xor_b_i(language, a, b):
     f1 = bitwise.bit_xor_b_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(1, False),(1, True)])
 def test_bit_or_i_b(language, a, b):
     f1 = bitwise.bit_or_i_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(1, 1),(1, 2)])
 def test_bit_or_i_i(language, a, b):
     f1 = bitwise.bit_or_i_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
@@ -104,21 +104,21 @@ def test_bit_or_i_i(language, a, b):
 )
 def test_bit_or_b_b(language):
     f1 = bitwise.bit_or_b_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(False, True) == f2(False, True)
     assert(type(f1(False, True)) == type(f2(False, True))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(1, True),(1, False)])
 def test_bit_and_i_b(language, a, b):
     f1 = bitwise.bit_and_i_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b",[(1, 1),(1, 2)])
 def test_bit_and_i_i(language, a, b):
     f1 = bitwise.bit_and_i_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b) == f2(a, b)
     assert(type(f1(a, b)) == type(f2(a, b))) # pylint: disable=unidiomatic-typecheck
 
@@ -133,34 +133,34 @@ def test_bit_and_i_i(language, a, b):
 )
 def test_bit_and_b_b(language):
     f1 = bitwise.bit_and_b_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(True, True) == f2(True, True)
     assert(type(f1(True, True)) == type(f2(True, True))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b, c",[(1, 0, 4), (1, 0, 4)])
 def test_bit_and_i_i_i(language, a, b, c):
     f1 = bitwise.bit_and_i_i_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b, c) == f2(a, b, c)
     assert(type(f1(a, b, c)) == type(f2(a, b, c))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a, b, c",[(True, True, 4), (True, False, 4)])
 def test_bit_and_b_b_i(language, a, b, c):
     f1 = bitwise.bit_and_b_b_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a, b, c) == f2(a, b, c)
     assert(type(f1(a, b, c)) == type(f2(a, b, c))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a",[True, False])
 def test_invert_b(language, a):
     f1 = bitwise.invert_b
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a) == f2(a)
     assert(type(f1(a)) == type(f2(a))) # pylint: disable=unidiomatic-typecheck
 
 @pytest.mark.parametrize("a",[1, 0])
 def test_invert_i(language, a):
     f1 = bitwise.invert_i
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1(a) == f2(a)
     assert(type(f1(a)) == type(f2(a))) # pylint: disable=unidiomatic-typecheck

--- a/tests/epyccel/test_compare_expressions.py
+++ b/tests/epyccel/test_compare_expressions.py
@@ -3,11 +3,15 @@ from pyccel.epyccel import epyccel
 from pyccel.decorators import types
 
 #==============================================================================
-def compare_epyccel(f1, *args):
-    f2 = epyccel(f1)
-    out1 = f1(*args)
-    out2 = f2(*args)
-    assert out1 == out2
+class epyccel_test:
+    def __init__(self, f, lang='fortran'):
+        self._f  = f
+        self._f2 = epyccel(f, language=lang)
+
+    def compare_epyccel(self, *args):
+        out1 = self._f(*args)
+        out2 = self._f2(*args)
+        assert np.equal(out1, out2 )
 
 #==============================================================================
 @types('int, int, int')
@@ -24,31 +28,34 @@ def idiv_gt_add(a, m, n):
 
 #==============================================================================
 def test_mod_eq_pow():
+    test = epyccel_test(mod_eq_pow)
     # True
-    compare_epyccel(mod_eq_pow, 10, 3, 1)
-    compare_epyccel(mod_eq_pow, 19, 10, 3)
-    compare_epyccel(mod_eq_pow, 21, 3, 0)
+    test.compare_epyccel(10, 3, 1)
+    test.compare_epyccel(19, 10, 3)
+    test.compare_epyccel(21, 3, 0)
     # False
-    compare_epyccel(mod_eq_pow, 10, 5, 2)
-    compare_epyccel(mod_eq_pow, 19, 10, 1)
-    compare_epyccel(mod_eq_pow, 21, 3, 1)
+    test.compare_epyccel(10, 5, 2)
+    test.compare_epyccel(19, 10, 1)
+    test.compare_epyccel(21, 3, 1)
 
 def test_mod_neq_pow():
+    test = epyccel_test(mod_neq_pow)
     # True
-    compare_epyccel(mod_neq_pow, 10, 5, 2)
-    compare_epyccel(mod_neq_pow, 19, 10, 1)
-    compare_epyccel(mod_neq_pow, 21, 3, 1)
+    test.compare_epyccel(10, 5, 2)
+    test.compare_epyccel(19, 10, 1)
+    test.compare_epyccel(21, 3, 1)
     # False
-    compare_epyccel(mod_neq_pow, 10, 3, 1)
-    compare_epyccel(mod_neq_pow, 19, 10, 3)
-    compare_epyccel(mod_neq_pow, 21, 3, 0)
+    test.compare_epyccel(10, 3, 1)
+    test.compare_epyccel(19, 10, 3)
+    test.compare_epyccel(21, 3, 0)
 
 def test_idiv_gt_add():
+    test = epyccel_test(idiv_gt_add)
     # True
-    compare_epyccel(idiv_gt_add, 10, 3, 2)
-    compare_epyccel(idiv_gt_add, 8, 2, 2)
-    compare_epyccel(idiv_gt_add, 16, 3, 4)
+    test.compare_epyccel(10, 3, 2)
+    test.compare_epyccel(8, 2, 2)
+    test.compare_epyccel(16, 3, 4)
     # False
-    compare_epyccel(idiv_gt_add, 10, 3, 2)
-    compare_epyccel(idiv_gt_add, 8, 2, 3)
-    compare_epyccel(idiv_gt_add, 16, 3, 5)
+    test.compare_epyccel(10, 3, 2)
+    test.compare_epyccel(8, 2, 3)
+    test.compare_epyccel(16, 3, 5)

--- a/tests/epyccel/test_compare_expressions.py
+++ b/tests/epyccel/test_compare_expressions.py
@@ -1,9 +1,15 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
+import numpy as np
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
 
 #==============================================================================
 class epyccel_test:
+    """
+    Class to pyccelize module then compare different results
+    This avoids the need to pyccelize the file multiple times
+    or write the arguments multiple times
+    """
     def __init__(self, f, lang='fortran'):
         self._f  = f
         self._f2 = epyccel(f, language=lang)

--- a/tests/epyccel/test_higherorder_functions.py
+++ b/tests/epyccel/test_higherorder_functions.py
@@ -3,81 +3,83 @@ import pytest
 import modules.highorder_functions as mod
 from pyccel.epyccel import epyccel
 
-@pytest.mark.c
-def test_int_1():
-    modnew = epyccel(mod, language = "c", verbose = True)
+@pytest.fixture( params=[
+        pytest.param("fortran", marks = [
+            pytest.mark.fortran,
+            pytest.mark.skip]),
+        pytest.param("c", marks = [
+            pytest.mark.c]
+        )
+    ]
+)
+def language(request):
+    return request.param
+
+def test_int_1(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_int_1()
     x = modnew.test_int_1()
     assert x == x_expected
 
-@pytest.mark.c
-def test_int_int_1():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_int_int_1(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_int_int_1()
     x = modnew.test_int_int_1()
     assert x == x_expected
 
-@pytest.mark.c
-def test_real_1():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_real_1(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_real_1()
     x = modnew.test_real_1()
     assert x == x_expected
 
-@pytest.mark.c
-def test_real_2():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_real_2(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_real_2()
     x = modnew.test_real_2()
     assert x == x_expected
 
-@pytest.mark.c
-def test_real_3():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_real_3(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_real_3()
     x = modnew.test_real_3()
     assert x == x_expected
 
-@pytest.mark.c
-def test_valuedarg_1():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_valuedarg_1(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_valuedarg_1()
     x = modnew.test_valuedarg_1()
     assert x == x_expected
 
-@pytest.mark.c
-def test_real_real_int_1():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_real_real_int_1(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_real_real_int_1()
     x = modnew.test_real_real_int_1()
     assert x == x_expected
 
-@pytest.mark.c
-def test_real_4():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_real_4(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_real_4()
     x = modnew.test_real_4()
     assert x == x_expected
 
-@pytest.mark.c
-def test_valuedarg_2():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_valuedarg_2(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_valuedarg_2()
     x = modnew.test_valuedarg_2()
     assert x == x_expected
 
-@pytest.mark.c
-def test_real_real_int_2():
-    modnew = epyccel(mod, language = "c", verbose = True)
+def test_real_real_int_2(language):
+    modnew = epyccel(mod, language = language)
 
     x_expected = mod.test_real_real_int_2()
     x = modnew.test_real_real_int_2()

--- a/tests/epyccel/test_higherorder_functions.py
+++ b/tests/epyccel/test_higherorder_functions.py
@@ -2,6 +2,7 @@
 import modules.highorder_functions as mod
 from pyccel.epyccel import epyccel
 
+@pytest.mark.c
 def test_int_1():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -9,6 +10,7 @@ def test_int_1():
     x = modnew.test_int_1()
     assert x == x_expected
 
+@pytest.mark.c
 def test_int_int_1():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -16,6 +18,7 @@ def test_int_int_1():
     x = modnew.test_int_int_1()
     assert x == x_expected
 
+@pytest.mark.c
 def test_real_1():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -23,6 +26,7 @@ def test_real_1():
     x = modnew.test_real_1()
     assert x == x_expected
 
+@pytest.mark.c
 def test_real_2():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -30,6 +34,7 @@ def test_real_2():
     x = modnew.test_real_2()
     assert x == x_expected
 
+@pytest.mark.c
 def test_real_3():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -37,6 +42,7 @@ def test_real_3():
     x = modnew.test_real_3()
     assert x == x_expected
 
+@pytest.mark.c
 def test_valuedarg_1():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -44,6 +50,7 @@ def test_valuedarg_1():
     x = modnew.test_valuedarg_1()
     assert x == x_expected
 
+@pytest.mark.c
 def test_real_real_int_1():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -51,6 +58,7 @@ def test_real_real_int_1():
     x = modnew.test_real_real_int_1()
     assert x == x_expected
 
+@pytest.mark.c
 def test_real_4():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -58,6 +66,7 @@ def test_real_4():
     x = modnew.test_real_4()
     assert x == x_expected
 
+@pytest.mark.c
 def test_valuedarg_2():
     modnew = epyccel(mod, language = "c", verbose = True)
 
@@ -65,6 +74,7 @@ def test_valuedarg_2():
     x = modnew.test_valuedarg_2()
     assert x == x_expected
 
+@pytest.mark.c
 def test_real_real_int_2():
     modnew = epyccel(mod, language = "c", verbose = True)
 

--- a/tests/epyccel/test_higherorder_functions.py
+++ b/tests/epyccel/test_higherorder_functions.py
@@ -1,6 +1,7 @@
  # pylint: disable=missing-function-docstring, missing-module-docstring/
-import modules.highorder_functions as mod
+import pytest
 from pyccel.epyccel import epyccel
+import modules.highorder_functions as mod
 
 @pytest.mark.c
 def test_int_1():

--- a/tests/epyccel/test_higherorder_functions.py
+++ b/tests/epyccel/test_higherorder_functions.py
@@ -1,7 +1,7 @@
  # pylint: disable=missing-function-docstring, missing-module-docstring/
 import pytest
-from pyccel.epyccel import epyccel
 import modules.highorder_functions as mod
+from pyccel.epyccel import epyccel
 
 @pytest.mark.c
 def test_int_1():

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -9,47 +9,47 @@ from modules        import loops
 
 def test_sum_natural_numbers(language):
     f1 = loops.sum_natural_numbers
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 42 ) == f2( 42 )
 
 def test_factorial(language):
     f1 = loops.factorial
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 11 ) == f2( 11 )
 
 def test_fibonacci(language):
     f1 = loops.fibonacci
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 42 ) == f2( 42 )
 
 def test_sum_nat_numbers_while(language):
     f1 = loops.sum_nat_numbers_while
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 42 ) == f2( 42 )
 
 def test_factorial_while(language):
     f1 = loops.factorial_while
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 10 ) == f2( 10 )
 
 def test_while_not_0(language):
     f1 = loops.while_not_0
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 42 ) == f2( 42 )
 
 def test_double_while_sum(language):
     f1 = loops.double_while_sum
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 10, 10 ) == f2( 10, 10 )
 
 def test_fibonacci_while(language):
     f1 = loops.fibonacci_while
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 42 ) == f2( 42 )
 
 def test_double_loop(language):
     f1 = loops.double_loop
-    f2 = epyccel( f1, language = language, verbose = True )
+    f2 = epyccel( f1, language = language )
     assert f1( 2 ) == f2( 2 )
 
 def test_double_loop_on_2d_array_C():

--- a/tests/errors/test_errors.py
+++ b/tests/errors/test_errors.py
@@ -132,9 +132,12 @@ if __name__ == '__main__':
     print('***   TESTING SYNTAX ERRORS   ***')
     print('***                           ***')
     print('*********************************')
-    for f in get_files_from_folder("syntax"):
+    for f in get_files_from_folder("syntax_errors"):
         print('> testing {0}'.format(str(os.path.basename(f))))
         test_syntax_errors(f)
+    for f in get_files_from_folder("syntax_blockers"):
+        print('> testing {0}'.format(str(os.path.basename(f))))
+        test_syntax_blockers(f)
     print('\n')
 
     print('*********************************')
@@ -142,7 +145,10 @@ if __name__ == '__main__':
     print('***  TESTING SEMANTIC ERRORS  ***')
     print('***                           ***')
     print('*********************************')
-    for f in get_files_from_folder("semantic"):
+    for f in get_files_from_folder("semantic/non_blocking"):
         print('> testing {0}'.format(str(os.path.basename(f))))
-        test_semantic_errors(f)
+        test_semantic_non_blocking_errors(f)
+    for f in get_files_from_folder("semantic/blocking"):
+        print('> testing {0}'.format(str(os.path.basename(f))))
+        test_semantic_blocking_errors(f)
     print('\n')

--- a/tests/syntax/scripts/expressions.py
+++ b/tests/syntax/scripts/expressions.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 # coding: utf-8
-# pylint: disable=pointless-statement
+# pylint: disable=pointless-statement, undefined-variable
 
 None
 

--- a/tests/syntax/scripts/slice.py
+++ b/tests/syntax/scripts/slice.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
-# pylint: disable=pointless-statement
+# pylint: disable=pointless-statement, undefined-variable
 
 a[0]
 a[:]


### PR DESCRIPTION
Reduce the number of warnings generated by the tests. Modify `compare_epyccel` function to avoid pyccelising the same function multiple times

- Raise an error for arrays as arguments in C
- Only provide libraries when linking (fixes #489)
- Provide language to compile_files to stop passing -J argument
- Only provide library directories when providing libraries
- Put argument for J with flag
- Mark C tests with missing c marker
- Modify compare_epyccel to be a class to avoid translating the same function multiple times
- Do not create function body if it will always raise an error to avoid unreachable-code warnings (functions as arguments)