### PR TITLE
Speed up macOS setup

### DIFF
--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -7,4 +7,7 @@ runs:
       run: |
         brew install open-mpi
         brew install libomp
+        brew --version
+        brew list
+        brew info
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -3,18 +3,8 @@ name: 'Macosx installation commands'
 runs:
   using: "composite"
   steps:
-    - name: Update packages
-      run:
-        brew update
-      shell: bash
     - name: Install MPI, OpenMP
       run: |
-        # Avoid upgrade of useless packages that depend on open-mpi
-        # We only let upgrading: hdf5 netcdf numpy openblas python3
-        brew pin ansible cairo cgal gdal geos glib gnupg gnutls libdap
-        brew pin libpq libxml2 libspatialite libssh mercurial nettle
-        brew pin poppler postgis postgresql pyenv sfcgal unbound
-        #brew install gcc openblas lapack
         brew install open-mpi
         brew install libomp
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -7,7 +7,4 @@ runs:
       run: |
         brew install open-mpi
         brew install libomp
-        brew --version
-        brew list
-        brew info
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -7,16 +7,13 @@ runs:
       run:
         brew update
       shell: bash
-    - name: Avoid upgrade of useless packages
+    - name: Install MPI, OpenMP
       run: |
         # Avoid upgrade of useless packages that depend on open-mpi
         # We only let upgrading: hdf5 netcdf numpy openblas python3
         brew pin ansible cairo cgal gdal geos glib gnupg gnutls libdap
         brew pin libpq libxml2 libspatialite libssh mercurial nettle
         brew pin poppler postgis postgresql pyenv sfcgal unbound
-      shell: bash
-    - name: Install MPI, OpenMP
-      run: |
         #brew install gcc openblas lapack
         brew install open-mpi
         brew install libomp

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -12,7 +12,7 @@ jobs:
   Linux:
 
     runs-on: ubuntu-latest
-    if: github.event_name == "push"
+    if: ${{ github.event_name == 'push' }}
 
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
   Windows:
 
     runs-on: windows-latest
-    if: github.event_name == "pull_request"
+    if: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v2
@@ -111,7 +111,7 @@ jobs:
   MacOSX:
 
     runs-on: macos-latest
-    if: github.event_name == "pull_request"
+    if: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,14 +5,14 @@ name: Pyccel tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: [ opened, reopened, edited ]
 
 jobs:
   Linux:
 
     runs-on: ubuntu-latest
+    if: github.event_name == "push"
 
     steps:
       - uses: actions/checkout@v2
@@ -73,6 +73,7 @@ jobs:
   Windows:
 
     runs-on: windows-latest
+    if: github.event_name == "pull_request"
 
     steps:
       - uses: actions/checkout@v2
@@ -110,6 +111,7 @@ jobs:
   MacOSX:
 
     runs-on: macos-latest
+    if: github.event_name == "pull_request"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -6,7 +6,10 @@ name: Pyccel tests
 on:
   push:
   pull_request:
-    types: [ opened, reopened, edited ]
+    types:
+      - opened
+      - reopened
+      - edited
 
 jobs:
   Linux:

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -114,7 +114,7 @@ jobs:
   MacOSX:
 
     runs-on: macos-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    #if: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,17 +5,14 @@ name: Pyccel tests
 
 on:
   push:
+    branches: [ master ]
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
+    branches: [ master ]
 
 jobs:
   Linux:
 
     runs-on: ubuntu-latest
-    on: push
 
     steps:
       - uses: actions/checkout@v2
@@ -76,7 +73,6 @@ jobs:
   Windows:
 
     runs-on: windows-latest
-    if: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v2
@@ -114,7 +110,6 @@ jobs:
   MacOSX:
 
     runs-on: macos-latest
-    if: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -10,6 +10,7 @@ on:
       - opened
       - reopened
       - edited
+      - synchronize
 
 jobs:
   Linux:

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -9,14 +9,13 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - synchronize
 
 jobs:
   Linux:
 
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
+    on: push
 
     steps:
       - uses: actions/checkout@v2
@@ -115,7 +114,7 @@ jobs:
   MacOSX:
 
     runs-on: macos-latest
-    #if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub provides an up-to-date version of Homebrew, so there is no need to update it and pin packages.