### PR TITLE
Process multiple decorators of the same kind

### DIFF
--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -654,7 +654,8 @@ class SyntaxParser(BasicParser):
             return EmptyNode()
 
         if 'stack_array' in decorators:
-            decorators['stack_array'] = tuple(str(a) for a in decorators['stack_array'].args)
+            decorators['stack_array'] = tuple(str(b) for a in decorators['stack_array']
+                for b in a.args)
 
         if 'allow_negative_index' in decorators:
             decorators['allow_negative_index'] = tuple(str(b) for a in decorators['allow_negative_index'] for b in a.args)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -155,7 +155,6 @@ class SyntaxParser(BasicParser):
         return ast
 
     def _treat_iterable(self, stmt):
-
         return [self._visit(i) for i in stmt]
 
     def _visit(self, stmt):
@@ -649,7 +648,7 @@ class SyntaxParser(BasicParser):
                 else:
                     decorators[tmp_var] = [decorators[tmp_var]] + [d]
             else:
-                decorators[tmp_var] = d
+                decorators[tmp_var] = [d]
 
         if 'bypass' in decorators:
             return EmptyNode()
@@ -658,7 +657,7 @@ class SyntaxParser(BasicParser):
             decorators['stack_array'] = tuple(str(a) for a in decorators['stack_array'].args)
 
         if 'allow_negative_index' in decorators:
-            decorators['allow_negative_index'] = tuple(str(a) for a in decorators['allow_negative_index'].args)
+            decorators['allow_negative_index'] = tuple(str(b) for a in decorators['allow_negative_index'] for b in a.args)
 
         # extract the templates
         if 'template' in decorators:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -643,10 +643,7 @@ class SyntaxParser(BasicParser):
         for d in self._visit(stmt.decorator_list):
             tmp_var = str(d) if isinstance(d, Symbol) else str(type(d))
             if tmp_var in decorators:
-                if isinstance(decorators[tmp_var], list):
-                    decorators[tmp_var] += [d]
-                else:
-                    decorators[tmp_var] = [decorators[tmp_var]] + [d]
+                decorators[tmp_var] += [d]
             else:
                 decorators[tmp_var] = [d]
 
@@ -662,8 +659,6 @@ class SyntaxParser(BasicParser):
 
         # extract the templates
         if 'template' in decorators:
-            if not isinstance(decorators['template'], list):
-                decorators['template'] = [decorators['template']]
             for comb_types in decorators['template']:
                 cache.clear_cache()
                 types = []
@@ -714,8 +709,6 @@ class SyntaxParser(BasicParser):
 
         # extract the types to construct a header
         if 'types' in decorators:
-            if not isinstance(decorators['types'], list):
-                decorators['types'] = [decorators['types']]
             for comb_types in decorators['types']:
 
                 cache.clear_cache()

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -602,36 +602,38 @@ def expr_negative_index(n, idx_1, idx_2):
 
 @allow_negative_index('a')
 @allow_negative_index('b')
-def test_multiple_negative_index():
+@types('int', 'int')
+def test_multiple_negative_index(c, d):
     import numpy as np
     a = np.array([1, 2, 3, 4, 5, 6])
     b = np.array([1, 2, 3])
-    x = a[-2]
-    y = b[-1]
+    x = a[c]
+    y = b[d]
 
     return x, y
 
 @allow_negative_index('a', 'b')
-@types('real', 'real')
+@types('int', 'int')
 def test_multiple_negative_index_2(c, d):
     import numpy as np
     a = np.array([1.2, 2.2, 3.2, 4.2])
     b = np.array([1, 5, 9, 13])
 
-    x = a[-4] * c
-    y = b[-2] * d
+    x = a[c] * d
+    y = b[d] * c
 
     return x, y
 
 @allow_negative_index('a')
 @allow_negative_index('b', 'c')
-def test_multiple_negative_index_3():
+@types('int', 'int', 'int')
+def test_multiple_negative_index_3(d, e, f):
     import numpy as np
     a = np.array([1.2, 2.2, 3.2, 4.2])
     b = np.array([1])
     c = np.array([1, 2, 3])
 
-    return a[-1], b[-1], c[-3]
+    return a[d], b[e], c[f]
 
 
 #==============================================================================

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -446,6 +446,29 @@ def array_real_1d_div_stack_array():
         s += 1.0 / a[i]
     return s
 
+@stack_array('a')
+@stack_array('b')
+def multiple_stack_array_1():
+    from numpy import ones, array
+    a = ones(5)
+    b = array([1, 3, 5, 7, 9])
+    s = 0.0
+    for i in range(5):
+        s += a[i] / b[i]
+    return s
+
+@stack_array('a')
+@stack_array('b', 'c')
+def multiple_stack_array_2():
+    from numpy import ones, array
+    a = ones(5)
+    b = array([2, 4, 6, 8, 10])
+    c = array([1, 3, 5, 7, 9])
+    s = 0.0
+    for i in range(5):
+        s = s + b[i] - a[i] / c[i]
+    return s
+
 #==============================================================================
 # TEST: Product and matrix multiplication
 #==============================================================================
@@ -576,6 +599,39 @@ def expr_negative_index(n, idx_1, idx_2):
         a[i] = i
 
     return a[idx_1-idx_2]
+
+@allow_negative_index('a')
+@allow_negative_index('b')
+def test_multiple_negative_index():
+    import numpy as np
+    a = np.array([1, 2, 3, 4, 5, 6])
+    b = np.array([1, 2, 3])
+    x = a[-2]
+    y = b[-1]
+
+    return x, y
+
+@allow_negative_index('a', 'b')
+@types('real', 'real')
+def test_multiple_negative_index_2(c, d):
+    import numpy as np
+    a = np.array([1.2, 2.2, 3.2, 4.2])
+    b = np.array([1, 5, 9, 13])
+
+    x = a[-4] * c
+    y = b[-2] * d
+
+    return x, y
+
+@allow_negative_index('a')
+@allow_negative_index('b', 'c')
+def test_multiple_negative_index_3():
+    import numpy as np
+    a = np.array([1.2, 2.2, 3.2, 4.2])
+    b = np.array([1])
+    c = np.array([1, 2, 3])
+
+    return a[-1], b[-1], c[-3]
 
 
 #==============================================================================

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1300,6 +1300,18 @@ def test_array_real_div_stack_array():
     x2 = f2()
     assert np.equal( x1, x2 )
 
+def test_multiple_stack_array_1():
+
+    f1 = arrays.multiple_stack_array_1
+    f2 = epyccel(f1)
+    assert np.equal(f1(), f2())
+
+def test_multiple_stack_array_2():
+
+    f1 = arrays.multiple_stack_array_2
+    f2 = epyccel(f1)
+    assert np.equal(f1(), f2())
+
 #==============================================================================
 # TEST: Product and matrix multiplication
 #==============================================================================
@@ -1445,6 +1457,24 @@ def test_expr_negative_index():
     f1 = arrays.expr_negative_index
     f2 = epyccel( f1 )
     assert f1(n,idx1,idx2) == f2(n,idx1,idx2)
+
+def test_multiple_negative_index():
+    f1 = arrays.test_multiple_negative_index
+    f2 = epyccel(f1)
+
+    assert np.array_equal(f1(), f2())
+
+def test_multiple_negative_index_2():
+    f1 = arrays.test_multiple_negative_index_2
+    f2 = epyccel(f1)
+
+    assert np.array_equal(f1(2.2, 3.1), f2(2.2, 3.1))
+
+def test_multiple_negative_index_3():
+    f1 = arrays.test_multiple_negative_index_3
+    f2 = epyccel(f1)
+
+    assert np.array_equal(f1(), f2())
 
 #==============================================================================
 # TEST: shape initialisation

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1462,19 +1462,19 @@ def test_multiple_negative_index():
     f1 = arrays.test_multiple_negative_index
     f2 = epyccel(f1)
 
-    assert np.array_equal(f1(), f2())
+    assert np.array_equal(f1(-2, -1), f2(-2, -1))
 
 def test_multiple_negative_index_2():
     f1 = arrays.test_multiple_negative_index_2
     f2 = epyccel(f1)
 
-    assert np.array_equal(f1(2.2, 3.1), f2(2.2, 3.1))
+    assert np.array_equal(f1(-4, -2), f2(-4, -2))
 
 def test_multiple_negative_index_3():
     f1 = arrays.test_multiple_negative_index_3
     f2 = epyccel(f1)
 
-    assert np.array_equal(f1(), f2())
+    assert np.array_equal(f1(-1, -1, -3), f2(-1, -1, -3))
 
 #==============================================================================
 # TEST: shape initialisation


### PR DESCRIPTION
Process multiple decorators of the same kind applied to a function. This solves #549.

- Always collect decorators as a list;
- Loop on dict value and collect arguments in allow_negative_index and stack_array;
- Add unit tests.