### PR TITLE
Increase python testing versions by 1 minor version

### DIFF
--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.5
+      - name: Set up Python 3.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.5
+          python-version: 3.6
       - name: Install dependencies
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
@@ -44,7 +44,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -113,10 +113,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         uses: ./.github/actions/macos_install
       - name: Install python dependencies


### PR DESCRIPTION
- Linux python 3.5 tests now use python 3.6
- Linux python 3.6/3.7/3.8 tests now use python 3.7/3.8/3.9
- Windows python 3.7 still uses python 3.7 to avoid conda collision problems
- Macos python 3.8 tests now use python 3.9