### PR TITLE
Handle order property

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -73,7 +73,6 @@ class PythonComplexProperty(Application, PyccelAstNode):
 
     def __init__(self, arg):
         self._precision = arg.precision
-        self._order     = arg.order
 
     @property
     def internal_var(self):
@@ -130,9 +129,6 @@ class PythonBool(Expr, PyccelAstNode):
     def __new__(cls, arg):
         return Expr.__new__(cls, arg)
 
-    def __init__(self, arg):
-        self._order     = arg.order
-
     @property
     def arg(self):
         return self.args[0]
@@ -186,10 +182,8 @@ class PythonComplex(Expr, PyccelAstNode):
         return Expr.__new__(cls, arg0, arg1)
 
     def __init__(self, arg0, arg1 = LiteralFloat(0)):
-        if arg0.order == "F" and arg1.order == "F":
-            self._order     = "F"
-        else:
-            self._order     = "C"
+        self._is_cast = arg0.dtype is NativeComplex() and \
+                        isinstance(arg1, Literal) and arg1.python_value == 0
 
         if self._is_cast:
             self._real_part = PythonReal(arg0)
@@ -275,9 +269,6 @@ class PythonFloat(Expr, PyccelAstNode):
         else:
             return Expr.__new__(cls, arg)
 
-    def __init__(self, arg):
-        self._order     = arg.order
-
     @property
     def arg(self):
         return self._args[0]
@@ -304,9 +295,6 @@ class PythonInt(Expr, PyccelAstNode):
             return LiteralInteger(arg.p, precision = cls._precision)
         else:
             return Expr.__new__(cls, arg)
-
-    def __init__(self, arg):
-        self._order     = arg.order
 
     @property
     def arg(self):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -73,6 +73,7 @@ class PythonComplexProperty(Application, PyccelAstNode):
 
     def __init__(self, arg):
         self._precision = arg.precision
+        self._order     = arg.order
 
     @property
     def internal_var(self):
@@ -129,6 +130,9 @@ class PythonBool(Expr, PyccelAstNode):
     def __new__(cls, arg):
         return Expr.__new__(cls, arg)
 
+    def __init__(self, arg):
+        self._order     = arg.order
+
     @property
     def arg(self):
         return self.args[0]
@@ -182,8 +186,11 @@ class PythonComplex(Expr, PyccelAstNode):
         return Expr.__new__(cls, arg0, arg1)
 
     def __init__(self, arg0, arg1 = LiteralFloat(0)):
-        self._is_cast = arg0.dtype is NativeComplex() and \
-                        isinstance(arg1, Literal) and arg1.python_value == 0
+        if arg0.order == "F" and arg1.order == "F":
+            self._order     = "F"
+        else:
+            self._order     = "C"
+
         if self._is_cast:
             self._real_part = PythonReal(arg0)
             self._imag_part = PythonImag(arg0)
@@ -268,6 +275,9 @@ class PythonFloat(Expr, PyccelAstNode):
         else:
             return Expr.__new__(cls, arg)
 
+    def __init__(self, arg):
+        self._order     = arg.order
+
     @property
     def arg(self):
         return self._args[0]
@@ -295,6 +305,9 @@ class PythonInt(Expr, PyccelAstNode):
         else:
             return Expr.__new__(cls, arg)
 
+    def __init__(self, arg):
+        self._order     = arg.order
+
     @property
     def arg(self):
         return self._args[0]
@@ -305,6 +318,7 @@ class PythonTuple(Expr, PyccelAstNode):
     """
     _iterable        = True
     _is_homogeneous  = False
+    _order = 'C'
 
     def __new__(cls, *args):
         return Expr.__new__(cls, *args)
@@ -400,6 +414,7 @@ class PythonLen(Function, PyccelAstNode):
 
 #==============================================================================
 class PythonList(Tuple, PyccelAstNode):
+    _order = 'C'
     """ Represent lists in the code with dynamic memory management."""
     def __init__(self, *args, **kwargs):
         if self.stage == 'syntactic':

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -626,6 +626,7 @@ class Dlist(Basic, PyccelAstNode):
     def __init__(self, val, length):
         self._rank = val.rank
         self._shape = tuple(s if i!= 0 else PyccelMul(s, length) for i,s in enumerate(val.shape))
+        self._order = val.order
 
     @property
     def val(self):
@@ -2513,6 +2514,7 @@ class DottedVariable(AtomicExpr, sp_Boolean, PyccelAstNode):
         self._rank      = rhs.rank
         self._precision = rhs.precision
         self._shape     = rhs.shape
+        self._order     = rhs.order
 
     @property
     def lhs(self):
@@ -2896,10 +2898,11 @@ class FunctionCall(Basic, PyccelAstNode):
 
         self._funcdef       = func
         self._arguments     = args
-        self._dtype         = func.results[0].dtype if len(func.results) == 1 else NativeTuple()
-        self._rank          = func.results[0].rank if len(func.results) == 1 else None
-        self._shape         = func.results[0].shape if len(func.results) == 1 else None
+        self._dtype         = func.results[0].dtype     if len(func.results) == 1 else NativeTuple()
+        self._rank          = func.results[0].rank      if len(func.results) == 1 else None
+        self._shape         = func.results[0].shape     if len(func.results) == 1 else None
         self._precision     = func.results[0].precision if len(func.results) == 1 else None
+        self._order         = func.results[0].order     if len(func.results) == 1 else None
 
     @property
     def arguments(self):
@@ -4773,6 +4776,7 @@ class IndexedVariable(IndexedBase, PyccelAstNode):
         self._dtype      = dtype
         self._precision  = prec
         self._rank       = rank
+        self._order      = order
         kw_args['order'] = order
         self._kw_args    = kw_args
         self._label      = label
@@ -4870,7 +4874,8 @@ class IndexedElement(Expr, PyccelAstNode):
         self._indices = self._args[1:]
         dtype = self.base.dtype
         shape = self.base.shape
-        rank = self.base.rank
+        rank  = self.base.rank
+        order = self.base.order
         self._precision = self.base.precision
         if isinstance(dtype, NativeInteger):
             self._dtype = NativeInteger()
@@ -5187,10 +5192,13 @@ class IfTernaryOperator(Basic, PyccelAstNode):
             errors.report('Ternary Operator results should have the same rank', severity='fatal')
         if value_false.shape != value_true.shape :
             errors.report('Ternary Operator results should have the same shape', severity='fatal')
+        if value_false.order != value_true.order :
+            errors.report('Ternary Operator results should have the same order', severity='fatal')
         self._dtype = max([value_true.dtype, value_false.dtype], key = lambda x : _tmp_list.index(x))
         self._precision = max([value_true.precision, value_false.precision])
         self._shape = value_true.shape
-        self._rank = value_true.rank
+        self._rank  = value_true.rank
+        self._order = value_true.order
 
 
     @property

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4891,8 +4891,6 @@ class IndexedElement(Expr, PyccelAstNode):
             raise TypeError('Undefined datatype')
 
         if shape is not None:
-            if self.order == 'C':
-                shape = shape[::-1]
             new_shape = []
             for a,s in zip(args, shape):
                 if isinstance(a, Slice):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5192,13 +5192,14 @@ class IfTernaryOperator(Basic, PyccelAstNode):
             errors.report('Ternary Operator results should have the same rank', severity='fatal')
         if value_false.shape != value_true.shape :
             errors.report('Ternary Operator results should have the same shape', severity='fatal')
-        if value_false.order != value_true.order :
-            errors.report('Ternary Operator results should have the same order', severity='fatal')
         self._dtype = max([value_true.dtype, value_false.dtype], key = lambda x : _tmp_list.index(x))
         self._precision = max([value_true.precision, value_false.precision])
         self._shape = value_true.shape
         self._rank  = value_true.rank
-        self._order = value_true.order
+        if self._rank > 1:
+            if value_false.order != value_true.order :
+                errors.report('Ternary Operator results should have the same order', severity='fatal')
+            self._order = value_true.order
 
 
     @property

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -837,7 +837,8 @@ class Allocate(Basic):
         if variable.rank != len(shape):
             raise ValueError("Incompatible rank in variable allocation")
 
-        if variable.rank > 1 and variable.order != order:
+        # rank is None for lambda functions
+        if variable.rank is not None and variable.rank > 1 and variable.order != order:
             raise ValueError("Incompatible order in variable allocation")
 
         if not isinstance(status, str):
@@ -5194,7 +5195,8 @@ class IfTernaryOperator(Basic, PyccelAstNode):
         self._precision = max([value_true.precision, value_false.precision])
         self._shape = value_true.shape
         self._rank  = value_true.rank
-        if self._rank > 1:
+        # rank is None for lambda functions
+        if self._rank is not None and self._rank > 1:
             if value_false.order != value_true.order :
                 errors.report('Ternary Operator results should have the same order', severity='fatal')
             self._order = value_true.order

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2673,7 +2673,7 @@ class TupleVariable(Variable):
             indexed_var = IndexedVariable(self, dtype=self.dtype, shape=self.shape,
                 prec=self.precision, order=self.order, rank=self. rank)
             args = [Slice(None,None)]*(self.rank-1)
-            return [indexed_var[args + [i]] for i in range(len(self._vars))]
+            return [indexed_var[[i] + args] for i in range(len(self._vars))]
         else:
             return self._vars
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -123,7 +123,6 @@ class NumpyNewArray(PyccelAstNode):
 # TODO [YG, 18.02.2020]: accept Numpy array argument
 # TODO [YG, 18.02.2020]: use order='K' as default, like in numpy.array
 # TODO [YG, 22.05.2020]: move dtype & prec processing to __init__
-# TODO [YG, 22.05.2020]: change properties to read _dtype, _prec, _rank, etc...
 class NumpyArray(Application, NumpyNewArray):
     """
     Represents a call to  numpy.array for code generation.

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -529,7 +529,7 @@ class NumpyFull(Application, NumpyNewArray):
 
         return Basic.__new__(cls, shape, dtype, order, precision, fill_value)
 
-    def __init__(self, arg, dtype=None, order='C'):
+    def __init__(self, shape, fill_value, dtype=None, order='C'):
         self._shape = self._args[0]
         self._rank  = len(self._shape)
         self._dtype = self._args[1]

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -575,18 +575,17 @@ class NumpyEmpty(NumpyAutoFill):
 class NumpyZeros(NumpyAutoFill):
     """ Represents a call to numpy.zeros for code generation.
     """
-    # TODO [YG, 09.11.2020]: create LiteralInteger/LiteralFloat/LiteralComplex w/ correct precision
     @property
     def fill_value(self):
         dtype = self.dtype
         if isinstance(dtype, NativeInteger):
-            value = LiteralInteger(0)
+            value = LiteralInteger(0, precision = self.precision)
         elif isinstance(dtype, NativeReal):
-            value = LiteralFloat(0)
+            value = LiteralFloat(0, precision = self.precision)
         elif isinstance(dtype, NativeComplex):
-            value = LiteralComplex(0., 0.)
+            value = LiteralComplex(0., 0., precision = self.precision)
         elif isinstance(dtype, NativeBool):
-            value = LiteralFalse()
+            value = LiteralFalse(precision = self.precision)
         else:
             raise TypeError('Unknown type')
         return value
@@ -595,18 +594,17 @@ class NumpyZeros(NumpyAutoFill):
 class NumpyOnes(NumpyAutoFill):
     """ Represents a call to numpy.ones for code generation.
     """
-    # TODO [YG, 09.11.2020]: create LiteralInteger/LiteralFloat/LiteralComplex w/ correct precision
     @property
     def fill_value(self):
         dtype = self.dtype
         if isinstance(dtype, NativeInteger):
-            value = LiteralInteger(1)
+            value = LiteralInteger(1, precision = self.precision)
         elif isinstance(dtype, NativeReal):
-            value = LiteralFloat(1.)
+            value = LiteralFloat(1., precision = self.precision)
         elif isinstance(dtype, NativeComplex):
-            value = LiteralComplex(1., 0.)
+            value = LiteralComplex(1., 0., precision = self.precision)
         elif isinstance(dtype, NativeBool):
-            value = LiteralTrue()
+            value = LiteralTrue(precision = self.precision)
         else:
             raise TypeError('Unknown type')
         return value

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -558,6 +558,10 @@ class NumpyAutoFill(NumpyFull):
         order = cls._process_order(order)
 
         return Basic.__new__(cls, shape, dtype, order, precision)
+
+    def __init__(self, shape, dtype=None, order='C'):
+        NumpyFull.__init__(self, shape, None, dtype, order)
+
 #==============================================================================
 class NumpyEmpty(NumpyAutoFill):
     """ Represents a call to numpy.empty for code generation.

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -282,6 +282,11 @@ class NumpyMatmul(Application, PyccelAstNode):
             n = 1 if b.rank < 2 else b.shape[1]
             self._shape = (m, n)
 
+        if a.order == b.order:
+            self._order = a.order
+        else:
+            self._order = 'C'
+
     @property
     def a(self):
         return self._args[0]
@@ -746,6 +751,7 @@ class NumpyUfuncUnary(NumpyUfuncBase):
         self._rank       = x.rank
         self._dtype      = x.dtype if x.dtype is NativeComplex() else NativeReal()
         self._precision  = default_precision[str_dtype(self._dtype)]
+        self._order      = x.order
 
 #------------------------------------------------------------------------------
 class NumpyUfuncBinary(NumpyUfuncBase):
@@ -757,6 +763,10 @@ class NumpyUfuncBinary(NumpyUfuncBase):
         self._rank      = x1.rank   # TODO ^^
         self._dtype     = NativeReal()
         self._precision = default_precision['real']
+        if x1.order == x2.order:
+            self._order = x1.order
+        else:
+            self._order = 'C'
 
 #------------------------------------------------------------------------------
 # Math operations

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -161,6 +161,9 @@ class NumpyArray(Application, NumpyNewArray):
         arg_shape   = numpy.asarray(arg).shape
         self._shape = process_shape(arg_shape)
         self._rank  = len(self._shape)
+        self._dtype = self._args[1]
+        self._order = self._args[2]
+        self._precision = self._args[3]
 
     def _sympystr(self, printer):
         return self.arg
@@ -168,26 +171,6 @@ class NumpyArray(Application, NumpyNewArray):
     @property
     def arg(self):
         return self._args[0]
-
-    @property
-    def dtype(self):
-        return self._args[1]
-
-    @property
-    def order(self):
-        return self._args[2]
-
-    @property
-    def precision(self):
-        return self._args[3]
-
-    @property
-    def shape(self):
-        return self._shape
-
-    @property
-    def rank(self):
-        return self._rank
 
 #==============================================================================
 class NumpySum(Function, PyccelAstNode):
@@ -546,30 +529,17 @@ class NumpyFull(Application, NumpyNewArray):
 
         return Basic.__new__(cls, shape, dtype, order, precision, fill_value)
 
+    def __init__(self, arg, dtype=None, order='C'):
+        self._shape = self._args[0]
+        self._rank  = len(self._shape)
+        self._dtype = self._args[1]
+        self._order = self._args[2]
+        self._precision = self._args[3]
+
     #--------------------------------------------------------------------------
-    @property
-    def shape(self):
-        return self._args[0]
-
-    @property
-    def dtype(self):
-        return self._args[1]
-
-    @property
-    def order(self):
-        return self._args[2]
-
-    @property
-    def precision(self):
-        return self._args[3]
-
     @property
     def fill_value(self):
         return self._args[4]
-
-    @property
-    def rank(self):
-        return len(self.shape)
 
 #==============================================================================
 class NumpyAutoFill(NumpyFull):

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -109,7 +109,8 @@ class PyccelOperator(Expr, PyccelAstNode):
             return
         self._set_dtype()
         self._set_shape_rank()
-        if self._rank > 1:
+        # rank is None for lambda functions
+        if self._rank is not None and self._rank > 1:
             self._set_order()
 
     @property

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -109,7 +109,8 @@ class PyccelOperator(Expr, PyccelAstNode):
             return
         self._set_dtype()
         self._set_shape_rank()
-        self._set_order()
+        if self._rank > 1:
+            self._set_order()
 
     @property
     def precedence(self):

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -109,6 +109,7 @@ class PyccelOperator(Expr, PyccelAstNode):
             return
         self._set_dtype()
         self._set_shape_rank()
+        self._set_order()
 
     @property
     def precedence(self):
@@ -156,6 +157,16 @@ class PyccelOperator(Expr, PyccelAstNode):
 
     def __str__(self):
         return repr(self)
+
+    def _set_order(self):
+        """ Sets the shape and rank
+        This is chosen to match the arguments if they are in agreement.
+        Otherwise it defaults to 'C'
+        """
+        if all(a.order == self._args[0].order for a in self._args):
+            self._order = self._args[0].order
+        else:
+            self._order = 'C'
 
 #==============================================================================
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -647,7 +647,6 @@ class CCodePrinter(CodePrinter):
         else:
             base = expr.base
         inds = list(expr.indices)
-        inds = inds[::-1]
         base_shape = base.shape
         allow_negative_indexes = (isinstance(expr.base, IndexedVariable) and \
                 base.allows_negative_indexes)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2618,6 +2618,8 @@ class FCodePrinter(CodePrinter):
             base_code = self._print(expr.base.label)
 
         inds = list(expr.indices)
+        if expr.base.order == 'C':
+            inds = inds[::-1]
         base_shape = Shape(expr.base)
         allow_negative_indexes = (isinstance(expr.base, IndexedVariable) and \
                 expr.base.internal_variable.allows_negative_indexes)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2610,10 +2610,10 @@ class FCodePrinter(CodePrinter):
             if len(expr.indices)==1:
                 return self._print(base[expr.indices[0]])
             else:
-                var = base[expr.indices[-1]]
+                var = base[expr.indices[0]]
                 return self._print(IndexedVariable(var, dtype = var.dtype,
                     shape = var.shape, prec = var.precision,
-                    order = var.order, rank = var.rank)[expr.indices[:-1]])
+                    order = var.order, rank = var.rank)[expr.indices[1:]])
         else:
             base_code = self._print(expr.base.label)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -873,8 +873,6 @@ class SemanticParser(BasicParser):
             else:
                 return self._visit(Indexed(var[args[0]],args[1:]))
 
-        if var.order == 'C':
-            args = args[::-1]
         args = tuple(args)
 
         if isinstance(var, TupleVariable) and not var.is_homogeneous:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -877,7 +877,7 @@ class SemanticParser(BasicParser):
 
         if isinstance(var, TupleVariable) and not var.is_homogeneous:
 
-            arg = args[-1]
+            arg = args[0]
 
             if isinstance(arg, Slice):
                 if ((arg.start is not None and not isinstance(arg.start, LiteralInteger)) or
@@ -893,13 +893,13 @@ class SemanticParser(BasicParser):
                         return selected_vars[0]
                     else:
                         var = selected_vars[0]
-                        return self._extract_indexed_from_var(var, args[:-1], name)
+                        return self._extract_indexed_from_var(var, args[1:], name)
                 elif len(selected_vars)<1:
                     return None
                 elif len(args)==1:
                     return PythonTuple(*selected_vars)
                 else:
-                    return PythonTuple(*[self._extract_indexed_from_var(var, args[:-1], name) for var in selected_vars])
+                    return PythonTuple(*[self._extract_indexed_from_var(var, args[1:], name) for var in selected_vars])
 
             elif isinstance(arg, LiteralInteger):
 
@@ -907,7 +907,7 @@ class SemanticParser(BasicParser):
                     return var[arg]
 
                 var = var[arg]
-                return self._extract_indexed_from_var(var, args[:-1], name)
+                return self._extract_indexed_from_var(var, args[1:], name)
 
             else:
                 errors.report(INDEXED_TUPLE, symbol=var,


### PR DESCRIPTION
Set PyccelAstNode order property. Use C ordering until printing.

**Commit Summary**

- Ensure order is set for all objects which inherit from PyccelAstNode with rank>1 (fixes #335);
- Preserve C indexing until printing stage;
- Use C ordering for tuples;
- Set PyccelAstNode properties for NumpyArray and NumpyFull.