### PR TITLE
Remove IndexedVariable type

### DIFF
--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -13,7 +13,6 @@ from pyccel.ast.core import Variable
 from pyccel.ast.core import Assign
 from pyccel.ast.core import Import
 from pyccel.ast.core import AsName
-from pyccel.ast.core import IndexedVariable
 
 __all__ = (
    'as_static_function',
@@ -27,15 +26,6 @@ def sanitize_arguments(args):
     for a in args:
         if isinstance(a, (Variable, FunctionAddress)):
             _args.append(a)
-
-        elif isinstance( a, IndexedVariable ):
-            a_new = Variable( a.dtype, str(a.name),
-                              shape       = a.shape,
-                              rank        = a.rank,
-                              order       = a.order,
-                              precision   = a.precision)
-
-            _args.append(a_new)
 
         else:
             raise NotImplementedError('TODO for {}'.format(type(a)))

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -326,8 +326,7 @@ def _atomic(e, cls=None,ignore=()):
     seen = []
     atoms_ = []
     if cls is None:
-        cls = (Application, DottedVariable, Variable,
-               IndexedElement)
+        cls = (Application, Variable, IndexedElement)
 
     for p in pot:
         if p in seen or isinstance(p, ignore):
@@ -4687,7 +4686,7 @@ class IndexedElement(Expr, PyccelAstNode):
 
         if not args:
             raise IndexError('Indexed needs at least one index.')
-        if not isinstance(base, (Variable, DottedVariable)):
+        if not isinstance(base, Variable):
             raise TypeError("Indexed expects Variable as base")
         return Expr.__new__(cls, base, *args, **kw_args)
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4725,7 +4725,7 @@ class IndexedElement(Expr, PyccelAstNode):
 
         # Add empty slices to fully index the object
         if len(args) < rank:
-            args = args + tuple([Slice(None, None)]*(var.rank-len(args)))
+            args = args + tuple([Slice(None, None)]*(rank-len(args)))
 
         self._label = base
         self._indices = args

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2582,12 +2582,7 @@ class TupleVariable(Variable):
 
     def __getitem__(self,idx):
         if self._is_homogeneous:
-            if isinstance(idx, tuple):
-                idx = list(idx)
-            else:
-                idx = [idx]
-            idx.extend([Slice(None,None) for _ in range(self.rank-len(idx))])
-            return IndexedElement(self, *idx)
+            return Variable.__getitem__(self, idx)
         else:
             if isinstance(idx, tuple):
                 sub_idx = idx[1:]

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2474,8 +2474,7 @@ class Variable(Symbol, PyccelAstNode):
         if self.rank < len(args):
             raise IndexError('Rank mismatch.')
 
-        obj = IndexedElement(self, *args)
-        return obj
+        return IndexedElement(self, *args)
 
 class DottedVariable(Variable):
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -103,7 +103,6 @@ __all__ = (
     'IfTernaryOperator',
     'Import',
     'IndexedElement',
-    'IndexedVariable',
     'Interface',
     'Load',
     'ModOp',
@@ -254,7 +253,7 @@ def allocatable_like(expr, verbose=False):
         talk more
     """
 
-    if isinstance(expr, (Variable, IndexedVariable, IndexedElement)):
+    if isinstance(expr, (Variable, IndexedElement)):
         return expr
     elif isinstance(expr, str):
         # if the rhs is a string
@@ -306,8 +305,7 @@ def allocatable_like(expr, verbose=False):
                 if verbose:
                     print('Functions not yet available')
                 return None
-            elif isinstance(a, (Variable, IndexedVariable,
-                            IndexedElement)):
+            elif isinstance(a, (Variable, IndexedElement)):
                 return a
             elif a.is_Symbol:
                 raise TypeError('Found an unknown symbol {0}'.format(str(a)))
@@ -328,7 +326,7 @@ def _atomic(e, cls=None,ignore=()):
     atoms_ = []
     if cls is None:
         cls = (Application, DottedVariable, Variable,
-               IndexedVariable,IndexedElement)
+               IndexedElement)
 
     for p in pot:
         if p in seen or isinstance(p, ignore):
@@ -765,7 +763,6 @@ class Assign(Basic):
         rhs = self.rhs
         cond = isinstance(rhs, Variable) and rhs.rank > 0
         cond = cond or isinstance(rhs, IndexedElement)
-        cond = cond or isinstance(rhs, IndexedVariable)
         cond = cond and isinstance(lhs, Symbol)
         cond = cond or isinstance(rhs, Variable) and rhs.is_pointer
         return cond
@@ -967,7 +964,7 @@ class AliasAssign(Basic):
         at this point we don't know yet all information about lhs, this is why a
         Symbol is the appropriate type.
 
-    rhs : Variable, IndexedVariable, IndexedElement
+    rhs : Variable, IndexedElement
         an assignable variable can be of any rank and any datatype, however its
         shape must be known (not None)
 
@@ -2492,7 +2489,6 @@ class DottedVariable(AtomicExpr, sp_Boolean, PyccelAstNode):
                 Literal,
                 Variable,
                 Symbol,
-                IndexedVariable,
                 IndexedElement,
                 IndexedBase,
                 Indexed,
@@ -2505,7 +2501,6 @@ class DottedVariable(AtomicExpr, sp_Boolean, PyccelAstNode):
             if not isinstance(rhs, (
                 Variable,
                 Symbol,
-                IndexedVariable,
                 IndexedElement,
                 IndexedBase,
                 Indexed,
@@ -2680,10 +2675,8 @@ class TupleVariable(Variable):
 
     def get_vars(self):
         if self._is_homogeneous:
-            indexed_var = IndexedVariable(self, dtype=self.dtype, shape=self.shape,
-                prec=self.precision, order=self.order, rank=self. rank)
             args = [Slice(None,None)]*(self.rank-1)
-            return [indexed_var[[i] + args] for i in range(len(self._vars))]
+            return [self[[i] + args] for i in range(len(self._vars))]
         else:
             return self._vars
 
@@ -4719,9 +4712,9 @@ class IndexedElement(Expr, PyccelAstNode):
     Examples
     --------
     >>> from sympy import symbols, Idx
-    >>> from pyccel.ast.core import IndexedVariable, IndexedElement
+    >>> from pyccel.ast.core import Variable, IndexedElement
     >>> i, j = symbols('i j', cls=Idx)
-    >>> A = IndexedVariable('A', dtype='int')
+    >>> A = Variable('A', dtype='int')
     >>> IndexedElement(A, i, j)
     IndexedElement(A, i, j)
     >>> IndexedElement(A, i, j) == A[i, j]
@@ -5102,7 +5095,7 @@ def is_simple_assign(expr):
     if not isinstance(expr, Assign):
         return False
 
-    assignable = [Variable, IndexedVariable, IndexedElement]
+    assignable = [Variable, IndexedElement]
     assignable += [sp_Integer, sp_Float]
     assignable = tuple(assignable)
     if isinstance(expr.rhs, assignable):
@@ -5294,7 +5287,7 @@ def get_iterable_ranges(it, var_name=None):
 
             args = []
             for i in [cls_base.start, cls_base.stop, cls_base.step]:
-                if isinstance(i, (Variable, IndexedVariable)):
+                if isinstance(i, Variable):
                     arg_name = _construct_arg_Range(i.name)
                     arg = i.clone(arg_name)
                 elif isinstance(i, IndexedElement):
@@ -5379,8 +5372,7 @@ def get_iterable_ranges(it, var_name=None):
                 for (a_old, a_new) in zip(args, params):
                     dtype = datatype(stmt.rhs.dtype)
                     v_old = Variable(dtype, a_old)
-                    if isinstance(a_new, (IndexedVariable,
-                                  IndexedElement, str, Variable)):
+                    if isinstance(a_new, (IndexedElement, str, Variable)):
                         v_new = Variable(dtype, a_new)
                     else:
                         v_new = a_new
@@ -5472,8 +5464,7 @@ def get_iterable_ranges(it, var_name=None):
                 for (a_old, a_new) in zip(args, params):
                     dtype = datatype(stmt.rhs.dtype)
                     v_old = Variable(dtype, a_old)
-                    if isinstance(a_new, (IndexedVariable,
-                                  IndexedElement, str, Variable)):
+                    if isinstance(a_new, (IndexedElement, str, Variable)):
                         v_new = Variable(dtype, a_new)
                     else:
                         v_new = a_new

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -16,7 +16,7 @@ from pyccel.symbolic import lambdify
 from pyccel.errors.errors import Errors
 
 from .core     import (AsName, Import, FunctionDef, Constant,
-                       Variable, IndexedVariable, ValuedVariable)
+                       Variable, ValuedVariable)
 
 from .builtins      import builtin_functions_dict, PythonMap
 from .itertoolsext  import Product
@@ -147,9 +147,6 @@ def build_types_decorator(args, order=None):
     types = []
     for a in args:
         if isinstance(a, Variable):
-            dtype = a.dtype.name.lower()
-
-        elif isinstance(a, IndexedVariable):
             dtype = a.dtype.name.lower()
 
         else:

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -725,7 +725,7 @@ class CWrapperCodePrinter(CCodePrinter):
 
     def _print_IndexedElement(self, expr):
         assert(len(expr.indices)==1)
-        return '{}[{}]'.format(self._print(expr.base.internal_variable), self._print(expr.indices[0]))
+        return '{}[{}]'.format(self._print(expr.base), self._print(expr.indices[0]))
 
     def _print_PyccelPyObject(self, expr):
         return 'pyobject'

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1152,7 +1152,7 @@ class FCodePrinter(CodePrinter):
             rhs = rhs.variable
 
         if isinstance(lhs, TupleVariable) and not lhs.is_homogeneous:
-            return self._print(CodeBlock([AliasAssign(l, rhs[i]) for i,l in enumerate(lhs)]))
+            return self._print(CodeBlock([AliasAssign(l, r) for l,r in zip(lhs,rhs)]))
 
         if isinstance(rhs, Dlist):
             pattern = 'allocate({lhs}(0:{length}-1))\n{lhs} = {init_value}\n'

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -36,7 +36,7 @@ from pyccel.ast.itertoolsext import Product
 from pyccel.ast.core import (Assign, AliasAssign, Variable,
                              VariableAddress,
                              TupleVariable, For, Declare,
-                             IndexedVariable, CodeBlock,
+                             CodeBlock,
                              IndexedElement, Slice, Dlist,
                              DottedName, AsName,
                              If, PyccelArraySize, IfTernaryOperator)
@@ -1149,10 +1149,7 @@ class FCodePrinter(CodePrinter):
             rhs = rhs.variable
 
         if isinstance(lhs, TupleVariable) and not lhs.is_homogeneous:
-            if isinstance(rhs, (TupleVariable, PythonTuple)):
-                return self._print(CodeBlock([AliasAssign(l, rhs[i]) for i,l in enumerate(lhs)]))
-            else:
-                return self._print(CodeBlock([AliasAssign(l, IndexedVariable(rhs)[i]) for i,l in enumerate(lhs)]))
+            return self._print(CodeBlock([AliasAssign(l, rhs[i]) for i,l in enumerate(lhs)]))
 
         if isinstance(rhs, Dlist):
             pattern = 'allocate({lhs}(0:{length}-1))\n{lhs} = {init_value}\n'
@@ -2611,10 +2608,7 @@ class FCodePrinter(CodePrinter):
         return "{0}_{1}".format(str(expr.p), iso_c_binding["integer"][expr.precision])
 
     def _print_IndexedElement(self, expr):
-        if isinstance(expr.base, IndexedVariable):
-            base = expr.base.internal_variable
-        else:
-            base = expr.base
+        base = expr.base
         if isinstance(base, Application) and not isinstance(base, PythonTuple):
             indexed_type = base.dtype
             if isinstance(indexed_type, PythonTuple):
@@ -2635,26 +2629,21 @@ class FCodePrinter(CodePrinter):
                     self._namespace.variables[var.name] = var
 
                 self._additional_code = self._additional_code + self._print(Assign(var,base)) + '\n'
-                return self._print(IndexedVariable(var, dtype=base.dtype,
-                   shape=base.shape,prec=base.precision,
-                   order=base.order,rank=base.rank)[expr.indices])
+                return self._print(var[expr.indices])
         elif isinstance(base, TupleVariable) and not base.is_homogeneous:
             if len(expr.indices)==1:
                 return self._print(base[expr.indices[0]])
             else:
                 var = base[expr.indices[0]]
-                return self._print(IndexedVariable(var, dtype = var.dtype,
-                    shape = var.shape, prec = var.precision,
-                    order = var.order, rank = var.rank)[expr.indices[1:]])
+                return self._print(var[expr.indices[1:]])
         else:
-            base_code = self._print(expr.base.label)
+            base_code = self._print(expr.base)
 
         inds = list(expr.indices)
         if expr.base.order == 'C':
             inds = inds[::-1]
         base_shape = Shape(expr.base)
-        allow_negative_indexes = (isinstance(expr.base, IndexedVariable) and \
-                expr.base.internal_variable.allows_negative_indexes)
+        allow_negative_indexes = base.allows_negative_indexes
 
         for i, ind in enumerate(inds):
             _shape = PyccelArraySize(base, i if expr.order != 'C' else len(inds) - i - 1)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -178,20 +178,6 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         args = ','.join(self._print(i) for i in expr.elements)
         return 'product({})'.format(args)
 
-    def _print_IndexedBase(self, expr):
-        return self._print(expr.label)
-
-    def _print_Indexed(self, expr):
-        inds = list(expr.indices)
-        #indices of indexedElement of len==1 shouldn't be a Tuple
-        for i, ind in enumerate(inds):
-            if isinstance(ind, Tuple) and len(ind) == 1:
-                inds[i] = ind[0]
-
-        inds = [self._print(i) for i in inds]
-
-        return "%s[%s]" % (self._print(expr.base.label), ", ".join(inds))
-
     def _print_Zeros(self, expr):
         return 'zeros('+ self._print(expr.shape)+')'
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1336,13 +1336,13 @@ class SemanticParser(BasicParser):
             # TODO uncomment this line, to make rhs target for
             #      lists/tuples.
             rhs.is_target = True
-        if isinstance(rhs, IndexedElement) and rhs.rank > 0 and rhs.base.internal_variable.allocatable:
+        if isinstance(rhs, IndexedElement) and rhs.rank > 0 and rhs.base.allocatable:
             d_lhs['allocatable'] = False
             d_lhs['is_pointer' ] = True
 
             # TODO uncomment this line, to make rhs target for
             #      lists/tuples.
-            rhs.base.internal_variable.is_target = True
+            rhs.base.is_target = True
 
     def _assign_lhs_variable(self, lhs, d_var, rhs, new_expressions, is_augassign, **settings):
         """

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -45,7 +45,7 @@ from pyccel.ast.core import While
 from pyccel.ast.core import SymbolicPrint
 from pyccel.ast.core import Del
 from pyccel.ast.core import EmptyNode
-from pyccel.ast.core import Slice, IndexedVariable, IndexedElement
+from pyccel.ast.core import Slice, IndexedElement
 from pyccel.ast.core import ValuedVariable
 from pyccel.ast.core import ValuedArgument
 from pyccel.ast.core import Import
@@ -114,7 +114,7 @@ errors = Errors()
 def _get_name(var):
     """."""
 
-    if isinstance(var, (Symbol, IndexedVariable, IndexedBase, DottedVariable)):
+    if isinstance(var, (Symbol, IndexedBase, DottedVariable)):
         return str(var)
     if isinstance(var, (IndexedElement, Indexed)):
         return str(var.base)
@@ -757,6 +757,7 @@ class SemanticParser(BasicParser):
     def _visit(self, expr, **settings):
         """Annotates the AST.
 
+        # TODO: Why is IndexedVariable mentioned here?
         IndexedVariable atoms are only used to manipulate expressions, we then,
         always have a Variable in the namespace."""
 
@@ -869,7 +870,7 @@ class SemanticParser(BasicParser):
 
     def _extract_indexed_from_var(self, var, args, name):
 
-        # case of Pyccel ast Variable, IndexedVariable
+        # case of Pyccel ast Variable
         # if not possible we use symbolic objects
 
         if not isinstance(var, (Variable, DottedVariable)):
@@ -920,26 +921,12 @@ class SemanticParser(BasicParser):
                     bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                     severity='fatal', blocker=self.blocking)
 
-        if hasattr(var, 'dtype'):
-            dtype = var.dtype
-            shape = var.shape
-            prec  = var.precision
-            order = var.order
-            rank  = var.rank
+        if isinstance(var, PythonTuple) and not var.is_homogeneous:
+            errors.report(LIST_OF_TUPLES, symbol=var,
+                bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
+                severity='error', blocker=self.blocking)
 
-            if isinstance(var, PythonTuple):
-                if not var.is_homogeneous:
-                    errors.report(LIST_OF_TUPLES, symbol=var,
-                        bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
-                        severity='error', blocker=self.blocking)
-                    dtype = 'int'
-                else:
-                    dtype = var.dtype
-
-            return IndexedVariable(var, dtype=dtype,
-                   shape=shape,prec=prec,order=order,rank=rank)[args]
-        else:
-            return IndexedVariable(name, dtype=dtype)[args]
+        return var[args]
 
     def _visit_IndexedBase(self, expr, **settings):
         return self._visit(expr.label)
@@ -1836,13 +1823,11 @@ class SemanticParser(BasicParser):
 
                 if rhs.is_homogeneous:
                     d_var = self._infere_type(rhs[0])
-                    indexed_rhs = IndexedVariable(rhs, dtype=rhs.dtype,
-                            shape=rhs.shape,prec=rhs.precision,order=rhs.order,rank=rhs.rank)
                     new_rhs = []
                     for i,l in enumerate(lhs):
                         new_lhs.append( self._assign_lhs_variable(l, d_var.copy(),
-                            indexed_rhs[i], new_expressions, isinstance(expr, AugAssign), **settings) )
-                        new_rhs.append(indexed_rhs[i])
+                            rhs[i], new_expressions, isinstance(expr, AugAssign), **settings) )
+                        new_rhs.append(rhs[i])
                     rhs = PythonTuple(*new_rhs)
                     d_var = [d_var]
                 else:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -982,11 +982,6 @@ class SemanticParser(BasicParser):
             args = new_args
             len_args = len(args)
 
-        if var.rank>len_args:
-            # add missing dimensions
-
-            args = args + [self._visit(Slice(None, None),**settings)]*(var.rank-len(args))
-
         return self._extract_indexed_from_var(var, args, name)
 
     def _visit_Symbol(self, expr, **settings):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -770,9 +770,12 @@ class SemanticParser(BasicParser):
     def _visit(self, expr, **settings):
         """Annotates the AST.
 
-        # TODO: Why is IndexedVariable mentioned here?
-        IndexedVariable atoms are only used to manipulate expressions, we then,
-        always have a Variable in the namespace."""
+        The annotation is done by finding the appropriate function _visit_X
+        for the object expr. X is the type of the object expr. If this function
+        does not exist then the method resolution order is used to search for
+        other compatible _visit_X functions. If none are found then an error is
+        raised
+        """
 
         # TODO - add settings to Errors
         #      - line and column


### PR DESCRIPTION
An `IndexedElement` has 2 properties, `base` and `indexes`
For `a[i]`, `a`  is the base and `i`  is the index. Previously the base was an `IndexedVariable` (most of the time). An `IndexedVariable` has most of the properties of a `Variable` but none of the newer ones (e.g allow_negative_indexes) as it was not well maintained. This means that the `Variable` has to be accessed via `a.internal_variable`. This leads to the code becoming less readable without providing any benefits. This PR removes the unnecessary `IndexedVariable` type which means that the base of an `IndexedElement` will always be up to date with the `Variable` type.

For the behaviour to remain the same in the rest of the code the magic `__getitem__` method is implemented for `Variable` and updated for `TupleVariable`. Previously the `__getitem__` method of a `TupleVariable` was only used when providing 1 index to a non-homogeneous tuple. It therefore returned the internal `Variable` at that index. It must now handle the indexing for homogeneous tuples (which is the same as for a normal `Variable`) and for inhomogeneous tuples (the first index is treated as before, the additional indices are passed to the `__getitem__` method of the returned `Variable`)

**Commit Summary**
- Remove `IndexedVariable` class
- Make `IndexedElement` base into `Variable`
- Add `__getitem__` method to `Variable`
- Update `__getitem__` method of `TupleVariable`
- Remove references to `IndexedVariable`
- Remove unnecessary code at end of `_extract_indexed_from_var` function
-  Add empty slices in `IndexedElement` constructor instead of `SemanticParser`
- Simplify `IndexedElement` constructor
- Remove obsolete methods `_print_IndexedBase` and `_print_Indexed` from Fortran printer