### PR TITLE
Ensure literals have the right argument. Create literals with a requested precision

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -17,7 +17,7 @@ from .basic     import Basic, PyccelAstNode
 from .datatypes import (NativeInteger, NativeBool, NativeReal,
                         NativeComplex, NativeString, str_dtype,
                         NativeGeneric, default_precision)
-from .literals  import LiteralInteger, LiteralFloat
+from .literals  import LiteralInteger, LiteralFloat, LiteralComplex
 
 __all__ = (
     'PythonBool',
@@ -87,13 +87,21 @@ class PythonComplex(Expr, PyccelAstNode):
     _dtype = NativeComplex()
 
     def __new__(cls, arg0, arg1=LiteralFloat(0)):
-        if isinstance(arg, LiteralFloat):
-            return LiteralFloat(arg.arg[0], precision = cls._precision)
-        elif isinstance(arg, LiteralInt):
-            return LiteralFloat(arg.p, precision = cls._precision)
+        if isinstance(arg0, LiteralFloat):
+            arg0 = LiteralFloat(arg0, precision = cls._precision)
+        elif isinstance(arg0, LiteralInteger):
+            arg0 = LiteralFloat(arg0.p, precision = cls._precision)
+        if isinstance(arg1, LiteralFloat):
+            arg1 = LiteralFloat(arg1, precision = cls._precision)
+        elif isinstance(arg1, LiteralInteger):
+            arg1 = LiteralFloat(arg1.p, precision = cls._precision)
+
+        if isinstance(arg0, LiteralFloat) and isinstance(arg1, LiteralFloat):
+            return LiteralComplex(arg0, arg1, precision = cls._precision)
+        elif isinstance(arg0, LiteralComplex):
+            return LiteralComplex(arg0.real, arg0.imag, precision = cls._precision)
         else:
-            return Expr.__new__(cls, arg)
-        return Expr.__new__(cls, arg0, arg1)
+            return Expr.__new__(cls, arg0, arg1)
 
     @property
     def real_part(self):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -265,6 +265,8 @@ class PythonTuple(Expr, PyccelAstNode):
             self._shape     = (LiteralInteger(len(args)), ) + args[0].shape
 
     def __getitem__(self,i):
+        if isinstance(i, LiteralInteger):
+            i = i.p
         return self._args[i]
 
     def __add__(self,other):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -202,6 +202,7 @@ class PythonComplex(Expr, PyccelAstNode):
         if self._is_cast:
             self._real_part = PythonReal(arg0)
             self._imag_part = PythonImag(arg0)
+            self._internal_var = arg0
         else:
             self._real_part = arg0
             self._imag_part = arg1
@@ -218,18 +219,13 @@ class PythonComplex(Expr, PyccelAstNode):
     def imag_part(self):
         return self._imag_part
 
+    @property
+    def internal_var(self):
+        assert(self._is_cast)
+        return self._internal_var
+
     def __str__(self):
-        return self.fprint(str)
-
-    def _sympystr(self, printer):
-        return self.fprint(str)
-
-    def fprint(self, printer):
-        """Fortran print."""
-        real = printer(self.real_part)
-        imag = printer(self.imag_part)
-        code = 'cmplx({0}, {1}, {2})'.format(real, imag, iso_c_binding["complex"][self.precision])
-        return code
+        return "complex({}, {})".format(str(self._args[0]), str(self._args[1]))
 
 #==============================================================================
 class PythonEnumerate(Basic):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -205,18 +205,22 @@ class PythonComplex(Expr, PyccelAstNode):
 
     @property
     def is_cast(self):
+        """ Indicates if the function is casting or assembling a complex """
         return self._is_cast
 
     @property
     def real_part(self):
+        """ Returns the real part of the complex """
         return self._real_part
 
     @property
     def imag_part(self):
+        """ Returns the imaginary part of the complex """
         return self._imag_part
 
     @property
     def internal_var(self):
+        """ When the complex call is a cast, returns the variable being cast """
         assert(self._is_cast)
         return self._internal_var
 

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -435,10 +435,6 @@ class PythonRange(Basic):
     def step(self):
         return self._args[2]
 
-    @property
-    def size(self):
-        return (self.stop - self.start) / self.step
-
 
 #==============================================================================
 class PythonZip(Basic):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -87,6 +87,12 @@ class PythonComplex(Expr, PyccelAstNode):
     _dtype = NativeComplex()
 
     def __new__(cls, arg0, arg1=LiteralFloat(0)):
+        if isinstance(arg, LiteralFloat):
+            return LiteralFloat(arg.arg[0], precision = cls._precision)
+        elif isinstance(arg, LiteralInt):
+            return LiteralFloat(arg.p, precision = cls._precision)
+        else:
+            return Expr.__new__(cls, arg)
         return Expr.__new__(cls, arg0, arg1)
 
     @property
@@ -137,7 +143,12 @@ class PythonFloat(Expr, PyccelAstNode):
     _dtype = NativeReal()
 
     def __new__(cls, arg):
-        return Expr.__new__(cls, arg)
+        if isinstance(arg, LiteralFloat):
+            return LiteralFloat(arg, precision = cls._precision)
+        elif isinstance(arg, LiteralInteger):
+            return LiteralFloat(arg.p, precision = cls._precision)
+        else:
+            return Expr.__new__(cls, arg)
 
     @property
     def arg(self):
@@ -168,7 +179,10 @@ class PythonInt(Expr, PyccelAstNode):
     _dtype     = NativeInteger()
 
     def __new__(cls, arg):
-        return Expr.__new__(cls, arg)
+        if isinstance(arg, LiteralInteger):
+            return LiteralInteger(arg.p, precision = cls._precision)
+        else:
+            return Expr.__new__(cls, arg)
 
     @property
     def arg(self):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -17,7 +17,7 @@ from .basic     import Basic, PyccelAstNode
 from .datatypes import (NativeInteger, NativeBool, NativeReal,
                         NativeComplex, NativeString, str_dtype,
                         NativeGeneric, default_precision)
-from .literals  import LiteralInteger, LiteralFloat, LiteralComplex
+from .literals  import LiteralInteger, LiteralFloat, LiteralComplex, get_default_literal_value
 
 __all__ = (
     'PythonBool',
@@ -573,7 +573,7 @@ class PythonImag(Function, PyccelAstNode):
     _shape = ()
     def __new__(cls, arg):
         if arg.dtype is not NativeComplex():
-            return LiteralFloat(0)
+            return get_default_literal_value(arg.dtype)
         else:
             return Function.__new__(cls, arg)
 

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -226,7 +226,7 @@ class PythonComplex(Expr, PyccelAstNode):
     @property
     def imag(self):
         """ Returns the imaginary part of the complex """
-        return self._imag
+        return self._imag_part
 
     @property
     def internal_var(self):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -34,6 +34,8 @@ __all__ = (
     'PythonZip',
     'PythonMax',
     'PythonMin',
+    'PythonReal',
+    'PythonImag',
     'python_builtin_datatype'
 )
 
@@ -525,6 +527,65 @@ class PythonMin(Function, PyccelAstNode):
         self._rank      = 0
         self._dtype     = x.dtype
         self._precision = x.precision
+
+#==============================================================================
+class PythonReal(Function, PyccelAstNode):
+    """Represents a call to the .real property
+
+    e.g:
+    > a = 1+2j
+    > a.real
+    1.0
+
+    arg : Variable, Literal
+    """
+    _dtype = NativeReal()
+    _rank  = 0
+    _shape = ()
+    def __new__(cls, arg):
+        if arg.dtype is not NativeComplex():
+            return arg
+        else:
+            return Function.__new__(cls, arg)
+
+    def __init__(self, arg):
+        self._precision = arg.precision
+
+    def internal_var(self):
+        return self._args[0]
+
+    def __str__(self):
+        return 'Real({0})'.format(str(self.arg))
+
+#==============================================================================
+class PythonImag(Function, PyccelAstNode):
+    """Represents a call to the .imag property
+
+    e.g:
+    > a = 1+2j
+    > a.imag
+    1.0
+
+    arg : Variable, Literal
+    """
+    _dtype = NativeReal()
+    _rank  = 0
+    _shape = ()
+    def __new__(cls, arg):
+        if arg.dtype is not NativeComplex():
+            return LiteralFloat(0)
+        else:
+            return Function.__new__(cls, arg)
+
+    def __init__(self, arg):
+        self._precision = arg.precision
+
+    def internal_var(self):
+        return self._args[0]
+
+    def __str__(self):
+        return 'Imag({0})'.format(str(self.arg))
+
 
 #==============================================================================
 python_builtin_datatypes_dict = {

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -6,13 +6,14 @@ always available.
 In this module we implement some of them in alphabetical order.
 
 """
-from pyccel.ast.datatypes import iso_c_binding
 
 from sympy import Symbol, Function, Tuple
 from sympy import Expr, Not
 from sympy import sympify
 from sympy.tensor import Indexed, IndexedBase
 from sympy.core.function import Application
+
+from pyccel.ast.datatypes import iso_c_binding
 
 from .basic     import Basic, PyccelAstNode
 from .datatypes import (NativeInteger, NativeBool, NativeReal,
@@ -176,11 +177,11 @@ class PythonComplex(Expr, PyccelAstNode):
 
         # Split arguments depending on their type to ensure that the arguments are
         # either a complex and LiteralFloat(0) or 2 floats
-        from .operators import PyccelAdd, PyccelMul, PyccelUnarySub
+        from .operators import PyccelAdd, PyccelMul
 
         if arg0.dtype is NativeComplex() and arg1.dtype is NativeComplex():
-                # both args are complex
-                return PyccelAdd(arg0, PyccelMul(arg1, LiteralImaginaryUnit()))
+            # both args are complex
+            return PyccelAdd(arg0, PyccelMul(arg1, LiteralImaginaryUnit()))
         return Expr.__new__(cls, arg0, arg1)
 
     def __init__(self, arg0, arg1 = LiteralFloat(0)):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -12,6 +12,7 @@ from sympy import Symbol, Function, Tuple
 from sympy import Expr, Not
 from sympy import sympify
 from sympy.tensor import Indexed, IndexedBase
+from sympy.core.function import Application
 
 from .basic     import Basic, PyccelAstNode
 from .datatypes import (NativeInteger, NativeBool, NativeReal,
@@ -51,7 +52,7 @@ local_sympify = {
 }
 
 #==============================================================================
-class PythonComplexProperty(Function, PyccelAstNode):
+class PythonComplexProperty(Application, PyccelAstNode):
     """Represents a call to the .real or .imag property
 
     e.g:
@@ -74,7 +75,7 @@ class PythonComplexProperty(Function, PyccelAstNode):
         return self._args[0]
 
     def __str__(self):
-        return 'Real({0})'.format(str(self.arg))
+        return 'Real({0})'.format(str(self.internal_var))
 
 #==============================================================================
 class PythonReal(PythonComplexProperty):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -219,14 +219,14 @@ class PythonComplex(Expr, PyccelAstNode):
         return self._is_cast
 
     @property
-    def real_part(self):
+    def real(self):
         """ Returns the real part of the complex """
         return self._real_part
 
     @property
-    def imag_part(self):
+    def imag(self):
         """ Returns the imaginary part of the complex """
-        return self._imag_part
+        return self._imag
 
     @property
     def internal_var(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -48,7 +48,7 @@ from .itertoolsext   import Product
 from .functionalexpr import GeneratorComprehension as GC
 from .functionalexpr import FunctionalFor
 
-from .operators import PyccelMinus
+from .operators import PyccelMinus, PyccelMul
 
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import *
@@ -621,7 +621,7 @@ class Dlist(Basic, PyccelAstNode):
 
     def __init__(self, val, length):
         self._rank = val.rank
-        self._shape = tuple(s if i!= 0 else s*length for i,s in enumerate(val.shape))
+        self._shape = tuple(s if i!= 0 else PyccelMul(s, length) for i,s in enumerate(val.shape))
 
     @property
     def val(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4774,8 +4774,6 @@ class IndexedVariable(IndexedBase, PyccelAstNode):
         if self.shape and len(self.shape) != len(args):
             raise IndexError('Rank mismatch.')
 
-        args = tuple(a.p if isinstance(a, LiteralInteger) else a for a in args)
-
         obj = IndexedElement(self, *args)
         return obj
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2649,6 +2649,8 @@ class TupleVariable(Variable):
         self._vars[variable_idx] = self._vars[variable_idx].clone(new_name)
 
     def __getitem__(self,idx):
+        if isinstance(idx, LiteralInteger):
+            idx = idx.p
         return self.get_var(idx)
 
     def __iter__(self):
@@ -4767,6 +4769,8 @@ class IndexedVariable(IndexedBase, PyccelAstNode):
 
         if self.shape and len(self.shape) != len(args):
             raise IndexError('Rank mismatch.')
+
+        args = tuple(a.p if isinstance(a, LiteralInteger) else a for a in args)
 
         obj = IndexedElement(self, *args)
         return obj

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -7,7 +7,7 @@ from ..errors.messages import PYCCEL_RESTRICTION_TODO
 
 from .basic     import Basic
 
-from .builtins  import PythonBool
+from .builtins  import PythonBool, PythonComplex
 
 from .datatypes import DataType
 from .datatypes import NativeInteger, NativeReal, NativeComplex
@@ -16,7 +16,7 @@ from .datatypes import NativeBool, NativeString, NativeGeneric
 from .core      import FunctionCall, FunctionDef, Variable, ValuedVariable, VariableAddress, FunctionAddress
 from .core      import AliasAssign, Assign, Return, If
 
-from .literals  import LiteralTrue, LiteralComplex
+from .literals  import LiteralTrue
 
 from .numpyext  import NumpyReal, NumpyImag
 
@@ -463,7 +463,7 @@ def pycomplex_to_complex(cast_function_name):
 
     cast_function_body = [Assign(real_part, FunctionCall(pycomplex_real, [cast_function_argument])),
                           Assign(imag_part, FunctionCall(pycomplex_imag, [cast_function_argument])),
-                          Assign(cast_function_result, LiteralComplex(real_part, imag_part)),
+                          Assign(cast_function_result, PythonComplex(real_part, imag_part)),
                           Return([cast_function_result])]
     return FunctionDef(name      = cast_function_name,
                        arguments = [cast_function_argument],

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -36,6 +36,10 @@ class Literal(PyccelAstNode):
         """ Set precision for a literal class"""
         self._precision = precision
 
+    @property
+    def python_value(self):
+        """ Get python literal represented by this instance """
+
 #------------------------------------------------------------------------------
 class LiteralTrue(sp_BooleanTrue, Literal):
     """Represents the python value True"""

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -45,6 +45,10 @@ class LiteralTrue(sp_BooleanTrue, Literal):
     def __init__(self, precision = default_precision['bool']):
         Literal.__init__(self, precision)
 
+    @property
+    def python_value(self):
+        return True
+
 #------------------------------------------------------------------------------
 class LiteralFalse(sp_BooleanFalse, Literal):
     """Represents the python value False"""
@@ -53,6 +57,10 @@ class LiteralFalse(sp_BooleanFalse, Literal):
         return sp_BooleanFalse.__new__(cls)
     def __init__(self,precision = default_precision['bool']):
         Literal.__init__(self, precision)
+
+    @property
+    def python_value(self):
+        return False
 
 #------------------------------------------------------------------------------
 class LiteralInteger(Basic, Literal):
@@ -67,6 +75,10 @@ class LiteralInteger(Basic, Literal):
             raise TypeError("A LiteralInteger can only be created with an integer")
         self.p = value
 
+    @property
+    def python_value(self):
+        return self.p
+
 #------------------------------------------------------------------------------
 class LiteralFloat(sp_Float, Literal):
     """Represents a float literal in python"""
@@ -78,6 +90,10 @@ class LiteralFloat(sp_Float, Literal):
         if not isinstance(value, (int, float, LiteralFloat)):
             raise TypeError("A LiteralFloat can only be created with an integer or a float")
         Literal.__init__(self, precision)
+
+    @property
+    def python_value(self):
+        return float(self)
 
 
 #------------------------------------------------------------------------------
@@ -125,6 +141,10 @@ class LiteralComplex(Basic, Literal):
         """ Return the imaginary part of the complex literal """
         return self._imag_part
 
+    @property
+    def python_value(self):
+        return self.real.python_value + self.imag.python_value*1j
+
 #------------------------------------------------------------------------------
 class LiteralImaginaryUnit(LiteralComplex):
     """Represents the python value j"""
@@ -133,6 +153,10 @@ class LiteralImaginaryUnit(LiteralComplex):
 
     def __init__(self):
         LiteralComplex.__init__(self, 0, 1)
+
+    @property
+    def python_value(self):
+        return 1j
 
 #------------------------------------------------------------------------------
 class LiteralString(Basic, Literal):
@@ -154,6 +178,10 @@ class LiteralString(Basic, Literal):
         return self._string
 
     def __str__(self):
+        return self.arg
+
+    @property
+    def python_value(self):
         return self.arg
 
 #------------------------------------------------------------------------------

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -42,6 +42,8 @@ class Literal(PyccelAstNode):
 class LiteralTrue(sp_BooleanTrue, Literal):
     """Represents the python value True"""
     _dtype     = NativeBool()
+    def __new__(cls, precision = default_precision['bool']):
+        return sp_BooleanTrue(cls)
     def __init__(self, precision = default_precision['bool']):
         Literal.__init__(self, precision)
 
@@ -49,6 +51,8 @@ class LiteralTrue(sp_BooleanTrue, Literal):
 class LiteralFalse(sp_BooleanFalse, Literal):
     """Represents the python value False"""
     _dtype     = NativeBool()
+    def __new__(cls, precision = default_precision['bool']):
+        return sp_BooleanFalse(cls)
     def __init__(self,precision = default_precision['bool']):
         Literal.__init__(self, precision)
 
@@ -56,6 +60,9 @@ class LiteralFalse(sp_BooleanFalse, Literal):
 class LiteralInteger(Basic, Literal):
     """Represents an integer literal in python"""
     _dtype     = NativeInteger()
+    def __new__(cls, value, precision = default_precision['integer']):
+        return Basic.__new__(cls, value)
+
     def __init__(self, value, precision = default_precision['integer']):
         Literal.__init__(self, precision)
         if not isinstance(value, int):
@@ -66,6 +73,9 @@ class LiteralInteger(Basic, Literal):
 class LiteralFloat(sp_Float, Literal):
     """Represents a float literal in python"""
     _dtype     = NativeReal()
+    def __new__(cls, value, *, precision = default_precision['float']):
+        return sp_Float.__new__(cls, value)
+
     def __init__(self, value, *, precision = default_precision['float']):
         if not isinstance(value, (int, float, LiteralFloat)):
             raise TypeError("A LiteralFloat can only be created with an integer or a float")
@@ -77,7 +87,7 @@ class LiteralComplex(Basic, Literal):
     """Represents a complex literal in python"""
     _dtype     = NativeComplex()
 
-    def __new__(cls, real, imag):
+    def __new__(cls, real, imag, precision = default_precision['complex']):
         return Basic.__new__(cls, real, imag)
 
     def __init__(self, real, imag, precision = default_precision['complex']):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -96,6 +96,8 @@ class LiteralComplex(Basic, Literal):
                 self._real_part = real
             else:
                 self._real_part = LiteralFloat(real.args[0], precision = precision)
+        elif isinstance(real, LiteralInteger):
+            self._real_part = LiteralFloat(real.p, precision = precision)
         elif isinstance(real, (int, float)):
             self._real_part = LiteralFloat(real, precision = precision)
         else:
@@ -106,6 +108,8 @@ class LiteralComplex(Basic, Literal):
                 self._imag_part = imag
             else:
                 self._imag_part = LiteralFloat(imag.args[0], precision = precision)
+        elif isinstance(imag, LiteralInteger):
+            self._imag_part = LiteralFloat(imag.p, precision = precision)
         elif isinstance(imag, (int, float)):
             self._imag_part = LiteralFloat(imag, precision = precision)
         else:

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -74,6 +74,7 @@ class LiteralInteger(Basic, Literal):
         return Basic.__new__(cls, value)
 
     def __init__(self, value, precision = default_precision['integer']):
+        Basic.__init__(self)
         Literal.__init__(self, precision)
         if not isinstance(value, int):
             raise TypeError("A LiteralInteger can only be created with an integer")

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -53,17 +53,12 @@ class LiteralFalse(sp_BooleanFalse, Literal):
         Literal.__init__(self, precision)
 
 #------------------------------------------------------------------------------
-class LiteralInteger(sp_Integer, Literal):
+class LiteralInteger(Basic, Literal):
     """Represents an integer literal in python"""
     _dtype     = NativeInteger()
-    def __new__(cls, val, precision = default_precision['integer']):
-        ival = int(val)
-        obj = Expr.__new__(cls, ival)
-        obj._precision = precision
-        obj.p = ival
-        return obj
     def __init__(self, value, precision = default_precision['integer']):
         Literal.__init__(self, precision)
+        self.p = value
 
 #------------------------------------------------------------------------------
 class LiteralFloat(sp_Float, Literal):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -107,34 +107,29 @@ class LiteralComplex(Basic, Literal):
     _dtype     = NativeComplex()
 
     def __new__(cls, real, imag, precision = default_precision['complex']):
-        return Basic.__new__(cls, real, imag)
+        if cls is LiteralImaginaryUnit:
+            return Basic.__new__(cls, real, imag)
+        real_part = cls._collect_python_val(real)
+        imag_part = cls._collect_python_val(imag)
+        if real_part == 0 and imag_part == 1:
+            return LiteralImaginaryUnit()
+        else:
+            return Basic.__new__(cls, real, imag)
 
     def __init__(self, real, imag, precision = default_precision['complex']):
         Basic.__init__(self)
         Literal.__init__(self, precision)
-        if isinstance(real, LiteralFloat):
-            if real.precision == precision:
-                self._real_part = real
-            else:
-                self._real_part = LiteralFloat(real.args[0], precision = precision)
-        elif isinstance(real, LiteralInteger):
-            self._real_part = LiteralFloat(real.p, precision = precision)
-        elif isinstance(real, (int, float)):
-            self._real_part = LiteralFloat(real, precision = precision)
-        else:
-            raise TypeError("The real part of a LiteralComplex must be an int/float/LiteralFloat")
+        self._real_part = LiteralFloat(self._collect_python_val(real))
+        self._imag_part = LiteralFloat(self._collect_python_val(imag))
 
-        if isinstance(imag, LiteralFloat):
-            if imag.precision == precision:
-                self._imag_part = imag
-            else:
-                self._imag_part = LiteralFloat(imag.args[0], precision = precision)
-        elif isinstance(imag, LiteralInteger):
-            self._imag_part = LiteralFloat(imag.p, precision = precision)
-        elif isinstance(imag, (int, float)):
-            self._imag_part = LiteralFloat(imag, precision = precision)
+    @staticmethod
+    def _collect_python_val(arg):
+        if isinstance(arg, Literal):
+            return arg.python_value
+        elif isinstance(arg, (int, float)):
+            return arg
         else:
-            raise TypeError("The imaginary part of a LiteralComplex must be an int/float/LiteralFloat")
+            raise TypeError("LiteralComplex argument must be an int/float/LiteralInt/LiteralFloat")
 
     @property
     def real(self):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -95,7 +95,7 @@ class LiteralComplex(Basic, Literal):
 
         if isinstance(imag, LiteralFloat):
             if imag.precision == precision:
-        self._imag_part = imag
+                self._imag_part = imag
             else:
                 self._imag_part = LiteralFloat(imag.args[0], precision = precision)
         elif isinstance(imag, (int, float)):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -151,7 +151,7 @@ class LiteralImaginaryUnit(LiteralComplex):
     def __new__(cls):
         return LiteralComplex.__new__(cls, 0, 1)
 
-    def __init__(self):
+    def __init__(self, real=0, imag=1, precision = default_precision['complex']):
         LiteralComplex.__init__(self, 0, 1)
 
     @property

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -58,6 +58,8 @@ class LiteralInteger(Basic, Literal):
     _dtype     = NativeInteger()
     def __init__(self, value, precision = default_precision['integer']):
         Literal.__init__(self, precision)
+        if not isinstance(value, int):
+            raise TypeError("A LiteralInteger can only be created with an integer")
         self.p = value
 
 #------------------------------------------------------------------------------
@@ -65,6 +67,8 @@ class LiteralFloat(sp_Float, Literal):
     """Represents a float literal in python"""
     _dtype     = NativeReal()
     def __init__(self, value, *, precision = default_precision['float']):
+        if not isinstance(value, (int, float, LiteralFloat)):
+            raise TypeError("A LiteralFloat can only be created with an integer or a float")
         Literal.__init__(self, precision)
 
 
@@ -78,9 +82,26 @@ class LiteralComplex(Basic, Literal):
 
     def __init__(self, real, imag, precision = default_precision['complex']):
         Basic.__init__(self)
-        self._real_part = real
-        self._imag_part = imag
         Literal.__init__(self, precision)
+        if isinstance(real, LiteralFloat):
+            if real.precision == precision:
+                self._real_part = real
+            else:
+                self._real_part = LiteralFloat(real.args[0], precision = precision)
+        elif isinstance(real, (int, float)):
+            self._real_part = LiteralFloat(real, precision = precision)
+        else:
+            raise TypeError("The real part of a LiteralComplex must be an int/float/LiteralFloat")
+
+        if isinstance(imag, LiteralFloat):
+            if imag.precision == precision:
+        self._imag_part = imag
+            else:
+                self._imag_part = LiteralFloat(imag.args[0], precision = precision)
+        elif isinstance(imag, (int, float)):
+            self._imag_part = LiteralFloat(imag, precision = precision)
+        else:
+            raise TypeError("The imaginary part of a LiteralComplex must be an int/float/LiteralFloat")
 
     @property
     def real(self):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -29,6 +29,10 @@ class Literal(PyccelAstNode):
     _rank      = 0
     _shape     = ()
 
+    def __init__(self, precision):
+        if not isinstance(precision, int):
+            raise TypeError("precision must be an integer")
+        self._precision = precision
     @PyccelAstNode.precision.setter
     def precision(self, precision):
         """ Set precision for a literal class"""
@@ -39,14 +43,14 @@ class LiteralTrue(sp_BooleanTrue, Literal):
     """Represents the python value True"""
     _dtype     = NativeBool()
     def __init__(self, precision = default_precision['bool']):
-        self._precision = precision
+        Literal.__init__(self, precision)
 
 #------------------------------------------------------------------------------
 class LiteralFalse(sp_BooleanFalse, Literal):
     """Represents the python value False"""
     _dtype     = NativeBool()
     def __init__(self,precision = default_precision['bool']):
-        self._precision = precision
+        Literal.__init__(self, precision)
 
 #------------------------------------------------------------------------------
 class LiteralInteger(sp_Integer, Literal):
@@ -59,14 +63,14 @@ class LiteralInteger(sp_Integer, Literal):
         obj.p = ival
         return obj
     def __init__(self, value, precision = default_precision['integer']):
-        self._precision = precision
+        Literal.__init__(self, precision)
 
 #------------------------------------------------------------------------------
 class LiteralFloat(sp_Float, Literal):
     """Represents a float literal in python"""
     _dtype     = NativeReal()
     def __init__(self, value, *, precision = default_precision['float']):
-        self._precision = precision
+        Literal.__init__(self, precision)
 
 
 #------------------------------------------------------------------------------
@@ -81,7 +85,7 @@ class LiteralComplex(Basic, Literal):
         Basic.__init__(self)
         self._real_part = real
         self._imag_part = imag
-        self._precision = precision
+        Literal.__init__(self, precision)
 
     @property
     def real(self):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -43,7 +43,7 @@ class LiteralTrue(sp_BooleanTrue, Literal):
     """Represents the python value True"""
     _dtype     = NativeBool()
     def __new__(cls, precision = default_precision['bool']):
-        return sp_BooleanTrue(cls)
+        return sp_BooleanTrue.__new__(cls)
     def __init__(self, precision = default_precision['bool']):
         Literal.__init__(self, precision)
 
@@ -52,7 +52,7 @@ class LiteralFalse(sp_BooleanFalse, Literal):
     """Represents the python value False"""
     _dtype     = NativeBool()
     def __new__(cls, precision = default_precision['bool']):
-        return sp_BooleanFalse(cls)
+        return sp_BooleanFalse.__new__(cls)
     def __init__(self,precision = default_precision['bool']):
         Literal.__init__(self, precision)
 

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -1,7 +1,5 @@
 """ This module contains all literal types
 """
-from sympy               import Expr
-from sympy               import Integer as sp_Integer
 from sympy               import Float as sp_Float
 from sympy.logic.boolalg import BooleanTrue as sp_BooleanTrue, BooleanFalse as sp_BooleanFalse
 
@@ -124,7 +122,7 @@ class LiteralComplex(Basic, Literal):
         return self._imag_part
 
 #------------------------------------------------------------------------------
-class LiteralImaginaryUnit(LiteralComplex, Literal):
+class LiteralImaginaryUnit(LiteralComplex):
     """Represents the python value j"""
     def __new__(cls):
         return LiteralComplex.__new__(cls, 0, 1)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -17,7 +17,7 @@ from .operators      import (PyccelPow, PyccelMinus, PyccelMul, PyccelAdd,
                              PyccelAssociativeParenthesis, broadcast)
 
 from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
-                             PythonComplex)
+                             PythonComplex, PythonReal, PythonImag)
 
 from .datatypes      import (dtype_and_precision_registry as dtype_registry,
                              default_precision, datatype, NativeInteger,
@@ -365,70 +365,22 @@ def Shape(arg):
         return PythonTuple(*arg.shape)
 
 #==============================================================================
-class NumpyReal(Function, PyccelAstNode):
-
+class NumpyReal(PythonReal):
     """Represents a call to  numpy.real for code generation.
 
     > a = 1+2j
     > np.real(a)
     1.0
-
-    arg : Variable, LiteralFloat, sp_Integer, LiteralComplex
     """
-
-    def __new__(cls, arg):
-
-        _valid_args = (Variable, IndexedElement, sp_Integer, Nil,
-                       LiteralFloat, Expr, Application)
-
-        if not isinstance(arg, _valid_args):
-            raise TypeError('Uknown type of  %s.' % type(arg))
-        return Basic.__new__(cls, arg)
-
-    def __init__(self, arg):
-        self._dtype = NativeReal()
-        self._rank  = 0
-        self._shape = ()
-        self._precision = default_precision['real']
-
-    @property
-    def arg(self):
-        return self._args[0]
-
-    def fprint(self, printer):
-        """Fortran print."""
-
-        value = printer(self.arg)
-        prec  = printer(self.precision)
-        code = 'Real({0}, {1})'.format(value, prec)
-        return code
-
-
-    def __str__(self):
-        return 'NumpyReal({0})'.format(str(self.arg))
-
-
-    def _sympystr(self, printer):
-        return self.__str__()
 
 #==============================================================================
-class NumpyImag(NumpyReal):
+class NumpyImag(PythonImag):
+    """Represents a call to  numpy.real for code generation.
 
-    """Represents a call to  numpy.imag for code generation.
-
-    arg : Variable, LiteralFloat, sp_Integer, LiteralComplex
+    > a = 1+2j
+    > np.imag(a)
+    2.0
     """
-
-    def fprint(self, printer):
-        """Fortran print."""
-
-        value = printer(self.arg)
-        code = 'aimag({0})'.format(value)
-        return code
-
-
-    def __str__(self):
-        return 'imag({0})'.format(str(self.arg))
 
 #==============================================================================
 class NumpyLinspace(Application, NumpyNewArray):

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -975,7 +975,7 @@ class NumpyZeros(NumpyEmpty):
         elif isinstance(dtype, NativeReal):
             value = LiteralFloat(0.)
         elif isinstance(dtype, NativeComplex):
-            value = LiteralComplex(LiteralFloat(0.), LiteralFloat(0.))
+            value = LiteralComplex(0., 0.)
         elif isinstance(dtype, NativeBool):
             value = LiteralFalse()
         else:
@@ -995,7 +995,7 @@ class NumpyOnes(NumpyEmpty):
         elif isinstance(dtype, NativeReal):
             value = LiteralFloat(1.)
         elif isinstance(dtype, NativeComplex):
-            value = LiteralComplex(LiteralFloat(1.), LiteralFloat(0.))
+            value = LiteralComplex(1., 0.)
         elif isinstance(dtype, NativeBool):
             value = LiteralTrue()
         else:

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -365,10 +365,13 @@ def Shape(arg):
         return PythonTuple(*arg.shape)
 
 #==============================================================================
-# TODO [YG, 09.03.2020]: Reconsider this class, given new ast.builtins.LiteralFloat
 class NumpyReal(Function, PyccelAstNode):
 
     """Represents a call to  numpy.real for code generation.
+
+    > a = 1+2j
+    > np.real(a)
+    1.0
 
     arg : Variable, LiteralFloat, sp_Integer, LiteralComplex
     """
@@ -402,7 +405,7 @@ class NumpyReal(Function, PyccelAstNode):
 
 
     def __str__(self):
-        return 'LiteralFloat({0})'.format(str(self.arg))
+        return 'NumpyReal({0})'.format(str(self.arg))
 
 
     def _sympystr(self, printer):

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -4,7 +4,6 @@
 import numpy
 
 from sympy.core.function import Application
-from sympy.logic.boolalg import BooleanTrue, BooleanFalse
 
 from sympy           import (Basic, Function, Tuple, Integer as sp_Integer,
                              Rational as sp_Rational, Expr)
@@ -25,6 +24,7 @@ from .datatypes      import (dtype_and_precision_registry as dtype_registry,
                              NativeReal, NativeComplex, NativeBool, str_dtype)
 
 from .literals       import LiteralInteger, LiteralFloat, LiteralComplex
+from .literals       import LiteralTrue, LiteralFalse
 from .basic          import PyccelAstNode
 
 
@@ -977,7 +977,7 @@ class NumpyZeros(NumpyEmpty):
         elif isinstance(dtype, NativeComplex):
             value = LiteralComplex(LiteralFloat(0.), LiteralFloat(0.))
         elif isinstance(dtype, NativeBool):
-            value = BooleanFalse()
+            value = LiteralFalse()
         else:
             raise TypeError('Unknown type')
         return value
@@ -997,7 +997,7 @@ class NumpyOnes(NumpyEmpty):
         elif isinstance(dtype, NativeComplex):
             value = LiteralComplex(LiteralFloat(1.), LiteralFloat(0.))
         elif isinstance(dtype, NativeBool):
-            value = BooleanTrue()
+            value = LiteralTrue()
         else:
             raise TypeError('Unknown type')
         return value

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -454,6 +454,10 @@ class PyccelAdd(PyccelArithmeticOperator):
            isinstance(arg2, LiteralComplex) and \
            arg2.real == LiteralFloat(0):
             return LiteralComplex(arg1, arg2.imag)
+        elif isinstance(arg2, (LiteralInteger, LiteralFloat)) and \
+           isinstance(arg1, LiteralComplex) and \
+           arg1.real == LiteralFloat(0):
+            return LiteralComplex(arg2, arg1.imag)
         else:
             return PyccelArithmeticOperator.__new__(cls, arg1, arg2)
 
@@ -502,7 +506,11 @@ class PyccelMinus(PyccelArithmeticOperator):
         if isinstance(arg1, LiteralFloat) and \
            isinstance(arg2, LiteralComplex) and \
            arg2.real_part == LiteralFloat(0):
-            return LiteralComplex(arg1, -float(arg2.imag_part))
+            return LiteralComplex(arg1, -arg2.imag_part.python_value)
+        elif isinstance(arg2, LiteralFloat) and \
+           isinstance(arg1, LiteralComplex) and \
+           arg1.real_part == LiteralFloat(0):
+            return LiteralComplex(-arg2.python_value, arg1.imag_part)
         else:
             return PyccelArithmeticOperator.__new__(cls, arg1, arg2)
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -505,12 +505,12 @@ class PyccelMinus(PyccelArithmeticOperator):
     def __new__(cls, arg1, arg2):
         if isinstance(arg1, LiteralFloat) and \
            isinstance(arg2, LiteralComplex) and \
-           arg2.real_part == LiteralFloat(0):
-            return LiteralComplex(arg1, -arg2.imag_part.python_value)
+           arg2.real == LiteralFloat(0):
+            return LiteralComplex(arg1, -arg2.imag.python_value)
         elif isinstance(arg2, LiteralFloat) and \
            isinstance(arg1, LiteralComplex) and \
-           arg1.real_part == LiteralFloat(0):
-            return LiteralComplex(-arg2.python_value, arg1.imag_part)
+           arg1.real == LiteralFloat(0):
+            return LiteralComplex(-arg2.python_value, arg1.imag)
         else:
             return PyccelArithmeticOperator.__new__(cls, arg1, arg2)
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -14,6 +14,8 @@ from .builtins import PythonInt
 
 from .datatypes import NativeBool, NativeInteger, NativeReal, NativeComplex, NativeString, default_precision
 
+from .literals import LiteralInteger, LiteralFloat, LiteralComplex
+
 errors = Errors()
 
 __all__ = (
@@ -447,6 +449,14 @@ class PyccelAdd(PyccelArithmeticOperator):
     """
     _precedence = 12
 
+    def __new__(self, arg1, arg2):
+        if isinstance(arg1, (LiteralInteger, LiteralFloat)) and \
+           isinstance(arg2, LiteralComplex) and \
+           arg2.real == LiteralFloat(0):
+            return LiteralComplex(arg1, arg2.imag)
+        else:
+            return PyccelArithmeticOperator.__new__(self, arg1, arg2)
+
     def _handle_str_type(self, strs):
         self._dtype = NativeString()
 
@@ -487,6 +497,14 @@ class PyccelMinus(PyccelArithmeticOperator):
         The second argument passed to the operator
     """
     _precedence = 12
+
+    def __new__(self, arg1, arg2):
+        if isinstance(arg1, LiteralFloat) and \
+           isinstance(arg2, LiteralComplex) and \
+           arg2.real_part == LiteralFloat(0):
+            return LiteralComplex(arg1, -float(arg2.imag_part))
+        else:
+            return PyccelArithmeticOperator.__new__(self, arg1, arg2)
 
 #==============================================================================
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -498,13 +498,13 @@ class PyccelMinus(PyccelArithmeticOperator):
     """
     _precedence = 12
 
-    def __new__(self, arg1, arg2):
+    def __new__(cls, arg1, arg2):
         if isinstance(arg1, LiteralFloat) and \
            isinstance(arg2, LiteralComplex) and \
            arg2.real_part == LiteralFloat(0):
             return LiteralComplex(arg1, -float(arg2.imag_part))
         else:
-            return PyccelArithmeticOperator.__new__(self, arg1, arg2)
+            return PyccelArithmeticOperator.__new__(cls, arg1, arg2)
 
 #==============================================================================
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -449,13 +449,13 @@ class PyccelAdd(PyccelArithmeticOperator):
     """
     _precedence = 12
 
-    def __new__(self, arg1, arg2):
+    def __new__(cls, arg1, arg2):
         if isinstance(arg1, (LiteralInteger, LiteralFloat)) and \
            isinstance(arg2, LiteralComplex) and \
            arg2.real == LiteralFloat(0):
             return LiteralComplex(arg1, arg2.imag)
         else:
-            return PyccelArithmeticOperator.__new__(self, arg1, arg2)
+            return PyccelArithmeticOperator.__new__(cls, arg1, arg2)
 
     def _handle_str_type(self, strs):
         self._dtype = NativeString()

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -31,7 +31,7 @@ def sympy_to_pyccel(expr, symbol_map):
 
     #Constants
     if isinstance(expr, sp.Integer):
-        return LiteralInteger(expr)
+        return LiteralInteger(expr.p)
     elif isinstance(expr, One):
         return LiteralInteger(1)
     elif isinstance(expr, NegativeOne):
@@ -110,7 +110,7 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
 
     #Constants
     if isinstance(expr, LiteralInteger):
-        return sp.Integer(expr)
+        return sp.Integer(expr.p)
 
     elif isinstance(expr, LiteralFloat):
         return sp.Float(expr)

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -180,15 +180,14 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
         start = pyccel_to_sympy(expr.start, symbol_map, used_names)
         stop  = pyccel_to_sympy(expr.stop , symbol_map, used_names)
         step  = pyccel_to_sympy(expr.step , symbol_map, used_names)
-        print(start, stop, step)
-        return PythonRange(start, stop, step)
+        return sp.Range(start, stop, step)
 
     elif isinstance(expr, Assign):
         lhs = pyccel_to_sympy(expr.lhs, symbol_map, used_names)
         rhs = pyccel_to_sympy(expr.rhs, symbol_map, used_names)
         return Assign(lhs, rhs)
 
-    elif isinstance(expr, (sp.core.basic.Atom, sp.core.operations.AssocOp)):
+    elif isinstance(expr, (sp.core.basic.Atom, sp.core.operations.AssocOp, sp.Set)):
         # Already translated
         return expr
 

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -39,11 +39,11 @@ def sympy_to_pyccel(expr, symbol_map):
     elif isinstance(expr, Zero):
         return LiteralInteger(0)
     elif isinstance(expr, sp.Float):
-        return LiteralFloat(expr)
+        return LiteralFloat(float(expr))
     elif isinstance(expr, Half):
         return LiteralFloat(0.5)
     elif isinstance(expr, sp.Rational):
-        return LiteralFloat(expr)
+        return LiteralFloat(float(expr))
     elif isinstance(expr, sp.Symbol) and expr in symbol_map:
         return symbol_map[expr]
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -280,7 +280,7 @@ class CCodePrinter(CodePrinter):
 
     def _print_LiteralComplex(self, expr):
         if expr.real == LiteralFloat(0):
-            return self._print(PyccelMul(expr.imag, LiteralImaginaryUnit()))
+            return self._print(PyccelAssociativeParenthesis(PyccelMul(expr.imag, LiteralImaginaryUnit())))
         else:
             return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
                             PyccelMul(expr.imag, LiteralImaginaryUnit()))))

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -290,8 +290,8 @@ class CCodePrinter(CodePrinter):
         if expr.is_cast:
             return self._print(expr.internal_var)
         else:
-            return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real_part,
-                            PyccelMul(expr.imag_part, LiteralImaginaryUnit()))))
+            return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
+                            PyccelMul(expr.imag, LiteralImaginaryUnit()))))
 
     def _print_LiteralImaginaryUnit(self, expr):
         return '_Complex_I'

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -275,6 +275,9 @@ class CCodePrinter(CodePrinter):
         value = self._print(expr.arg)
         return '({} != 0)'.format(value)
 
+    def _print_LiteralInteger(self, expr):
+        return str(expr.p)
+
     def _print_LiteralComplex(self, expr):
         return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
                         PyccelMul(expr.imag, LiteralImaginaryUnit()))))
@@ -665,7 +668,7 @@ class CCodePrinter(CodePrinter):
                         inds[i] = Slice(start, end)
                     else:
                         #setting the Slice start and end to their correct value when try to get a view with scalar index
-                        inds[i] = Slice(ind, ind + 1)
+                        inds[i] = Slice(ind, PyccelAdd(ind, LiteralInteger(1)))
                 inds = [self._print(i) for i in inds]
                 return "array_slicing(%s, %s)" % (base_name, ", ".join(inds))
             inds = [self._print(i) for i in inds]

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -284,8 +284,11 @@ class CCodePrinter(CodePrinter):
 
     def _print_PythonComplex(self, expr):
         self._additional_imports.add("complex")
-        return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real_part,
-                        PyccelMul(expr.imag_part, LiteralImaginaryUnit()))))
+        if expr.is_cast:
+            return self._print(expr.internal_var)
+        else:
+            return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real_part,
+                            PyccelMul(expr.imag_part, LiteralImaginaryUnit()))))
 
     def _print_LiteralImaginaryUnit(self, expr):
         return '_Complex_I'
@@ -1055,17 +1058,11 @@ class CCodePrinter(CodePrinter):
     def _print_NegativeInfinity(self, expr):
         return '-HUGE_VAL'
 
-    def _print_NumpyReal(self, expr):
-        if expr.arg.dtype is NativeComplex():
-            return 'creal({})'.format(self._print(expr.arg))
-        else:
-            return self._print(expr.arg)
+    def _print_PythonReal(self, expr):
+        return 'creal({})'.format(self._print(expr.arg))
 
-    def _print_NumpyImag(self, expr):
-        if expr.arg.dtype is NativeComplex():
-            return 'cimag({})'.format(self._print(expr.arg))
-        else:
-            return '0'
+    def _print_PythonImag(self, expr):
+        return 'cimag({})'.format(self._print(expr.arg))
 
     def _handle_is_operator(self, Op, expr):
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1059,10 +1059,10 @@ class CCodePrinter(CodePrinter):
         return '-HUGE_VAL'
 
     def _print_PythonReal(self, expr):
-        return 'creal({})'.format(self._print(expr.arg))
+        return 'creal({})'.format(self._print(expr.internal_var))
 
     def _print_PythonImag(self, expr):
-        return 'cimag({})'.format(self._print(expr.arg))
+        return 'cimag({})'.format(self._print(expr.internal_var))
 
     def _handle_is_operator(self, Op, expr):
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -279,8 +279,11 @@ class CCodePrinter(CodePrinter):
         return str(expr.p)
 
     def _print_LiteralComplex(self, expr):
-        return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
-                        PyccelMul(expr.imag, LiteralImaginaryUnit()))))
+        if expr.real == LiteralFloat(0):
+            return self._print(PyccelMul(expr.imag, LiteralImaginaryUnit()))
+        else:
+            return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
+                            PyccelMul(expr.imag, LiteralImaginaryUnit()))))
 
     def _print_PythonComplex(self, expr):
         self._additional_imports.add("complex")

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -666,7 +666,15 @@ class FCodePrinter(CodePrinter):
         return expr.fprint(self._print)
 
     def _print_PythonComplex(self, expr):
-        return expr.fprint(self._print)
+        if expr.is_cast:
+            code = 'cmplx({0}, kind={1})'.format(expr.internal_var,
+                                iso_c_binding["complex"][expr.precision])
+        else:
+            real = self._print(expr.real_part)
+            imag = self._print(expr.imag_part)
+            code = 'cmplx({0}, {1}, {2})'.format(real, imag,
+                                iso_c_binding["complex"][expr.precision])
+        return code
 
     def _print_PythonBool(self, expr):
         return expr.fprint(self._print)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2433,8 +2433,8 @@ class FCodePrinter(CodePrinter):
         return "{}_{}".format(printed, iso_c_binding["real"][expr.precision])
 
     def _print_LiteralComplex(self, expr):
-        real_str = self._print_Float(expr.real)
-        imag_str = self._print_Float(expr.imag)
+        real_str = self._print(expr.real)
+        imag_str = self._print(expr.imag)
         return "({}, {})".format(real_str, imag_str)
 
     def _print_LiteralInteger(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -61,10 +61,10 @@ from pyccel.ast.literals  import LiteralTrue
 from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
 
 from pyccel.ast.numpyext import NumpyFull, NumpyArray, NumpyLinspace, NumpyDiag, NumpyCross
-from pyccel.ast.numpyext import NumpyReal, NumpyWhere
+from pyccel.ast.numpyext import NumpyWhere
 from pyccel.ast.numpyext import NumpyMod, NumpyFloat
 from pyccel.ast.numpyext import NumpyFullLike, NumpyEmptyLike, NumpyZerosLike, NumpyOnesLike
-from pyccel.ast.numpyext import NumpyRand, NumpyRandint
+from pyccel.ast.numpyext import NumpyRand
 from pyccel.ast.numpyext import NumpyNewArray
 from pyccel.ast.numpyext import Shape
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -601,6 +601,16 @@ class FCodePrinter(CodePrinter):
         args = [self._print(arg) for arg in expr.args]
         return "sum({})".format(", ".join(args))
 
+    def _print_PythonReal(self, expr):
+        value = self._print(expr.internal_var)
+        prec  = str(iso_c_binding[dtype][expr.precision])
+        return 'real({0}, {1})'.format(value, prec)
+
+    def _print_PythonImag(self, expr):
+        value = self._print(expr.internal_var)
+        prec  = str(iso_c_binding[dtype][expr.precision])
+        return 'aimag({0}, {1})'.format(value, prec)
+
     #========================== Numpy Elements ===============================#
 
     def _print_NumpySum(self, expr):
@@ -628,14 +638,14 @@ class FCodePrinter(CodePrinter):
         result_code = self._print_MathFloor(expr)
         return 'real({}, {})'.format(result_code, iso_c_binding["real"][8])
 
-    def _print_PythonFloat(self, expr):
-        return expr.fprint(self._print)
-
     # ======================================================================= #
     def _print_PyccelArraySize(self, expr):
         return expr.fprint(self._print)
 
     def _print_PythonInt(self, expr):
+        return expr.fprint(self._print)
+
+    def _print_PythonFloat(self, expr):
         return expr.fprint(self._print)
 
     def _print_MathFloor(self, expr):
@@ -1073,11 +1083,7 @@ class FCodePrinter(CodePrinter):
         if isinstance(rhs, (PythonRange, Product)):
             return ''
 
-        if isinstance(rhs, (PythonLen, NumpyRandint)):
-            rhs_code = self._print(expr.rhs)
-            return '{0} = {1}\n'.format(lhs_code, rhs_code)
-
-        if isinstance(rhs, (PythonInt, NumpyReal, NumpyComplex)):
+        if isinstance(rhs, (PythonInt, NumpyComplex)):
             lhs = self._print(expr.lhs)
             rhs = expr.rhs.fprint(self._print)
             return '{0} = {1}\n'.format(lhs,rhs)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2429,8 +2429,8 @@ class FCodePrinter(CodePrinter):
         return self._get_statement(code)
 
     def _print_LiteralImaginaryUnit(self, expr):
-        # purpose: print complex numbers nicely in Fortran.
-        return "cmplx(0,1)"
+        """ purpose: print complex numbers nicely in Fortran."""
+        return "cmplx(0,1, kind = {})".format(iso_c_binding["complex"][expr.precision])
 
     def _print_int(self, expr):
         return str(expr)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -670,8 +670,8 @@ class FCodePrinter(CodePrinter):
             code = 'cmplx({0}, kind={1})'.format(expr.internal_var,
                                 iso_c_binding["complex"][expr.precision])
         else:
-            real = self._print(expr.real_part)
-            imag = self._print(expr.imag_part)
+            real = self._print(expr.real)
+            imag = self._print(expr.imag)
             code = 'cmplx({0}, {1}, {2})'.format(real, imag,
                                 iso_c_binding["complex"][expr.precision])
         return code

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2430,10 +2430,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_LiteralFloat(self, expr):
         printed = CodePrinter._print_Float(self, expr)
-        e = printed.find('e')
-        if e > -1:
-            return "%sd%s" % (printed[:e], printed[e + 1:])
-        return "%s_C_DOUBLE" % printed
+        return "{}_{}".format(printed, iso_c_binding["real"][expr.precision])
 
     def _print_LiteralComplex(self, expr):
         real_str = self._print_Float(expr.real)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -603,13 +603,11 @@ class FCodePrinter(CodePrinter):
 
     def _print_PythonReal(self, expr):
         value = self._print(expr.internal_var)
-        prec  = str(iso_c_binding[dtype][expr.precision])
-        return 'real({0}, {1})'.format(value, prec)
+        return 'real({0})'.format(value)
 
     def _print_PythonImag(self, expr):
         value = self._print(expr.internal_var)
-        prec  = str(iso_c_binding[dtype][expr.precision])
-        return 'aimag({0}, {1})'.format(value, prec)
+        return 'aimag({0})'.format(value)
 
     #========================== Numpy Elements ===============================#
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -62,7 +62,7 @@ from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_impo
 
 from pyccel.ast.numpyext import NumpyFull, NumpyArray, NumpyLinspace, NumpyDiag, NumpyCross
 from pyccel.ast.numpyext import NumpyReal, NumpyWhere
-from pyccel.ast.numpyext import NumpyComplex, NumpyMod, NumpyFloat
+from pyccel.ast.numpyext import NumpyMod, NumpyFloat
 from pyccel.ast.numpyext import NumpyFullLike, NumpyEmptyLike, NumpyZerosLike, NumpyOnesLike
 from pyccel.ast.numpyext import NumpyRand, NumpyRandint
 from pyccel.ast.numpyext import NumpyNewArray
@@ -1088,11 +1088,6 @@ class FCodePrinter(CodePrinter):
 
         if isinstance(rhs, (PythonRange, Product)):
             return ''
-
-        if isinstance(rhs, (PythonInt, NumpyComplex)):
-            lhs = self._print(expr.lhs)
-            rhs = expr.rhs.fprint(self._print)
-            return '{0} = {1}\n'.format(lhs,rhs)
 
         if isinstance(rhs, (NumpyArray, NumpyLinspace, NumpyDiag, NumpyCross,\
 						NumpyWhere, PyccelArraySize)):

--- a/pyccel/complexity/arithmetic.py
+++ b/pyccel/complexity/arithmetic.py
@@ -7,6 +7,7 @@ from sympy import Tuple
 from pyccel.ast.core     import For, Assign, NewLine, CodeBlock, Comment
 from pyccel.ast.numpyext import NumpyZeros, NumpyOnes
 from pyccel.ast.builtins import PythonTuple
+from pyccel.ast.sympy_helper import pyccel_to_sympy
 from pyccel.complexity.basic import Complexity
 
 __all__ = ["count_ops", "OpComplexity"]
@@ -25,6 +26,10 @@ class OpComplexity(Complexity):
 
 
 def count_ops(expr, visual=None):
+
+    symbol_map = {}
+    used_names = set()
+    expr = pyccel_to_sympy(expr, symbol_map, used_names)
 
     if isinstance(expr, Assign):
         return sympy_count_ops(expr.rhs, visual)

--- a/pyccel/complexity/memory.py
+++ b/pyccel/complexity/memory.py
@@ -7,6 +7,7 @@ from sympy.core.expr import Expr
 
 from pyccel.ast.core     import For, Assign, NewLine, CodeBlock, Comment
 from pyccel.ast.numpyext import NumpyZeros, NumpyOnes
+from pyccel.ast.sympy_helper import pyccel_to_sympy
 from pyccel.complexity.basic import Complexity
 
 
@@ -30,6 +31,10 @@ def count_access(expr, visual=True):
 
     WRITE = Symbol('WRITE')
     READ  = Symbol('READ')
+
+    symbol_map = {}
+    used_names = set()
+    expr = pyccel_to_sympy(expr, symbol_map, used_names)
 
 
     if isinstance(expr, Expr):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2972,6 +2972,8 @@ class SemanticParser(BasicParser):
 
         val = expr.args[0]
         length = expr.args[1]
+        if isinstance(length, LiteralInteger):
+            length = length.p
         if isinstance(val, (TupleVariable, PythonTuple)):
             if isinstance(val, TupleVariable):
                 return PythonTuple(*(val.get_vars()*length))
@@ -2983,7 +2985,10 @@ class SemanticParser(BasicParser):
         name = expr.args_var
         var = self._visit(name)
         assert(var.rank==1)
-        return StarredArguments([self._visit(Indexed(name,i)) for i in range(var.shape[0])])
+        size = var.shape[0]
+        if isinstance(size, LiteralInteger):
+            size = size.p
+        return StarredArguments([self._visit(Indexed(name,i)) for i in range(size)])
 
 #==============================================================================
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2972,9 +2972,9 @@ class SemanticParser(BasicParser):
 
         val = expr.args[0]
         length = expr.args[1]
-        if isinstance(length, LiteralInteger):
-            length = length.p
         if isinstance(val, (TupleVariable, PythonTuple)):
+            if isinstance(length, LiteralInteger):
+                length = length.p
             if isinstance(val, TupleVariable):
                 return PythonTuple(*(val.get_vars()*length))
             else:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -806,7 +806,7 @@ class SemanticParser(BasicParser):
         return expr
     def _visit_Integer(self, expr, **settings):
         """Visit sympy.Integer"""
-        return LiteralInteger(expr)
+        return LiteralInteger(expr.p)
     def _visit_Float(self, expr, **settings):
         """Visit sympy.Integer"""
         return LiteralFloat(expr)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -751,7 +751,7 @@ class SemanticParser(BasicParser):
                 return obj
 
         # Unknown object, we raise an error.
-        errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
+        errors.report(PYCCEL_RESTRICTION_TODO, symbol=type(expr),
             bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
             severity='fatal', blocker=self.blocking)
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -325,7 +325,7 @@ class SyntaxParser(BasicParser):
         elif isinstance(val, float):
             return LiteralFloat(val)
         elif isinstance(val, complex):
-            return LiteralComplex(LiteralFloat(val.real), LiteralFloat(val.imag))
+            return LiteralComplex(val.real, val.imag)
         else:
             raise NotImplementedError('Num type {} not recognised'.format(type(val)))
 
@@ -402,7 +402,7 @@ class SyntaxParser(BasicParser):
             return LiteralFloat(stmt.value)
 
         elif isinstance(stmt.value, complex):
-            return LiteralComplex(LiteralFloat(stmt.value.real), LiteralFloat(stmt.value.imag))
+            return LiteralComplex(stmt.value.real, stmt.value.imag)
 
         elif isinstance(stmt.value, str):
             return self._visit_Str(stmt)

--- a/tests/epyccel/modules/complex_func.py
+++ b/tests/epyccel/modules/complex_func.py
@@ -2,40 +2,40 @@
 from pyccel.decorators import types
 
 def create_complex_literal__int_int():
-    a = complex(1,2)
+    a = complex(1,-2)
     return a
 
 def create_complex_literal__int_float():
-    a = complex(1,2.7)
+    a = complex(-1,2.7)
     return a
 
 def create_complex_literal__int_complex():
-    a = complex(1,2j)
+    a = complex(1,-2j)
     b = complex(1,1+3j)
     return a, b
 
 def create_complex_literal__float_int():
-    a = complex(1.6,2)
+    a = complex(-1.6,2)
     return a
 
 def create_complex_literal__float_float():
-    a = complex(1.6,2.9)
+    a = complex(1.6,-2.9)
     return a
 
 def create_complex_literal__float_complex():
-    a = complex(1.6,2.8+7j)
+    a = complex(1.6,2.8-7j)
     return a
 
 def create_complex_literal__complex_int():
-    a = complex(2.8+7j,1)
+    a = complex(2.8-7j,1)
     return a
 
 def create_complex_literal__complex_float():
-    a = complex(2.8+7j,1.8)
+    a = complex(-2.8+7j,1.8)
     return a
 
 def create_complex_literal__complex_complex():
-    a = complex(2.8+7j,1.5+22j)
+    a = complex(2.8+7j,-1.5-22j)
     return a
 
 @types('int','int')
@@ -72,7 +72,7 @@ def create_complex_0__float_float(a):
 
 @types('complex')
 def create_complex__complex_complex(a):
-    return complex(a,1+2j), complex(1+2j,a)
+    return complex(a,1-2j), complex(1+2j,a)
 
 @types('complex64')
 def cast_complex_1(a):

--- a/tests/epyccel/modules/complex_func.py
+++ b/tests/epyccel/modules/complex_func.py
@@ -1,0 +1,84 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+from pyccel.decorators import types
+
+def create_complex_literal__int_int():
+    a = complex(1,2)
+    return a
+
+def create_complex_literal__int_float():
+    a = complex(1,2.7)
+    return a
+
+def create_complex_literal__int_complex():
+    a = complex(1,2j)
+    b = complex(1,1+3j)
+    return a, b
+
+def create_complex_literal__float_int():
+    a = complex(1.6,2)
+    return a
+
+def create_complex_literal__float_float():
+    a = complex(1.6,2.9)
+    return a
+
+def create_complex_literal__float_complex():
+    a = complex(1.6,2.8+7j)
+    return a
+
+def create_complex_literal__complex_int():
+    a = complex(2.8+7j,1)
+    return a
+
+def create_complex_literal__complex_float():
+    a = complex(2.8+7j,1.8)
+    return a
+
+def create_complex_literal__complex_complex():
+    a = complex(2.8+7j,1.5+22j)
+    return a
+
+@types('int','int')
+def create_complex_var__int_int(a,b):
+    return complex(a,b)
+
+@types('int','complex')
+def create_complex_var__int_complex(a,b):
+    return complex(a,b)
+
+@types('complex', 'float')
+def create_complex_var__complex_float(a,b):
+    return complex(a,b)
+
+@types('complex', 'complex')
+def create_complex_var__complex_complex(a,b):
+    return complex(a,b)
+
+@types('int')
+def create_complex__int_int(a):
+    return complex(a,1), complex(1,a)
+
+@types('int')
+def create_complex_0__int_int(a):
+    return complex(a,0), complex(0,a)
+
+@types('float')
+def create_complex__float_float(a):
+    return complex(a,1.5), complex(1.5, a)
+
+@types('float')
+def create_complex_0__float_float(a):
+    return complex(a,0.0), complex(0.0, a)
+
+@types('complex')
+def create_complex__complex_complex(a):
+    return complex(a,1+2j), complex(1+2j,a)
+
+@types('complex64')
+def cast_complex_1(a):
+    return complex(a)
+
+@types('complex128')
+def cast_complex_2(a):
+    return complex(a)
+

--- a/tests/epyccel/test_epyccel_complex_func.py
+++ b/tests/epyccel/test_epyccel_complex_func.py
@@ -1,0 +1,103 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+import numpy as np
+import pytest
+
+from numpy.random import rand, randint
+
+from pyccel.epyccel import epyccel
+import modules.complex_func as mod
+
+@pytest.mark.parametrize("f", [ mod.create_complex_literal__int_int,
+                           mod.create_complex_literal__int_float,
+                           mod.create_complex_literal__int_complex,
+                           mod.create_complex_literal__float_int,
+                           mod.create_complex_literal__float_float,
+                           mod.create_complex_literal__float_complex,
+                           mod.create_complex_literal__complex_int,
+                           mod.create_complex_literal__complex_float,
+                           mod.create_complex_literal__complex_complex] )
+def test_create_complex_literal(f, language):
+    f_epyc = epyccel(f, language = language)
+    assert f_epyc() == f()
+
+def test_create_complex_var__int_int(language):
+    f = mod.create_complex_var__int_int
+    f_epyc = epyccel(f, language = language)
+
+    a = randint(100)
+    b = randint(100)
+    assert f_epyc(a,b) == f(a,b)
+
+def test_create_complex_var__int_complex(language):
+    f = mod.create_complex_var__int_complex
+    f_epyc = epyccel(f, language = language)
+
+    a = randint(100)
+    b = complex(randint(100), randint(100))
+    assert f_epyc(a,b) == f(a,b)
+
+def test_create_complex_var__complex_float(language):
+    f = mod.create_complex_var__complex_float
+    f_epyc = epyccel(f, language = language)
+
+    a = complex(randint(100), randint(100))
+    b = rand()*100
+    assert f_epyc(a,b) == f(a,b)
+
+def test_create_complex_var__complex_complex(language):
+    f = mod.create_complex_var__complex_complex
+    f_epyc = epyccel(f, language = language)
+
+    a = complex(randint(100), randint(100))
+    b = complex(randint(100), randint(100))
+    assert f_epyc(a,b) == f(a,b)
+
+def test_create_complex__int_int(language):
+    f = mod.create_complex__int_int
+    f_epyc = epyccel(f, language = language)
+
+    a = randint(100)
+    assert f_epyc(a) == f(a)
+
+def test_create_complex_0__int_int(language):
+    f = mod.create_complex_0__int_int
+    f_epyc = epyccel(f, language = language)
+
+    a = randint(100)
+    assert f_epyc(a) == f(a)
+
+def test_create_complex__float_float(language):
+    f = mod.create_complex__float_float
+    f_epyc = epyccel(f, language = language)
+
+    a = rand()*100
+    assert f_epyc(a) == f(a)
+
+def test_create_complex_0__float_float(language):
+    f = mod.create_complex_0__float_float
+    f_epyc = epyccel(f, language = language)
+
+    a = rand()*100
+    assert f_epyc(a) == f(a)
+
+def test_create_complex__complex_complex(language):
+    f = mod.create_complex__complex_complex
+    f_epyc = epyccel(f, language = language)
+
+    a = complex(randint(100), randint(100))
+    assert f_epyc(a) == f(a)
+
+def test_cast_complex_1(language):
+    f = mod.create_complex__complex_complex
+    f_epyc = epyccel(f, language = language)
+
+    a = np.complex64(complex(randint(100), randint(100)))
+    assert np.isclose(f_epyc(a), f(a), rtol = 1e-7, atol = 1e-8)
+
+def test_cast_complex_1(language):
+    f = mod.create_complex__complex_complex
+    f_epyc = epyccel(f, language = language)
+
+    a = np.complex128(complex(randint(100), randint(100)))
+    assert f_epyc(a) == f(a)
+

--- a/tests/epyccel/test_epyccel_complex_func.py
+++ b/tests/epyccel/test_epyccel_complex_func.py
@@ -4,8 +4,8 @@ import pytest
 
 from numpy.random import rand, randint
 
-from pyccel.epyccel import epyccel
 import modules.complex_func as mod
+from pyccel.epyccel import epyccel
 
 @pytest.mark.parametrize("f", [ mod.create_complex_literal__int_int,
                            mod.create_complex_literal__int_float,
@@ -88,14 +88,14 @@ def test_create_complex__complex_complex(language):
     assert f_epyc(a) == f(a)
 
 def test_cast_complex_1(language):
-    f = mod.create_complex__complex_complex
+    f = mod.cast_complex_1
     f_epyc = epyccel(f, language = language)
 
     a = np.complex64(complex(randint(100), randint(100)))
     assert np.isclose(f_epyc(a), f(a), rtol = 1e-7, atol = 1e-8)
 
-def test_cast_complex_1(language):
-    f = mod.create_complex__complex_complex
+def test_cast_complex_2(language):
+    f = mod.cast_complex_2
     f_epyc = epyccel(f, language = language)
 
     a = np.complex128(complex(randint(100), randint(100)))


### PR DESCRIPTION
Add type checks to Literal classes to ensure that they contain arguments of the correct type. Use the precision argument to translate precision modifiers of literals to a literal of the correct precision. E.g:
```
np.float32(2)
```
Is now translated to:
```
2.0_C_FLOAT
```
instead of:
```
a = Real(2_C_LONG_LONG, 4)
```
Casts are still printed for truncated values

**Commit summary**
- Use inheritance to set `Literal` precision and check its type
- Remove unused `sympy.Integer` inheritance from `LiteralInteger` (this has many knock-on effects as it makes it obvious when we are not using pyccel operators)
- Add type checks and conversions to `Literal` classes
- Use literal precision to translate expressions such as `np.float32(2)` directly to `2.0_C_FLOAT`
- Print floats with correct precision in fortran
- Fix `unexpected keyword argument : "precision"`
- ensure that `complex` function works when complex arguments are passed
- Simplify phrases such as `2+5j` to `LiteralComplex(2,5)`