### PR TITLE
Use stdint.h for integer types in arrays

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -205,10 +205,10 @@ ndarray_type_registry = {('real',8)    : 'nd_double',
                   ('real',4)    : 'nd_float',
                   ('complex',8) : 'nd_cdouble',
                   ('complex',4) : 'nd_cfloat',
-                  ('int',4)     : 'nd_int',
-                  ('int',8)     : 'nd_long',
-                  ('int',2)     : 'nd_sint',
-                  ('int',1)     : 'nd_char',
+                  ('int',8)     : 'nd_int64',
+                  ('int',4)     : 'nd_int32',
+                  ('int',2)     : 'nd_int16',
+                  ('int',1)     : 'nd_int8',
                   ('bool',4)    : 'nd_bool'}
 
 import_dict = {'omp_lib' : 'omp' }

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -4,7 +4,7 @@
 ** allocation
 */
 
-t_ndarray   array_create(int nd, int *shape, enum e_types type)
+t_ndarray   array_create(int32_t nd, int32_t *shape, enum e_types type)
 {
     t_ndarray arr;
 
@@ -42,18 +42,18 @@ t_ndarray   array_create(int nd, int *shape, enum e_types type)
     }
     arr.is_slice = false;
     arr.length = 1;
-    arr.shape = malloc(arr.nd * sizeof(int));
-    for (int i = 0; i < arr.nd; i++)
+    arr.shape = malloc(arr.nd * sizeof(int32_t));
+    for (int32_t i = 0; i < arr.nd; i++)
     {
         arr.length *= shape[i];
         arr.shape[i] = shape[i];
     }
     arr.buffer_size = arr.length * arr.type_size;
-    arr.strides = malloc(nd * sizeof(int));
-    for (int i = 0; i < arr.nd; i++)
+    arr.strides = malloc(nd * sizeof(int32_t));
+    for (int32_t i = 0; i < arr.nd; i++)
     {
         arr.strides[i] = 1;
-        for (int j = i + 1; j < arr.nd; j++)
+        for (int32_t j = i + 1; j < arr.nd; j++)
             arr.strides[i] *= arr.shape[j];
     }
     arr.raw_data = malloc(arr.buffer_size);
@@ -65,7 +65,7 @@ void   _array_fill_int8(int8_t c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_int8[i] = c;
 }
 
@@ -74,7 +74,7 @@ void   _array_fill_int16(int16_t c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_int16[i] = c;
 }
 
@@ -83,7 +83,7 @@ void   _array_fill_int32(int32_t c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_int32[i] = c;
 }
 
@@ -92,7 +92,7 @@ void   _array_fill_int64(int64_t c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_int64[i] = c;
 }
 
@@ -101,7 +101,7 @@ void   _array_fill_bool(bool c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_bool[i] = c;
 }
 
@@ -110,7 +110,7 @@ void   _array_fill_float(float c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_float[i] = c;
 }
 
@@ -119,7 +119,7 @@ void   _array_fill_double(double c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_double[i] = c;
 }
 
@@ -128,7 +128,7 @@ void   _array_fill_cfloat(float complex c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_cfloat[i] = c;
 }
 
@@ -138,7 +138,7 @@ void   _array_fill_cdouble(double complex c, t_ndarray arr)
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
-        for (int i = 0; i < arr.length; i++)
+        for (int32_t i = 0; i < arr.length; i++)
             arr.nd_cdouble[i] = c;
 }
 
@@ -146,7 +146,7 @@ void   _array_fill_cdouble(double complex c, t_ndarray arr)
 ** deallocation
 */
 
-int free_array(t_ndarray dump)
+int32_t free_array(t_ndarray dump)
 {
     if (!dump.is_slice)
     {
@@ -164,7 +164,7 @@ int free_array(t_ndarray dump)
 ** slices
 */
 
-t_slice new_slice(int start, int end, int step)
+t_slice new_slice(int32_t start, int32_t end, int32_t step)
 {
     t_slice slice_d;
 
@@ -179,17 +179,17 @@ t_ndarray array_slicing(t_ndarray p, ...)
     t_ndarray slice;
     va_list  va;
     t_slice slice_data;
-    int start = 0;
+    int32_t start = 0;
 
     slice.nd = p.nd;
     slice.type = p.type;
     slice.type_size = p.type_size;
-    slice.shape = malloc(sizeof(int) * p.nd);
-    slice.strides = malloc(sizeof(int) * p.nd);
-    memcpy(slice.strides, p.strides, sizeof(int) * p.nd);
+    slice.shape = malloc(sizeof(int32_t) * p.nd);
+    slice.strides = malloc(sizeof(int32_t) * p.nd);
+    memcpy(slice.strides, p.strides, sizeof(int32_t) * p.nd);
     slice.is_slice = true;
     va_start(va, p);
-    for (int i = 0; i < p.nd ; i++)
+    for (int32_t i = 0; i < p.nd ; i++)
     {
         slice_data = va_arg(va, t_slice);
         slice.shape[i] = (slice_data.end - slice_data.start + (slice_data.step - 1)) / slice_data.step; // we need to round up the shape
@@ -199,7 +199,7 @@ t_ndarray array_slicing(t_ndarray p, ...)
     va_end(va);
     slice.raw_data = p.raw_data + start * p.type_size;
     slice.length = 1;
-    for (int i = 0; i < slice.nd; i++)
+    for (int32_t i = 0; i < slice.nd; i++)
             slice.length *= slice.shape[i];
     return (slice);
 }
@@ -208,16 +208,16 @@ t_ndarray array_slicing(t_ndarray p, ...)
 ** indexing
 */
 
-int get_index(t_ndarray arr, ...)
+int32_t get_index(t_ndarray arr, ...)
 {
     va_list va;
-    int index;
+    int32_t index;
 
     va_start(va, arr);
     index = 0;
-    for (int i = 0; i < arr.nd; i++)
+    for (int32_t i = 0; i < arr.nd; i++)
     {
-        index += va_arg(va, int) * arr.strides[i];
+        index += va_arg(va, int32_t) * arr.strides[i];
     }
     va_end(va);
     return (index);

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -12,23 +12,26 @@ t_ndarray   array_create(int nd, int *shape, enum e_types type)
     arr.type = type;
     switch (type)
     {
-        case nd_bool:
-            arr.type_size = sizeof(bool);
+        case nd_int8:
+            arr.type_size = sizeof(int8_t);
             break;
-        case nd_sint:
-            arr.type_size = sizeof(short int);
+        case nd_int16:
+            arr.type_size = sizeof(int16_t);
             break;
-        case nd_int:
-            arr.type_size = sizeof(int);
+        case nd_int32:
+            arr.type_size = sizeof(int32_t);
             break;
-        case nd_long:
-            arr.type_size = sizeof(long);
+        case nd_int64:
+            arr.type_size = sizeof(int64_t);
             break;
         case nd_float:
             arr.type_size = sizeof(float);
             break;
         case nd_double:
             arr.type_size = sizeof(double);
+            break;
+        case nd_bool:
+            arr.type_size = sizeof(bool);
             break;
         case nd_cfloat:
             arr.type_size = sizeof(float complex);
@@ -57,30 +60,42 @@ t_ndarray   array_create(int nd, int *shape, enum e_types type)
     return (arr);
 }
 
-void   _array_fill_int(int c, t_ndarray arr)
+void   _array_fill_int8(int8_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
         for (int i = 0; i < arr.length; i++)
-            arr.nd_int[i] = c;
+            arr.nd_int8[i] = c;
 }
-void   _array_fill_long(long c, t_ndarray arr)
+
+void   _array_fill_int16(int16_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
         for (int i = 0; i < arr.length; i++)
-            arr.nd_long[i] = c;
+            arr.nd_int16[i] = c;
 }
-void   _array_fill_sint(short int c, t_ndarray arr)
+
+void   _array_fill_int32(int32_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
         for (int i = 0; i < arr.length; i++)
-            arr.nd_sint[i] = c;
+            arr.nd_int32[i] = c;
 }
+
+void   _array_fill_int64(int64_t c, t_ndarray arr)
+{
+    if (c == 0)
+        memset(arr.raw_data, 0, arr.buffer_size);
+    else
+        for (int i = 0; i < arr.length; i++)
+            arr.nd_int64[i] = c;
+}
+
 void   _array_fill_bool(bool c, t_ndarray arr)
 {
     if (c == 0)
@@ -89,13 +104,14 @@ void   _array_fill_bool(bool c, t_ndarray arr)
         for (int i = 0; i < arr.length; i++)
             arr.nd_bool[i] = c;
 }
-void   _array_fill_cfloat(float complex c, t_ndarray arr)
+
+void   _array_fill_float(float c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
     else
         for (int i = 0; i < arr.length; i++)
-            arr.nd_cfloat[i] = c;
+            arr.nd_float[i] = c;
 }
 
 void   _array_fill_double(double c, t_ndarray arr)
@@ -106,6 +122,16 @@ void   _array_fill_double(double c, t_ndarray arr)
         for (int i = 0; i < arr.length; i++)
             arr.nd_double[i] = c;
 }
+
+void   _array_fill_cfloat(float complex c, t_ndarray arr)
+{
+    if (c == 0)
+        memset(arr.raw_data, 0, arr.buffer_size);
+    else
+        for (int i = 0; i < arr.length; i++)
+            arr.nd_cfloat[i] = c;
+}
+
 
 void   _array_fill_cdouble(double complex c, t_ndarray arr)
 {
@@ -196,4 +222,3 @@ int get_index(t_ndarray arr, ...)
     va_end(va);
     return (index);
 }
-

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -21,9 +21,9 @@
                                         double complex : _array_fill_cdouble)(c, arr)
 typedef struct  s_slice
 {
-    int start;
-    int end;
-    int step;
+    int32_t start;
+    int32_t end;
+    int32_t step;
 }               t_slice;
 
 enum e_types
@@ -55,26 +55,26 @@ typedef struct  s_ndarray
             float  complex  *nd_cfloat;
             };
     /* number of dimensions */
-    int                 nd;
+    int32_t                 nd;
     /* shape 'size of each dimension' */
-    int                 *shape;
+    int32_t                 *shape;
     /* strides 'number of bytes to skip to get the next element' */
-    int                 *strides;
+    int32_t                 *strides;
     /* type of the array elements */
     enum e_types        type;
     /* type size of the array elements */
-    int                 type_size;
+    int32_t                 type_size;
     /* number of element in the array */
-    int                 length;
+    int32_t                 length;
     /* size of the array */
-    int                 buffer_size;
+    int32_t                 buffer_size;
     bool                is_slice;
 }               t_ndarray;
 
 /* functions prototypes */
 
 /* allocations */
-t_ndarray   array_create(int nd, int *shape, enum e_types type);
+t_ndarray   array_create(int32_t nd, int32_t *shape, enum e_types type);
 void        _array_fill_int8(int8_t c, t_ndarray arr);
 void        _array_fill_int16(int16_t c, t_ndarray arr);
 void        _array_fill_int32(int32_t c, t_ndarray arr);
@@ -87,14 +87,14 @@ void        _array_fill_cdouble(double complex c, t_ndarray arr);
 
 /* slicing */
                 /* creating a Slice object */
-t_slice     new_slice(int start, int end, int step);
+t_slice     new_slice(int32_t start, int32_t end, int32_t step);
                 /* creating an array view */
 t_ndarray   array_slicing(t_ndarray p, ...);
 
 /* free */
-int         free_array(t_ndarray dump);
+int32_t         free_array(t_ndarray dump);
 
 /* indexing */
-int         get_index(t_ndarray arr, ...);
+int32_t         get_index(t_ndarray arr, ...);
 
 #endif

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -7,10 +7,17 @@
 # include <stdio.h>
 # include <stdarg.h>
 # include <stdbool.h>
+# include <stdint.h>
 
-# define array_fill(c, arr) _Generic((c), int : _array_fill_int,\
+/* mapping the function array_fill to the correct type */
+# define array_fill(c, arr) _Generic((c), int64_t : _array_fill_int64,\
+                                        int32_t : _array_fill_int32,\
+                                        int16_t : _array_fill_int16,\
+                                        int8_t : _array_fill_int8,\
                                         float : _array_fill_float,\
                                         double : _array_fill_double,\
+                                        bool : _array_fill_bool,\
+                                        float complex : _array_fill_cfloat,\
                                         double complex : _array_fill_cdouble)(c, arr)
 typedef struct  s_slice
 {
@@ -22,9 +29,10 @@ typedef struct  s_slice
 enum e_types
 {
         nd_bool,
-        nd_int,
-        nd_sint,
-        nd_long,
+        nd_int8,
+        nd_int16,
+        nd_int32,
+        nd_int64,
         nd_float,
         nd_double,
         nd_cfloat,
@@ -36,41 +44,51 @@ typedef struct  s_ndarray
     /* raw data buffer*/
     union {
             char            *raw_data;
-            int             *nd_int;
+            int8_t          *nd_int8;
+            int16_t         *nd_int16;
+            int32_t         *nd_int32;
+            int64_t         *nd_int64;
             float           *nd_float;
             double          *nd_double;
+            bool            *nd_bool;
             double complex  *nd_cdouble;
             float  complex  *nd_cfloat;
-            long            *nd_long;
-            short int       *nd_sint;
-            char            *nd_char;
-            bool            *nd_bool;
             };
     /* number of dimensions */
-    int             nd;
+    int                 nd;
     /* shape 'size of each dimension' */
-    int             *shape;
+    int                 *shape;
     /* strides 'number of bytes to skip to get the next element' */
-    int             *strides;
+    int                 *strides;
     /* type of the array elements */
-    enum e_types    type;
-    int             type_size;
-    int             length;
-    int             buffer_size;
-    bool            is_slice;
+    enum e_types        type;
+    /* type size of the array elements */
+    int                 type_size;
+    /* number of element in the array */
+    int                 length;
+    /* size of the array */
+    int                 buffer_size;
+    bool                is_slice;
 }               t_ndarray;
 
 /* functions prototypes */
 
 /* allocations */
 t_ndarray   array_create(int nd, int *shape, enum e_types type);
-void        _array_fill_int(int c, t_ndarray arr);
+void        _array_fill_int8(int8_t c, t_ndarray arr);
+void        _array_fill_int16(int16_t c, t_ndarray arr);
+void        _array_fill_int32(int32_t c, t_ndarray arr);
+void        _array_fill_int64(int64_t c, t_ndarray arr);
 void        _array_fill_float(float c, t_ndarray arr);
 void        _array_fill_double(double c, t_ndarray arr);
-void        _array_fill_cdouble(complex double c, t_ndarray arr);
+void        _array_fill_bool(bool c, t_ndarray arr);
+void        _array_fill_cfloat(float complex c, t_ndarray arr);
+void        _array_fill_cdouble(double complex c, t_ndarray arr);
 
 /* slicing */
+                /* creating a Slice object */
 t_slice     new_slice(int start, int end, int step);
+                /* creating an array view */
 t_ndarray   array_slicing(t_ndarray p, ...);
 
 /* free */

--- a/tests/ndarrays/test_ndarrays.c
+++ b/tests/ndarrays/test_ndarrays.c
@@ -5,13 +5,13 @@
 #define getname(X) #X
 #define my_assert(X , Y, dscr) _Generic((X), double: assert_double,\
                             float: assert_float,\
-                            int32: assert_int,\
+                            int32_t: assert_int32,\
                             double complex : assert_cdouble,\
                             default: assert_ns)(X , Y, getname(X), getname(Y), dscr, __func__, __FILE__, __LINE__)
 
 void assert_double(double v1 , double v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int32 line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -26,7 +26,7 @@ void assert_double(double v1 , double v2,
 
 void assert_float(float v1 , float v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int32 line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -39,9 +39,9 @@ void assert_float(float v1 , float v2,
     printf("[DSCR] %s\n", dscr);
 }
 
-void assert_int(int32 v1 , int32 v2,
+void assert_int32(int32_t v1 , int32_t v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int32 line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -56,7 +56,7 @@ void assert_int(int32 v1 , int32 v2,
 
 void assert_cdouble(double complex v1 , double complex v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int32 line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -71,28 +71,28 @@ void assert_cdouble(double complex v1 , double complex v2,
 
 void assert_ns(float v1 , float v2,
         const char *v1_name, const char *v2_name, const char *dscr,
-        const char * func, const char *file, int32 line)
+        const char * func, const char *file, int32_t line)
 {
     printf("[FAIL] %s:%d:%s\n", file, line, func);
     printf("[INFO] not supported type\n");
     printf("[DSCR] %s\n", dscr);
 }
 
-int32 test_indexing_int(void)
+int32_t test_indexing_int32(void)
 {
-    int32 m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
+    int32_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                 12, 260, 6, 8, 8, 0, 45, 0,
                 1, 0, 0, 1, 200, 33, 5, 57,
                 62, 70, 103, 141, 122, 26, 36, 82,
                 8, 10, 4115, 22, 1, 11, 1, 19};
-    int32 m_1_shape[] = {5, 8};
+    int32_t m_1_shape[] = {5, 8};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
-    int32 value;
-    int32 c_value;
+    int32_t index;
+    int32_t c_index;
+    int32_t value;
+    int32_t c_value;
 
-    x = array_create(2, m_1_shape, nd_int);
+    x = array_create(2, m_1_shape, nd_int32);
     memcpy(x.raw_data, m_1, x.buffer_size);
     // testing the index [3, 2]
     index = 3 * x.strides[0] + 2 * x.strides[1];
@@ -100,24 +100,24 @@ int32 test_indexing_int(void)
     my_assert(index , c_index, "testing the strides");
     my_assert(get_index(x, 3, 2) , c_index, "testing the indexing function");
     // testing the value with the index [3, 2]
-    value = x.nd_int[index];
+    value = x.nd_int32[index];
     c_value = 103;
     my_assert(value , c_value, "testing the value");
     free_array(x);
     return (0);
 }
 
-int32 test_indexing_double(void)
+int32_t test_indexing_double(void)
 {
     double m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                     12, 260, 6.34, 8, 8.002, 0.056, 45, 0.1,
                     1.02, 0.25, 0.00005, 1, 200, 33, 5, 57,
                     62, 70, 103.009, 141, 122, 26.50, 36.334, 82,
                     8.44002, 10.056, 4115, 22.1, 1.1102, 011.25, 1.01110005, 19};
-    int32 m_1_shape[] = {5, 8};
+    int32_t m_1_shape[] = {5, 8};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
+    int32_t index;
+    int32_t c_index;
     double value;
     double c_value;
 
@@ -136,17 +136,17 @@ int32 test_indexing_double(void)
     return (0);
 }
 
-int32 test_indexing_cdouble(void)
+int32_t test_indexing_cdouble(void)
 {
     double complex m_1[] = {0.37 + 0.588*I,  0.92689451+0.57106791*I,
                             0.93598206+0.30289964*I,  0.54404246+0.09516331*I,
                             0.02827254+0.00432899*I,  0.06873651+0.24810741*I,
                             0.94040543+0.43508215*I,  0.58532094+0.67890618*I,
                             0.68742283+0.64951155*I,  0.15372315+0.89699101*I};
-    int32 m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
+    int32_t index;
+    int32_t c_index;
     double complex value;
     double complex c_value;
 
@@ -170,9 +170,9 @@ int32 test_indexing_cdouble(void)
 **  slicing tests
 */
 
-int32 test_slicing_int(void)
+int32_t test_slicing_int32(void)
 {
-    int32 m_1[] = {2, 3, 5, 5, 6,
+    int32_t m_1[] = {2, 3, 5, 5, 6,
                 7, 10, 11, 12, 260,
                 6, 8, 8, 0, 45,
                 0, 1, 0, 0, 1,
@@ -180,22 +180,22 @@ int32 test_slicing_int(void)
                 70, 103, 141, 122, 26,
                 36, 82, 8, 10, 4115,
                 22, 1, 11, 1, 19};
-    int32 m_1_shape[] = {8, 5};
+    int32_t m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int32 c_index;
-    int32 value;
-    int32 c_value;
+    int32_t c_index;
+    int32_t value;
+    int32_t c_value;
 
-    x = array_create(2, m_1_shape, nd_int);
+    x = array_create(2, m_1_shape, nd_int32);
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int32 i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int32 j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
-            value = xview.nd_int[get_index(xview, i, j)];
+            value = xview.nd_int32[get_index(xview, i, j)];
             c_value = m_1[c_index];
             c_index+=2;
             if (value != c_value)
@@ -203,15 +203,15 @@ int32 test_slicing_int(void)
         }
     }
     c_value = 1337;
-    xview.nd_int[get_index(xview, 0, 1)] = c_value;
-    value = x.nd_int[get_index(x, 1, 2)];
+    xview.nd_int32[get_index(xview, 0, 1)] = c_value;
+    value = x.nd_int32[get_index(x, 1, 2)];
     my_assert(value , c_value, "testing xview assignment");
     free_array(x);
     free_array(xview);
     return (0);
 }
 
-int32 test_slicing_double(void)
+int32_t test_slicing_double(void)
 {
     double m_1[] = {2, 3, 5, 5, 6,
                     7, 10, 11, 12, 260,
@@ -221,10 +221,10 @@ int32 test_slicing_double(void)
                     103.009, 141, 122, 26.50, 36.334,
                     82, 8.44002, 10.056, 4115, 22.1,
                     1.1102, 011.25, 1.01110005, 19, 70};
-    int32 m_1_shape[] = {8, 5};
+    int32_t m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int32 c_index;
+    int32_t c_index;
     double value;
     double c_value;
 
@@ -232,9 +232,9 @@ int32 test_slicing_double(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int32 i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int32 j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_double[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -252,16 +252,16 @@ int32 test_slicing_double(void)
     return (0);
 }
 
-int32 test_slicing_cdouble(void)
+int32_t test_slicing_cdouble(void)
 {
     double complex m_1[] = {
                     0.37 + 0.588*I,  0.92+0.57*I, 0.93+0.30*I,  0.54+0.09*I, 0.02+0.01*I,
                     0.03+0.24*I, 0.94+0.43*I,  0.58+0.67*I, 0.68+0.64*I,  0.15+0.89*I
                     };
-    int32 m_1_shape[] = {2, 5};
+    int32_t m_1_shape[] = {2, 5};
     t_ndarray x;
     t_ndarray xview;
-    int32 c_index;
+    int32_t c_index;
     double complex value;
     double complex c_value;
 
@@ -269,9 +269,9 @@ int32 test_slicing_cdouble(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int32 i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int32 j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_cdouble[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -291,16 +291,16 @@ int32 test_slicing_cdouble(void)
 
 /* array_fill tests */
 
-int32 test_array_fill_int(void)
+int32_t test_array_fill_int32(void)
 {
-    int32 m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
-    int32 value;
-    int32 c_value;
+    int32_t index;
+    int32_t c_index;
+    int32_t value;
+    int32_t c_value;
 
-    x = array_create(2, m_1_shape, nd_int);
+    x = array_create(2, m_1_shape, nd_int32);
     array_fill(32, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
@@ -308,19 +308,19 @@ int32 test_array_fill_int(void)
     my_assert(index , c_index, "testing the strides");
     my_assert(get_index(x, 3, 1) , c_index, "testing the indexing function");
     // testing the value with the index [3, 1]
-    value = x.nd_int[index];
+    value = x.nd_int32[index];
     c_value = 32;
     my_assert(value , c_value, "testing the value");
     free_array(x);
     return (0);
 }
 
-int32 test_array_fill_double(void)
+int32_t test_array_fill_double(void)
 {
-    int32 m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
+    int32_t index;
+    int32_t c_index;
     double value;
     double c_value;
 
@@ -339,12 +339,12 @@ int32 test_array_fill_double(void)
     return (0);
 }
 
-int32 test_array_fill_cdouble(void)
+int32_t test_array_fill_cdouble(void)
 {
-    int32 m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
+    int32_t index;
+    int32_t c_index;
     double complex value;
     double complex c_value;
 
@@ -365,12 +365,12 @@ int32 test_array_fill_cdouble(void)
 
 /* array_zeros tests */
 
-int32 test_array_zeros_double(void)
+int32_t test_array_zeros_double(void)
 {
-    int32 m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
+    int32_t index;
+    int32_t c_index;
     double value;
     double c_value;
 
@@ -389,16 +389,16 @@ int32 test_array_zeros_double(void)
     return (0);
 }
 
-int32 test_array_zeros_int(void)
+int32_t test_array_zeros_int32(void)
 {
-    int32 m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
-    int32 value;
-    int32 c_value;
+    int32_t index;
+    int32_t c_index;
+    int32_t value;
+    int32_t c_value;
 
-    x = array_create(2, m_1_shape, nd_int);
+    x = array_create(2, m_1_shape, nd_int32);
     array_fill(0, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
@@ -406,19 +406,19 @@ int32 test_array_zeros_int(void)
     my_assert(index , c_index, "testing the strides");
     my_assert(get_index(x, 3, 1) , c_index, "testing the indexing function");
     // testing the value with the index [3, 1]
-    value = x.nd_int[index];
+    value = x.nd_int32[index];
     c_value = 0;
     my_assert(value , c_value, "testing the value");
     free_array(x);
     return (0);
 }
 
-int32 test_array_zeros_cdouble(void)
+int32_t test_array_zeros_cdouble(void)
 {
-    int32 m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32 index;
-    int32 c_index;
+    int32_t index;
+    int32_t c_index;
     double complex value;
     double complex c_value;
 
@@ -437,22 +437,22 @@ int32 test_array_zeros_cdouble(void)
     return (0);
 }
 
-int32 main(void)
+int32_t main(void)
 {
     /* indexing tests */
     test_indexing_double();
-    test_indexing_int();
+    test_indexing_int32();
     test_indexing_cdouble();
     /* slicing tests */
     test_slicing_double();
-    test_slicing_int();
+    test_slicing_int32();
     test_slicing_cdouble();
     /* array_fill tests */
-    test_array_fill_int();
+    test_array_fill_int32();
     test_array_fill_double();
     test_array_fill_cdouble();
     /* array_zeros tests */
-    test_array_zeros_int();
+    test_array_zeros_int32();
     test_array_zeros_double();
     test_array_zeros_cdouble();
     return (0);

--- a/tests/ndarrays/test_ndarrays.c
+++ b/tests/ndarrays/test_ndarrays.c
@@ -5,13 +5,17 @@
 #define getname(X) #X
 #define my_assert(X , Y, dscr) _Generic((X), double: assert_double,\
                             float: assert_float,\
+                            int64_t: assert_int64,\
                             int32_t: assert_int32,\
+                            int16_t: assert_int16,\
+                            int8_t: assert_int8,\
+                            float complex : assert_cfloat,\
                             double complex : assert_cdouble,\
                             default: assert_ns)(X , Y, getname(X), getname(Y), dscr, __func__, __FILE__, __LINE__)
 
 void assert_double(double v1 , double v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int32_t line)
+        const char * func, const char *file, int line)
 {
     if (v1 != v2)
     {
@@ -26,7 +30,7 @@ void assert_double(double v1 , double v2,
 
 void assert_float(float v1 , float v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int32_t line)
+        const char * func, const char *file, int line)
 {
     if (v1 != v2)
     {
@@ -39,9 +43,24 @@ void assert_float(float v1 , float v2,
     printf("[DSCR] %s\n", dscr);
 }
 
+void assert_int64(int64_t v1 , int64_t v2,
+        const char *v1_name, const char *v2_name,const char *dscr,
+        const char * func, const char *file, int line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%ld != %s:%ld\n", v1_name, v1, v2_name,v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
 void assert_int32(int32_t v1 , int32_t v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int32_t line)
+        const char * func, const char *file, int line)
 {
     if (v1 != v2)
     {
@@ -54,9 +73,54 @@ void assert_int32(int32_t v1 , int32_t v2,
     printf("[DSCR] %s\n", dscr);
 }
 
+void assert_int16(int16_t v1 , int16_t v2,
+        const char *v1_name, const char *v2_name,const char *dscr,
+        const char * func, const char *file, int line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%d != %s:%d\n", v1_name, v1, v2_name,v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
+void assert_int8(int8_t v1 , int8_t v2,
+        const char *v1_name, const char *v2_name,const char *dscr,
+        const char * func, const char *file, int line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%d != %s:%d\n", v1_name, v1, v2_name,v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
+void assert_cfloat(float complex v1 , float complex v2,
+        const char *v1_name, const char *v2_name,const char *dscr,
+        const char * func, const char *file, int line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%f+%f*I != %s:%f+%f*I\n", v1_name, creal(v1), cimag(v1), v2_name,creal(v2), cimag(v2));
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
 void assert_cdouble(double complex v1 , double complex v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int32_t line)
+        const char * func, const char *file, int line)
 {
     if (v1 != v2)
     {
@@ -71,24 +135,53 @@ void assert_cdouble(double complex v1 , double complex v2,
 
 void assert_ns(float v1 , float v2,
         const char *v1_name, const char *v2_name, const char *dscr,
-        const char * func, const char *file, int32_t line)
+        const char * func, const char *file, int line)
 {
     printf("[FAIL] %s:%d:%s\n", file, line, func);
     printf("[INFO] not supported type\n");
     printf("[DSCR] %s\n", dscr);
 }
 
-int32_t test_indexing_int32(void)
+int test_indexing_int64(void)
+{
+    int64_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
+                12, 260, 6, 8, 8, 0, 45, 0,
+                1, 0, 0, 1, 200, 33, 5, 57,
+                62, 70, 103, 141, 122, 26, 36, 82,
+                8, 10, 4115, 22, 1, 11, 1, 19};
+    int m_1_shape[] = {5, 8};
+    t_ndarray x;
+    int index;
+    int c_index;
+    int64_t value;
+    int64_t c_value;
+
+    x = array_create(2, m_1_shape, nd_int64);
+    memcpy(x.raw_data, m_1, x.buffer_size);
+    // testing the index [3, 2]
+    index = 3 * x.strides[0] + 2 * x.strides[1];
+    c_index = 26;
+    my_assert(index , c_index, "testing the strides");
+    my_assert(get_index(x, 3, 2) , c_index, "testing the indexing function");
+    // testing the value with the index [3, 2]
+    value = x.nd_int64[index];
+    c_value = 103;
+    my_assert(value , c_value, "testing the value");
+    free_array(x);
+    return (0);
+}
+
+int test_indexing_int32(void)
 {
     int32_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                 12, 260, 6, 8, 8, 0, 45, 0,
                 1, 0, 0, 1, 200, 33, 5, 57,
                 62, 70, 103, 141, 122, 26, 36, 82,
                 8, 10, 4115, 22, 1, 11, 1, 19};
-    int32_t m_1_shape[] = {5, 8};
+    int m_1_shape[] = {5, 8};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
     int32_t value;
     int32_t c_value;
 
@@ -107,17 +200,75 @@ int32_t test_indexing_int32(void)
     return (0);
 }
 
-int32_t test_indexing_double(void)
+int test_indexing_int16(void)
+{
+    int16_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
+                12, 260, 6, 8, 8, 0, 45, 0,
+                1, 0, 0, 1, 200, 33, 5, 57,
+                62, 70, 103, 141, 122, 26, 36, 82,
+                8, 10, 4115, 22, 1, 11, 1, 19};
+    int m_1_shape[] = {5, 8};
+    t_ndarray x;
+    int index;
+    int c_index;
+    int16_t value;
+    int16_t c_value;
+
+    x = array_create(2, m_1_shape, nd_int16);
+    memcpy(x.raw_data, m_1, x.buffer_size);
+    // testing the index [3, 2]
+    index = 3 * x.strides[0] + 2 * x.strides[1];
+    c_index = 26;
+    my_assert(index , c_index, "testing the strides");
+    my_assert(get_index(x, 3, 2) , c_index, "testing the indexing function");
+    // testing the value with the index [3, 2]
+    value = x.nd_int16[index];
+    c_value = 103;
+    my_assert(value , c_value, "testing the value");
+    free_array(x);
+    return (0);
+}
+
+int test_indexing_int8(void)
+{
+    int8_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
+                12, 250, 6, 8, 8, 0, 45, 0,
+                1, 0, 0, 1, 200, 33, 5, 57,
+                62, 70, 103, 141, 122, 26, 36, 82,
+                8, 10, 251, 22, 1, 11, 1, 19};
+    int m_1_shape[] = {5, 8};
+    t_ndarray x;
+    int index;
+    int c_index;
+    int8_t value;
+    int8_t c_value;
+
+    x = array_create(2, m_1_shape, nd_int8);
+    memcpy(x.raw_data, m_1, x.buffer_size);
+    // testing the index [3, 2]
+    index = 3 * x.strides[0] + 2 * x.strides[1];
+    c_index = 26;
+    my_assert(index , c_index, "testing the strides");
+    my_assert(get_index(x, 3, 2) , c_index, "testing the indexing function");
+    // testing the value with the index [3, 2]
+    value = x.nd_int8[index];
+    c_value = 103;
+    my_assert(value , c_value, "testing the value");
+    free_array(x);
+    return (0);
+}
+
+int test_indexing_double(void)
 {
     double m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                     12, 260, 6.34, 8, 8.002, 0.056, 45, 0.1,
                     1.02, 0.25, 0.00005, 1, 200, 33, 5, 57,
                     62, 70, 103.009, 141, 122, 26.50, 36.334, 82,
                     8.44002, 10.056, 4115, 22.1, 1.1102, 011.25, 1.01110005, 19};
-    int32_t m_1_shape[] = {5, 8};
+    int m_1_shape[] = {5, 8};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
     double value;
     double c_value;
 
@@ -136,17 +287,17 @@ int32_t test_indexing_double(void)
     return (0);
 }
 
-int32_t test_indexing_cdouble(void)
+int test_indexing_cdouble(void)
 {
     double complex m_1[] = {0.37 + 0.588*I,  0.92689451+0.57106791*I,
                             0.93598206+0.30289964*I,  0.54404246+0.09516331*I,
                             0.02827254+0.00432899*I,  0.06873651+0.24810741*I,
                             0.94040543+0.43508215*I,  0.58532094+0.67890618*I,
                             0.68742283+0.64951155*I,  0.15372315+0.89699101*I};
-    int32_t m_1_shape[] = {5, 2};
+    int m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
     double complex value;
     double complex c_value;
 
@@ -165,12 +316,81 @@ int32_t test_indexing_cdouble(void)
     return (0);
 }
 
+int test_indexing_cfloat(void)
+{
+    float complex m_1[] = {0.37 + 0.588*I,  0.92689451+0.57106791*I,
+                            0.93598206+0.30289964*I,  0.54404246+0.09516331*I,
+                            0.02827254+0.00432899*I,  0.06873651+0.24810741*I,
+                            0.94040543+0.43508215*I,  0.58532094+0.67890618*I,
+                            0.68742283+0.64951155*I,  0.15372315+0.89699101*I};
+    int m_1_shape[] = {5, 2};
+    t_ndarray x;
+    int index;
+    int c_index;
+    float complex value;
+    float complex c_value;
+
+    x = array_create(2, m_1_shape, nd_cfloat);
+    memcpy(x.raw_data, m_1, x.buffer_size);
+    // testing the index [3, 1]
+    index = 3 * x.strides[0] + 1 * x.strides[1];
+    c_index = 7;
+    my_assert(index , c_index, "testing the strides");
+    my_assert(get_index(x, 3, 1) , c_index, "testing the indexing function");
+    // testing the value with the index [3, 1]
+    value = x.nd_cfloat[index];
+    c_value = 0.58532094+0.67890618*I;
+    my_assert(value , c_value, "testing the value");
+    free_array(x);
+    return (0);
+}
 
 /* 
 **  slicing tests
 */
 
-int32_t test_slicing_int32(void)
+int test_slicing_int64(void)
+{
+    int64_t m_1[] = {2, 3, 5, 5, 6,
+                7, 10, 11, 12, 260,
+                6, 8, 8, 0, 45,
+                0, 1, 0, 0, 1,
+                200, 33, 5, 57, 62,
+                70, 103, 141, 122, 26,
+                36, 82, 8, 10, 4115,
+                22, 1, 11, 1, 19};
+    int m_1_shape[] = {8, 5};
+    t_ndarray x;
+    t_ndarray xview;
+    int c_index;
+    int64_t value;
+    int64_t c_value;
+
+    x = array_create(2, m_1_shape, nd_int64);
+    memcpy(x.raw_data, m_1, x.buffer_size);
+    xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
+    c_index = 5;
+    for (int i = 0; i < xview.shape[0]; i++)
+    {
+        for (int j = 0; j < xview.shape[1]; j++)
+        {
+            value = xview.nd_int64[get_index(xview, i, j)];
+            c_value = m_1[c_index];
+            c_index+=2;
+            if (value != c_value)
+                my_assert(value , c_value, "testing xview values");
+        }
+    }
+    c_value = 1337;
+    xview.nd_int64[get_index(xview, 0, 1)] = c_value;
+    value = x.nd_int64[get_index(x, 1, 2)];
+    my_assert(value , c_value, "testing xview assignment");
+    free_array(x);
+    free_array(xview);
+    return (0);
+}
+
+int test_slicing_int32(void)
 {
     int32_t m_1[] = {2, 3, 5, 5, 6,
                 7, 10, 11, 12, 260,
@@ -180,10 +400,10 @@ int32_t test_slicing_int32(void)
                 70, 103, 141, 122, 26,
                 36, 82, 8, 10, 4115,
                 22, 1, 11, 1, 19};
-    int32_t m_1_shape[] = {8, 5};
+    int m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int32_t c_index;
+    int c_index;
     int32_t value;
     int32_t c_value;
 
@@ -191,9 +411,9 @@ int32_t test_slicing_int32(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int32_t i = 0; i < xview.shape[0]; i++)
+    for (int i = 0; i < xview.shape[0]; i++)
     {
-        for (int32_t j = 0; j < xview.shape[1]; j++)
+        for (int j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_int32[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -210,8 +430,89 @@ int32_t test_slicing_int32(void)
     free_array(xview);
     return (0);
 }
+int test_slicing_int16(void)
+{
+    int16_t m_1[] = {2, 3, 5, 5, 6,
+                7, 10, 11, 12, 260,
+                6, 8, 8, 0, 45,
+                0, 1, 0, 0, 1,
+                200, 33, 5, 57, 62,
+                70, 103, 141, 122, 26,
+                36, 82, 8, 10, 4115,
+                22, 1, 11, 1, 19};
+    int m_1_shape[] = {8, 5};
+    t_ndarray x;
+    t_ndarray xview;
+    int c_index;
+    int16_t value;
+    int16_t c_value;
 
-int32_t test_slicing_double(void)
+    x = array_create(2, m_1_shape, nd_int16);
+    memcpy(x.raw_data, m_1, x.buffer_size);
+    xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
+    c_index = 5;
+    for (int i = 0; i < xview.shape[0]; i++)
+    {
+        for (int j = 0; j < xview.shape[1]; j++)
+        {
+            value = xview.nd_int16[get_index(xview, i, j)];
+            c_value = m_1[c_index];
+            c_index+=2;
+            if (value != c_value)
+                my_assert(value , c_value, "testing xview values");
+        }
+    }
+    c_value = 1337;
+    xview.nd_int16[get_index(xview, 0, 1)] = c_value;
+    value = x.nd_int16[get_index(x, 1, 2)];
+    my_assert(value , c_value, "testing xview assignment");
+    free_array(x);
+    free_array(xview);
+    return (0);
+}
+
+int test_slicing_int8(void)
+{
+    int8_t m_1[] = {2, 3, 5, 5, 6,
+                7, 10, 11, 12, 250,
+                6, 8, 8, 0, 45,
+                0, 1, 0, 0, 1,
+                200, 33, 5, 57, 62,
+                70, 103, 141, 122, 26,
+                36, 82, 8, 10, 251,
+                22, 1, 11, 1, 19};
+    int m_1_shape[] = {8, 5};
+    t_ndarray x;
+    t_ndarray xview;
+    int c_index;
+    int8_t value;
+    int8_t c_value;
+
+    x = array_create(2, m_1_shape, nd_int8);
+    memcpy(x.raw_data, m_1, x.buffer_size);
+    xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
+    c_index = 5;
+    for (int i = 0; i < xview.shape[0]; i++)
+    {
+        for (int j = 0; j < xview.shape[1]; j++)
+        {
+            value = xview.nd_int8[get_index(xview, i, j)];
+            c_value = m_1[c_index];
+            c_index+=2;
+            if (value != c_value)
+                my_assert(value , c_value, "testing xview values");
+        }
+    }
+    c_value = 133;
+    xview.nd_int8[get_index(xview, 0, 1)] = c_value;
+    value = x.nd_int8[get_index(x, 1, 2)];
+    my_assert(value , c_value, "testing xview assignment");
+    free_array(x);
+    free_array(xview);
+    return (0);
+}
+
+int test_slicing_double(void)
 {
     double m_1[] = {2, 3, 5, 5, 6,
                     7, 10, 11, 12, 260,
@@ -221,10 +522,10 @@ int32_t test_slicing_double(void)
                     103.009, 141, 122, 26.50, 36.334,
                     82, 8.44002, 10.056, 4115, 22.1,
                     1.1102, 011.25, 1.01110005, 19, 70};
-    int32_t m_1_shape[] = {8, 5};
+    int m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int32_t c_index;
+    int c_index;
     double value;
     double c_value;
 
@@ -232,9 +533,9 @@ int32_t test_slicing_double(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int32_t i = 0; i < xview.shape[0]; i++)
+    for (int i = 0; i < xview.shape[0]; i++)
     {
-        for (int32_t j = 0; j < xview.shape[1]; j++)
+        for (int j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_double[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -252,16 +553,16 @@ int32_t test_slicing_double(void)
     return (0);
 }
 
-int32_t test_slicing_cdouble(void)
+int test_slicing_cdouble(void)
 {
     double complex m_1[] = {
                     0.37 + 0.588*I,  0.92+0.57*I, 0.93+0.30*I,  0.54+0.09*I, 0.02+0.01*I,
                     0.03+0.24*I, 0.94+0.43*I,  0.58+0.67*I, 0.68+0.64*I,  0.15+0.89*I
                     };
-    int32_t m_1_shape[] = {2, 5};
+    int m_1_shape[] = {2, 5};
     t_ndarray x;
     t_ndarray xview;
-    int32_t c_index;
+    int c_index;
     double complex value;
     double complex c_value;
 
@@ -269,9 +570,9 @@ int32_t test_slicing_cdouble(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int32_t i = 0; i < xview.shape[0]; i++)
+    for (int i = 0; i < xview.shape[0]; i++)
     {
-        for (int32_t j = 0; j < xview.shape[1]; j++)
+        for (int j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_cdouble[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -291,17 +592,41 @@ int32_t test_slicing_cdouble(void)
 
 /* array_fill tests */
 
-int32_t test_array_fill_int32(void)
+int test_array_fill_int64(void)
 {
-    int32_t m_1_shape[] = {5, 2};
+    int m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
+    int64_t value;
+    int64_t c_value;
+
+    x = array_create(2, m_1_shape, nd_int64);
+    array_fill((int64_t)32, x);
+    // testing the index [3, 1]
+    index = 3 * x.strides[0] + 1 * x.strides[1];
+    c_index = 7;
+    my_assert(index , c_index, "testing the strides");
+    my_assert(get_index(x, 3, 1) , c_index, "testing the indexing function");
+    // testing the value with the index [3, 1]
+    value = x.nd_int64[index];
+    c_value = 32;
+    my_assert(value , c_value, "testing the value");
+    free_array(x);
+    return (0);
+}
+
+int test_array_fill_int32(void)
+{
+    int m_1_shape[] = {5, 2};
+    t_ndarray x;
+    int index;
+    int c_index;
     int32_t value;
     int32_t c_value;
 
     x = array_create(2, m_1_shape, nd_int32);
-    array_fill(32, x);
+    array_fill((int32_t)32, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -315,12 +640,60 @@ int32_t test_array_fill_int32(void)
     return (0);
 }
 
-int32_t test_array_fill_double(void)
+int test_array_fill_int16(void)
 {
-    int32_t m_1_shape[] = {5, 2};
+    int m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
+    int16_t value;
+    int16_t c_value;
+
+    x = array_create(2, m_1_shape, nd_int16);
+    array_fill((int16_t)32, x);
+    // testing the index [3, 1]
+    index = 3 * x.strides[0] + 1 * x.strides[1];
+    c_index = 7;
+    my_assert(index , c_index, "testing the strides");
+    my_assert(get_index(x, 3, 1) , c_index, "testing the indexing function");
+    // testing the value with the index [3, 1]
+    value = x.nd_int16[index];
+    c_value = 32;
+    my_assert(value , c_value, "testing the value");
+    free_array(x);
+    return (0);
+}
+
+int test_array_fill_int8(void)
+{
+    int m_1_shape[] = {5, 2};
+    t_ndarray x;
+    int index;
+    int c_index;
+    int8_t value;
+    int8_t c_value;
+
+    x = array_create(2, m_1_shape, nd_int8);
+    array_fill((int8_t)32, x);
+    // testing the index [3, 1]
+    index = 3 * x.strides[0] + 1 * x.strides[1];
+    c_index = 7;
+    my_assert(index , c_index, "testing the strides");
+    my_assert(get_index(x, 3, 1) , c_index, "testing the indexing function");
+    // testing the value with the index [3, 1]
+    value = x.nd_int8[index];
+    c_value = 32;
+    my_assert(value , c_value, "testing the value");
+    free_array(x);
+    return (0);
+}
+
+int test_array_fill_double(void)
+{
+    int m_1_shape[] = {5, 2};
+    t_ndarray x;
+    int index;
+    int c_index;
     double value;
     double c_value;
 
@@ -339,12 +712,12 @@ int32_t test_array_fill_double(void)
     return (0);
 }
 
-int32_t test_array_fill_cdouble(void)
+int test_array_fill_cdouble(void)
 {
-    int32_t m_1_shape[] = {5, 2};
+    int m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
     double complex value;
     double complex c_value;
 
@@ -365,12 +738,12 @@ int32_t test_array_fill_cdouble(void)
 
 /* array_zeros tests */
 
-int32_t test_array_zeros_double(void)
+int test_array_zeros_double(void)
 {
-    int32_t m_1_shape[] = {5, 2};
+    int m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
     double value;
     double c_value;
 
@@ -389,12 +762,12 @@ int32_t test_array_zeros_double(void)
     return (0);
 }
 
-int32_t test_array_zeros_int32(void)
+int test_array_zeros_int32(void)
 {
-    int32_t m_1_shape[] = {5, 2};
+    int m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
     int32_t value;
     int32_t c_value;
 
@@ -413,12 +786,12 @@ int32_t test_array_zeros_int32(void)
     return (0);
 }
 
-int32_t test_array_zeros_cdouble(void)
+int test_array_zeros_cdouble(void)
 {
-    int32_t m_1_shape[] = {5, 2};
+    int m_1_shape[] = {5, 2};
     t_ndarray x;
-    int32_t index;
-    int32_t c_index;
+    int index;
+    int c_index;
     double complex value;
     double complex c_value;
 
@@ -437,18 +810,27 @@ int32_t test_array_zeros_cdouble(void)
     return (0);
 }
 
-int32_t main(void)
+int main(void)
 {
     /* indexing tests */
     test_indexing_double();
+    test_indexing_int64();
     test_indexing_int32();
+    test_indexing_int16();
+    test_indexing_int8();
     test_indexing_cdouble();
     /* slicing tests */
     test_slicing_double();
+    test_slicing_int64();
     test_slicing_int32();
+    test_slicing_int16();
+    test_slicing_int8();
     test_slicing_cdouble();
     /* array_fill tests */
+    test_array_fill_int64();
     test_array_fill_int32();
+    test_array_fill_int16();
+    test_array_fill_int8();
     test_array_fill_double();
     test_array_fill_cdouble();
     /* array_zeros tests */

--- a/tests/ndarrays/test_ndarrays.c
+++ b/tests/ndarrays/test_ndarrays.c
@@ -5,13 +5,13 @@
 #define getname(X) #X
 #define my_assert(X , Y, dscr) _Generic((X), double: assert_double,\
                             float: assert_float,\
-                            int: assert_int,\
+                            int32: assert_int,\
                             double complex : assert_cdouble,\
                             default: assert_ns)(X , Y, getname(X), getname(Y), dscr, __func__, __FILE__, __LINE__)
 
 void assert_double(double v1 , double v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32 line)
 {
     if (v1 != v2)
     {
@@ -26,7 +26,7 @@ void assert_double(double v1 , double v2,
 
 void assert_float(float v1 , float v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32 line)
 {
     if (v1 != v2)
     {
@@ -39,9 +39,9 @@ void assert_float(float v1 , float v2,
     printf("[DSCR] %s\n", dscr);
 }
 
-void assert_int(int v1 , int v2,
+void assert_int(int32 v1 , int32 v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32 line)
 {
     if (v1 != v2)
     {
@@ -56,7 +56,7 @@ void assert_int(int v1 , int v2,
 
 void assert_cdouble(double complex v1 , double complex v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32 line)
 {
     if (v1 != v2)
     {
@@ -71,26 +71,26 @@ void assert_cdouble(double complex v1 , double complex v2,
 
 void assert_ns(float v1 , float v2,
         const char *v1_name, const char *v2_name, const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32 line)
 {
     printf("[FAIL] %s:%d:%s\n", file, line, func);
     printf("[INFO] not supported type\n");
     printf("[DSCR] %s\n", dscr);
 }
 
-int test_indexing_int(void)
+int32 test_indexing_int(void)
 {
-    int m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
+    int32 m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                 12, 260, 6, 8, 8, 0, 45, 0,
                 1, 0, 0, 1, 200, 33, 5, 57,
                 62, 70, 103, 141, 122, 26, 36, 82,
                 8, 10, 4115, 22, 1, 11, 1, 19};
-    int m_1_shape[] = {5, 8};
+    int32 m_1_shape[] = {5, 8};
     t_ndarray x;
-    int index;
-    int c_index;
-    int value;
-    int c_value;
+    int32 index;
+    int32 c_index;
+    int32 value;
+    int32 c_value;
 
     x = array_create(2, m_1_shape, nd_int);
     memcpy(x.raw_data, m_1, x.buffer_size);
@@ -107,17 +107,17 @@ int test_indexing_int(void)
     return (0);
 }
 
-int test_indexing_double(void)
+int32 test_indexing_double(void)
 {
     double m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                     12, 260, 6.34, 8, 8.002, 0.056, 45, 0.1,
                     1.02, 0.25, 0.00005, 1, 200, 33, 5, 57,
                     62, 70, 103.009, 141, 122, 26.50, 36.334, 82,
                     8.44002, 10.056, 4115, 22.1, 1.1102, 011.25, 1.01110005, 19};
-    int m_1_shape[] = {5, 8};
+    int32 m_1_shape[] = {5, 8};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32 index;
+    int32 c_index;
     double value;
     double c_value;
 
@@ -136,17 +136,17 @@ int test_indexing_double(void)
     return (0);
 }
 
-int test_indexing_cdouble(void)
+int32 test_indexing_cdouble(void)
 {
     double complex m_1[] = {0.37 + 0.588*I,  0.92689451+0.57106791*I,
                             0.93598206+0.30289964*I,  0.54404246+0.09516331*I,
                             0.02827254+0.00432899*I,  0.06873651+0.24810741*I,
                             0.94040543+0.43508215*I,  0.58532094+0.67890618*I,
                             0.68742283+0.64951155*I,  0.15372315+0.89699101*I};
-    int m_1_shape[] = {5, 2};
+    int32 m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32 index;
+    int32 c_index;
     double complex value;
     double complex c_value;
 
@@ -170,9 +170,9 @@ int test_indexing_cdouble(void)
 **  slicing tests
 */
 
-int test_slicing_int(void)
+int32 test_slicing_int(void)
 {
-    int m_1[] = {2, 3, 5, 5, 6,
+    int32 m_1[] = {2, 3, 5, 5, 6,
                 7, 10, 11, 12, 260,
                 6, 8, 8, 0, 45,
                 0, 1, 0, 0, 1,
@@ -180,20 +180,20 @@ int test_slicing_int(void)
                 70, 103, 141, 122, 26,
                 36, 82, 8, 10, 4115,
                 22, 1, 11, 1, 19};
-    int m_1_shape[] = {8, 5};
+    int32 m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
-    int value;
-    int c_value;
+    int32 c_index;
+    int32 value;
+    int32 c_value;
 
     x = array_create(2, m_1_shape, nd_int);
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32 i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32 j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_int[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -211,7 +211,7 @@ int test_slicing_int(void)
     return (0);
 }
 
-int test_slicing_double(void)
+int32 test_slicing_double(void)
 {
     double m_1[] = {2, 3, 5, 5, 6,
                     7, 10, 11, 12, 260,
@@ -221,10 +221,10 @@ int test_slicing_double(void)
                     103.009, 141, 122, 26.50, 36.334,
                     82, 8.44002, 10.056, 4115, 22.1,
                     1.1102, 011.25, 1.01110005, 19, 70};
-    int m_1_shape[] = {8, 5};
+    int32 m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
+    int32 c_index;
     double value;
     double c_value;
 
@@ -232,9 +232,9 @@ int test_slicing_double(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32 i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32 j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_double[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -252,16 +252,16 @@ int test_slicing_double(void)
     return (0);
 }
 
-int test_slicing_cdouble(void)
+int32 test_slicing_cdouble(void)
 {
     double complex m_1[] = {
                     0.37 + 0.588*I,  0.92+0.57*I, 0.93+0.30*I,  0.54+0.09*I, 0.02+0.01*I,
                     0.03+0.24*I, 0.94+0.43*I,  0.58+0.67*I, 0.68+0.64*I,  0.15+0.89*I
                     };
-    int m_1_shape[] = {2, 5};
+    int32 m_1_shape[] = {2, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
+    int32 c_index;
     double complex value;
     double complex c_value;
 
@@ -269,9 +269,9 @@ int test_slicing_cdouble(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32 i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32 j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_cdouble[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -291,14 +291,14 @@ int test_slicing_cdouble(void)
 
 /* array_fill tests */
 
-int test_array_fill_int(void)
+int32 test_array_fill_int(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32 m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
-    int value;
-    int c_value;
+    int32 index;
+    int32 c_index;
+    int32 value;
+    int32 c_value;
 
     x = array_create(2, m_1_shape, nd_int);
     array_fill(32, x);
@@ -315,12 +315,12 @@ int test_array_fill_int(void)
     return (0);
 }
 
-int test_array_fill_double(void)
+int32 test_array_fill_double(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32 m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32 index;
+    int32 c_index;
     double value;
     double c_value;
 
@@ -339,12 +339,12 @@ int test_array_fill_double(void)
     return (0);
 }
 
-int test_array_fill_cdouble(void)
+int32 test_array_fill_cdouble(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32 m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32 index;
+    int32 c_index;
     double complex value;
     double complex c_value;
 
@@ -365,12 +365,12 @@ int test_array_fill_cdouble(void)
 
 /* array_zeros tests */
 
-int test_array_zeros_double(void)
+int32 test_array_zeros_double(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32 m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32 index;
+    int32 c_index;
     double value;
     double c_value;
 
@@ -389,14 +389,14 @@ int test_array_zeros_double(void)
     return (0);
 }
 
-int test_array_zeros_int(void)
+int32 test_array_zeros_int(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32 m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
-    int value;
-    int c_value;
+    int32 index;
+    int32 c_index;
+    int32 value;
+    int32 c_value;
 
     x = array_create(2, m_1_shape, nd_int);
     array_fill(0, x);
@@ -413,12 +413,12 @@ int test_array_zeros_int(void)
     return (0);
 }
 
-int test_array_zeros_cdouble(void)
+int32 test_array_zeros_cdouble(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32 m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32 index;
+    int32 c_index;
     double complex value;
     double complex c_value;
 
@@ -437,7 +437,7 @@ int test_array_zeros_cdouble(void)
     return (0);
 }
 
-int main(void)
+int32 main(void)
 {
     /* indexing tests */
     test_indexing_double();

--- a/tests/ndarrays/test_ndarrays.c
+++ b/tests/ndarrays/test_ndarrays.c
@@ -15,7 +15,7 @@
 
 void assert_double(double v1 , double v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -30,7 +30,7 @@ void assert_double(double v1 , double v2,
 
 void assert_float(float v1 , float v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -45,7 +45,7 @@ void assert_float(float v1 , float v2,
 
 void assert_int64(int64_t v1 , int64_t v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -60,7 +60,7 @@ void assert_int64(int64_t v1 , int64_t v2,
 
 void assert_int32(int32_t v1 , int32_t v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -75,7 +75,7 @@ void assert_int32(int32_t v1 , int32_t v2,
 
 void assert_int16(int16_t v1 , int16_t v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -90,7 +90,7 @@ void assert_int16(int16_t v1 , int16_t v2,
 
 void assert_int8(int8_t v1 , int8_t v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -105,7 +105,7 @@ void assert_int8(int8_t v1 , int8_t v2,
 
 void assert_cfloat(float complex v1 , float complex v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -120,7 +120,7 @@ void assert_cfloat(float complex v1 , float complex v2,
 
 void assert_cdouble(double complex v1 , double complex v2,
         const char *v1_name, const char *v2_name,const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
@@ -135,24 +135,24 @@ void assert_cdouble(double complex v1 , double complex v2,
 
 void assert_ns(float v1 , float v2,
         const char *v1_name, const char *v2_name, const char *dscr,
-        const char * func, const char *file, int line)
+        const char * func, const char *file, int32_t line)
 {
     printf("[FAIL] %s:%d:%s\n", file, line, func);
     printf("[INFO] not supported type\n");
     printf("[DSCR] %s\n", dscr);
 }
 
-int test_indexing_int64(void)
+int32_t test_indexing_int64(void)
 {
     int64_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                 12, 260, 6, 8, 8, 0, 45, 0,
                 1, 0, 0, 1, 200, 33, 5, 57,
                 62, 70, 103, 141, 122, 26, 36, 82,
                 8, 10, 4115, 22, 1, 11, 1, 19};
-    int m_1_shape[] = {5, 8};
+    int32_t m_1_shape[] = {5, 8};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int64_t value;
     int64_t c_value;
 
@@ -171,17 +171,17 @@ int test_indexing_int64(void)
     return (0);
 }
 
-int test_indexing_int32(void)
+int32_t test_indexing_int32(void)
 {
     int32_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                 12, 260, 6, 8, 8, 0, 45, 0,
                 1, 0, 0, 1, 200, 33, 5, 57,
                 62, 70, 103, 141, 122, 26, 36, 82,
                 8, 10, 4115, 22, 1, 11, 1, 19};
-    int m_1_shape[] = {5, 8};
+    int32_t m_1_shape[] = {5, 8};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int32_t value;
     int32_t c_value;
 
@@ -200,17 +200,17 @@ int test_indexing_int32(void)
     return (0);
 }
 
-int test_indexing_int16(void)
+int32_t test_indexing_int16(void)
 {
     int16_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                 12, 260, 6, 8, 8, 0, 45, 0,
                 1, 0, 0, 1, 200, 33, 5, 57,
                 62, 70, 103, 141, 122, 26, 36, 82,
                 8, 10, 4115, 22, 1, 11, 1, 19};
-    int m_1_shape[] = {5, 8};
+    int32_t m_1_shape[] = {5, 8};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int16_t value;
     int16_t c_value;
 
@@ -229,17 +229,17 @@ int test_indexing_int16(void)
     return (0);
 }
 
-int test_indexing_int8(void)
+int32_t test_indexing_int8(void)
 {
     int8_t m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                 12, 250, 6, 8, 8, 0, 45, 0,
                 1, 0, 0, 1, 200, 33, 5, 57,
                 62, 70, 103, 141, 122, 26, 36, 82,
                 8, 10, 251, 22, 1, 11, 1, 19};
-    int m_1_shape[] = {5, 8};
+    int32_t m_1_shape[] = {5, 8};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int8_t value;
     int8_t c_value;
 
@@ -258,17 +258,17 @@ int test_indexing_int8(void)
     return (0);
 }
 
-int test_indexing_double(void)
+int32_t test_indexing_double(void)
 {
     double m_1[] = {2, 3, 5, 5, 6, 7, 10, 11,
                     12, 260, 6.34, 8, 8.002, 0.056, 45, 0.1,
                     1.02, 0.25, 0.00005, 1, 200, 33, 5, 57,
                     62, 70, 103.009, 141, 122, 26.50, 36.334, 82,
                     8.44002, 10.056, 4115, 22.1, 1.1102, 011.25, 1.01110005, 19};
-    int m_1_shape[] = {5, 8};
+    int32_t m_1_shape[] = {5, 8};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     double value;
     double c_value;
 
@@ -287,17 +287,17 @@ int test_indexing_double(void)
     return (0);
 }
 
-int test_indexing_cdouble(void)
+int32_t test_indexing_cdouble(void)
 {
     double complex m_1[] = {0.37 + 0.588*I,  0.92689451+0.57106791*I,
                             0.93598206+0.30289964*I,  0.54404246+0.09516331*I,
                             0.02827254+0.00432899*I,  0.06873651+0.24810741*I,
                             0.94040543+0.43508215*I,  0.58532094+0.67890618*I,
                             0.68742283+0.64951155*I,  0.15372315+0.89699101*I};
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     double complex value;
     double complex c_value;
 
@@ -316,17 +316,17 @@ int test_indexing_cdouble(void)
     return (0);
 }
 
-int test_indexing_cfloat(void)
+int32_t test_indexing_cfloat(void)
 {
     float complex m_1[] = {0.37 + 0.588*I,  0.92689451+0.57106791*I,
                             0.93598206+0.30289964*I,  0.54404246+0.09516331*I,
                             0.02827254+0.00432899*I,  0.06873651+0.24810741*I,
                             0.94040543+0.43508215*I,  0.58532094+0.67890618*I,
                             0.68742283+0.64951155*I,  0.15372315+0.89699101*I};
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     float complex value;
     float complex c_value;
 
@@ -349,7 +349,7 @@ int test_indexing_cfloat(void)
 **  slicing tests
 */
 
-int test_slicing_int64(void)
+int32_t test_slicing_int64(void)
 {
     int64_t m_1[] = {2, 3, 5, 5, 6,
                 7, 10, 11, 12, 260,
@@ -359,10 +359,10 @@ int test_slicing_int64(void)
                 70, 103, 141, 122, 26,
                 36, 82, 8, 10, 4115,
                 22, 1, 11, 1, 19};
-    int m_1_shape[] = {8, 5};
+    int32_t m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
+    int32_t c_index;
     int64_t value;
     int64_t c_value;
 
@@ -370,9 +370,9 @@ int test_slicing_int64(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_int64[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -390,7 +390,7 @@ int test_slicing_int64(void)
     return (0);
 }
 
-int test_slicing_int32(void)
+int32_t test_slicing_int32(void)
 {
     int32_t m_1[] = {2, 3, 5, 5, 6,
                 7, 10, 11, 12, 260,
@@ -400,10 +400,10 @@ int test_slicing_int32(void)
                 70, 103, 141, 122, 26,
                 36, 82, 8, 10, 4115,
                 22, 1, 11, 1, 19};
-    int m_1_shape[] = {8, 5};
+    int32_t m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
+    int32_t c_index;
     int32_t value;
     int32_t c_value;
 
@@ -411,9 +411,9 @@ int test_slicing_int32(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_int32[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -430,7 +430,7 @@ int test_slicing_int32(void)
     free_array(xview);
     return (0);
 }
-int test_slicing_int16(void)
+int32_t test_slicing_int16(void)
 {
     int16_t m_1[] = {2, 3, 5, 5, 6,
                 7, 10, 11, 12, 260,
@@ -440,10 +440,10 @@ int test_slicing_int16(void)
                 70, 103, 141, 122, 26,
                 36, 82, 8, 10, 4115,
                 22, 1, 11, 1, 19};
-    int m_1_shape[] = {8, 5};
+    int32_t m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
+    int32_t c_index;
     int16_t value;
     int16_t c_value;
 
@@ -451,9 +451,9 @@ int test_slicing_int16(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_int16[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -471,7 +471,7 @@ int test_slicing_int16(void)
     return (0);
 }
 
-int test_slicing_int8(void)
+int32_t test_slicing_int8(void)
 {
     int8_t m_1[] = {2, 3, 5, 5, 6,
                 7, 10, 11, 12, 250,
@@ -481,10 +481,10 @@ int test_slicing_int8(void)
                 70, 103, 141, 122, 26,
                 36, 82, 8, 10, 251,
                 22, 1, 11, 1, 19};
-    int m_1_shape[] = {8, 5};
+    int32_t m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
+    int32_t c_index;
     int8_t value;
     int8_t c_value;
 
@@ -492,9 +492,9 @@ int test_slicing_int8(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_int8[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -512,7 +512,7 @@ int test_slicing_int8(void)
     return (0);
 }
 
-int test_slicing_double(void)
+int32_t test_slicing_double(void)
 {
     double m_1[] = {2, 3, 5, 5, 6,
                     7, 10, 11, 12, 260,
@@ -522,10 +522,10 @@ int test_slicing_double(void)
                     103.009, 141, 122, 26.50, 36.334,
                     82, 8.44002, 10.056, 4115, 22.1,
                     1.1102, 011.25, 1.01110005, 19, 70};
-    int m_1_shape[] = {8, 5};
+    int32_t m_1_shape[] = {8, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
+    int32_t c_index;
     double value;
     double c_value;
 
@@ -533,9 +533,9 @@ int test_slicing_double(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_double[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -553,16 +553,16 @@ int test_slicing_double(void)
     return (0);
 }
 
-int test_slicing_cdouble(void)
+int32_t test_slicing_cdouble(void)
 {
     double complex m_1[] = {
                     0.37 + 0.588*I,  0.92+0.57*I, 0.93+0.30*I,  0.54+0.09*I, 0.02+0.01*I,
                     0.03+0.24*I, 0.94+0.43*I,  0.58+0.67*I, 0.68+0.64*I,  0.15+0.89*I
                     };
-    int m_1_shape[] = {2, 5};
+    int32_t m_1_shape[] = {2, 5};
     t_ndarray x;
     t_ndarray xview;
-    int c_index;
+    int32_t c_index;
     double complex value;
     double complex c_value;
 
@@ -570,9 +570,9 @@ int test_slicing_cdouble(void)
     memcpy(x.raw_data, m_1, x.buffer_size);
     xview = array_slicing(x, new_slice(1, 2, 1), new_slice(0, 5, 2));
     c_index = 5;
-    for (int i = 0; i < xview.shape[0]; i++)
+    for (int32_t i = 0; i < xview.shape[0]; i++)
     {
-        for (int j = 0; j < xview.shape[1]; j++)
+        for (int32_t j = 0; j < xview.shape[1]; j++)
         {
             value = xview.nd_cdouble[get_index(xview, i, j)];
             c_value = m_1[c_index];
@@ -592,12 +592,12 @@ int test_slicing_cdouble(void)
 
 /* array_fill tests */
 
-int test_array_fill_int64(void)
+int32_t test_array_fill_int64(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int64_t value;
     int64_t c_value;
 
@@ -616,12 +616,12 @@ int test_array_fill_int64(void)
     return (0);
 }
 
-int test_array_fill_int32(void)
+int32_t test_array_fill_int32(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int32_t value;
     int32_t c_value;
 
@@ -640,12 +640,12 @@ int test_array_fill_int32(void)
     return (0);
 }
 
-int test_array_fill_int16(void)
+int32_t test_array_fill_int16(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int16_t value;
     int16_t c_value;
 
@@ -664,12 +664,12 @@ int test_array_fill_int16(void)
     return (0);
 }
 
-int test_array_fill_int8(void)
+int32_t test_array_fill_int8(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int8_t value;
     int8_t c_value;
 
@@ -688,12 +688,12 @@ int test_array_fill_int8(void)
     return (0);
 }
 
-int test_array_fill_double(void)
+int32_t test_array_fill_double(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     double value;
     double c_value;
 
@@ -712,12 +712,12 @@ int test_array_fill_double(void)
     return (0);
 }
 
-int test_array_fill_cdouble(void)
+int32_t test_array_fill_cdouble(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     double complex value;
     double complex c_value;
 
@@ -738,12 +738,12 @@ int test_array_fill_cdouble(void)
 
 /* array_zeros tests */
 
-int test_array_zeros_double(void)
+int32_t test_array_zeros_double(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     double value;
     double c_value;
 
@@ -762,12 +762,12 @@ int test_array_zeros_double(void)
     return (0);
 }
 
-int test_array_zeros_int32(void)
+int32_t test_array_zeros_int32(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     int32_t value;
     int32_t c_value;
 
@@ -786,12 +786,12 @@ int test_array_zeros_int32(void)
     return (0);
 }
 
-int test_array_zeros_cdouble(void)
+int32_t test_array_zeros_cdouble(void)
 {
-    int m_1_shape[] = {5, 2};
+    int32_t m_1_shape[] = {5, 2};
     t_ndarray x;
-    int index;
-    int c_index;
+    int32_t index;
+    int32_t c_index;
     double complex value;
     double complex c_value;
 
@@ -810,7 +810,7 @@ int test_array_zeros_cdouble(void)
     return (0);
 }
 
-int main(void)
+int32_t main(void)
 {
     /* indexing tests */
     test_indexing_double();


### PR DESCRIPTION
As discussed in PR #548, we are now using stdint.h for integer types in C. This PR makes those changes for arrays in C.

cc: @saniQQ 