### PR TITLE
Update iso_c_binding dictionary to match types between Fortran and C printers

### DIFF
--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -61,10 +61,10 @@ __all__ = (
 #==============================================================================
 iso_c_binding = {
     "integer" : {
-        1  : 'C_SIGNED_CHAR',
-        2  : 'C_SHORT',
-        4  : 'C_INT',
-        8  : 'C_LONG_LONG',
+        1  : 'C_INT8_T',
+        2  : 'C_INT16_T',
+        4  : 'C_INT32_T',
+        8  : 'C_INT64_T',
         16 : 'C_INT128'}, #no supported yet
     "real"    : {
         4  : 'C_FLOAT',


### PR DESCRIPTION
The `iso_c_binding` dictionary is defined in module `pyccel.ast.datatypes`, and is used by the Fortran printer to print integer/real/complex variables with the correct kind type parameter (= precision).

Since the C printer was recently changed to use the `stdint.h` header, with this PR we change the values in `iso_c_binding` to match the printed types between the two languages.