### PR TITLE
Use equality operator for non Logical variables.

### DIFF
--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2349,6 +2349,8 @@ class FCodePrinter(CodePrinter):
 
     def _print_PyccelNot(self, expr):
         a = self._print(expr.args[0])
+        if (expr.args[0].dtype is not NativeBool()):
+            return '{} == 0'.format(a)
         return '.not. {}'.format(a)
 
     def _print_Header(self, expr):

--- a/tests/epyccel/modules/base.py
+++ b/tests/epyccel/modules/base.py
@@ -92,6 +92,13 @@ def not_val(a):
         c = True
     return c
 
+@types('int')
+def not_int(a):
+    c = False
+    if not a:
+        c = True
+    return c
+
 @types('bool')
 def is_nil(a = None):
     c = False

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -94,6 +94,11 @@ def test_not(language):
     test.compare_epyccel( True )
     test.compare_epyccel( False )
 
+def test_not_int(language):
+    test = epyccel_test(base.not_int, lang=language)
+    test.compare_epyccel( 0 )
+    test.compare_epyccel( 4 )
+
 @pytest.mark.parametrize( 'language', [
         pytest.param("fortran", marks = [
             pytest.mark.fortran]),


### PR DESCRIPTION
When the variable `x` is not a `bool`, we now print `not x` as `x == 0` in Fortran. This fixes #560.