### PR TITLE
Add continue and break statements for C 

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -319,10 +319,10 @@ class CCodePrinter(CodePrinter):
                         body    = body)
 
     def _print_Break(self, expr):
-        return 'break;\n'
+        return 'break;'
 
     def _print_Continue(self, expr):
-        return 'continue;\n'
+        return 'continue;'
 
     def _print_While(self, expr):
         body = self._print(expr.body)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -318,6 +318,12 @@ class CCodePrinter(CodePrinter):
                         imports = imports,
                         body    = body)
 
+    def _print_Break(self, expr):
+        return 'break;\n'
+
+    def _print_Continue(self, expr):
+        return 'continue;\n'
+
     def _print_While(self, expr):
         body = self._print(expr.body)
         cond = self._print(expr.test)

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -148,9 +148,9 @@ def test_loop_on_real_array():
 
     assert np.array_equal( out1, out2 )
 
-def test_breaks():
+def test_breaks(language):
     f1 = loops.fizzbuzz_search_with_breaks
-    f2 = epyccel( f1 )
+    f2 = epyccel( f1, language = language )
 
     fizz = 2
     buzz = 3
@@ -161,9 +161,9 @@ def test_breaks():
 
     assert( out1 == out2 )
 
-def test_continue():
+def test_continue(language):
     f1 = loops.fizzbuzz_sum_with_continue
-    f2 = epyccel( f1 )
+    f2 = epyccel( f1, language = language )
 
     fizz = 2
     buzz = 3


### PR DESCRIPTION
Add `continue` and `break` statements to the C printer, and activate tests for them.