### PR TITLE
Finish cleaning up the class FunctionDef

### DIFF
--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -117,7 +117,8 @@ def as_static_function(func, name=None):
                         functions = functions,
                         interfaces = interfaces,
                         imports = func.imports,
-                        original_function = func
+                        original_function = func,
+                        doc_string = func.doc_string,
                         )
 
 #=======================================================================================
@@ -147,6 +148,7 @@ def as_static_function_call(func, mod_name, name=None):
                        functions = func.functions,
                        interfaces = func.interfaces,
                        imports = imports,
+                       doc_string = func.doc_string,
                        )
 
     # make it compatible with c

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3149,46 +3149,58 @@ class FunctionDef(Basic):
 
     @property
     def name(self):
+        """ Name of the function """
         return self._name
 
     @property
     def arguments(self):
+        """ List of variables which are the function arguments """
         return self._arguments
 
     @property
     def results(self):
+        """ List of variables which are the function results """
         return self._results
 
     @property
     def body(self):
+        """ CodeBlock containing all the statements in the function """
         return self._body
 
     @property
     def local_vars(self):
+        """ List of variables defined in the function """
         return self._local_vars
 
     @property
     def global_vars(self):
+        """ List of global variables used in the function """
         return self._global_vars
 
     @property
     def cls_name(self):
+        """ String containing the name of the class to which the method belongs.
+        If the function is not a class procedure then this returns None """
         return self._cls_name
 
     @property
     def hide(self):
+        """ False if function is pyccelized, True otherwise """
         return self._hide
 
     @property
     def kind(self):
+        """ Returns function or procedure """
         return self._kind
 
     @property
     def imports(self):
+        """ List of imports in the function """
         return self._imports
 
     @property
     def decorators(self):
+        """ List of decorators applied to the function """
         return self._decorators
 
     @property
@@ -3197,42 +3209,74 @@ class FunctionDef(Basic):
 
     @property
     def templates(self):
+        """ List of templates used to determine the types """
         return self._templates
 
     @property
     def is_recursive(self):
+        """ Returns True if the function is recursive (i.e. calls itself)
+        and False otherwise """
         return self._is_recursive
 
     @property
     def is_pure(self):
+        """ Returns True if the function is marked as pure and False otherwise
+        Pure functions must not have any side effects.
+        In other words this means that the result must be the same no matter 
+        how many times the function is called
+        e.g:
+        >>> a = f()
+        >>> a = f()
+
+        gives the same result as
+        >>> a = f()
+
+        This is notably not true for I/O functions
+        """
         return self._is_pure
 
     @property
     def is_elemental(self):
+        """ returns True if the function is marked as elemental and
+        False otherwise
+        An elemental function is a function with a single scalar operator
+        and a scalar return value which can also be called on an array.
+        When it is called on an array it returns the result of the function
+        called elementwise on the array """
         return self._is_elemental
 
     @property
     def is_private(self):
+        """ True if the function should not be exposed to
+        other modules. This includes the wrapper module and
+        means that the function cannot be used in an import
+        or exposed to python """
         return self._is_private
 
     @property
     def is_header(self):
+        """ True if the function body is not provided
+        False otherwise """
         return self._is_header
 
     @property
     def arguments_inout(self):
+        """ List of variables which are the modifiable function arguments """
         return self._arguments_inout
 
     @property
     def functions(self):
+        """ List of functions within this function """
         return self._functions
 
     @property
     def interfaces(self):
+        """ List of interfaces within this function """
         return self._interfaces
 
     @property
     def doc_string(self):
+        """ The docstring of the function """
         return ""
 
     def set_recursive(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3287,27 +3287,6 @@ class FunctionDef(Basic):
 
         self._name = newname
 
-    @property
-    def is_procedure(self):
-        """Returns True if a procedure."""
-
-        flag = False
-        if len(self.results) == 1 and isinstance(self.results[0], Expr):
-            vars_ = [i for i in preorder_traversal(self.results)
-                     if isinstance(i, Variable)]
-            flag = flag or any([i.allocatable or i.rank > 0 for i in
-                               vars_])
-        else:
-            flag = flag or len(self.results) == 1 \
-                and self.results[0].allocatable
-            flag = flag or len(self.results) == 1 \
-                and self.results[0].rank > 0
-        flag = flag or len(self.results) > 1
-        flag = flag or len(self.results) == 0
-        flag = flag \
-            or len(set(self.results).intersection(self.arguments)) > 0
-        return flag
-
 
     def __getnewargs__(self):
         """

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1954,8 +1954,6 @@ class ConstructorCall(AtomicExpr):
     arguments: list, tuple, None
         a list of arguments.
 
-    kind: str
-        'function' or 'procedure'. default value: 'function'
     """
 
     is_commutative = True
@@ -1967,7 +1965,6 @@ class ConstructorCall(AtomicExpr):
         func,
         arguments,
         cls_variable=None,
-        kind='function',
         ):
         if not isinstance(func, (FunctionDef, Interface, str)):
             raise TypeError('Expecting func to be a FunctionDef or str')
@@ -1981,15 +1978,9 @@ class ConstructorCall(AtomicExpr):
         func,
         arguments,
         cls_variable=None,
-        kind='function',
         ):
 
-        if isinstance(func, FunctionDef):
-            kind = func.kind
-
         self._cls_variable = cls_variable
-
-        self._kind = kind
         self._func = func
         self._arguments = arguments
 
@@ -2004,10 +1995,6 @@ class ConstructorCall(AtomicExpr):
     @property
     def func(self):
         return self._func
-
-    @property
-    def kind(self):
-        return self._kind
 
     @property
     def arguments(self):
@@ -2943,9 +2930,6 @@ class FunctionDef(Basic):
     hide: bool
         if True, the function definition will not be generated.
 
-    kind: str
-        'function' or 'procedure'. default value: 'function'
-
     is_pure: bool
         True for a function without side effect
 
@@ -3013,7 +2997,6 @@ class FunctionDef(Basic):
         global_vars=[],
         cls_name=None,
         hide=False,
-        kind='function',
         is_static=False,
         imports=[],
         decorators={},
@@ -3078,17 +3061,8 @@ class FunctionDef(Basic):
             # if not cls_variable:
              #   raise TypeError('Expecting a instance of {0}'.format(cls_name))
 
-        if kind is None:
-            kind = 'function'
-
-        if not isinstance(kind, str):
-            raise TypeError('Expecting a string for kind.')
-
         if not isinstance(is_static, bool):
             raise TypeError('Expecting a boolean for is_static attribute')
-
-        if not kind in ['function', 'procedure']:
-            raise ValueError("kind must be one among {'function', 'procedure'}")
 
         if not iterable(imports):
             raise TypeError('imports must be an iterable')
@@ -3132,7 +3106,6 @@ class FunctionDef(Basic):
         self._global_vars     = global_vars
         self._cls_name        = cls_name
         self._hide            = hide
-        self._kind            = kind
         self._is_static       = is_static
         self._imports         = imports
         self._decorators      = decorators
@@ -3191,11 +3164,6 @@ class FunctionDef(Basic):
     def hide(self):
         """ False if function is pyccelized, True otherwise """
         return self._hide
-
-    @property
-    def kind(self):
-        """ Returns function or procedure """
-        return self._kind
 
     @property
     def imports(self):
@@ -3334,7 +3302,6 @@ class FunctionDef(Basic):
                 and self.results[0].rank > 0
         flag = flag or len(self.results) > 1
         flag = flag or len(self.results) == 0
-        flag = flag or self.kind == 'procedure'
         flag = flag \
             or len(set(self.results).intersection(self.arguments)) > 0
         return flag
@@ -3356,7 +3323,6 @@ class FunctionDef(Basic):
         'global_vars':self._global_vars,
         'cls_name':self._cls_name,
         'hide':self._hide,
-        'kind':self._kind,
         'is_static':self._is_static,
         'imports':self._imports,
         'decorators':self._decorators,
@@ -3873,7 +3839,7 @@ class ClassDef(Basic):
 
          #   free = FunctionDef('__del__', [this], [], \
          #                      body, local_vars=[], global_vars=[], \
-         #                      cls_name='__UNDEFINED__', kind='procedure', imports=[])
+         #                      cls_name='__UNDEFINED__', imports=[])
 
          #  methods = list(methods) + [free]
          # TODO move this somewhere else

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3183,6 +3183,10 @@ class FunctionDef(Basic):
         If the function is not a class procedure then this returns None """
         return self._cls_name
 
+    @cls_name.setter
+    def cls_name(self, cls_name):
+        self._cls_name = cls_name
+
     @property
     def hide(self):
         """ False if function is pyccelized, True otherwise """
@@ -3281,10 +3285,8 @@ class FunctionDef(Basic):
         return ""
 
     def set_recursive(self):
+        """ Mark the function as a recursive function """
         self._is_recursive = True
-
-    def set_cls_name(self, cls_name):
-        self._cls_name = cls_name
 
     def clone(self, newname):
         """

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4655,7 +4655,7 @@ class CommentBlock(Basic):
     txt : str
 
     """
-    def __new__(cls, txt):
+    def __new__(cls, txt, header = 'CommentBlock'):
         if not isinstance(txt, str):
             raise TypeError('txt must be of type str')
         txt = txt.replace('"','')
@@ -4663,9 +4663,20 @@ class CommentBlock(Basic):
 
         return Basic.__new__(cls, txts)
 
+    def __init__(self, txt, header = 'CommentBlock'):
+        self._header = header
+
     @property
     def comments(self):
         return self._args[0]
+
+    @property
+    def header(self):
+        return self._header
+
+    @header.setter
+    def header(self, header):
+        self._header = header
 
 class IndexedVariable(IndexedBase, PyccelAstNode):
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2927,9 +2927,6 @@ class FunctionDef(Basic):
     cls_name: str
         Class name if the function is a method of cls_name
 
-    hide: bool
-        if True, the function definition will not be generated.
-
     is_pure: bool
         True for a function without side effect
 
@@ -2996,7 +2993,6 @@ class FunctionDef(Basic):
         local_vars=[],
         global_vars=[],
         cls_name=None,
-        hide=False,
         is_static=False,
         imports=[],
         decorators={},
@@ -3106,7 +3102,6 @@ class FunctionDef(Basic):
         self._local_vars      = local_vars
         self._global_vars     = global_vars
         self._cls_name        = cls_name
-        self._hide            = hide
         self._is_static       = is_static
         self._imports         = imports
         self._decorators      = decorators
@@ -3161,11 +3156,6 @@ class FunctionDef(Basic):
     @cls_name.setter
     def cls_name(self, cls_name):
         self._cls_name = cls_name
-
-    @property
-    def hide(self):
-        """ False if function is pyccelized, True otherwise """
-        return self._hide
 
     @property
     def imports(self):
@@ -3303,7 +3293,6 @@ class FunctionDef(Basic):
         'local_vars':self._local_vars,
         'global_vars':self._global_vars,
         'cls_name':self._cls_name,
-        'hide':self._hide,
         'is_static':self._is_static,
         'imports':self._imports,
         'decorators':self._decorators,

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3220,8 +3220,8 @@ class FunctionDef(Basic):
 
     @property
     def is_header(self):
-        """ True if the function body is not provided
-        False otherwise """
+        """ True if the implementation of the function body
+        is not provided False otherwise """
         return self._is_header
 
     @property

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3205,6 +3205,7 @@ class FunctionDef(Basic):
 
     @property
     def headers(self):
+        """ List of headers applied to the function """
         return self._headers
 
     @property

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3009,7 +3009,8 @@ class FunctionDef(Basic):
         is_header=False,
         arguments_inout=[],
         functions=[],
-        interfaces=[]):
+        interfaces=[],
+        doc_string=None):
 
         if isinstance(name, str):
             name = Symbol(name)
@@ -3119,6 +3120,7 @@ class FunctionDef(Basic):
         self._arguments_inout = arguments_inout
         self._functions       = functions
         self._interfaces      = interfaces
+        self._doc_string      = doc_string
 
     @property
     def name(self):
@@ -3250,7 +3252,7 @@ class FunctionDef(Basic):
     @property
     def doc_string(self):
         """ The docstring of the function """
-        return ""
+        return self._doc_string
 
     def set_recursive(self):
         """ Mark the function as a recursive function """

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -259,7 +259,6 @@ class FunctionHeader(Header):
 
         body      = []
         cls_name  = None
-        hide      = False
         is_static = self.is_static
         imports   = []
         funcs = []
@@ -362,7 +361,6 @@ class FunctionHeader(Header):
                              local_vars=[],
                              global_vars=[],
                              cls_name=cls_name,
-                             hide=hide,
                              is_static=is_static,
                              imports=imports,
                              is_header=True)

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -204,9 +204,6 @@ class FunctionHeader(Header):
         a list of datatypes. an element of this list can be str/DataType of a
         tuple (str/DataType, attr, allocatable)
 
-    kind: str
-        'function' or 'procedure'. default value: 'function'
-
     is_static: bool
         True if we want to pass arrays in bind(c) mode. every argument of type
         array will be preceeded by its shape, the later will appear in the
@@ -223,7 +220,6 @@ class FunctionHeader(Header):
     # TODO dtypes should be a dictionary (useful in syntax)
     def __new__(cls, name, dtypes,
                 results=None,
-                kind='function',
                 is_static=False):
         name = str(name)
         if not(iterable(dtypes)):
@@ -233,16 +229,10 @@ class FunctionHeader(Header):
             if not(iterable(results)):
                 raise TypeError("Expecting results to be iterable.")
 
-        if not isinstance(kind, str):
-            raise TypeError("Expecting a string for kind.")
-
-        if kind not in ['function', 'procedure']:
-            raise ValueError("kind must be one among {'function', 'procedure'}")
-
         if not isinstance(is_static, bool):
             raise TypeError('is_static must be a boolean')
 
-        return Basic.__new__(cls, name, dtypes, results, kind, is_static)
+        return Basic.__new__(cls, name, dtypes, results, is_static)
 
     @property
     def name(self):
@@ -257,12 +247,8 @@ class FunctionHeader(Header):
         return self._args[2]
 
     @property
-    def kind(self):
-        return self._args[3]
-
-    @property
     def is_static(self):
-        return self._args[4]
+        return self._args[3]
 
     def create_definition(self, templates = ()):
         """Returns a FunctionDef with empy body."""
@@ -274,7 +260,6 @@ class FunctionHeader(Header):
         body      = []
         cls_name  = None
         hide      = False
-        kind      = self.kind
         is_static = self.is_static
         imports   = []
         funcs = []
@@ -378,7 +363,6 @@ class FunctionHeader(Header):
                              global_vars=[],
                              cls_name=cls_name,
                              hide=hide,
-                             kind=kind,
                              is_static=is_static,
                              imports=imports,
                              is_header=True)
@@ -391,7 +375,6 @@ class FunctionHeader(Header):
         return FunctionHeader(self.name,
                               self.dtypes,
                               self.results,
-                              self.kind,
                               True)
 
     def vectorize(self,index):
@@ -402,7 +385,6 @@ class FunctionHeader(Header):
         return FunctionHeader(self.name,
                               types,
                               self.results,
-                              self.kind,
                               self.is_static)
 
 
@@ -429,7 +411,6 @@ class FunctionHeader(Header):
         args = (self.name,
             self.dtypes,
             self.results,
-            self.kind,
             self.is_static,)
         return (self.__class__, args)
 
@@ -450,9 +431,6 @@ class MethodHeader(FunctionHeader):
         a list of datatypes. an element of this list can be str/DataType of a
         tuple (str/DataType, attr)
 
-    kind: str
-        'function' or 'procedure'. default value: 'function'
-
     is_static: bool
         True if we want to pass arrays in bind(c) mode. every argument of type
         array will be preceeded by its shape, the later will appear in the
@@ -468,7 +446,7 @@ class MethodHeader(FunctionHeader):
     'point.rotate'
     """
 
-    def __new__(cls, name, dtypes, results=None, kind='function', is_static=False):
+    def __new__(cls, name, dtypes, results=None, is_static=False):
         if not isinstance(name, (list, tuple)):
             raise TypeError("Expecting a list/tuple of strings.")
 
@@ -484,16 +462,10 @@ class MethodHeader(FunctionHeader):
                 raise TypeError("Wrong element in dtypes.")
 
 
-        if not isinstance(kind, str):
-            raise TypeError("Expecting a string for kind.")
-
-        if kind not in ['function', 'procedure']:
-            raise ValueError("kind must be one among {'function', 'procedure'}")
-
         if not isinstance(is_static, bool):
             raise TypeError('is_static must be a boolean')
 
-        return Basic.__new__(cls, name, dtypes, results, kind, is_static)
+        return Basic.__new__(cls, name, dtypes, results, is_static)
 
     @property
     def name(self):
@@ -512,12 +484,8 @@ class MethodHeader(FunctionHeader):
         return self._args[2]
 
     @property
-    def kind(self):
-        return self._args[3]
-
-    @property
     def is_static(self):
-        return self._args[4]
+        return self._args[3]
 
 
     def __reduce_ex__(self, i):
@@ -543,7 +511,6 @@ class MethodHeader(FunctionHeader):
         args = (self.name,
             self.dtypes,
             self.results,
-            self.kind,
             self.is_static,)
         return (self.__class__, args)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -825,18 +825,18 @@ class CCodePrinter(CodePrinter):
         if self._additional_args :
             self._additional_args.pop()
         imports = ''.join(self._print(i) for i in expr.imports)
+        doc_string = self._print(expr.doc_string) if expr.doc_string else ''
 
-        return ('{sep}\n'
-                '{signature}\n{{\n'
-                '{imports}\n'
-                '{decs}\n\n'
-                '{body}\n'
-                '}}\n{sep}'.format(
-                    sep = sep,
-                    signature = self.function_signature(expr),
-                    imports = imports,
-                    decs = decs,
-                    body = body))
+        parts = [sep,
+                 doc_string,
+                '{signature}\n{{'.format(signature=self.function_signature(expr)),
+                 imports,
+                 decs,
+                 body,
+                 '}',
+                 sep]
+
+        return '\n'.join(p for p in parts if p)
 
     def stored_in_c_pointer(self, a):
         if not isinstance(a, Variable):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1149,10 +1149,13 @@ class CCodePrinter(CodePrinter):
 
     def _print_CommentBlock(self, expr):
         txts = expr.comments
+        header = expr.header
+        header_size = len(expr.header)
+
         ln = max(len(i) for i in txts)
-        if ln<20:
+        if ln<max(20, header_size+2):
             ln = 20
-        top  = '/*' + '_'*int((ln-12)/2) + 'CommentBlock' + '_'*int((ln-12)/2) + '*/'
+        top  = '/*' + '_'*int((ln-header_size)/2) + header + '_'*int((ln-header_size)/2) + '*/'
         ln = len(top)
         bottom = '/*' + '_'*(ln-2) + '*/'
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1153,13 +1153,13 @@ class CCodePrinter(CodePrinter):
         header_size = len(expr.header)
 
         ln = max(len(i) for i in txts)
-        if ln<max(20, header_size+2):
+        if ln<max(20, header_size+4):
             ln = 20
         top  = '/*' + '_'*int((ln-header_size)/2) + header + '_'*int((ln-header_size)/2) + '*/'
-        ln = len(top)
-        bottom = '/*' + '_'*(ln-2) + '*/'
+        ln = len(top)-4
+        bottom = '/*' + '_'*ln + '*/'
 
-        txts = ['/*' + t + ' '*(ln -2 - len(t)) + '*/' for t in txts]
+        txts = ['/*' + t + ' '*(ln - len(t)) + '*/' for t in txts]
 
         body = '\n'.join(i for i in txts)
 

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -899,7 +899,8 @@ class CWrapperCodePrinter(CCodePrinter):
                                      '}}').format(
                                             name = f.name,
                                             wrapper_name = self._function_wrapper_names[f.name],
-                                            doc_string = self._print(LiteralString('\n'.join(f.doc_string.comments))))
+                                            doc_string = self._print(LiteralString('\n'.join(f.doc_string.comments))) \
+                                                        if f.doc_string else '""')
                                      for f in funcs)
 
         method_def_name = self.get_new_name(self._global_names, '{}_methods'.format(expr.name))

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -789,6 +789,14 @@ class CWrapperCodePrinter(CCodePrinter):
         wrapper_args    = [python_func_selfarg, python_func_args, python_func_kwargs]
         wrapper_results = [self.get_new_PyObject("result", used_names)]
 
+        if expr.is_private:
+            wrapper_func = FunctionDef(name = wrapper_name,
+                arguments = wrapper_args,
+                results = wrapper_results,
+                body = [PyErr_SetString('PyExc_NotImplementedError', '"Private functions are not accessible from python"'),
+                        AliasAssign(wrapper_results[0], Nil()),
+                        Return(wrapper_results)])
+            return CCodePrinter._print_FunctionDef(self, wrapper_func)
         if any(isinstance(arg, FunctionAddress) for arg in expr.arguments):
             wrapper_func = FunctionDef(name = wrapper_name,
                 arguments = wrapper_args,

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pyccel.codegen.printing.ccode import CCodePrinter
 
-from pyccel.ast.literals  import LiteralTrue, LiteralInteger
+from pyccel.ast.literals  import LiteralTrue, LiteralInteger, LiteralString
 
 from pyccel.ast.builtins import PythonPrint
 
@@ -895,11 +895,11 @@ class CWrapperCodePrinter(CCodePrinter):
                                      '"{name}",\n'
                                      '(PyCFunction){wrapper_name},\n'
                                      'METH_VARARGS | METH_KEYWORDS,\n'
-                                     '"{doc_string}"\n'
+                                     '{doc_string}\n'
                                      '}}').format(
                                             name = f.name,
                                             wrapper_name = self._function_wrapper_names[f.name],
-                                            doc_string = f.doc_string)
+                                            doc_string = self._print(LiteralString('\n'.join(f.doc_string.comments))))
                                      for f in funcs)
 
         method_def_name = self.get_new_name(self._global_names, '{}_methods'.format(expr.name))

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1392,15 +1392,17 @@ class FCodePrinter(CodePrinter):
         imports += 'use ISO_C_BINDING'
         prelude   = ''.join(self._print(i) for i in args_decs.values())
         body_code = self._print(expr.body)
+        doc_string = self._print(expr.doc_string) if expr.doc_string else ''
 
-        parts = ['{0} {1}({2}) bind(c) {3}\n'.format(func_type, name, arg_code, func_end),
+        parts = [doc_string,
+                '{0} {1}({2}) bind(c) {3}\n'.format(func_type, name, arg_code, func_end),
                  imports,
                 'implicit none\n',
                  prelude,
                  interfaces,
                  body_code,
                  'end {} {}\n'.format(func_type, name)]
-        return '\n'.join(parts)
+        return '\n'.join(p for p in parts if p)
 
     def _print_FunctionAddress(self, expr):
         return expr.name
@@ -1512,6 +1514,7 @@ class FCodePrinter(CodePrinter):
         functions = expr.functions
         func_interfaces = '\n'.join(self._print(i) for i in expr.interfaces)
         body_code = self._print(expr.body)
+        doc_string = self._print(expr.doc_string) if expr.doc_string else ''
 
         for i in expr.local_vars:
             dec = Declare(i.dtype, i)
@@ -1530,7 +1533,8 @@ class FCodePrinter(CodePrinter):
 
         self.set_current_function(None)
 
-        parts = parts = ["{}({}) {}\n".format(sig_parts['sig'], sig_parts['arg_code'], sig_parts['func_end']),
+        parts = [doc_string,
+                "{}({}) {}\n".format(sig_parts['sig'], sig_parts['arg_code'], sig_parts['func_end']),
                 imports,
                 'implicit none\n',
                 prelude,

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1411,7 +1411,7 @@ class FCodePrinter(CodePrinter):
 
         func_end  = ''
         rec = 'recursive' if expr.is_recursive else ''
-        if len(expr.results) == 1:
+        if len(expr.results) != 1:
             func_type = 'subroutine'
             out_args = list(expr.results)
             for result in out_args:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1476,9 +1476,6 @@ class FCodePrinter(CodePrinter):
         self._handle_fortran_specific_a_prioris(list(expr.local_vars) +
                                                 list(expr.arguments)  +
                                                 list(expr.results))
-        # ... we don't print 'hidden' functions
-        if expr.hide:
-            return ''
 
         name = self._print(expr.name)
         self.set_current_function(name)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -449,11 +449,14 @@ class FCodePrinter(CodePrinter):
         return '!' + comments + '\n'
 
     def _print_CommentBlock(self, expr):
-        txts = expr.comments
+        txts   = expr.comments
+        header = expr.header
+        header_size = len(expr.header)
+
         ln = max(len(i) for i in txts)
-        if ln<20:
+        if ln<max(20, header_size+2):
             ln = 20
-        top  = '!' + '_'*int((ln-12)/2) + 'CommentBlock' + '_'*int((ln-12)/2) + '!'
+        top  = '!' + '_'*int((ln-header_size)/2) + header + '_'*int((ln-header_size)/2) + '!'
         ln = len(top)
         bottom = '!' + '_'*(ln-2) + '!'
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -460,9 +460,7 @@ class FCodePrinter(CodePrinter):
         ln = len(top)
         bottom = '!' + '_'*(ln-2) + '!'
 
-        for i,txt in enumerate(txts):
-            txts[i] = '!' + txt + ' '*(ln -2 - len(txt)) + '!'
-
+        txts = ['!' + txt + ' '*(ln -2 - len(txt)) + '!' for txt in txts]
 
         body = '\n'.join(i for i in txts)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -457,10 +457,10 @@ class FCodePrinter(CodePrinter):
         if ln<max(20, header_size+2):
             ln = 20
         top  = '!' + '_'*int((ln-header_size)/2) + header + '_'*int((ln-header_size)/2) + '!'
-        ln = len(top)
-        bottom = '!' + '_'*(ln-2) + '!'
+        ln = len(top) - 2
+        bottom = '!' + '_'*ln + '!'
 
-        txts = ['!' + txt + ' '*(ln -2 - len(txt)) + '!' for txt in txts]
+        txts = ['!' + txt + ' '*(ln - len(txt)) + '!' for txt in txts]
 
         body = '\n'.join(i for i in txts)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1138,7 +1138,6 @@ class FCodePrinter(CodePrinter):
             rhs_code = self._print(name)
             rhs_code = '{0} % {1}'.format(lhs_code, rhs_code)
             #TODO use is_procedure property
-            is_procedure = (rhs.kind == 'procedure')
 
             code_args = ', '.join(self._print(i) for i in rhs.arguments)
             return 'call {0}({1})\n'.format(rhs_code, code_args)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -23,7 +23,7 @@ errors = Errors()
 def _construct_header(func_name, args):
     args = build_types_decorator(args, order='F')
     args = ','.join("{}".format(i) for i in args)
-    pattern = '#$ header procedure static {name}({args})'
+    pattern = '#$ header function static {name}({args})'
     return pattern.format(name=func_name, args=args)
 
 #==============================================================================

--- a/pyccel/codegen/python_wrapper.py
+++ b/pyccel/codegen/python_wrapper.py
@@ -63,7 +63,7 @@ def create_shared_library(codegen,
         extra_libdirs = []
         if language == 'fortran':
             # Construct static interface for passing array shapes and write it to file bind_c_MOD.f90
-            funcs = codegen.routines
+            funcs = [f for f in codegen.routines if not f.is_private]
             sep = fcode(SeparatorComment(40), codegen.parser)
             bind_c_funcs = [as_static_function_call(f, module_name, name=f.name) for f in funcs]
             bind_c_code = '\n'.join([sep + fcode(f, codegen.parser) + sep for f in bind_c_funcs])

--- a/pyccel/parser/grammar/headers.tx
+++ b/pyccel/parser/grammar/headers.tx
@@ -35,7 +35,7 @@ FunctionHeaderStmt:
 
 TemplateStmt: 'template' name = ID '(' dtypes+=TypeHeader['|'] ')';
 
-FunctionKind: 'function' | 'procedure' | 'method';
+FunctionKind: 'function' | 'method';
 Static: 'static';
 HeaderResults: 'results' '(' decs+=TypeHeader[','] ')'; 
 

--- a/pyccel/parser/grammar/pyccel.tx
+++ b/pyccel/parser/grammar/pyccel.tx
@@ -121,7 +121,7 @@ FunctionHeaderStmt:
   (results=HeaderResults)?
 ;
 
-FunctionKind: 'function' | 'procedure';
+FunctionKind: 'function';
 
 ClassOptions: 
     'abstract' 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2305,7 +2305,6 @@ class SemanticParser(BasicParser):
         name            = name.replace("'", '')
         cls_name        = expr.cls_name
         hide            = False
-        kind            = 'function'
         decorators      = expr.decorators
         funcs           = []
         sub_funcs       = []
@@ -2360,10 +2359,7 @@ class SemanticParser(BasicParser):
         for hd in header:
             interfaces += hd.create_definition(templates)
 
-        if header:
-            # get function kind from the header
-            kind = header[0].kind
-        elif not interfaces:
+        if not interfaces:
             # this for the case of a function without arguments => no header
             interfaces = [FunctionDef(name, [], [], [])]
 
@@ -2584,7 +2580,6 @@ class SemanticParser(BasicParser):
                     global_vars=global_vars,
                     cls_name=cls_name,
                     hide=hide,
-                    kind=kind,
                     is_pure=is_pure,
                     is_elemental=is_elemental,
                     is_private=is_private,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2255,27 +2255,6 @@ class SemanticParser(BasicParser):
         self.insert_header(expr)
         return expr
 
-    def _visit_InterfaceHeader(self, expr, **settings):
-
-        containers = [self.namespace.functions ,
-        self.namespace.imports['functions']]
-        # TODO improve test all possible containers
-        name = None
-        for container in containers:
-            if set(expr.funcs).issubset(container.keys()):
-                name  = expr.name
-                funcs = []
-                for i in expr.funcs:
-                    funcs += [container[i]]
-
-        if name is None:
-            errors.report(UNDEFINED_INTERFACE_FUNCTION, symbol=expr.funcs,
-                   bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
-                   severity='fatal', blocker=self.blocking)
-        expr            = Interface(name, funcs, hide=True)
-        container[name] = expr
-        return expr
-
     def _visit_Return(self, expr, **settings):
 
         results     = expr.expr
@@ -2304,7 +2283,6 @@ class SemanticParser(BasicParser):
         name            = str(expr.name)
         name            = name.replace("'", '')
         cls_name        = expr.cls_name
-        hide            = False
         decorators      = expr.decorators
         funcs           = []
         sub_funcs       = []
@@ -2580,7 +2558,6 @@ class SemanticParser(BasicParser):
                     local_vars=local_vars,
                     global_vars=global_vars,
                     cls_name=cls_name,
-                    hide=hide,
                     is_pure=is_pure,
                     is_elemental=is_elemental,
                     is_private=is_private,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2312,6 +2312,7 @@ class SemanticParser(BasicParser):
         is_pure         = expr.is_pure
         is_elemental    = expr.is_elemental
         is_private      = expr.is_private
+        doc_string      = self._visit(expr.doc_string)
 
         header = expr.headers
 
@@ -2588,7 +2589,8 @@ class SemanticParser(BasicParser):
                     is_recursive=is_recursive,
                     arguments_inout=args_inout,
                     functions = sub_funcs,
-                    interfaces = func_interfaces)
+                    interfaces = func_interfaces,
+                    doc_string = doc_string)
 
             if cls_name:
                 cls = self.get_class(cls_name)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2312,7 +2312,7 @@ class SemanticParser(BasicParser):
         is_pure         = expr.is_pure
         is_elemental    = expr.is_elemental
         is_private      = expr.is_private
-        doc_string      = self._visit(expr.doc_string)
+        doc_string      = self._visit(expr.doc_string) if expr.doc_string else expr.doc_string
 
         header = expr.headers
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -620,6 +620,7 @@ class SyntaxParser(BasicParser):
         is_elemental = False
         is_private   = False
         imports      = []
+        doc_string   = None
 
         def fill_types(ls):
             container = []
@@ -765,6 +766,10 @@ class SyntaxParser(BasicParser):
 
         else:
             body = self._visit(body)
+        if len(body) > 0 and isinstance(body[0], CommentBlock):
+            doc_string = body[0]
+            doc_string.header = True
+            body = body[1:]
 
         if 'pure' in decorators.keys():
             is_pure = True
@@ -812,7 +817,8 @@ class SyntaxParser(BasicParser):
                imports=imports,
                decorators=decorators,
                headers=headers,
-               templates=templates)
+               templates=templates,
+               doc_string=doc_string)
 
         func.set_fst(stmt)
         return func

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -824,7 +824,7 @@ class SyntaxParser(BasicParser):
         name = stmt.name
         methods = [self._visit(i) for i in stmt.body if isinstance(i, ast.FunctionDef)]
         for i in methods:
-            i.set_cls_name(name)
+            i.cls_name = name
         attributes = methods[0].arguments
         parent = [self._visit(i) for i in stmt.bases]
         expr = ClassDef(name=name, attributes=attributes,

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -768,7 +768,7 @@ class SyntaxParser(BasicParser):
             body = self._visit(body)
         if len(body) > 0 and isinstance(body[0], CommentBlock):
             doc_string = body[0]
-            doc_string.header = True
+            doc_string.header = ''
             body = body[1:]
 
         if 'pure' in decorators.keys():

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -616,7 +616,6 @@ class SyntaxParser(BasicParser):
         headers      = []
         templates    = {}
         hide         = False
-        kind         = 'function'
         is_pure      = False
         is_elemental = False
         is_private   = False
@@ -807,7 +806,6 @@ class SyntaxParser(BasicParser):
                local_vars=local_vars,
                global_vars=global_vars,
                hide=hide,
-               kind=kind,
                is_pure=is_pure,
                is_elemental=is_elemental,
                is_private=is_private,

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -615,7 +615,6 @@ class SyntaxParser(BasicParser):
         global_vars  = []
         headers      = []
         templates    = {}
-        hide         = False
         is_pure      = False
         is_elemental = False
         is_private   = False
@@ -810,7 +809,6 @@ class SyntaxParser(BasicParser):
                body,
                local_vars=local_vars,
                global_vars=global_vars,
-               hide=hide,
                is_pure=is_pure,
                is_elemental=is_elemental,
                is_private=is_private,

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -291,13 +291,11 @@ class FunctionHeaderStmt(BasicStmt):
             else:
                 cls_instance = dtype['datatype']
             dtypes = dtypes[1:] # remove the attribut
-            kind = 'function'
-            return MethodHeader((cls_instance, self.name), dtypes, [],kind=kind )
+            return MethodHeader((cls_instance, self.name), dtypes, [] )
         else:
             return FunctionHeader(self.name,
                                   dtypes,
                                   results=results,
-                                  kind=kind,
                                   is_static=is_static)
 
 class ClassHeaderStmt(BasicStmt):

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -249,7 +249,7 @@ class FunctionHeaderStmt(BasicStmt):
         name: str
             function name
         kind: str
-            one among {function, procedure, method}
+            one among {function, method}
         decs: list, tuple
             list of argument types
         results: list, tuple
@@ -291,9 +291,7 @@ class FunctionHeaderStmt(BasicStmt):
             else:
                 cls_instance = dtype['datatype']
             dtypes = dtypes[1:] # remove the attribut
-            kind = 'procedure'
-            if results:
-                kind = 'function'
+            kind = 'function'
             return MethodHeader((cls_instance, self.name), dtypes, [],kind=kind )
         else:
             return FunctionHeader(self.name,

--- a/pyccel/stdlib/internal/hdf5.pyh
+++ b/pyccel/stdlib/internal/hdf5.pyh
@@ -7,289 +7,289 @@
 #$ header metavar save=True
 
 # .......................................
-#        H5: General Library Functions   
+#        H5: General Library Functions
 # .......................................
-#$ header procedure h5check_version_f(int, int, int, int)
-#$ header procedure h5close_f(int) 
-#$ header procedure h5dont_atexit_f(int)   
-#$ header procedure h5garbage_collect_f(int)   
-#$ header procedure h5get_libversion_f(int, int, int, int)   
-#$ header procedure h5open_f(int)  
-# .......................................
-
-# .......................................
-#        H5A: Attribute Interface     
-# .......................................
-#$ header procedure h5aclose_f(attr_id, hdferr)   
-#$ header procedure h5acreate_f(loc_id, name, type_id, space_id, attr_id, hdferr, acpl_id, aapl_id )   
-#$ header procedure h5acreate_by_name_f(loc_id, obj_name, attr_name, type_id, space_id, attr, hdferr, acpl_id, aapl_id, lapl_id)   
-#$ header procedure h5adelete_f(obj_id, name, hdferr)   
-#$ header procedure h5adelete_by_idx_f(loc_id, obj_name, idx_type, order, n, hdferr, lapl_id)   
-#$ header procedure h5adelete_by_name_f(loc_id, obj_name, attr_name, hdferr, lapl_id)   
-#$ header procedure h5aexists_f(obj_id, attr_name, attr_exists, hdferr)   
-#$ header procedure h5aexists_by_name_f(loc_id, obj_name, attr_name, attr_exists, hdferr,lapl_id)   
-#$ header procedure h5aget_create_plist_f(attr_id, creation_prop_id, hdferr)   
-#$ header procedure h5aget_info_f(attr_id, f_corder_valid, corder, cset, data_size,hdferr)   
-#$ header procedure h5aget_info_by_idx_f(loc_id, obj_name, idx_type, order, n, f_corder_valid, corder, cset, data_size, hdferr, lapl_id)   
-#$ header procedure h5aget_info_by_name_f(loc_id, obj_name, attr_name, f_corder_valid, corder, cset, data_size, hdferr, lapl_id)   
-#$ header procedure h5aget_name_f(attr_id, size, buf, hdferr)   
-#$ header procedure h5aget_name_by_idx_f(loc_id, obj_name, idx_type, order, n, name, hdferr, size, lapl_id)   
-#$ header procedure h5aget_num_attrs_f(obj_id, attr_num, hdferr)    
-#$ header procedure h5aget_space_f(attr_id, space_id, hdferr)   
-#$ header procedure h5aget_storage_size_f(attr_id, size, hdferr)   
-#$ header procedure h5aget_type_f(attr_id, type_id, hdferr)    
-#$ header procedure h5aopen_f(obj_id, attr_name, attr_id, hdferr, aapl_id)   
-#$ header procedure h5aopen_by_idx_f(loc_id, obj_name, idx_type, order, n, attr_id, hdferr, aapl_id, lapl_id)   
-#$ header procedure h5aopen_by_name_f(loc_id, obj_name, attr_name, attr_id, hdferr, aapl_id, lapl_id)   
-#$ header procedure h5aopen_idx_f(obj_id, index, attr_id, hdferr)   
-#$ header procedure h5aopen_name_f(obj_id, name, attr_id, hdferr)   
-#$ header procedure h5aread_f(attr_id, memtype_id, buf, dims, hdferr)   
-#$ header procedure h5aread_f(attr_id, memtype_id, buf, hdferr)   
-#$ header procedure h5arename_f(loc_id, old_attr_name, new_attr_name, hdferr)   
-#$ header procedure h5arename_by_name_f(loc_id, obj_name, old_attr_name, new_attr_name, hdferr, lapl_id)   
-#$ header procedure h5awrite_f(attr_id, memtype_id, buf, dims, hdferr)   
-#$ header procedure h5awrite_f(attr_id, memtype_id, buf, hdferr)
+#$ header function h5check_version_f(int, int, int, int)
+#$ header function h5close_f(int)
+#$ header function h5dont_atexit_f(int)
+#$ header function h5garbage_collect_f(int)
+#$ header function h5get_libversion_f(int, int, int, int)
+#$ header function h5open_f(int)
 # .......................................
 
 # .......................................
-#        H5D: Datasets Interface       
-# ....................................... 
-#$ header procedure h5dclose_f(dset_id, hdferr)   
-#$ header procedure h5dcreate_f(loc_id, name, type_id, space_id, dset_id, hdferr, dcpl_id, lcpl_id, dapl_id)   
-#$ header procedure h5dcreate_anon_f(loc_id, type_id, space_id, dset_id, hdferr, dcpl_id, dapl_id)   
-#$ header procedure h5dextend_f(dataset_id, size, hdferr)   
-#$ header procedure h5dfill_f(fill_value, space_id, buf, hdferr)   
-#$ header procedure h5dget_create_plist_f(dataset_id, creation_id, hdferr)   
-#$ header procedure h5dget_space_f(dataset_id, dataspace_id, hdferr)   
-#$ header procedure h5dget_space_status_f(dset_id, flag, hdferr)   
-#$ header procedure h5dget_storage_size_f(dset_id, size, hdferr)   
-#$ header procedure h5dget_type_f(dataset_id, datatype_id, hdferr)   
-#$ header procedure h5dopen_f(loc_id, name, dset_id, hdferr, dapl_id)   
-#$ header procedure h5dread_f(dset_id, mem_type_id, buf, dims, hdferr, mem_space_id, file_space_id, xfer_prp)   
-#$ header procedure h5dread_vl_f(dset_id, mem_type_id, buf, dims, len, hdferr, mem_space_id, file_space_id, xfer_prp)   
-#$ header procedure h5dread_f(dset_id, mem_type_id, buf, hdferr, mem_space_id, file_space_id, xfer_prp)   
-#$ header procedure h5dset_extent_f(dataset_id, size, hdferr)   
-#$ header procedure h5dvlen_get_max_len_f(dset_id, size, hdferr)   
-#$ header procedure h5dvlen_reclaim_f(type_id, space_id, plist_id, buf, hdferr)   
-#$ header procedure h5dwrite_f(dset_id, mem_type_id, buf, dims, hdferr, mem_space_id, file_space_id, xfer_prp)   
-#$ header procedure h5dwrite_vl_f(dset_id, mem_type_id, buf, dims, len, hdferr, mem_space_id, file_space_id, xfer_prp)   
+#        H5A: Attribute Interface
+# .......................................
+#$ header function h5aclose_f(attr_id, hdferr)
+#$ header function h5acreate_f(loc_id, name, type_id, space_id, attr_id, hdferr, acpl_id, aapl_id )
+#$ header function h5acreate_by_name_f(loc_id, obj_name, attr_name, type_id, space_id, attr, hdferr, acpl_id, aapl_id, lapl_id)
+#$ header function h5adelete_f(obj_id, name, hdferr)
+#$ header function h5adelete_by_idx_f(loc_id, obj_name, idx_type, order, n, hdferr, lapl_id)
+#$ header function h5adelete_by_name_f(loc_id, obj_name, attr_name, hdferr, lapl_id)
+#$ header function h5aexists_f(obj_id, attr_name, attr_exists, hdferr)
+#$ header function h5aexists_by_name_f(loc_id, obj_name, attr_name, attr_exists, hdferr,lapl_id)
+#$ header function h5aget_create_plist_f(attr_id, creation_prop_id, hdferr)
+#$ header function h5aget_info_f(attr_id, f_corder_valid, corder, cset, data_size,hdferr)
+#$ header function h5aget_info_by_idx_f(loc_id, obj_name, idx_type, order, n, f_corder_valid, corder, cset, data_size, hdferr, lapl_id)
+#$ header function h5aget_info_by_name_f(loc_id, obj_name, attr_name, f_corder_valid, corder, cset, data_size, hdferr, lapl_id)
+#$ header function h5aget_name_f(attr_id, size, buf, hdferr)
+#$ header function h5aget_name_by_idx_f(loc_id, obj_name, idx_type, order, n, name, hdferr, size, lapl_id)
+#$ header function h5aget_num_attrs_f(obj_id, attr_num, hdferr)
+#$ header function h5aget_space_f(attr_id, space_id, hdferr)
+#$ header function h5aget_storage_size_f(attr_id, size, hdferr)
+#$ header function h5aget_type_f(attr_id, type_id, hdferr)
+#$ header function h5aopen_f(obj_id, attr_name, attr_id, hdferr, aapl_id)
+#$ header function h5aopen_by_idx_f(loc_id, obj_name, idx_type, order, n, attr_id, hdferr, aapl_id, lapl_id)
+#$ header function h5aopen_by_name_f(loc_id, obj_name, attr_name, attr_id, hdferr, aapl_id, lapl_id)
+#$ header function h5aopen_idx_f(obj_id, index, attr_id, hdferr)
+#$ header function h5aopen_name_f(obj_id, name, attr_id, hdferr)
+#$ header function h5aread_f(attr_id, memtype_id, buf, dims, hdferr)
+#$ header function h5aread_f(attr_id, memtype_id, buf, hdferr)
+#$ header function h5arename_f(loc_id, old_attr_name, new_attr_name, hdferr)
+#$ header function h5arename_by_name_f(loc_id, obj_name, old_attr_name, new_attr_name, hdferr, lapl_id)
+#$ header function h5awrite_f(attr_id, memtype_id, buf, dims, hdferr)
+#$ header function h5awrite_f(attr_id, memtype_id, buf, hdferr)
 # .......................................
 
 # .......................................
-#        H5E: Error Interface       
-# ....................................... 
-#$ header procedure h5eclear_f(hdferr)  
-#$ header procedure h5eget_major_f(error_no, name, hdferr)  
-#$ header procedure h5eget_minor_f(error_no, name, hdferr)   
-#$ header procedure h5eprint_f(hdferr, name)   
-#$ header procedure h5eset_auto_f(printflag, hdferr)   
+#        H5D: Datasets Interface
+# .......................................
+#$ header function h5dclose_f(dset_id, hdferr)
+#$ header function h5dcreate_f(loc_id, name, type_id, space_id, dset_id, hdferr, dcpl_id, lcpl_id, dapl_id)
+#$ header function h5dcreate_anon_f(loc_id, type_id, space_id, dset_id, hdferr, dcpl_id, dapl_id)
+#$ header function h5dextend_f(dataset_id, size, hdferr)
+#$ header function h5dfill_f(fill_value, space_id, buf, hdferr)
+#$ header function h5dget_create_plist_f(dataset_id, creation_id, hdferr)
+#$ header function h5dget_space_f(dataset_id, dataspace_id, hdferr)
+#$ header function h5dget_space_status_f(dset_id, flag, hdferr)
+#$ header function h5dget_storage_size_f(dset_id, size, hdferr)
+#$ header function h5dget_type_f(dataset_id, datatype_id, hdferr)
+#$ header function h5dopen_f(loc_id, name, dset_id, hdferr, dapl_id)
+#$ header function h5dread_f(dset_id, mem_type_id, buf, dims, hdferr, mem_space_id, file_space_id, xfer_prp)
+#$ header function h5dread_vl_f(dset_id, mem_type_id, buf, dims, len, hdferr, mem_space_id, file_space_id, xfer_prp)
+#$ header function h5dread_f(dset_id, mem_type_id, buf, hdferr, mem_space_id, file_space_id, xfer_prp)
+#$ header function h5dset_extent_f(dataset_id, size, hdferr)
+#$ header function h5dvlen_get_max_len_f(dset_id, size, hdferr)
+#$ header function h5dvlen_reclaim_f(type_id, space_id, plist_id, buf, hdferr)
+#$ header function h5dwrite_f(dset_id, mem_type_id, buf, dims, hdferr, mem_space_id, file_space_id, xfer_prp)
+#$ header function h5dwrite_vl_f(dset_id, mem_type_id, buf, dims, len, hdferr, mem_space_id, file_space_id, xfer_prp)
 # .......................................
 
 # .......................................
-#        H5F: File Interface       
-# ....................................... 
-#$ header procedure h5fclose_f(file_id, hdferr)   
-#$ header procedure h5fcreate_f(name, access_flags, file_id, hdferr, creation_prp, access_prp)   
-#$ header procedure h5fflush_f(obj_id, scope, hdferr)   
-#$ header procedure h5fget_access_plist_f(file_id, fcpl_id, hdferr)   
-#$ header procedure h5fget_create_plist_f(file_id, fcpl_id, hdferr)   
-#$ header procedure h5fget_filesize_f(file_id, size, hdferr)   
-#$ header procedure h5fget_freespace_f(file_id, free_space, hdferr)   
-#$ header procedure h5fget_name_f(obj_id, buf, size, hdferr)   
-#$ header procedure h5fget_obj_count_f(file_id, obj_type, obj_count, hdferr)   
-#$ header procedure h5fis_hdf5_f(name, status, hdferr)   
-#$ header procedure h5fmount_f(loc_id, name, child_id, hdferr)   
-#$ header procedure h5fopen_f(name, access_flags, file_id, hdferr, access_prp)   
-#$ header procedure h5freopen_f(file_id, new_file_id, hdferr) 
-#$ header procedure h5funmount_f(loc_id, name, child_id, hdferr)
+#        H5E: Error Interface
+# .......................................
+#$ header function h5eclear_f(hdferr)
+#$ header function h5eget_major_f(error_no, name, hdferr)
+#$ header function h5eget_minor_f(error_no, name, hdferr)
+#$ header function h5eprint_f(hdferr, name)
+#$ header function h5eset_auto_f(printflag, hdferr)
 # .......................................
 
 # .......................................
-#        H5G: Group Interface       
-# .......................................   
-#$ header procedure h5gclose_f( gr_id, hdferr)   
-#$ header procedure h5gcreate_f(loc_id, name, grp_id, hdferr, size_hint, lcpl_id, gcpl_id, gapl_id)   
-#$ header procedure h5gcreate_anon_f(loc_id, grp_id, hdferr, gcpl_id, gapl_id   
-#$ header procedure h5gget_comment_f(loc_id, name, size, buffer, hdferr)   
-#$ header procedure h5gget_create_plist_f(grp_id, gcpl_id, hdferr)   
-#$ header procedure h5gget_info_f(group_id, storage_type, nlinks, max_corder, hdferr, mounted)   
-#$ header procedure h5gget_info_by_idx_f(loc_id, group_name, index_type, order, n, storage_type, nlinks, max_corder, hdferr, lapl_id, mounted)   
-#$ header procedure h5gget_info_by_name_f(loc_id, group_name, storage_type, nlinks, max_corder, hdferr, lapl_id, mounted)   
-#$ header procedure h5gget_linkval_f(loc_id, name, size, buffer, hdferr)   
-#$ header procedure h5gn_members_f(loc_id, name, nmembers, hdferr)   
-#$ header procedure h5gget_obj_info_idx_f(loc_id, name, idx, obj_name, obj_type, hdferr)   
-#$ header procedure h5glink_f(loc_id, link_type, current_name, new_name, hdferr)   
-#$ header procedure h5glink2_f(cur_loc_id, cur_name, link_type, new_loc_id, new_name, hdferr)   
-#$ header procedure h5gmove_f(loc_id, name, new_name, hdferr)   
-#$ header procedure h5gmove2_f(src_loc_id, src_name, dst_loc_id, dst_name, hdferr)   
-#$ header procedure h5gopen_f(loc_id, name, grp_id, hdferr, gapl_id)   
-#$ header procedure h5gset_comment_f(loc_id, name, comment, hdferr)   
-#$ header procedure h5gunlink_f(loc_id, name, hdferr)
+#        H5F: File Interface
+# .......................................
+#$ header function h5fclose_f(file_id, hdferr)
+#$ header function h5fcreate_f(name, access_flags, file_id, hdferr, creation_prp, access_prp)
+#$ header function h5fflush_f(obj_id, scope, hdferr)
+#$ header function h5fget_access_plist_f(file_id, fcpl_id, hdferr)
+#$ header function h5fget_create_plist_f(file_id, fcpl_id, hdferr)
+#$ header function h5fget_filesize_f(file_id, size, hdferr)
+#$ header function h5fget_freespace_f(file_id, free_space, hdferr)
+#$ header function h5fget_name_f(obj_id, buf, size, hdferr)
+#$ header function h5fget_obj_count_f(file_id, obj_type, obj_count, hdferr)
+#$ header function h5fis_hdf5_f(name, status, hdferr)
+#$ header function h5fmount_f(loc_id, name, child_id, hdferr)
+#$ header function h5fopen_f(name, access_flags, file_id, hdferr, access_prp)
+#$ header function h5freopen_f(file_id, new_file_id, hdferr)
+#$ header function h5funmount_f(loc_id, name, child_id, hdferr)
 # .......................................
 
 # .......................................
-#        H5I: Identifier Interface       
-# .......................................    
-#$ header procedure h5idec_ref_f(obj_id, ref_count, hdferr)   
-#$ header procedure h5iget_file_id_f(obj_id, file_id, hdferr)   
-#$ header procedure h5iget_name_f(obj_id, buf, buf_size, name_size, hdferr)   
-#$ header procedure h5iget_ref_f(obj_id, ref_count, hdferr)   
-#$ header procedure h5iget_type_f(obj_id, type, hdferr)   
-#$ header procedure h5iinc_ref_f(obj_id, ref_count, hdferr)   
-#$ header procedure h5iis_valid_f(id, valid, hdferr)  
+#        H5G: Group Interface
+# .......................................
+#$ header function h5gclose_f( gr_id, hdferr)
+#$ header function h5gcreate_f(loc_id, name, grp_id, hdferr, size_hint, lcpl_id, gcpl_id, gapl_id)
+#$ header function h5gcreate_anon_f(loc_id, grp_id, hdferr, gcpl_id, gapl_id
+#$ header function h5gget_comment_f(loc_id, name, size, buffer, hdferr)
+#$ header function h5gget_create_plist_f(grp_id, gcpl_id, hdferr)
+#$ header function h5gget_info_f(group_id, storage_type, nlinks, max_corder, hdferr, mounted)
+#$ header function h5gget_info_by_idx_f(loc_id, group_name, index_type, order, n, storage_type, nlinks, max_corder, hdferr, lapl_id, mounted)
+#$ header function h5gget_info_by_name_f(loc_id, group_name, storage_type, nlinks, max_corder, hdferr, lapl_id, mounted)
+#$ header function h5gget_linkval_f(loc_id, name, size, buffer, hdferr)
+#$ header function h5gn_members_f(loc_id, name, nmembers, hdferr)
+#$ header function h5gget_obj_info_idx_f(loc_id, name, idx, obj_name, obj_type, hdferr)
+#$ header function h5glink_f(loc_id, link_type, current_name, new_name, hdferr)
+#$ header function h5glink2_f(cur_loc_id, cur_name, link_type, new_loc_id, new_name, hdferr)
+#$ header function h5gmove_f(loc_id, name, new_name, hdferr)
+#$ header function h5gmove2_f(src_loc_id, src_name, dst_loc_id, dst_name, hdferr)
+#$ header function h5gopen_f(loc_id, name, grp_id, hdferr, gapl_id)
+#$ header function h5gset_comment_f(loc_id, name, comment, hdferr)
+#$ header function h5gunlink_f(loc_id, name, hdferr)
 # .......................................
 
 # .......................................
-#        H5L: Link Interface       
-# .......................................   
-#$ header procedure h5lcopy_f(src_loc_id, src_name, dest_loc_id, dest_name, hdferr, lcpl_id, lapl_id)   
-#$ header procedure h5lcreate_external_f(file_name, obj_name, link_loc_id, link_name, hdferr, lcpl_id, lapl_id)   
-#$ header procedure h5lcreate_hard_f(obj_loc_id, obj_name, link_loc_id, link_name, hdferr, lcpl_id, lapl_id)   
-#$ header procedure h5lcreate_soft_f(target_path, link_loc_id, link_name, hdferr, lcpl_id, lapl_id)   
-#$ header procedure h5ldelete_f(loc_id, name, hdferr, lapl_id)   
-#$ header procedure h5ldelete_by_idx_f(loc_id, group_name, index_field, order, n, hdferr, lapl_id)   
-#$ header procedure h5lexists_f(loc_id, name, link_exists, hdferr, lapl_id)  
-#$ header procedure h5lget_info_f(link_loc_id, link_name, cset, corder, f_corder_valid, link_type, address, val_size, hdferr, lapl_id)   
-#$ header procedure h5lget_info_by_idx_f(loc_id, group_name, index_field, order, n, link_type, f_corder_valid, corder, cset, address, val_size, hdferr, lapl_id)   
-#$ header procedure h5lget_name_by_idx_f(loc_id, group_name, index_field, order, n, name, hdferr, lapl_id, size)   
-#$ header procedure H5Lis_registered_f(link_cls_id, registered, hdferr)   
-#$ header procedure h5literate_f(group_id, index_type, order, idx, op, op_data, return_value, hdferr)   
-#$ header procedure h5literate_by_name_f(loc_id, group_name, index_type, order, idx, op, op_data, return_value, hdferr, lapl_id)   
-#$ header procedure h5lmove_f(src_loc_id, src_name, dest_loc_id, dest_name, hdferr, lcpl_id, lapl_id)  
+#        H5I: Identifier Interface
+# .......................................
+#$ header function h5idec_ref_f(obj_id, ref_count, hdferr)
+#$ header function h5iget_file_id_f(obj_id, file_id, hdferr)
+#$ header function h5iget_name_f(obj_id, buf, buf_size, name_size, hdferr)
+#$ header function h5iget_ref_f(obj_id, ref_count, hdferr)
+#$ header function h5iget_type_f(obj_id, type, hdferr)
+#$ header function h5iinc_ref_f(obj_id, ref_count, hdferr)
+#$ header function h5iis_valid_f(id, valid, hdferr)
 # .......................................
 
 # .......................................
-#        H5O: Object Interface       
-# .......................................    
+#        H5L: Link Interface
+# .......................................
+#$ header function h5lcopy_f(src_loc_id, src_name, dest_loc_id, dest_name, hdferr, lcpl_id, lapl_id)
+#$ header function h5lcreate_external_f(file_name, obj_name, link_loc_id, link_name, hdferr, lcpl_id, lapl_id)
+#$ header function h5lcreate_hard_f(obj_loc_id, obj_name, link_loc_id, link_name, hdferr, lcpl_id, lapl_id)
+#$ header function h5lcreate_soft_f(target_path, link_loc_id, link_name, hdferr, lcpl_id, lapl_id)
+#$ header function h5ldelete_f(loc_id, name, hdferr, lapl_id)
+#$ header function h5ldelete_by_idx_f(loc_id, group_name, index_field, order, n, hdferr, lapl_id)
+#$ header function h5lexists_f(loc_id, name, link_exists, hdferr, lapl_id)
+#$ header function h5lget_info_f(link_loc_id, link_name, cset, corder, f_corder_valid, link_type, address, val_size, hdferr, lapl_id)
+#$ header function h5lget_info_by_idx_f(loc_id, group_name, index_field, order, n, link_type, f_corder_valid, corder, cset, address, val_size, hdferr, lapl_id)
+#$ header function h5lget_name_by_idx_f(loc_id, group_name, index_field, order, n, name, hdferr, lapl_id, size)
+#$ header function H5Lis_registered_f(link_cls_id, registered, hdferr)
+#$ header function h5literate_f(group_id, index_type, order, idx, op, op_data, return_value, hdferr)
+#$ header function h5literate_by_name_f(loc_id, group_name, index_type, order, idx, op, op_data, return_value, hdferr, lapl_id)
+#$ header function h5lmove_f(src_loc_id, src_name, dest_loc_id, dest_name, hdferr, lcpl_id, lapl_id)
+# .......................................
+
+# .......................................
+#        H5O: Object Interface
+# .......................................
 # TODO: NOT HANDLED YET
 # .......................................
 
 # .......................................
-#        H5P: Property List Interface       
-# .......................................    
+#        H5P: Property List Interface
+# .......................................
 # TODO: NOT HANDLED YET
-# .......................................    
-
-# .......................................
-#        H5R: Reference Interface       
-# .......................................    
-#$ header procedure h5rcreate_f(loc_id, name, ref, hdferr) 
-#$ header procedure h5rcreate_f(loc_id, name, space_id, ref, hdferr)   
-#$ header procedure h5rcreate_f(loc_id, name, ref_type, ref, hdferr, space_id)   
-#$ header procedure h5rdereference_f(obj_id, ref, ref_obj_id, hdferr)   
-#$ header procedure h5rdereference_f(obj_id, ref_type, ref, ref_obj_id, hdferr)
-#$ header procedure h5rget_name_object_f(loc_id, ref, name, hdferr, size)   
-#$ header procedure h5rget_name_region_f(loc_id, ref, name, hdferr, size)   
-#$ header procedure h5rget_name_f(loc_id, ref_type, ref, name, hdferr, size)   
-#$ header procedure h5rget_object_type_f(loc_id, ref, obj_type, hdferr)   
-#$ header procedure h5rget_object_type_f(loc_id, ref_type, ref, obj_type, hdferr)   
-#$ header procedure h5rget_region_f(obj_id, ref, space_id, hdferr)  
 # .......................................
 
 # .......................................
-#        H5S: Dataspace Interface       
-# .......................................    
-#$ header procedure h5sclose_f(space_id, hdferr)   
-#$ header procedure h5scopy_f(space_id, new_space_id, hdferr)   
-#$ header procedure h5screate_f(classtype, space_id, hdferr)   
-#$ header procedure h5screate_simple_f(rank, dims, space_id, hdferr, maxdims)   
-#$ header procedure h5sdecode_f(buf, obj_id, hdferr)   
-#$ header procedure h5sencode_f(obj_id, buf, nalloc, hdferr)
-#$ header procedure h5sextent_copy_f(dest_space_id, source_space_id, hdferr)   
-#$ header procedure h5sextent_equal_f(space1_id, space2_id, equal, hdferr)   
-#$ header procedure h5sget_select_bounds_f(space_id, start, end, hdferr)   
-#$ header procedure h5sget_select_elem_npoints_f(space_id, num_points, hdferr)   
-#$ header procedure h5sget_select_elem_pointlist_f(space_id, startpoint, num_points, buf, hdferr)   
-#$ header procedure h5sget_select_hyper_blocklist_f(space_id, startblock, num_blocks, buf, hdferr)   
-#$ header procedure h5sget_select_hyper_nblocks_f(space_id, num_blocks, hdferr)   
-#$ header procedure h5sget_select_npoints_f(space_id, npoints, hdferr)   
-#$ header procedure h5sget_select_type_f(space_id, type, hdferr)   
-#$ header procedure h5sget_simple_extent_dims_f(space_id, dims, maxdims, hdferr)   
-#$ header procedure h5sget_simple_extent_ndims_f(space_id, rank, hdferr)   
-#$ header procedure h5sget_simple_extent_npoints_f(space_id, npoints, hdferr)   
-#$ header procedure h5sget_simple_extent_type_f(space_id, classtype, hdferr)   
-#$ header procedure h5sis_simple_f(space_id, flag, hdferr)  
-#$ header procedure h5soffset_simple_f(space_id, offset, hdferr)   
-#$ header procedure h5sselect_all_f(dspace_id, hdferr)   
-#$ header procedure h5sselect_elements_f(space_id, operator, rank, num_elements, coord, hdferr)   
-#$ header procedure h5sselect_hyperslab_f(space_id, operator, start, count, hdferr, stride, block)   
-#$ header procedure h5sselect_none_f(space_id, hdferr)   
-#$ header procedure h5sselect_valid_f(space_id, flag, hdferr)   
-#$ header procedure h5sset_extent_none_f(space_id, hdferr)   
-#$ header procedure h5sset_extent_simple_f(space_id, rank, current_size, maximum_size, hdferr)   
+#        H5R: Reference Interface
+# .......................................
+#$ header function h5rcreate_f(loc_id, name, ref, hdferr)
+#$ header function h5rcreate_f(loc_id, name, space_id, ref, hdferr)
+#$ header function h5rcreate_f(loc_id, name, ref_type, ref, hdferr, space_id)
+#$ header function h5rdereference_f(obj_id, ref, ref_obj_id, hdferr)
+#$ header function h5rdereference_f(obj_id, ref_type, ref, ref_obj_id, hdferr)
+#$ header function h5rget_name_object_f(loc_id, ref, name, hdferr, size)
+#$ header function h5rget_name_region_f(loc_id, ref, name, hdferr, size)
+#$ header function h5rget_name_f(loc_id, ref_type, ref, name, hdferr, size)
+#$ header function h5rget_object_type_f(loc_id, ref, obj_type, hdferr)
+#$ header function h5rget_object_type_f(loc_id, ref_type, ref, obj_type, hdferr)
+#$ header function h5rget_region_f(obj_id, ref, space_id, hdferr)
 # .......................................
 
 # .......................................
-#        H5T: Datatype Interface       
-# .......................................    
-#$ header procedure h5tarray_create_f(base_id, rank, dims, type_id, hdferr)   
-#$ header procedure h5tarray_create_f(base_id, rank, dims, type_id, hdferr)   
-#$ header procedure h5tclose_f(type_id, hdferr)   
-#$ header procedure h5tcommit_f(loc_id, name, type_id, hdferr, lcpl_id, tcpl_id, tapl_id )   
-#$ header procedure h5tcommit_anon_f(loc_id, dtype_id, hdferr, tcpl_id, tapl_id)   
-#$ header procedure h5tcommitted_f(dtype_id, committed, hdferr)   
-#$ header procedure h5tcompiler_conv_f( src_id, dst_id, flag, hdferr)   
-#$ header procedure h5tconvert_f(src_id, dst_id, nelmts, buf, hdferr, background, plist_id)   
-#$ header procedure h5tcopy_f(type_id, new_type_id, hdferr)   
-#$ header procedure h5tcreate_f(class, size, type_id, hdferr)   
-#$ header procedure h5tdecode_f(buf, obj_id, hdferr)   
-#$ header procedure h5tencode_f(obj_id, buf, nalloc, hdferr)   
-#$ header procedure h5tenum_create_f(parent_id, new_type_id, hdferr)   
-#$ header procedure h5tenum_insert_f(type_id, name, value, hdferr)   
-#$ header procedure h5tenum_nameof_f(type_id, value, namelen, name, hdferr)  
-#$ header procedure h5tenum_valueof_f(type_id, name, value, hdferr)   
-#$ header procedure h5tequal_f(type1_id, type2_id, flag, hdferr)   
-#$ header procedure h5tarray_create_f(base_id, rank, dims, type_id, hdferr)   
-#$ header procedure h5tget_array_dims_f(type_id, dims, hdferr)   
-#$ header procedure h5tget_array_ndims_f(type_id, ndims, hdferr)   
-#$ header procedure h5tget_class_f(type_id, class, hdferr)   
-#$ header procedure h5tget_create_plist_f(dtype_id, dtpl_id, hdferr)   
-#$ header procedure h5tget_cset_f(type_id, cset, hdferr)   
-#$ header procedure h5tget_ebias_f(type_id, ebias, hdferr)   
-#$ header procedure h5tget_fields_f(type_id, spos, epos, esize, mpos, msize, hdferr)   
-#$ header procedure h5tget_inpad_f(type_id, padtype, hdferr)   
-#$ header procedure h5tget_member_class_f(type_id, member_no, class, hdferr)   
-#$ header procedure h5tget_member_index_f(type_id, name, index, hdferr)   
-#$ header procedure h5tget_member_name_f(type_id,index, member_name, namelen, hdferr)   
-#$ header procedure h5tget_member_offset_f(type_id, member_no, offset, hdferr)   
-#$ header procedure h5tget_member_type_f(type_id, field_idx, datatype, hdferr)   
-#$ header procedure h5tget_member_value_f(type_id,  member_no, value, hdferr) 
-#$ header procedure h5tget_native_type_f(dtype_id, direction, native_dtype_id, hdferr)   
-#$ header procedure h5tget_nmembers_f(type_id, num_members, hdferr)   
-#$ header procedure h5tget_norm_f(type_id, norm, hdferr)   
-#$ header procedure h5tget_offset_f(type_id, offset, hdferr) 
-#$ header procedure h5tget_order_f(type_id, order, hdferr)   
-#$ header procedure h5tget_pad_f(type_id, lsbpad, msbpad, hdferr)  
-#$ header procedure h5tget_precision_f(type_id, precision, hdferr)   
-#$ header procedure h5tget_sign_f(type_id, sign, hdferr)   
-#$ header procedure h5tget_size_f(type_id, size, hdferr)   
-#$ header procedure h5tget_strpad_f(type_id, strpad, hdferr)   
-#$ header procedure h5tget_super_f(type_id, base_type_id, hdferr)   
-#$ header procedure h5tget_tag_f(type_id, tag,taglen, hdferr)   
-#$ header procedure h5tinsert_f(type_id, name, offset, field_id, hdferr)   
-#$ header procedure h5tis_variable_str_f(type_id, status, hdferr)   
-#$ header procedure h5topen_f(loc_id, name, type_id, hdferr, tapl_id)   
-#$ header procedure h5tpack_f(type_id, hdferr)   
-#$ header procedure h5tset_cset_f(type_id, cset, hdferr)   
-#$ header procedure h5tset_ebias_f(type_id, ebias, hdferr)  
-#$ header procedure h5tset_fields_f(type_id, spos, epos, esize, mpos, msize, hdferr)  
-#$ header procedure h5tset_inpad_f(type_id, padtype, hdferr)   
-#$ header procedure h5tset_norm_f(type_id, norm, hdferr)   
-#$ header procedure h5tset_offset_f(type_id, offset, hdferr)   
-#$ header procedure h5tset_order_f(type_id, order, hdferr)   
-#$ header procedure h5tset_pad_f(type_id, lsbpad, msbpad, hdferr)   
-#$ header procedure h5tset_precision_f(type_id, precision, hdferr)   
-#$ header procedure h5tset_sign_f(type_id, sign, hdferr)   
-#$ header procedure h5tset_size_f(type_id, size, hdferr)   
-#$ header procedure h5tset_strpad_f(type_id, strpad, hdferr)   
-#$ header procedure h5tset_tag_f(type_id, tag, hdferr)   
-#$ header procedure h5tvlen_create_f(type_id, vltype_id, hdferr)  
+#        H5S: Dataspace Interface
+# .......................................
+#$ header function h5sclose_f(space_id, hdferr)
+#$ header function h5scopy_f(space_id, new_space_id, hdferr)
+#$ header function h5screate_f(classtype, space_id, hdferr)
+#$ header function h5screate_simple_f(rank, dims, space_id, hdferr, maxdims)
+#$ header function h5sdecode_f(buf, obj_id, hdferr)
+#$ header function h5sencode_f(obj_id, buf, nalloc, hdferr)
+#$ header function h5sextent_copy_f(dest_space_id, source_space_id, hdferr)
+#$ header function h5sextent_equal_f(space1_id, space2_id, equal, hdferr)
+#$ header function h5sget_select_bounds_f(space_id, start, end, hdferr)
+#$ header function h5sget_select_elem_npoints_f(space_id, num_points, hdferr)
+#$ header function h5sget_select_elem_pointlist_f(space_id, startpoint, num_points, buf, hdferr)
+#$ header function h5sget_select_hyper_blocklist_f(space_id, startblock, num_blocks, buf, hdferr)
+#$ header function h5sget_select_hyper_nblocks_f(space_id, num_blocks, hdferr)
+#$ header function h5sget_select_npoints_f(space_id, npoints, hdferr)
+#$ header function h5sget_select_type_f(space_id, type, hdferr)
+#$ header function h5sget_simple_extent_dims_f(space_id, dims, maxdims, hdferr)
+#$ header function h5sget_simple_extent_ndims_f(space_id, rank, hdferr)
+#$ header function h5sget_simple_extent_npoints_f(space_id, npoints, hdferr)
+#$ header function h5sget_simple_extent_type_f(space_id, classtype, hdferr)
+#$ header function h5sis_simple_f(space_id, flag, hdferr)
+#$ header function h5soffset_simple_f(space_id, offset, hdferr)
+#$ header function h5sselect_all_f(dspace_id, hdferr)
+#$ header function h5sselect_elements_f(space_id, operator, rank, num_elements, coord, hdferr)
+#$ header function h5sselect_hyperslab_f(space_id, operator, start, count, hdferr, stride, block)
+#$ header function h5sselect_none_f(space_id, hdferr)
+#$ header function h5sselect_valid_f(space_id, flag, hdferr)
+#$ header function h5sset_extent_none_f(space_id, hdferr)
+#$ header function h5sset_extent_simple_f(space_id, rank, current_size, maximum_size, hdferr)
 # .......................................
 
 # .......................................
-#        H5Z: Filter and Compression Interface       
-# .......................................    
-#$ header procedure h5zfilter_avail_f(filter, status, hdferr)   
-#$ header procedure h5zget_filter_info_f(filter, config_flags, hdferr)   
-#$ header procedure h5zunregister_f(filter, hdferr)   
-# .......................................    
+#        H5T: Datatype Interface
+# .......................................
+#$ header function h5tarray_create_f(base_id, rank, dims, type_id, hdferr)
+#$ header function h5tarray_create_f(base_id, rank, dims, type_id, hdferr)
+#$ header function h5tclose_f(type_id, hdferr)
+#$ header function h5tcommit_f(loc_id, name, type_id, hdferr, lcpl_id, tcpl_id, tapl_id )
+#$ header function h5tcommit_anon_f(loc_id, dtype_id, hdferr, tcpl_id, tapl_id)
+#$ header function h5tcommitted_f(dtype_id, committed, hdferr)
+#$ header function h5tcompiler_conv_f( src_id, dst_id, flag, hdferr)
+#$ header function h5tconvert_f(src_id, dst_id, nelmts, buf, hdferr, background, plist_id)
+#$ header function h5tcopy_f(type_id, new_type_id, hdferr)
+#$ header function h5tcreate_f(class, size, type_id, hdferr)
+#$ header function h5tdecode_f(buf, obj_id, hdferr)
+#$ header function h5tencode_f(obj_id, buf, nalloc, hdferr)
+#$ header function h5tenum_create_f(parent_id, new_type_id, hdferr)
+#$ header function h5tenum_insert_f(type_id, name, value, hdferr)
+#$ header function h5tenum_nameof_f(type_id, value, namelen, name, hdferr)
+#$ header function h5tenum_valueof_f(type_id, name, value, hdferr)
+#$ header function h5tequal_f(type1_id, type2_id, flag, hdferr)
+#$ header function h5tarray_create_f(base_id, rank, dims, type_id, hdferr)
+#$ header function h5tget_array_dims_f(type_id, dims, hdferr)
+#$ header function h5tget_array_ndims_f(type_id, ndims, hdferr)
+#$ header function h5tget_class_f(type_id, class, hdferr)
+#$ header function h5tget_create_plist_f(dtype_id, dtpl_id, hdferr)
+#$ header function h5tget_cset_f(type_id, cset, hdferr)
+#$ header function h5tget_ebias_f(type_id, ebias, hdferr)
+#$ header function h5tget_fields_f(type_id, spos, epos, esize, mpos, msize, hdferr)
+#$ header function h5tget_inpad_f(type_id, padtype, hdferr)
+#$ header function h5tget_member_class_f(type_id, member_no, class, hdferr)
+#$ header function h5tget_member_index_f(type_id, name, index, hdferr)
+#$ header function h5tget_member_name_f(type_id,index, member_name, namelen, hdferr)
+#$ header function h5tget_member_offset_f(type_id, member_no, offset, hdferr)
+#$ header function h5tget_member_type_f(type_id, field_idx, datatype, hdferr)
+#$ header function h5tget_member_value_f(type_id,  member_no, value, hdferr)
+#$ header function h5tget_native_type_f(dtype_id, direction, native_dtype_id, hdferr)
+#$ header function h5tget_nmembers_f(type_id, num_members, hdferr)
+#$ header function h5tget_norm_f(type_id, norm, hdferr)
+#$ header function h5tget_offset_f(type_id, offset, hdferr)
+#$ header function h5tget_order_f(type_id, order, hdferr)
+#$ header function h5tget_pad_f(type_id, lsbpad, msbpad, hdferr)
+#$ header function h5tget_precision_f(type_id, precision, hdferr)
+#$ header function h5tget_sign_f(type_id, sign, hdferr)
+#$ header function h5tget_size_f(type_id, size, hdferr)
+#$ header function h5tget_strpad_f(type_id, strpad, hdferr)
+#$ header function h5tget_super_f(type_id, base_type_id, hdferr)
+#$ header function h5tget_tag_f(type_id, tag,taglen, hdferr)
+#$ header function h5tinsert_f(type_id, name, offset, field_id, hdferr)
+#$ header function h5tis_variable_str_f(type_id, status, hdferr)
+#$ header function h5topen_f(loc_id, name, type_id, hdferr, tapl_id)
+#$ header function h5tpack_f(type_id, hdferr)
+#$ header function h5tset_cset_f(type_id, cset, hdferr)
+#$ header function h5tset_ebias_f(type_id, ebias, hdferr)
+#$ header function h5tset_fields_f(type_id, spos, epos, esize, mpos, msize, hdferr)
+#$ header function h5tset_inpad_f(type_id, padtype, hdferr)
+#$ header function h5tset_norm_f(type_id, norm, hdferr)
+#$ header function h5tset_offset_f(type_id, offset, hdferr)
+#$ header function h5tset_order_f(type_id, order, hdferr)
+#$ header function h5tset_pad_f(type_id, lsbpad, msbpad, hdferr)
+#$ header function h5tset_precision_f(type_id, precision, hdferr)
+#$ header function h5tset_sign_f(type_id, sign, hdferr)
+#$ header function h5tset_size_f(type_id, size, hdferr)
+#$ header function h5tset_strpad_f(type_id, strpad, hdferr)
+#$ header function h5tset_tag_f(type_id, tag, hdferr)
+#$ header function h5tvlen_create_f(type_id, vltype_id, hdferr)
+# .......................................
+
+# .......................................
+#        H5Z: Filter and Compression Interface
+# .......................................
+#$ header function h5zfilter_avail_f(filter, status, hdferr)
+#$ header function h5zget_filter_info_f(filter, config_flags, hdferr)
+#$ header function h5zunregister_f(filter, hdferr)
+# .......................................

--- a/tests/codegen/fcode/scripts/functions_inout.py
+++ b/tests/codegen/fcode/scripts/functions_inout.py
@@ -1,23 +1,23 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 # TODO add AugAssign to these tests
 
-#$ header procedure f_assign(int, double [:])
+#$ header function f_assign(int, double [:])
 def f_assign(m1, x):
     x[:] = 0.
     for i in range(0, m1):
         x[i] = i * 1.
 
-#$ header procedure f_for(int, double [:])
+#$ header function f_for(int, double [:])
 def f_for(m1, x):
     for i in range(0, m1):
         x[i] = i * 1.
 
-#$ header procedure f_if(int, double [:])
+#$ header function f_if(int, double [:])
 def f_if(m1, x):
     if m1 == 1:
         x[1] = 1.
 
-#$ header procedure f_while(int, double [:])
+#$ header function f_while(int, double [:])
 def f_while(m1, x):
     i = 0
     while(i < 10):

--- a/tests/epyccel/test_docstrings.py
+++ b/tests/epyccel/test_docstrings.py
@@ -1,0 +1,46 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+from pyccel.epyccel import epyccel
+
+def test_1_line_docstring(language):
+    def f():
+        """ short doc string """
+        return 1
+
+    g = epyccel(f, language=language)
+    assert(f.__doc__ == g.__doc__)
+
+def test_multiline_line_docstring(language):
+    def f():
+        """
+        Big beautiful doc string
+
+        Parameters
+        ----------
+
+        Results
+        -------
+        1 : int
+            no description
+        """
+        return 1
+
+    g = epyccel(f, language=language)
+
+    # Remove empty lines as ast does not preserve them
+    python_doc = [p for p in f.__doc__.split('\n') if p.strip()]
+    pyccel_doc = [p for p in g.__doc__.split('\n') if p.strip()]
+
+    # Pad the smaller doc string to ensure a match
+    extra_spaces = len(python_doc[0]) - len(pyccel_doc[0])
+    if extra_spaces>0:
+        pyccel_doc = [' '*extra_spaces+p for p in pyccel_doc]
+    if extra_spaces<0:
+        extra_spaces = -extra_spaces
+        python_doc = [' '*extra_spaces+p for p in python_doc]
+
+    python_doc = '\n'.join(python_doc)
+    pyccel_doc = '\n'.join(pyccel_doc)
+    assert(python_doc == pyccel_doc)
+
+
+

--- a/tests/epyccel/test_epyccel_decorators.py
+++ b/tests/epyccel/test_epyccel_decorators.py
@@ -1,0 +1,17 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+# coding: utf-8
+
+import pytest
+from pyccel.epyccel import epyccel
+from pyccel.decorators import private
+
+def test_private(language):
+    @private
+    def f():
+        print("hidden")
+
+    g = epyccel(f, language=language)
+
+    with pytest.raises(NotImplementedError):
+        g()
+


### PR DESCRIPTION
- Add doc-strings to FunctionDef (fixes #550);
- Collect and print function doc strings;
- Remove obsolete constructor arguments `kind` and `hide`;
- Remove `procedure` from `FunctionKind` values in header grammar;
- Add test for function doc strings;
- Add test for private decorator.