### PR TITLE
Put back codacy coverage

### DIFF
--- a/.github/actions/coverage_collection/action.yml
+++ b/.github/actions/coverage_collection/action.yml
@@ -5,11 +5,8 @@ runs:
   steps:
     - name: Coverage collection
       run: |
-        cd tests
         coverage combine
         coverage xml
         rm ${SITE_DIR}/pyccel_cov.pth
-        bash <(wget -q -O - https://coverage.codacy.com/get.sh)
-        cd ..
       shell: bash
 

--- a/.github/actions/coverage_install/action.yml
+++ b/.github/actions/coverage_install/action.yml
@@ -6,7 +6,6 @@ runs:
     - name: Installation
       run: |
         python -m pip install coverage
-        sudo apt-get install default-jre
       shell: bash
     - name: Directory Creation
       run: |
@@ -14,5 +13,5 @@ runs:
         SITE_DIR=$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
         echo -e "import coverage; coverage.process_startup()" > ${SITE_DIR}/pyccel_cov.pth
         echo -e "[run]\nparallel = True\nsource = ${INSTALL_DIR}\ndata_file = $(pwd)/.coverage\n[report]\ninclude = ${INSTALL_DIR}/*\n[xml]\noutput = cobertura.xml" > .coveragerc
-        export COVERAGE_PROCESS_START=$(pwd)/.coveragerc
+        echo "COVERAGE_PROCESS_START=$(pwd)/.coveragerc" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -5,11 +5,10 @@ runs:
   steps:
     - name: Test with pytest
       run: |
-        cd tests
         python -m pytest -rx -m "not parallel and c" --ignore=ast --ignore=printers --ignore=symbolic --ignore=ndarrays
         python -m pytest -rx -m "not parallel and not c" --ignore=ast --ignore=printers --ignore=symbolic --ignore=ndarrays
         python -m pytest ndarrays/ -rx
         mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rx
         #mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel -v -m parallel -rx
-        cd ..
       shell: bash
+      working-directory: ./tests

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -13,16 +13,13 @@ jobs:
   Linux:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.5]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.5
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.5
       - name: Install dependencies
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
@@ -34,6 +31,12 @@ jobs:
       - name: Collect coverage information
         continue-on-error: True
         uses: ./.github/actions/coverage_collection
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
+        continue-on-error: True
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: cobertura.xml
 
   Linux-Master:
 
@@ -60,6 +63,12 @@ jobs:
       - name: Collect coverage information
         continue-on-error: True
         uses: ./.github/actions/coverage_collection
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
+        continue-on-error: True
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: cobertura.xml
 
   #Windows:
 
@@ -79,16 +88,12 @@ jobs:
 
     runs-on: macos-latest
 
-    strategy:
-      matrix:
-        python-version: [3.8]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
       - name: Install dependencies
         uses: ./.github/actions/macos_install
       - name: Install python dependencies


### PR DESCRIPTION
Create necessary environment variables for codacy coverage. Use correct working directory. Use codacy-coverage-reporter github action to avoid manual install