### PR TITLE
Fortran: print PythonLen as size or len depending on dtype

### DIFF
--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -603,7 +603,11 @@ class FCodePrinter(CodePrinter):
     def _print_PythonLen(self, expr):
         var = expr.arg
         idx = 1 if var.order == 'F' else var.rank
-        return 'size({},{})'.format(self._print(var), self._print(idx))
+        dtype = var.dtype
+        if dtype is NativeString():
+            return 'len({})'.format(self._print(var))
+        else:
+            return 'size({},{})'.format(self._print(var), self._print(idx))
 
     def _print_PythonSum(self, expr):
         args = [self._print(arg) for arg in expr.args]

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -606,6 +606,8 @@ class FCodePrinter(CodePrinter):
         dtype = var.dtype
         if dtype is NativeString():
             return 'len({})'.format(self._print(var))
+        elif var.rank == 1:
+            return 'size({})'.format(self._print(var))
         else:
             return 'size({},{})'.format(self._print(var), self._print(idx))
 


### PR DESCRIPTION
Fixes #619 and fixes #620