### PR TITLE
Create missing gfortran symbolic link on macOS

### DIFF
--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -5,8 +5,8 @@ runs:
   steps:
     - name: Install MPI, OpenMP
       run: |
-        brew install gfortran
         brew install open-mpi
         brew install libomp
+        ln -s gfortran-8 gfortran
         echo "MPI_OPTS='--oversubscribe'" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -8,5 +8,5 @@ runs:
         brew install open-mpi
         brew install libomp
         ln -s /usr/local/bin/gfortran-8 bin/gfortran
-        echo "MPI_OPTS='--oversubscribe'" >> $GITHUB_ENV
+        echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -7,6 +7,6 @@ runs:
       run: |
         brew install open-mpi
         brew install libomp
-        ln -s /usr/local/bin/gfortran-8 bin/gfortran
+        ln -s /usr/local/bin/gfortran-8 /usr/local/bin/gfortran
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -7,6 +7,6 @@ runs:
       run: |
         brew install open-mpi
         brew install libomp
-        ln -s gfortran-8 gfortran
+        ln -s /usr/local/bin/gfortran-8 bin/gfortran
         echo "MPI_OPTS='--oversubscribe'" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - name: Install MPI, OpenMP
       run: |
+        brew install gfortran
         brew install open-mpi
         brew install libomp
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -8,4 +8,5 @@ runs:
         brew install gfortran
         brew install open-mpi
         brew install libomp
+        echo "MPI_OPTS='--oversubscribe'" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
Further, the `--oversubscribe` flag is passed to `mpirun` on the macOS platform.