### PR TITLE
Use iso_c types for fortran to ensure compatibility for the cwrapper

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -6,6 +6,7 @@ always available.
 In this module we implement some of them in alphabetical order.
 
 """
+from pyccel.ast.datatypes import iso_c_binding
 
 from sympy import Symbol, Function, Tuple
 from sympy import Expr
@@ -104,8 +105,7 @@ class PythonComplex(Expr, PyccelAstNode):
         """Fortran print."""
         real = printer(self.real_part)
         imag = printer(self.imag_part)
-        prec = printer(self.precision)
-        code = 'cmplx({0}, {1}, {2})'.format(real, imag, prec)
+        code = 'cmplx({0}, {1}, {2})'.format(real, imag, iso_c_binding["complex"][self.precision])
         return code
 
 #==============================================================================

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -70,7 +70,7 @@ class PythonBool(Expr, PyccelAstNode):
     def fprint(self, printer):
         """ Fortran printer. """
         if isinstance(self.arg.dtype, NativeBool):
-            return 'logical({}, kind = {prec})'.format(printer(self.arg), prec = self.precision)
+            return 'logical({}, kind = {prec})'.format(printer(self.arg), prec = iso_c_binding["logical"][self.precision])
         else:
             return '{} /= 0'.format(printer(self.arg))
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -73,7 +73,8 @@ iso_c_binding = {
         4 : 'C_FLOAT_COMPLEX',
 	    8 : 'C_DOUBLE_COMPLEX',
         16 : 'C_LONG_DOUBLE_COMPLEX'},
-    "logical" : "C_BOOL"
+    "logical" : {
+		4 : "C_BOOL"}
 }
 
 default_precision = {'real': 8, 'int': numpy.dtype(int).alignment, 'integer': numpy.dtype(int).alignment, 'complex': 8, 'bool':4, 'float':8}

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -58,6 +58,23 @@ __all__ = (
 )
 
 #==============================================================================
+iso_c_binding = {
+    "integer" : {
+        1 : 'C_SIGNED_CHAR',
+	    2 : 'C_SHORT',
+        4 : 'C_INT',
+	    8 : 'C_LONG_LONG',
+        16 : 'C_INT128'}, #no supported yet
+    "real" : {
+        4 : 'C_FLOAT',
+	    8 : 'C_DOUBLE',
+        16 : 'C_LONG_DOUBLE'},
+    "complex" : {
+        4 : 'C_FLOAT_COMPLEX',
+	    8 : 'C_DOUBLE_COMPLEX',
+        16 : 'C_LONG_DOUBLE_COMPLEX'},
+    "logical" : "C_BOOL"
+}
 
 default_precision = {'real': 8, 'int': numpy.dtype(int).alignment, 'integer': numpy.dtype(int).alignment, 'complex': 8, 'bool':4, 'float':8}
 dtype_and_precision_registry = { 'real':('real',default_precision['float']),

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -277,7 +277,7 @@ class FCodePrinter(CodePrinter):
                                             name=name)
 
         imports = ''.join(self._print(i) for i in expr.imports)
-        imports += 'use ISO_C_BINDING'
+        imports += 'use ISO_C_BINDING\n'
         decs    = ''.join(self._print(i) for i in expr.declarations)
         body    = ''
 
@@ -330,7 +330,7 @@ class FCodePrinter(CodePrinter):
         self._handle_fortran_specific_a_prioris(self.parser.get_variables(self._namespace))
         name    = 'prog_{0}'.format(self._print(expr.name)).replace('.', '_')
         imports = ''.join(self._print(i) for i in expr.imports)
-        imports += 'use ISO_C_BINDING'
+        imports += 'use ISO_C_BINDING\n'
         body    = self._print(expr.body)
 
         # Print the declarations of all variables in the namespace, which include:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -165,7 +165,7 @@ iso_c_binding = {
 	    2 : 'C_INT_LEAST16_T',
         4 : 'C_INT_LEAST32_T',
 	    8 : 'C_INT_LEAST64_T',
-        16 : 'C_INT'},
+        16 : 'C_INT128'}, #no supported yet
     "real" : {
         4 : 'C_FLOAT',
 	    8 : 'C_DOUBLE',

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -161,10 +161,10 @@ _default_methods = {
 
 iso_c_binding = {
     "integer" : {
-	    1 : 'C_INT_LEAST8_T',
-	    2 : 'C_INT_LEAST16_T',
-        4 : 'C_INT_LEAST32_T',
-	    8 : 'C_INT_LEAST64_T',
+        1 : 'C_SIGNED_CHAR',
+	    2 : 'C_SHORT',
+        4 : 'C_INT',
+	    8 : 'C_LONG_LONG',
         16 : 'C_INT128'}, #no supported yet
     "real" : {
         4 : 'C_FLOAT',
@@ -634,7 +634,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_NumpyFloor(self, expr):
         result_code = self._print_MathFloor(expr)
-        return 'real({}, {})'.format(result_code, expr.precision)
+        return 'real({}, {})'.format(result_code, iso_c_binding["real"][8])
 
     def _print_PythonFloat(self, expr):
         return expr.fprint(self._print)
@@ -2228,7 +2228,7 @@ class FCodePrinter(CodePrinter):
             adtype = bdtype
             code = 'FLOOR({}/{},{})'.format(code, c, expr.precision)
             if is_real:
-                code = 'real({}, {})'.format(code, expr.precision)
+                code = 'real({}, {})'.format(code, iso_c_binding["real"][expr.precision])
         return code
 
     def _print_PyccelRShift(self, expr):
@@ -2396,7 +2396,7 @@ class FCodePrinter(CodePrinter):
         e = printed.find('e')
         if e > -1:
             return "%sd%s" % (printed[:e], printed[e + 1:])
-        return "%sd0" % printed
+        return "%s_C_DOUBLE" % printed
 
     def _print_Complex(self, expr):
         real_str = self._print_Float(expr.real)
@@ -2404,7 +2404,7 @@ class FCodePrinter(CodePrinter):
         return "({}, {})".format(real_str, imag_str)
 
     def _print_Integer(self, expr):
-        return "{0}_{1}".format(str(expr.p), expr.precision)
+        return "{0}_{1}".format(str(expr.p), iso_c_binding["integer"][expr.precision])
 
     def _print_IndexedElement(self, expr):
         if isinstance(expr.base, IndexedVariable):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -161,11 +161,11 @@ _default_methods = {
 
 iso_c_binding = {
     "integer" : {
-	    1 : 'C_INT8',
-	    2 : 'C_INT16',
-        4 : 'C_INT32',
-	    8 : 'C_INT64',
-        16 : 'C_INT128'},
+	    1 : 'C_INT_LEAST8_T',
+	    2 : 'C_INT_LEAST16_T',
+        4 : 'C_INT_LEAST32_T',
+	    8 : 'C_INT_LEAST64_T',
+        16 : 'C_INT'},
     "real" : {
         4 : 'C_FLOAT',
 	    8 : 'C_DOUBLE',
@@ -173,7 +173,7 @@ iso_c_binding = {
     "complex" : {
         4 : 'C_FLOAT_COMPLEX',
 	    8 : 'C_DOUBLE_COMPLEX',
-        16 : 'C_LONG_DOUBLE_COMPLEX'}
+        16 : 'C_LONG_DOUBLE_COMPLEX'},
 }
 
 python_builtin_datatypes = {
@@ -286,7 +286,6 @@ class FCodePrinter(CodePrinter):
 
     def _print_Module(self, expr):
         self._handle_fortran_specific_a_prioris(self.parser.get_variables(self._namespace))
-
         name = self._print(expr.name)
         name = name.replace('.', '_')
         if not name.startswith('mod_') and self.prefix_module:
@@ -294,6 +293,7 @@ class FCodePrinter(CodePrinter):
                                             name=name)
 
         imports = ''.join(self._print(i) for i in expr.imports)
+        imports += 'use ISO_C_BINDING'
         decs    = ''.join(self._print(i) for i in expr.declarations)
         body    = ''
 
@@ -344,9 +344,9 @@ class FCodePrinter(CodePrinter):
 
     def _print_Program(self, expr):
         self._handle_fortran_specific_a_prioris(self.parser.get_variables(self._namespace))
-
         name    = 'prog_{0}'.format(self._print(expr.name)).replace('.', '_')
         imports = ''.join(self._print(i) for i in expr.imports)
+        imports += 'use ISO_C_BINDING'
         body    = self._print(expr.body)
 
         # Print the declarations of all variables in the namespace, which include:
@@ -1346,6 +1346,7 @@ class FCodePrinter(CodePrinter):
         interfaces = '\n'.join(self._print(i) for i in expr.interfaces)
         arg_code  = ', '.join(self._print(i) for i in chain( arguments, results ))
         imports   = ''.join(self._print(i) for i in expr.imports)
+        imports += 'use ISO_C_BINDING'
         prelude   = ''.join(self._print(i) for i in args_decs.values())
         body_code = self._print(expr.body)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2210,7 +2210,7 @@ class FCodePrinter(CodePrinter):
                 b = PythonFloat(b)
             c = self._print(b)
             adtype = bdtype
-            code = 'FLOOR({}/{},{})'.format(code, c, expr.precision)
+            code = 'FLOOR({}/{},{})'.format(code, c, iso_c_binding["integer"][expr.precision])
             if is_real:
                 code = 'real({}, {})'.format(code, iso_c_binding["real"][expr.precision])
         return code

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -159,6 +159,13 @@ _default_methods = {
     '__del__' : 'free',
 }
 
+iso_c_binding = {
+	'integer' : 'C_INT',
+	'real' : 'C_FLOAT',
+	'complex' : 'C_LONG_DOUBLE',
+	'LOGICAL' : 'C_BOOL'
+}
+
 python_builtin_datatypes = {
     'integer' : PythonInt,
     'real'    : PythonFloat,

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1350,7 +1350,7 @@ class FCodePrinter(CodePrinter):
         prelude   = ''.join(self._print(i) for i in args_decs.values())
         body_code = self._print(expr.body)
 
-        parts = ['{0} {1}({2}) {3}\n'.format(func_type, name, arg_code, func_end),
+        parts = ['{0} {1}({2}) bind(c) {3}\n'.format(func_type, name, arg_code, func_end),
                  imports,
                 'implicit none\n',
                  prelude,

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -160,10 +160,20 @@ _default_methods = {
 }
 
 iso_c_binding = {
-	'integer' : 'C_INT',
-	'real' : 'C_FLOAT',
-	'complex' : 'C_LONG_DOUBLE',
-	'LOGICAL' : 'C_BOOL'
+    "integer" : {
+	    1 : 'C_INT8',
+	    2 : 'C_INT16',
+        4 : 'C_INT32',
+	    8 : 'C_INT64',
+        16 : 'C_INT128'},
+    "real" : {
+        4 : 'C_FLOAT',
+	    8 : 'C_DOUBLE',
+        16 : 'C_LONG_DOUBLE'},
+    "complex" : {
+        4 : 'C_FLOAT_COMPLEX',
+	    8 : 'C_DOUBLE_COMPLEX',
+        16 : 'C_LONG_DOUBLE_COMPLEX'}
 }
 
 python_builtin_datatypes = {
@@ -912,7 +922,7 @@ class FCodePrinter(CodePrinter):
                     dtype = dtype[:9] +'(len =*)'
                     #TODO improve ,this is the case of character as argument
             else:
-                dtype += '(kind={0})'.format(str(expr.variable.precision))
+                dtype += '({0})'.format(str(iso_c_binding[dtype][expr.variable.precision]))
 
         code_value = ''
         if expr.value:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -50,6 +50,7 @@ from pyccel.ast.datatypes import is_pyccel_datatype
 from pyccel.ast.datatypes import is_iterable_datatype, is_with_construct_datatype
 from pyccel.ast.datatypes import NativeSymbol, NativeString
 from pyccel.ast.datatypes import NativeInteger, NativeBool, NativeReal
+from pyccel.ast.datatypes import iso_c_binding
 from pyccel.ast.datatypes import NativeRange, NativeTensor, NativeTuple
 from pyccel.ast.datatypes import CustomDataType
 from pyccel.ast.numbers   import Integer, Float
@@ -157,23 +158,6 @@ math_function_to_fortran = {
 _default_methods = {
     '__init__': 'create',
     '__del__' : 'free',
-}
-
-iso_c_binding = {
-    "integer" : {
-        1 : 'C_SIGNED_CHAR',
-	    2 : 'C_SHORT',
-        4 : 'C_INT',
-	    8 : 'C_LONG_LONG',
-        16 : 'C_INT128'}, #no supported yet
-    "real" : {
-        4 : 'C_FLOAT',
-	    8 : 'C_DOUBLE',
-        16 : 'C_LONG_DOUBLE'},
-    "complex" : {
-        4 : 'C_FLOAT_COMPLEX',
-	    8 : 'C_DOUBLE_COMPLEX',
-        16 : 'C_LONG_DOUBLE_COMPLEX'},
 }
 
 python_builtin_datatypes = {


### PR DESCRIPTION
- [x] Use iso_c_binding to specify precision

- [x] Mark all structures and functions in the f2py_X.F90 file with bind (c)