### PR TITLE
Make Fortran printer handle numpy.array when rank > 2

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -316,7 +316,8 @@ class PythonTuple(Expr, PyccelAstNode):
             return
         is_homogeneous = all(a.dtype is not NativeGeneric() and \
                              args[0].dtype == a.dtype and \
-                             args[0].rank  == a.rank  for a in args[1:])
+                             args[0].rank  == a.rank  and \
+                             args[0].order == a.order for a in args[1:])
         self._inconsistent_shape = not all(args[0].shape==a.shape   for a in args[1:])
         self._is_homogeneous = is_homogeneous
         if is_homogeneous:
@@ -402,10 +403,16 @@ class PythonLen(Function, PyccelAstNode):
 #==============================================================================
 class PythonList(Tuple, PyccelAstNode):
     _order = 'C'
+    _is_homogeneous = True
     """ Represent lists in the code with dynamic memory management."""
     def __init__(self, *args, **kwargs):
         if self.stage == 'syntactic':
             return
+        self._is_homogeneous = all(a.dtype is not NativeGeneric() and \
+                             args[0].dtype == a.dtype and \
+                             args[0].rank  == a.rank  and \
+                             args[0].order == a.order for a in args[1:])
+
         bools     = [a for a in args if a.dtype is NativeBool()]
         integers  = [a for a in args if a.dtype is NativeInteger()]
         reals     = [a for a in args if a.dtype is NativeReal()]
@@ -429,14 +436,16 @@ class PythonList(Tuple, PyccelAstNode):
             elif bools:
                 self._dtype     = NativeBool()
                 self._precision  = max(a.precision for a in bools)
-            else:
-                raise TypeError('cannot determine the type of {}'.format(self))
 
             shapes = [a.shape for a in args]
             self._rank = max(a.rank for a in args) + 1
             if all(sh is not None for sh in shapes):
                 self._shape = (LiteralInteger(len(args)), ) + shapes[0]
                 self._rank  = len(self._shape)
+
+    @property
+    def is_homogeneous(self):
+        return self._is_homogeneous
 
 #==============================================================================
 class PythonMap(Basic):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -422,7 +422,7 @@ class PythonList(Tuple, PyccelAstNode):
             self._dtype = NativeString()
             self._rank  = 0
             self._shape = ()
-            assert len(integers + reals + complexes) == 0
+
         else:
             if complexes:
                 self._dtype     = NativeComplex()

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -344,13 +344,12 @@ class PythonTuple(Expr, PyccelAstNode):
                     raise TypeError('cannot determine the type of {}'.format(self))
 
 
-                shapes = [a.shape for a in args]
-
+                shapes     = [a.shape for a in args]
+                self._rank = max(a.rank for a in args) + 1
                 if all(sh is not None for sh in shapes):
                     self._shape = (LiteralInteger(len(args)), ) + shapes[0]
                     self._rank  = len(self._shape)
-                else:
-                    self._rank = max(a.rank for a in args) + 1
+
         else:
             self._rank      = max(a.rank for a in args) + 1
             self._dtype     = NativeGeneric()
@@ -431,13 +430,11 @@ class PythonList(Tuple, PyccelAstNode):
                 raise TypeError('cannot determine the type of {}'.format(self))
 
             shapes = [a.shape for a in args]
-
+            self._rank = max(a.rank for a in args) + 1
             if all(sh is not None for sh in shapes):
-                assert all(sh==shapes[0] for sh in shapes)
                 self._shape = (LiteralInteger(len(args)), ) + shapes[0]
                 self._rank  = len(self._shape)
-            else:
-                self._rank = max(a.rank for a in args) + 1
+
 #==============================================================================
 class PythonMap(Basic):
     """ Represents the map stmt

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1054,27 +1054,22 @@ class NativeOp(with_metaclass(Singleton, Basic)):
 
 
 class AddOp(NativeOp):
-
     _symbol = '+'
 
 
 class SubOp(NativeOp):
-
     _symbol = '-'
 
 
 class MulOp(NativeOp):
-
     _symbol = '*'
 
 
 class DivOp(NativeOp):
-
     _symbol = '/'
 
 
 class ModOp(NativeOp):
-
     _symbol = '%'
 
 
@@ -2279,7 +2274,8 @@ class Variable(Symbol, PyccelAstNode):
             elif s is None or isinstance(s,(Variable, Slice, PyccelAstNode, Function)):
                 new_shape.append(PyccelArraySize(self, i))
             else:
-                raise TypeError('shape elements cannot be '+str(type(s))+'. They must be one of the following types: Integer(pyccel), Variable, Slice, PyccelAstNode, Integer(sympy), int, Function')
+                raise TypeError('shape elements cannot be '+str(type(s))+'. They must be one of the following types: Integer(pyccel),'
+                                'Variable, Slice, PyccelAstNode, Integer(sympy), int, Function')
         return tuple(new_shape)
 
     @property
@@ -5715,7 +5711,7 @@ def process_shape(shape):
 
     new_shape = []
     for s in shape:
-        if isinstance(s,(LiteralInteger,Variable, Slice, PyccelAstNode, Function)):
+        if isinstance(s,(LiteralInteger, Variable, Slice, PyccelAstNode, Function)):
             new_shape.append(s)
         elif isinstance(s, sp_Integer):
             new_shape.append(LiteralInteger(s.p))

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -136,6 +136,10 @@ class NumpyArray(Application, NumpyNewArray):
         if not isinstance(arg, (PythonTuple, PythonList)):
             raise TypeError('Uknown type of  %s.' % type(arg))
 
+        # TODO: treat inhomogenous lists and tuples when they have mixed ordering
+        if not arg.is_homogeneous:
+            raise TypeError('we only accept a homogeneous list or tuple ')
+
         # Verify dtype and get precision
         if dtype is None:
             dtype = arg.dtype

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -134,7 +134,7 @@ class NumpyArray(Application, NumpyNewArray):
 
     def __new__(cls, arg, dtype=None, order='C'):
 
-        if not isinstance(arg, (Tuple, PythonTuple, PythonList)):
+        if not isinstance(arg, (PythonTuple, PythonList)):
             raise TypeError('Uknown type of  %s.' % type(arg))
 
         # Verify dtype and get precision
@@ -158,7 +158,7 @@ class NumpyArray(Application, NumpyNewArray):
         return Basic.__new__(cls, arg, dtype, order, prec)
 
     def __init__(self, arg, dtype=None, order='C'):
-        arg_shape   = numpy.asarray(arg).shape
+        arg_shape   = arg.shape
         self._shape = process_shape(arg_shape)
         self._rank  = len(self._shape)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -499,8 +499,7 @@ class FCodePrinter(CodePrinter):
     def _print_Tuple(self, expr):
         shape = list(reversed(asarray(expr).shape))
         if len(shape)>1:
-            arg = functools.reduce(operator.concat, expr)
-            elements = ', '.join(self._print(i) for i in arg)
+            elements = ', '.join(self._print(i) for i in expr)
             return 'reshape(['+ elements + '], '+ self._print(Tuple(*shape)) + ')'
         fs = ', '.join(self._print(f) for f in expr)
         return '[{0}]'.format(fs)
@@ -688,17 +687,8 @@ class FCodePrinter(CodePrinter):
     def _print_NumpyArray(self, expr):
         """Fortran print."""
 
-        # Always transpose indices because Numpy initial values are given with
-        # row-major ordering, while Fortran initial values are column-major
-        shape = expr.shape[::-1]
-
         # Construct right-hand-side code
-        if expr.rank > 1:
-            arg = functools.reduce(operator.concat, expr.arg)
-            rhs_code = 'reshape({array}, {shape})'.format(
-                    array=self._print(arg), shape=self._print(Tuple(*shape)))
-        else:
-            rhs_code = self._print(expr.arg)
+        rhs_code = self._print(expr.arg)
 
         # If Numpy array is stored with column-major ordering, transpose values
         if expr.order == 'F' and expr.rank > 1:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2815,7 +2815,7 @@ class FCodePrinter(CodePrinter):
         result = []
         trailing = ' &'
         for line in lines:
-            if len(line)>72 and ('"' in line[72:] or "'" in line[72:] or '!' in line[72:]):
+            if len(line)>72 and ('"' in line[72:] or "'" in line[72:] or '!' in line[:72]):
                 result.append(line)
 
             elif len(line)>72:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2815,7 +2815,7 @@ class FCodePrinter(CodePrinter):
         result = []
         trailing = ' &'
         for line in lines:
-            if len(line)>72 and('"' in line or "'" in line or '!' in line):
+            if len(line)>72 and ('"' in line[72:] or "'" in line[72:] or '!' in line[72:]):
                 result.append(line)
 
             elif len(line)>72:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -602,7 +602,7 @@ class FCodePrinter(CodePrinter):
     def _print_PythonLen(self, expr):
         var = expr.arg
         idx = 1 if var.order == 'F' else var.rank
-        prec = self._print(expr.precision)
+        prec = iso_c_binding["integer"][expr.precision]
 
         dtype = var.dtype
         if dtype is NativeString():
@@ -715,7 +715,7 @@ class FCodePrinter(CodePrinter):
     # ======================================================================= #
     def _print_PyccelArraySize(self, expr):
         init_value = self._print(expr.arg)
-        prec       = self._print(expr.precision)
+        prec = iso_c_binding["integer"][expr.precision]
         if expr.arg.order == 'C':
             index = self._print(expr.arg.rank - expr.index)
         else:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -699,12 +699,15 @@ class FCodePrinter(CodePrinter):
         rhs_code = self._print(expr.arg)
         # If Numpy array is stored with column-major ordering, transpose values
         # use reshape with order for rank > 2
-        if expr.order == 'F' and expr.rank > 1:
-            shape    = ', '.join(self._print(i) for i in expr.shape)
-            order    = [LiteralInteger(i) for i in range(1, expr.rank+1)]
-            order    = order[1:]+ order[:1]
-            order    = ', '.join(self._print(i) for i in order)
-            rhs_code = 'reshape({},[{}], order=[{}])'.format(rhs_code, shape, order)
+        if expr.order == 'F':
+            if expr.rank == 2:
+                rhs_code = 'transpose({})'.format(rhs_code)
+            elif expr.rank > 2:
+                shape    = ', '.join(self._print(i) for i in expr.shape)
+                order    = [LiteralInteger(i) for i in range(1, expr.rank+1)]
+                order    = order[1:]+ order[:1]
+                order    = ', '.join(self._print(i) for i in order)
+                rhs_code = 'reshape({},[{}], order=[{}])'.format(rhs_code, shape, order)
 
         return rhs_code
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -17,8 +17,6 @@ from collections import OrderedDict
 import functools
 import operator
 
-from numpy import asarray
-
 from sympy.core import Symbol
 from sympy.core import Tuple
 from sympy.core.function import Function, Application
@@ -497,10 +495,8 @@ class FCodePrinter(CodePrinter):
         return '!${0} {1}\n'.format(accel, txt)
 
     def _print_Tuple(self, expr):
-        size = len(expr)
         if expr[0].rank>0:
             raise NotImplementedError(' Tuple with elements of rank > 0 is not implemented')
-
         fs = ', '.join(self._print(f) for f in expr)
         return '[{0}]'.format(fs)
 
@@ -612,7 +608,7 @@ class FCodePrinter(CodePrinter):
         if dtype is NativeString():
             return 'len({})'.format(self._print(var))
         elif var.rank == 1:
-            return 'size({}, kind={})'.format(self._print(var), self._print(idx), prec)
+            return 'size({}, kind={})'.format(self._print(var), prec)
         else:
             return 'size({},{},{})'.format(self._print(var), self._print(idx), prec)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -799,12 +799,13 @@ class SemanticParser(BasicParser):
 
     def _visit_PythonList(self, expr, **settings):
         ls = [self._visit(i, **settings) for i in expr]
-        dtypes = set(i.dtype for i in ls)
-        if len(dtypes) != 1:
+        expr = PythonList(*ls, sympify=False)
+
+        if not expr.is_homogeneous:
             errors.report(PYCCEL_RESTRICTION_INHOMOG_LIST, symbol=expr,
                 bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                 severity='fatal')
-        return PythonList(*ls, sympify=False)
+        return expr
 
     def _visit_ValuedArgument(self, expr, **settings):
         value = self._visit(expr.value, **settings)

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -322,11 +322,23 @@ def array_real_2d_C_div( x, y ):
     x[:,:] /= y
 
 @types('real[:,:]')
-def array_real_2d_C_initialization(a):
+def array_real_2d_C_array_initialization(a):
     from numpy import array
     tmp = array([[1, 2, 3], [4, 5, 6]], dtype='float')
     a[:,:] = tmp[:,:]
 
+
+@types('real[:,:]','real[:,:]', 'real[:,:,:]')
+def array_real_3d_C_array_initialization(x, y, a):
+    from numpy import array
+    tmp      = array([x, y], dtype='float')
+    a[:,:,:] = tmp[:,:,:]
+
+@types('real[:,:,:]','real[:,:,:]', 'real[:,:,:,:]')
+def array_real_4d_C_array_initialization(x, y, a):
+    from numpy import array
+    tmp      = array([x, y], dtype='float')
+    a[:,:,:,:] = tmp[:,:,:,:]
 
 #==============================================================================
 # 2D ARRAYS OF REAL WITH F ORDERING
@@ -365,12 +377,22 @@ def array_real_2d_F_div( x, y ):
     x[:,:] /= y
 
 @types('real[:,:](order=F)')
-def array_real_2d_F_initialization(a):
+def array_real_2d_F_array_initialization(a):
     from numpy import array
     tmp = array([[1, 2, 3], [4, 5, 6]], dtype='float', order='F')
     a[:,:] = tmp[:,:]
 
+@types('real[:,:](order=F)','real[:,:](order=F)', 'real[:,:,:](order=F)')
+def array_real_3d_F_array_initialization(x, y, a):
+    from numpy import array
+    tmp      = array([x, y], dtype='float', order='F')
+    a[:,:,:] = tmp[:,:,:]
 
+@types('real[:,:,:](order=F)','real[:,:,:](order=F)', 'real[:,:,:,:](order=F)')
+def array_real_4d_F_array_initialization(x, y, a):
+    from numpy import array
+    tmp      = array([x, y], dtype='float', order='F')
+    a[:,:,:,:] = tmp[:,:,:,:]
 #==============================================================================
 # COMPLEX EXPRESSIONS IN 3D : TEST CONSTANT AND UNKNOWN SHAPES
 #==============================================================================

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -327,18 +327,25 @@ def array_real_2d_C_array_initialization(a):
     tmp = array([[1, 2, 3], [4, 5, 6]], dtype='float')
     a[:,:] = tmp[:,:]
 
-
 @types('real[:,:]','real[:,:]', 'real[:,:,:]')
-def array_real_3d_C_array_initialization(x, y, a):
+def array_real_3d_C_array_initialization_1(x, y, a):
     from numpy import array
     tmp      = array([x, y], dtype='float')
     a[:,:,:] = tmp[:,:,:]
+
+@types('real[:,:,:]')
+def array_real_3d_C_array_initialization_2(a):
+    from numpy import array
+    x = array([[[0., 1., 2., 3.], [4., 5., 6., 7.], [8., 9., 10., 11.]],
+              [[12., 13., 14., 15.], [16., 17., 18., 19.], [20., 21., 22., 23.]]], order='C')
+    a[:,:,:] = x[:,:,:]
 
 @types('real[:,:,:]','real[:,:,:]', 'real[:,:,:,:]')
 def array_real_4d_C_array_initialization(x, y, a):
     from numpy import array
     tmp      = array([x, y], dtype='float')
     a[:,:,:,:] = tmp[:,:,:,:]
+
 
 #==============================================================================
 # 2D ARRAYS OF REAL WITH F ORDERING
@@ -383,16 +390,37 @@ def array_real_2d_F_array_initialization(a):
     a[:,:] = tmp[:,:]
 
 @types('real[:,:](order=F)','real[:,:](order=F)', 'real[:,:,:](order=F)')
-def array_real_3d_F_array_initialization(x, y, a):
+def array_real_3d_F_array_initialization_1(x, y, a):
     from numpy import array
     tmp      = array([x, y], dtype='float', order='F')
     a[:,:,:] = tmp[:,:,:]
+
+@types('real[:,:,:](order=F)')
+def array_real_3d_F_array_initialization_2(a):
+    from numpy import array
+    x = array([[[0., 1., 2., 3.], [4., 5., 6., 7.], [8., 9., 10., 11.]],
+                 [[12., 13., 14., 15.], [16., 17., 18., 19.], [20., 21., 22., 23.]]], order='F')
+    a[:,:,:] = x[:,:,:]
 
 @types('real[:,:,:](order=F)','real[:,:,:](order=F)', 'real[:,:,:,:](order=F)')
 def array_real_4d_F_array_initialization(x, y, a):
     from numpy import array
     tmp      = array([x, y], dtype='float', order='F')
     a[:,:,:,:] = tmp[:,:,:,:]
+
+@types('real[:,:](order=F)', 'real[:,:,:,:](order=F)')
+def array_real_4d_F_array_initialization_mixed_ordering(x, a):
+    import numpy as np
+    tmp      = np.array(((((0., 1.), (2., 3.)),
+                          ((4., 5.), (6., 7.)),
+                          ((8., 9.), (10., 11.))),
+                          (((12., 13.), (14., 15.)),
+                          x,
+                          ((20., 21.), (22., 23.)))),
+                          dtype='float', order='F')
+
+    a[:,:,:,:] = tmp[:,:,:,:]
+
 #==============================================================================
 # COMPLEX EXPRESSIONS IN 3D : TEST CONSTANT AND UNKNOWN SHAPES
 #==============================================================================

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1015,9 +1015,9 @@ def test_array_real_2d_C_array_initialization():
 
     assert np.array_equal(x1, x2)
 
-def test_array_real_3d_C_array_initialization():
+def test_array_real_3d_C_array_initialization_1():
 
-    f1 = arrays.array_real_3d_C_array_initialization
+    f1 = arrays.array_real_3d_C_array_initialization_1
     f2 = epyccel(f1)
 
     x  = np.random.random((3,2))
@@ -1029,6 +1029,19 @@ def test_array_real_3d_C_array_initialization():
 
     f1(x, y, x1)
     f2(x, y, x2)
+
+    assert np.array_equal(x1, x2)
+
+def test_array_real_3d_C_array_initialization_2():
+
+    f1 = arrays.array_real_3d_C_array_initialization_2
+    f2 = epyccel(f1)
+
+    x1 = np.zeros((2,3,4))
+    x2 = np.zeros((2,3,4))
+
+    f1(x1)
+    f2(x2)
 
     assert np.array_equal(x1, x2)
 
@@ -1178,9 +1191,9 @@ def test_array_real_2d_F_array_initialization():
     assert np.array_equal(x1, x2)
 
 
-def test_array_real_3d_F_array_initialization():
+def test_array_real_3d_F_array_initialization_1():
 
-    f1 = arrays.array_real_3d_F_array_initialization
+    f1 = arrays.array_real_3d_F_array_initialization_1
     f2 = epyccel(f1)
 
     x  = np.random.random((3,2)).copy(order='F')
@@ -1192,6 +1205,19 @@ def test_array_real_3d_F_array_initialization():
 
     f1(x, y, x1)
     f2(x, y, x2)
+
+    assert np.array_equal(x1, x2)
+
+def test_array_real_3d_F_array_initialization_2():
+
+    f1 = arrays.array_real_3d_F_array_initialization_2
+    f2 = epyccel(f1)
+
+    x1 = np.zeros((2,3,4), order='F')
+    x2 = np.zeros((2,3,4), order='F')
+
+    f1(x1)
+    f2(x2)
 
     assert np.array_equal(x1, x2)
 
@@ -1212,6 +1238,28 @@ def test_array_real_4d_F_array_initialization():
 
     assert np.array_equal(x1, x2)
 
+@pytest.mark.xfail
+def test_array_real_4d_F_array_initialization_mixed_ordering():
+
+    f1 = arrays.array_real_4d_F_array_initialization_mixed_ordering
+    f2 = epyccel(f1)
+
+    x  = np.array([[16., 17.], [18., 19.]], dtype='float', order='F')
+    a  = np.array(([[[0., 1.], [2., 3.]],
+                  [[4., 5.], [6., 7.]],
+                  [[8., 9.], [10., 11.]]],
+                  [[[12., 13.], [14., 15.]],
+                  x,
+                  [[20., 21.], [22., 23.]]]),
+                  dtype='float', order='F')
+
+    x1 = np.zeros_like(a)
+    x2 = np.zeros_like(a)
+
+    f1(x, x1)
+    f2(x, x2)
+
+    assert np.array_equal(x1, x2)
 #==============================================================================
 # TEST: COMPLEX EXPRESSIONS IN 3D : TEST CONSTANT AND UNKNOWN SHAPES
 #==============================================================================

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1002,9 +1002,9 @@ def test_array_real_2d_C_div():
 
     assert np.array_equal( x1, x2 )
 
-def test_array_real_2d_C_initialization():
+def test_array_real_2d_C_array_initialization():
 
-    f1 = arrays.array_real_2d_C_initialization
+    f1 = arrays.array_real_2d_C_array_initialization
     f2 = epyccel(f1)
 
     x1 = np.zeros((2, 3), dtype=float )
@@ -1015,6 +1015,39 @@ def test_array_real_2d_C_initialization():
 
     assert np.array_equal(x1, x2)
 
+def test_array_real_3d_C_array_initialization():
+
+    f1 = arrays.array_real_3d_C_array_initialization
+    f2 = epyccel(f1)
+
+    x  = np.random.random((3,2))
+    y  = np.random.random((3,2))
+    a  = np.array([x,y])
+
+    x1 = np.zeros_like(a)
+    x2 = np.zeros_like(a)
+
+    f1(x, y, x1)
+    f2(x, y, x2)
+
+    assert np.array_equal(x1, x2)
+
+def test_array_real_4d_C_array_initialization():
+
+    f1 = arrays.array_real_4d_C_array_initialization
+    f2 = epyccel(f1)
+
+    x  = np.random.random((3,2,4))
+    y  = np.random.random((3,2,4))
+    a  = np.array([x,y])
+
+    x1 = np.zeros_like(a)
+    x2 = np.zeros_like(a)
+
+    f1(x, y, x1)
+    f2(x, y, x2)
+
+    assert np.array_equal(x1, x2)
 #==============================================================================
 # TEST: 2D ARRAYS OF REAL WITH F ORDERING
 #==============================================================================
@@ -1131,9 +1164,9 @@ def test_array_real_2d_F_div():
 
     assert np.array_equal( x1, x2 )
 
-def test_array_real_2d_F_initialization():
+def test_array_real_2d_F_array_initialization():
 
-    f1 = arrays.array_real_2d_F_initialization
+    f1 = arrays.array_real_2d_F_array_initialization
     f2 = epyccel(f1)
 
     x1 = np.zeros((2, 3), dtype=float, order='F')
@@ -1145,6 +1178,39 @@ def test_array_real_2d_F_initialization():
     assert np.array_equal(x1, x2)
 
 
+def test_array_real_3d_F_array_initialization():
+
+    f1 = arrays.array_real_3d_F_array_initialization
+    f2 = epyccel(f1)
+
+    x  = np.random.random((3,2)).copy(order='F')
+    y  = np.random.random((3,2)).copy(order='F')
+    a  = np.array([x,y], order='F')
+
+    x1 = np.zeros_like(a)
+    x2 = np.zeros_like(a)
+
+    f1(x, y, x1)
+    f2(x, y, x2)
+
+    assert np.array_equal(x1, x2)
+
+def test_array_real_4d_F_array_initialization():
+
+    f1 = arrays.array_real_4d_F_array_initialization
+    f2 = epyccel(f1)
+
+    x  = np.random.random((3,2,4)).copy(order='F')
+    y  = np.random.random((3,2,4)).copy(order='F')
+    a  = np.array([x,y], order='F')
+
+    x1 = np.zeros_like(a)
+    x2 = np.zeros_like(a)
+
+    f1(x, y, x1)
+    f2(x, y, x2)
+
+    assert np.array_equal(x1, x2)
 
 #==============================================================================
 # TEST: COMPLEX EXPRESSIONS IN 3D : TEST CONSTANT AND UNKNOWN SHAPES


### PR DESCRIPTION
* Update `PythonTuple` and `PythonList`;
* Correctly print `numpy.array(expr)` to Fortran when `expr.rank > 2`;
* When necessary, use `transpose` for `rank = 2` and `reshape` for `rank > 2`;
* Use precision from `iso_c_bindings` dictionary;
* Fix bug in line splitting when len(line)>71;
* Don't split a comment line;
* Add unit tests.
