### PR TITLE
Allow slices with negative step in C

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -674,7 +674,7 @@ class CCodePrinter(CodePrinter):
                         inds[i] = self._new_slice_with_processed_arguments(ind, PyccelArraySize(base, i),
                             allow_negative_indexes)
                 inds = [self._print(i) for i in inds]
-                return "array_slicing(%s, %s)" % (base_name, ", ".join(inds))
+                return "array_slicing(&%s, %s)" % (base_name, ", ".join(inds))
             inds = [self._print(i) for i in inds]
         else:
             raise NotImplementedError(expr)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -725,8 +725,9 @@ class CCodePrinter(CodePrinter):
 
         # variable step in slice
         elif allow_negative_index and step and not isinstance(step, LiteralInteger):
+            og_start = start
             start = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)), start, PyccelMinus(stop, LiteralInteger(1)))
-            stop = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)), stop, start)
+            stop = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)), stop, og_start)
 
         return Slice(start, stop, step)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -674,7 +674,7 @@ class CCodePrinter(CodePrinter):
                         inds[i] = self._new_slice_with_processed_arguments(ind, PyccelArraySize(base, i),
                             allow_negative_indexes)
                 inds = [self._print(i) for i in inds]
-                return "array_slicing(&%s, %s)" % (base_name, ", ".join(inds))
+                return "array_slicing(%s, %s)" % (base_name, ", ".join(inds))
             inds = [self._print(i) for i in inds]
         else:
             raise NotImplementedError(expr)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -702,13 +702,13 @@ class CCodePrinter(CodePrinter):
         # negative start and end in slice
         if isinstance(start, PyccelUnarySub) and isinstance(start.args[0], LiteralInteger):
             start = PyccelMinus(array_size, start.args[0])
-        elif allow_negative_index and not isinstance(start, LiteralInteger) and not isinstance(start, PyccelArraySize):
+        elif allow_negative_index and not isinstance(start, (LiteralInteger, PyccelArraySize)):
             start = IfTernaryOperator(PyccelLt(start, LiteralInteger(0)),
                             PyccelMinus(array_size, start), start)
 
         if isinstance(stop, PyccelUnarySub) and isinstance(stop.args[0], LiteralInteger):
             stop = PyccelMinus(array_size, stop.args[0])
-        elif allow_negative_index and not isinstance(stop, LiteralInteger) and not isinstance(stop, PyccelArraySize):
+        elif allow_negative_index and not isinstance(stop, (LiteralInteger, PyccelArraySize)):
             stop = IfTernaryOperator(PyccelLt(stop, LiteralInteger(0)),
                             PyccelMinus(array_size, stop), stop)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -702,13 +702,13 @@ class CCodePrinter(CodePrinter):
         # negative start and end in slice
         if isinstance(start, PyccelUnarySub) and isinstance(start.args[0], LiteralInteger):
             start = PyccelMinus(array_size, start.args[0])
-        elif allow_negative_index and not isinstance(start, LiteralInteger):
+        elif allow_negative_index and not isinstance(start, LiteralInteger) and not isinstance(start, PyccelArraySize):
             start = IfTernaryOperator(PyccelLt(start, LiteralInteger(0)),
                             PyccelMinus(array_size, start), start)
 
         if isinstance(stop, PyccelUnarySub) and isinstance(stop.args[0], LiteralInteger):
             stop = PyccelMinus(array_size, stop.args[0])
-        elif allow_negative_index and not isinstance(stop, LiteralInteger):
+        elif allow_negative_index and not isinstance(stop, LiteralInteger) and not isinstance(stop, PyccelArraySize):
             stop = IfTernaryOperator(PyccelLt(stop, LiteralInteger(0)),
                             PyccelMinus(array_size, stop), stop)
 
@@ -720,12 +720,12 @@ class CCodePrinter(CodePrinter):
 
         # negative step in slice
         elif isinstance(step, PyccelUnarySub) and isinstance(step.args[0], LiteralInteger):
-            start = array_size if _slice.start is None else start
+            start = PyccelMinus(array_size, LiteralInteger(1)) if _slice.start is None else start
             stop = LiteralInteger(0) if _slice.stop is None else stop
 
         # variable step in slice
         elif allow_negative_index and step and not isinstance(step, LiteralInteger):
-            start = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)), start, stop)
+            start = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)), start, PyccelMinus(stop, LiteralInteger(1)))
             stop = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)), stop, start)
 
         return Slice(start, stop, step)

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -208,7 +208,7 @@ t_ndarray array_slicing(t_ndarray arr, ...)
     {
         slice = va_arg(va, t_slice);
         view.shape[i] = (slice.end - slice.start + (slice.step - 1)) / slice.step; // we need to round up the shape
-        start += slice.start * arr.strides[i];
+        start += (slice.step > 0) ? slice.start * arr.strides[i] : (slice.start - 1) * arr.strides[i];
         view.strides[i] *= slice.step;
     }
     va_end(va);

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -208,7 +208,7 @@ t_ndarray array_slicing(t_ndarray arr, ...)
     {
         slice = va_arg(va, t_slice);
         view.shape[i] = (slice.end - slice.start + (slice.step - 1)) / slice.step; // we need to round up the shape
-        start += (slice.step > 0) ? slice.start * arr.strides[i] : (slice.start - 1) * arr.strides[i];
+        start += slice.start * arr.strides[i];
         view.strides[i] *= slice.step;
     }
     va_end(va);

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -74,7 +74,7 @@ typedef struct  s_ndarray
     int32_t                 length;
     /* size of the array */
     int32_t                 buffer_size;
-    /* True if the array do not own the data */
+    /* True if the array does not own the data */
     bool                    is_view;
 }               t_ndarray;
 

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -74,7 +74,7 @@ typedef struct  s_ndarray
     int32_t                 length;
     /* size of the array */
     int32_t                 buffer_size;
-    /*  */
+    /* True if the array do not own the data */
     bool                    is_view;
 }               t_ndarray;
 

--- a/tests/pyccel/scripts/arrays_view.py
+++ b/tests/pyccel/scripts/arrays_view.py
@@ -1,0 +1,46 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+import numpy as np
+from pyccel.decorators import allow_negative_index
+
+def array_view():
+    a = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    b = a[:, :]
+    for i in range(2):
+        for j in range(5):
+            print(b[i][j])
+
+def array_view_negative_literal_step():
+    a = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    b = a[:, ::-1]
+    for i in range(2):
+        for j in range(5):
+            print(b[i][j])
+
+def array_view_negative_literal_step__2():
+    a = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    b = a[:, 4:2:-1]
+    for i in range(2):
+        for j in range(2):
+            print(b[i][j])
+
+def array_view_negative_literal_step__3():
+    a = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    b = a[:, 3::-2]
+    for i in range(2):
+        for j in range(2):
+            print(b[i][j])
+
+@allow_negative_index('a')
+def array_view_negative_variable_step():
+    a = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    i = -1
+    b = a[::i, :]
+    for i in range(2):
+        for j in range(5):
+            print(b[i][j])
+
+array_view()
+array_view_negative_literal_step()
+array_view_negative_literal_step__2()
+array_view_negative_literal_step__3()
+array_view_negative_variable_step()

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -182,24 +182,6 @@ def compare_pyth_fort_output( p_output, f_output, dtype=float ):
             compare_pyth_fort_output_by_type(p,f,dtype)
 
 #------------------------------------------------------------------------------
-def compare_pyth_c_output( p_output, f_output, dtype=float ):
-
-    if isinstance(dtype,list):
-        for d in dtype:
-            p_output,f_output = compare_pyth_fort_output_by_type(p_output,f_output,d)
-    elif dtype is complex:
-        while len(p_output)>0 and len(f_output)>0:
-            p_output,f_output = compare_pyth_fort_output_by_type(p_output,f_output,complex)
-    elif dtype is str:
-        compare_pyth_fort_output_by_type(p_output,f_output,dtype)
-    else:
-        p_output = p_output.strip().split()
-        f_output = f_output.strip().split()
-        for p, f in zip(p_output, f_output):
-            compare_pyth_fort_output_by_type(p,f,dtype)
-    assert(p_output == f_output)
-
-#------------------------------------------------------------------------------
 def pyccel_test(test_file, dependencies = None, compile_with_pyccel = True,
         cwd = None, pyccel_commands = "", output_dtype = float,
         language = None):
@@ -239,10 +221,7 @@ def pyccel_test(test_file, dependencies = None, compile_with_pyccel = True,
             compile_c(cwd, test_file, dependencies)
 
     lang_out = get_lang_output(get_exe(test_file))
-    if (language == 'c'):
-        compare_pyth_c_output(pyth_out, lang_out, output_dtype)
-    else:
-        compare_pyth_fort_output(pyth_out, lang_out, output_dtype)
+    compare_pyth_fort_output(pyth_out, lang_out, output_dtype)
 
 
 #==============================================================================
@@ -547,7 +526,7 @@ def test_c_arrays(language):
     pyccel_test("scripts/c_arrays.py", language=language, output_dtype=types)
 
 def test_arrays_view(language):
-    types = [int, int, int]
+    types = [int] * 10 + [int] * 10 + [int] * 4 + [int] * 4 + [int] * 10
     pyccel_test("scripts/arrays_view.py", language=language, output_dtype=types)
 
 def test_headers(language):

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -182,6 +182,24 @@ def compare_pyth_fort_output( p_output, f_output, dtype=float ):
             compare_pyth_fort_output_by_type(p,f,dtype)
 
 #------------------------------------------------------------------------------
+def compare_pyth_c_output( p_output, f_output, dtype=float ):
+
+    if isinstance(dtype,list):
+        for d in dtype:
+            p_output,f_output = compare_pyth_fort_output_by_type(p_output,f_output,d)
+    elif dtype is complex:
+        while len(p_output)>0 and len(f_output)>0:
+            p_output,f_output = compare_pyth_fort_output_by_type(p_output,f_output,complex)
+    elif dtype is str:
+        compare_pyth_fort_output_by_type(p_output,f_output,dtype)
+    else:
+        p_output = p_output.strip().split()
+        f_output = f_output.strip().split()
+        for p, f in zip(p_output, f_output):
+            compare_pyth_fort_output_by_type(p,f,dtype)
+    assert(p_output == f_output)
+
+#------------------------------------------------------------------------------
 def pyccel_test(test_file, dependencies = None, compile_with_pyccel = True,
         cwd = None, pyccel_commands = "", output_dtype = float,
         language = None):
@@ -221,8 +239,10 @@ def pyccel_test(test_file, dependencies = None, compile_with_pyccel = True,
             compile_c(cwd, test_file, dependencies)
 
     lang_out = get_lang_output(get_exe(test_file))
-
-    compare_pyth_fort_output(pyth_out, lang_out, output_dtype)
+    if (language == 'c'):
+        compare_pyth_c_output(pyth_out, lang_out, output_dtype)
+    else:
+        compare_pyth_fort_output(pyth_out, lang_out, output_dtype)
 
 
 #==============================================================================
@@ -525,6 +545,10 @@ def test_c_arrays(language):
             [complex] * 3 * 10 + [complex] * 5 + [float] * 10 + [float] * 6 + \
             [float] * 2 * 3 + [complex] * 3 * 10 + [float] * 2 * 3
     pyccel_test("scripts/c_arrays.py", language=language, output_dtype=types)
+
+def test_arrays_view(language):
+    types = [int, int, int]
+    pyccel_test("scripts/arrays_view.py", language=language, output_dtype=types)
 
 def test_headers(language):
     test_file = "scripts/test_headers.py"


### PR DESCRIPTION
- Use ternary operator to handle slices with negative `step` when `allow_negative_index` decorator is used;
- Fix duplicated operator in case of literal values;
- Add tests.