### PR TITLE
Keep hidden imports 

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4032,8 +4032,9 @@ class Import(Basic):
 
         return Basic.__new__(cls, source)
 
-    def __init__(self, source, target = None):
+    def __init__(self, source, target = None, ignore_at_print = False):
         self._target = []
+        self._ignore_at_print = ignore_at_print
         if isinstance(target, (str, Symbol, DottedName, AsName)):
             self._target = [Import._format(target)]
         elif iterable(target):
@@ -4061,6 +4062,16 @@ class Import(Basic):
     @property
     def source(self):
         return self._args[0]
+
+    @property
+    def ignore(self):
+        return self._ignore_at_print
+
+    @ignore.setter
+    def ignore(self, to_ignore):
+        if not isinstance(to_ignore, bool):
+            raise TypeError('to_ignore must be a boolean.')
+        self._ignore_at_print = to_ignore
 
     def _sympystr(self, printer):
         sstr = printer.doprint

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4025,7 +4025,7 @@ class Import(Basic):
     import foo, foo.bar.baz
     """
 
-    def __new__(cls, source, target = None):
+    def __new__(cls, source, target = None, ignore_at_print = False):
 
         if not source is None:
             source = Import._format(source)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -456,7 +456,7 @@ class CCodePrinter(CodePrinter):
         return code
 
     def _print_Import(self, expr):
-        if str(expr.source) in pyccel_builtin_import_registery:
+        if expr.ignore:
             return ''
         if isinstance(expr.source, DottedName):
             source = expr.source.name[-1]

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -34,8 +34,6 @@ from pyccel.ast.literals  import LiteralString, LiteralInteger, Literal
 from pyccel.ast.numpyext import NumpyFull, NumpyArray
 from pyccel.ast.numpyext import NumpyReal, NumpyImag, NumpyFloat
 
-from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
-
 from pyccel.codegen.printing.codeprinter import CodePrinter
 
 from pyccel.errors.errors   import Errors

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -35,6 +35,7 @@ from pyccel.ast.literals  import Nil
 from pyccel.ast.numpyext import NumpyFull, NumpyArray
 from pyccel.ast.numpyext import NumpyReal, NumpyImag, NumpyFloat
 
+
 from pyccel.codegen.printing.codeprinter import CodePrinter
 
 from pyccel.errors.errors   import Errors

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -34,6 +34,7 @@ from pyccel.ast.literals  import LiteralString, LiteralInteger, Literal
 from pyccel.ast.numpyext import NumpyFull, NumpyArray
 from pyccel.ast.numpyext import NumpyReal, NumpyImag, NumpyFloat
 
+from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
 
 from pyccel.codegen.printing.codeprinter import CodePrinter
 
@@ -455,6 +456,8 @@ class CCodePrinter(CodePrinter):
         return code
 
     def _print_Import(self, expr):
+        if str(expr.source) in pyccel_builtin_import_registery:
+            return ''
         if isinstance(expr.source, DottedName):
             source = expr.source.name[-1]
         else:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -369,7 +369,7 @@ class FCodePrinter(CodePrinter):
     def _print_Import(self, expr):
 
         source = ''
-        if str(expr.source) in pyccel_builtin_import_registery or expr.ignore:
+        if expr.ignore:
             return ''
 
         if isinstance(expr.source, DottedName):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -370,7 +370,7 @@ class FCodePrinter(CodePrinter):
     def _print_Import(self, expr):
 
         source = ''
-        if str(expr.source) in pyccel_builtin_import_registery:
+        if str(expr.source) in pyccel_builtin_import_registery or expr.ignore:
             return ''
 
         if isinstance(expr.source, DottedName):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -122,6 +122,12 @@ class PythonCodePrinter(SympyPythonCodePrinter):
             code += 'return {}'.format(ret)
         return code
 
+    def _print_AsName(self, expr):
+        name = self._print(expr.name)
+        target = self._print(expr.target)
+
+        return '{name} as {target}'.format(name = name, target = target)
+
     def _print_PythonTuple(self, expr):
         args = ', '.join(self._print(i) for i in expr.args)
         return '('+args+')'

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -134,6 +134,9 @@ class PythonCodePrinter(SympyPythonCodePrinter):
 
     def _print_Import(self, expr):
         target = ', '.join([self._print(i) for i in expr.target])
+
+        if target == '' and expr.source is not None:
+            return 'import {source}'.format(source=self._print(expr.source))
         if expr.source is None:
             return 'import {target}'.format(target=target)
         else:

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -172,7 +172,7 @@ class PythonCodePrinter(SympyPythonCodePrinter):
 
     def _print_Import(self, expr):
         source = self._print(expr.source)
-        if expr.target is None:
+        if not expr.target:
             return 'import {source}'.format(source=source)
         else:
             target = ', '.join([self._print(i) for i in expr.target])

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -146,9 +146,9 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         return '.'.join(self._print(n) for n in expr.name)
 
     def _print_FunctionCall(self, expr):
-        func = self._print(expr.func)
-        args = ','.join(self._print(i) for i in expr.arguments)
-        return'{func}({args})'.format(func=func, args=args)
+        func = expr.funcdef
+        args = ','.join(self._print(i) for i in expr.args)
+        return'{func}({args})'.format(func=func.name, args=args)
 
     def _print_Len(self, expr):
         return 'len({})'.format(self._print(expr.arg))
@@ -276,9 +276,13 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         return 'print({0})'.format(fs)
 
     def _print_Module(self, expr):
-        code = '\n'.join(self._print(e) for e in expr.body)
-        imports = '\n'.join(self._print(i) for i in self._additional_imports)
-        return '\n'.join([imports, code])
+        body = '\n'.join(self._print(e) for e in expr.body)
+        imports  = [*expr.imports, *self._additional_imports]
+        imports  = '\n'.join(self._print(i) for i in imports)
+        return ('{imports}\n\n'
+                '{body}').format(
+                        imports = imports,
+                        body    = body)
 
     def _print_PyccelPow(self, expr):
         base = self._print(expr.args[0])

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -122,6 +122,18 @@ class PythonCodePrinter(SympyPythonCodePrinter):
             code += 'return {}'.format(ret)
         return code
 
+    def _print_Program(self, expr):
+        body  = self._print(expr.body)
+        body = self._indent_codestring(body)
+        imports  = [*expr.imports, *self._additional_imports]
+        imports  = '\n'.join(self._print(i) for i in imports)
+
+        return ('{imports}\n'
+                'if __name__ == "__main__":\n'
+                '{body}\n').format(imports=imports,
+                                    body=body)
+
+
     def _print_AsName(self, expr):
         name = self._print(expr.name)
         target = self._print(expr.target)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -134,9 +134,6 @@ class PythonCodePrinter(SympyPythonCodePrinter):
 
     def _print_Import(self, expr):
         target = ', '.join([self._print(i) for i in expr.target])
-
-        if target == '' and expr.source is not None:
-            return 'import {source}'.format(source=self._print(expr.source))
         if expr.source is None:
             return 'import {target}'.format(target=target)
         else:

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -114,7 +114,13 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         return code
 
     def _print_Return(self, expr):
-        return 'return {}'.format(self._print(expr.expr))
+        code = ''
+        if expr.stmt:
+            code += self._print(expr.stmt)+'\n'
+        if expr.args:
+            ret = ','.join([self._print(i) for i in expr.expr])
+            code += 'return {}'.format(ret)
+        return code
 
     def _print_PythonTuple(self, expr):
         args = ', '.join(self._print(i) for i in expr.args)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -164,7 +164,7 @@ class PythonCodePrinter(SympyPythonCodePrinter):
 
     def _print_FunctionCall(self, expr):
         func = expr.funcdef
-        args = ','.join(self._print(i) for i in expr.args)
+        args = ', '.join(self._print(i) for i in expr.args)
         return'{func}({args})'.format(func=func.name, args=args)
 
     def _print_Len(self, expr):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -144,6 +144,11 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         args = ', '.join(self._print(i) for i in expr.args)
         return '('+args+')'
 
+    def _print_PyccelArraySize(self, expr):
+        arg = self._print(expr.arg)
+        index = self._print(expr.index)
+        return 'shape({0})[{1}]'.format(arg, index)
+
     def _print_Comment(self, expr):
         txt = self._print(expr.text)
         return '# {0} '.format(txt)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -117,7 +117,7 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         code = ''
         if expr.stmt:
             code += self._print(expr.stmt)+'\n'
-        if expr.args:
+        if expr.expr:
             ret = ','.join([self._print(i) for i in expr.expr])
             code += 'return {}'.format(ret)
         return code

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2848,6 +2848,7 @@ class SemanticParser(BasicParser):
         return IsClass(var1, var2)
 
     def _visit_Import(self, expr, **settings):
+
         # TODO - must have a dict where to store things that have been
         #        imported
         #      - should not use namespace
@@ -2863,6 +2864,7 @@ class SemanticParser(BasicParser):
 
         if source in pyccel_builtin_import_registery:
             imports = pyccel_builtin_import(expr)
+
             def _insert_obj(location, target, obj):
                 F = self.check_for_variable(target)
 
@@ -2875,7 +2877,7 @@ class SemanticParser(BasicParser):
                     errors.report(IMPORTING_EXISTING_IDENTIFIED,
                                   bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                                   severity='fatal')
-            expr.ignore = True
+
             if expr.target:
                 for (name, atom) in imports:
                     if not name is None:
@@ -2883,7 +2885,6 @@ class SemanticParser(BasicParser):
                             _insert_obj('variables', name, atom)
                         else:
                             _insert_obj('functions', name, atom)
-
             else:
                 _insert_obj('variables', source_target, imports)
             key = expr.source if isinstance(expr.source, AsName) else source

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2833,7 +2833,6 @@ class SemanticParser(BasicParser):
         #      - should not use namespace
 
         container = self.namespace.imports
-
         if isinstance(expr.source, AsName):
             source        = str(expr.source.name)
             source_target = str(expr.source.target)
@@ -2843,7 +2842,6 @@ class SemanticParser(BasicParser):
 
         if source in pyccel_builtin_import_registery:
             imports = pyccel_builtin_import(expr)
-
             def _insert_obj(location, target, obj):
                 F = self.check_for_variable(target)
 
@@ -2867,6 +2865,7 @@ class SemanticParser(BasicParser):
                         _insert_obj('imports', source, expr)
             else:
                 _insert_obj('variables', source_target, imports)
+                _insert_obj('imports', source, expr)
         else:
 
             # in some cases (blas, lapack, openmp and openacc level-0)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1057,7 +1057,6 @@ class SemanticParser(BasicParser):
                     if new_name != rhs_name:
                         if hasattr(func, 'clone'):
                             func  = func.clone(new_name)
-                        #TODO add clone methode to numpyext and mathext ??
                     return self._handle_function(func, args, **settings)
                 elif isinstance(rhs, Constant):
                     var = first[rhs_name]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -443,13 +443,15 @@ class SemanticParser(BasicParser):
 
 
     def get_import(self, name):
-        """."""
+        """
+        Search for a Import object with the given name in the current namespace.
+        Return None if not found.
+        """
 
         imp = None
         container = self.namespace
         while container:
 
-            #case import x as y
             for key,_ in container.imports['imports'].items():
                 if key == name:
                     imp = container.imports['imports'][key]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2854,6 +2854,8 @@ class SemanticParser(BasicParser):
                     errors.report(IMPORTING_EXISTING_IDENTIFIED,
                                   bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                                   severity='fatal')
+            expr.ignore = True
+            _insert_obj('imports', source, expr)
 
             if expr.target:
                 for (name, atom) in imports:
@@ -2862,10 +2864,8 @@ class SemanticParser(BasicParser):
                             _insert_obj('variables', name, atom)
                         else:
                             _insert_obj('functions', name, atom)
-                        _insert_obj('imports', source, expr)
             else:
                 _insert_obj('variables', source_target, imports)
-                _insert_obj('imports', source, expr)
         else:
 
             # in some cases (blas, lapack, openmp and openacc level-0)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -449,14 +449,12 @@ class SemanticParser(BasicParser):
         """
 
         imp = None
+
         container = self.namespace
         while container:
 
-            for key in container.imports['imports'].keys():
-                if key == name:
-                    imp = container.imports['imports'][key]
-
-            if imp:
+            if name in container.imports['imports']:
+                imp =  container.imports['imports'][name]
                 break
             container = container.parent_scope
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -444,7 +444,7 @@ class SemanticParser(BasicParser):
 
     def get_import(self, name):
         """
-        Search for a Import object with the given name in the current namespace.
+        Search for an import with the given name in the current namespace.
         Return None if not found.
         """
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -456,6 +456,8 @@ class SemanticParser(BasicParser):
                 if key == name:
                     imp = container.imports['imports'][key]
 
+            if imp:
+                break
             container = container.parent_scope
 
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1054,7 +1054,10 @@ class SemanticParser(BasicParser):
                     args  = self._handle_function_args(rhs.args, **settings)
                     func  = first[rhs_name]
                     if new_name != rhs_name:
-                        func  = func.clone(new_name)
+                        if hasattr(func, 'clone'):
+                            func  = func.clone(new_name)
+                        else : #TODO add clone methode to numpyext and mathext ??
+                            func = func
                     return self._handle_function(func, args, **settings)
                 elif isinstance(rhs, Constant):
                     var = first[rhs_name]
@@ -2885,7 +2888,7 @@ class SemanticParser(BasicParser):
 
             else:
                 _insert_obj('variables', source_target, imports)
-            _insert_obj('imports', expr.source, Import(expr.source, expr.target, True))
+            _insert_obj('imports', expr.source, Import(source, expr.target, True))
 
         else:
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -450,7 +450,7 @@ class SemanticParser(BasicParser):
         while container:
 
             #case import x as y
-            for key, value in container.imports['imports'].items():
+            for key,_ in container.imports['imports'].items():
                 if str(key) == str(name) or (isinstance(key, AsName)
                                             and str(key.target) == str(name)):
                     imp = container.imports['imports'][key]
@@ -1056,8 +1056,7 @@ class SemanticParser(BasicParser):
                     if new_name != rhs_name:
                         if hasattr(func, 'clone'):
                             func  = func.clone(new_name)
-                        else : #TODO add clone methode to numpyext and mathext ??
-                            func = func
+                        #TODO add clone methode to numpyext and mathext ??
                     return self._handle_function(func, args, **settings)
                 elif isinstance(rhs, Constant):
                     var = first[rhs_name]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2864,6 +2864,7 @@ class SemanticParser(BasicParser):
                             _insert_obj('variables', name, atom)
                         else:
                             _insert_obj('functions', name, atom)
+                        _insert_obj('imports', source, expr)
             else:
                 _insert_obj('variables', source_target, imports)
         else:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -508,6 +508,15 @@ class SemanticParser(BasicParser):
 
         return None
 
+    def insert_import(self, name, target):
+        imp = self.get_import(name)
+
+        if imp is not None:
+            imp.define_target(target)
+        else:
+            container = self.namespace.imports
+            container['imports'][name] = Import(name, target)
+
     def insert_macro(self, macro):
         """."""
 
@@ -1138,6 +1147,7 @@ class SemanticParser(BasicParser):
                             'property' in i.decorators.keys():
                         if 'numpy_wrapper' in i.decorators.keys():
                             func = i.decorators['numpy_wrapper']
+                            self.insert_import('numpy', rhs)
                             return func(visited_lhs)
                         else:
                             return DottedFunctionCall(i, [], prefix = visited_lhs,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2856,7 +2856,7 @@ class SemanticParser(BasicParser):
                                   bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                                   severity='fatal')
             expr.ignore = True
-
+            #TODO "import numpy" should be also collected
             if expr.target:
                 for (name, atom) in imports:
                     if not name is None:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2571,8 +2571,7 @@ class SemanticParser(BasicParser):
             global_vars = [v for v in self.get_variables(self.namespace.parent_scope) if v not in args + results + local_vars]
 
             # get the imports
-            imports   = list(self.namespace.imports['imports'].values())
-            imports += list(self.namespace.parent_scope.imports['imports'].values())
+            imports   = self.namespace.imports['imports'].values()
             imports   = list(set(imports))
 
             # remove the FunctionDef from the function scope

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2843,7 +2843,6 @@ class SemanticParser(BasicParser):
 
         if source in pyccel_builtin_import_registery:
             imports = pyccel_builtin_import(expr)
-
             def _insert_obj(location, target, obj):
                 F = self.check_for_variable(target)
 
@@ -2857,7 +2856,6 @@ class SemanticParser(BasicParser):
                                   bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                                   severity='fatal')
             expr.ignore = True
-            _insert_obj('imports', source, expr)
 
             if expr.target:
                 for (name, atom) in imports:
@@ -2866,6 +2864,8 @@ class SemanticParser(BasicParser):
                             _insert_obj('variables', name, atom)
                         else:
                             _insert_obj('functions', name, atom)
+                        _insert_obj('imports', expr.source, expr)
+
             else:
                 _insert_obj('variables', source_target, imports)
         else:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2903,8 +2903,7 @@ class SemanticParser(BasicParser):
                             _insert_obj('functions', name, atom)
             else:
                 _insert_obj('variables', source_target, imports)
-            key = expr.source if isinstance(expr.source, AsName) else source
-            _insert_obj('imports', key, Import(source, expr.target, True))
+            _insert_obj('imports', source_target, Import(source, expr.target, True))
 
         else:
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2833,6 +2833,7 @@ class SemanticParser(BasicParser):
         #      - should not use namespace
 
         container = self.namespace.imports
+
         if isinstance(expr.source, AsName):
             source        = str(expr.source.name)
             source_target = str(expr.source.target)
@@ -2842,6 +2843,7 @@ class SemanticParser(BasicParser):
 
         if source in pyccel_builtin_import_registery:
             imports = pyccel_builtin_import(expr)
+
             def _insert_obj(location, target, obj):
                 F = self.check_for_variable(target)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -452,7 +452,7 @@ class SemanticParser(BasicParser):
         container = self.namespace
         while container:
 
-            for key,_ in container.imports['imports'].items():
+            for key in container.imports['imports'].keys():
                 if key == name:
                     imp = container.imports['imports'][key]
 
@@ -509,6 +509,10 @@ class SemanticParser(BasicParser):
         return None
 
     def insert_import(self, name, target):
+        """
+            Create and insert a new import in namespace if it's not defined
+            otherwise append target to existing import.
+        """
         imp = self.get_import(name)
 
         if imp is not None:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -451,8 +451,7 @@ class SemanticParser(BasicParser):
 
             #case import x as y
             for key,_ in container.imports['imports'].items():
-                if str(key) == str(name) or (isinstance(key, AsName)
-                                            and str(key.target) == str(name)):
+                if key == name:
                     imp = container.imports['imports'][key]
 
             container = container.parent_scope
@@ -2887,7 +2886,8 @@ class SemanticParser(BasicParser):
 
             else:
                 _insert_obj('variables', source_target, imports)
-            _insert_obj('imports', expr.source, Import(source, expr.target, True))
+            key = expr.source if isinstance(expr.source, AsName) else source
+            _insert_obj('imports', key, Import(source, expr.target, True))
 
         else:
 

--- a/tests/epyccel/test_imports.py
+++ b/tests/epyccel/test_imports.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 
 import pytest
-import numpy as np
+from numpy import ones
 
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
@@ -18,12 +18,12 @@ def language(request):
 def test_import(language):
     @types('int[:]')
     def f1(x):
-        import numpy  # pylint: disable=import-error
+        import numpy
         s = numpy.shape(x)[0]
         return s
 
     f = epyccel(f1, language = language)
-    x = np.ones(10, dtype=int)
+    x = ones(10, dtype=int)
     assert f(x) == f1(x)
 
 def test_import_from(language):
@@ -35,18 +35,18 @@ def test_import_from(language):
 
 
     f = epyccel(f2, language = language)
-    x = np.ones(10, dtype=int)
+    x = ones(10, dtype=int)
     assert f(x) == f2(x)
 
 def test_import_as(language):
     @types('int[:]')
     def f3(x):
-        import numpy as np  # pylint: disable=import-error
+        import numpy as np
         s = np.shape(x)[0]
         return s
 
     f = epyccel(f3, language = language)
-    x = np.ones(10, dtype=int)
+    x = ones(10, dtype=int)
     assert f(x) == f3(x)
 
 def test_import_collision(language):

--- a/tests/epyccel/test_imports.py
+++ b/tests/epyccel/test_imports.py
@@ -18,7 +18,7 @@ def language(request):
 def test_import(language):
     @types('int[:]')
     def f1(x):
-        import numpy
+        import numpy  # pylint: disable=import-error
         s = numpy.shape(x)[0]
         return s
 
@@ -33,6 +33,7 @@ def test_import_from(language):
         s = shape(x)[0]
         return s
 
+
     f = epyccel(f2, language = language)
     x = np.ones(10, dtype=int)
     assert f(x) == f2(x)
@@ -40,7 +41,7 @@ def test_import_from(language):
 def test_import_as(language):
     @types('int[:]')
     def f3(x):
-        import numpy as np
+        import numpy as np  # pylint: disable=import-error
         s = np.shape(x)[0]
         return s
 

--- a/tests/epyccel/test_imports.py
+++ b/tests/epyccel/test_imports.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 
 import pytest
-from numpy import ones
+from numpy import ones, array_equal
 
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
@@ -58,3 +58,13 @@ def test_import_collision(language):
 
     f = epyccel(f4, language = language)
     assert f(5) == f4(5)
+
+def test_import_method(language):
+    @types('int[:]')
+    def f5(x):
+        s = x.shape[0]
+        return s
+
+    f = epyccel(f5, language = language)
+    x = ones(10, dtype=int)
+    assert f(x) == f5(x)

--- a/tests/epyccel/test_imports.py
+++ b/tests/epyccel/test_imports.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 
 import pytest
-from numpy import ones, array_equal
+from numpy import ones
 
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types

--- a/tests/epyccel/test_imports.py
+++ b/tests/epyccel/test_imports.py
@@ -1,0 +1,59 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+
+import pytest
+import numpy as np
+
+from pyccel.epyccel import epyccel
+from pyccel.decorators import types
+
+#------------------------------------------------------------------------------
+@pytest.fixture(params=[
+    pytest.param('python', marks = pytest.mark.python)]
+)
+def language(request):
+    return request.param
+
+#==============================================================================
+
+def test_import(language):
+    @types('int[:]')
+    def f1(x):
+        import numpy
+        s = numpy.shape(x)[0]
+        return s
+
+    f = epyccel(f1, language = language)
+    x = np.ones(10, dtype=int)
+    assert f(x) == f1(x)
+
+def test_import_from(language):
+    @types('int[:]')
+    def f2(x):
+        from numpy import shape
+        s = shape(x)[0]
+        return s
+
+    f = epyccel(f2, language = language)
+    x = np.ones(10, dtype=int)
+    assert f(x) == f2(x)
+
+def test_import_as(language):
+    @types('int[:]')
+    def f3(x):
+        import numpy as np
+        s = np.shape(x)[0]
+        return s
+
+    f = epyccel(f3, language = language)
+    x = np.ones(10, dtype=int)
+    assert f(x) == f3(x)
+
+def test_import_collision(language):
+    @types('int')
+    def f4(x):
+        import modules.Module_3 as mod
+        add_one = mod.add_one(x)
+        return add_one
+
+    f = epyccel(f4, language = language)
+    assert f(5) == f4(5)


### PR DESCRIPTION
Keep information about all imported modules, as required by Python printer. Closes #644 
- always collect import at the semantic stage.
- add property ignore in import class.
- ignore collected import in the C and Fortran printing stage.
- search import by name and Asname