### PR TITLE
Allow translating from python to python

### DIFF
--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -6,7 +6,8 @@ runs:
     - name: Test with pytest
       run: |
         python -m pytest -rx -m "not parallel and c" --ignore=ast --ignore=printers --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rx -m "not parallel and not c" --ignore=ast --ignore=printers --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rx -m "not parallel and not c and not python" --ignore=ast --ignore=printers --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rx -m "not parallel and python" --ignore=ast --ignore=printers --ignore=symbolic --ignore=ndarrays
         python -m pytest ndarrays/ -rx
         mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rx
         #mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel -v -m parallel -rx

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -211,8 +211,8 @@ def execute_pyccel(fname, *,
             libs.append('iomp5')
 
     # ...
-    # Construct flags for the Fortran compiler
-    if fflags is None:
+    # Construct flags for the compiler (if one is required)
+    if fflags is None and compiler:
         fflags = construct_flags(f90exec,
                                  fflags=None,
                                  debug=debug,
@@ -295,6 +295,14 @@ def execute_pyccel(fname, *,
         if errors.has_errors():
             handle_error('code generation')
             raise PyccelCodegenError('Code generation failed')
+
+        if language == 'python':
+            basename = os.path.basename(fname)
+            new_location = os.path.join(folder, basename)
+            if verbose:
+                print("cp {} {}".format(fname, new_location))
+            shutil.copyfile(fname, new_location)
+            continue
 
         #------------------------------------------------------
         # TODO: collect dependencies and proceed recursively

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -15,8 +15,10 @@ from sympy.printing.pycode import _known_functions
 from sympy.printing.pycode import _known_functions_math
 from sympy.printing.pycode import _known_constants_math
 
+from pyccel.decorators import __all__ as pyccel_decorators
+
 from pyccel.ast.utilities  import build_types_decorator
-from pyccel.ast.core       import CodeBlock
+from pyccel.ast.core       import CodeBlock, Import, DottedName
 
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import *
@@ -42,6 +44,11 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         self.assert_contiguous = settings.pop('assert_contiguous', False)
         self.parser = parser
         SympyPythonCodePrinter.__init__(self, settings=settings)
+        self._additional_imports = set()
+
+    def get_additional_imports(self):
+        """return the additional imports collected in printing stage"""
+        return self._additional_imports
 
     def _print_Variable(self, expr):
         return self._print(expr.name)
@@ -83,6 +90,8 @@ class PythonCodePrinter(SympyPythonCodePrinter):
 
         if decorators:
             for n,f in decorators.items():
+                if n in pyccel_decorators:
+                    self._additional_imports.add(Import(DottedName('pyccel.decorators'), n))
                 # TODO - All decorators must be stored in a list
                 if not isinstance(f, list):
                     f = [f]
@@ -133,11 +142,11 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         return 'len({})'.format(self._print(expr.arg))
 
     def _print_Import(self, expr):
-        target = ', '.join([self._print(i) for i in expr.target])
-        if expr.source is None:
-            return 'import {target}'.format(target=target)
+        source = self._print(expr.source)
+        if expr.target is None:
+            return 'import {source}'.format(source=source)
         else:
-            source = self._print(expr.source)
+            target = ', '.join([self._print(i) for i in expr.target])
             return 'from {source} import {target}'.format(source=source, target=target)
 
     def _print_CodeBlock(self, expr):
@@ -269,7 +278,9 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         return 'print({0})'.format(fs)
 
     def _print_Module(self, expr):
-        return '\n'.join(self._print(e) for e in expr.body)
+        code = '\n'.join(self._print(e) for e in expr.body)
+        imports = '\n'.join(self._print(i) for i in self._additional_imports)
+        return '\n'.join([imports, code])
 
     def _print_PyccelPow(self, expr):
         base = self._print(expr.args[0])

--- a/pyccel/commands/console.py
+++ b/pyccel/commands/console.py
@@ -234,6 +234,10 @@ def pyccel(files=None, openmp=None, openacc=None, output_dir=None, compiler=None
 
     base_dirpath = os.getcwd()
 
+    if args.language == 'python' and args.output == '':
+        print("Cannot output python file to same folder as this would overwrite the original file. Please specify --output")
+        sys.exit(1)
+
     try:
         # TODO: prune options
         execute_pyccel(filename,

--- a/pyccel/epyccel.py
+++ b/pyccel/epyccel.py
@@ -149,10 +149,11 @@ def epyccel_seq(function_or_module, *,
     package = importlib.import_module(module_name)
     sys.path.remove(epyccel_dirpath)
 
-    # Verify that we have imported the shared library, not the Python one
-    loader = getattr(package, '__loader__', None)
-    if not isinstance(loader, ExtensionFileLoader):
-        raise ImportError('Could not load shared library')
+    if language != 'python':
+        # Verify that we have imported the shared library, not the Python one
+        loader = getattr(package, '__loader__', None)
+        if not isinstance(loader, ExtensionFileLoader):
+            raise ImportError('Could not load shared library')
 
     # If Python object was function, extract it from module
     if isinstance(function_or_module, FunctionType):

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -34,6 +34,12 @@ def test_func_no_args_2(language):
     with pytest.raises(TypeError):
         c_lose(unexpected_arg)
 
+@pytest.mark.parametrize( 'language', [
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("python", marks = pytest.mark.python),
+    ]
+)
 def test_func_no_return_1(language):
     '''Test function with args and no return '''
     @types(int)

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -131,7 +131,7 @@ def test_decorator_f4():
         epyccel(f4)
 
 #------------------------------------------------------------------------------
-def test_decorator_f5():
+def test_decorator_f5(language):
     @types('int', 'real [:]')
     def f5(m1, x):
         x[:] = 0.
@@ -178,7 +178,7 @@ def test_decorator_f6():
 #------------------------------------------------------------------------------
 # in order to call the pyccelized function here, we have to create x with
 # Fortran ordering
-def test_decorator_f7():
+def test_decorator_f7(language):
 
     @types('int', 'int', 'real [:,:](order=F)')
     def f7(m1, m2, x):
@@ -215,12 +215,17 @@ def test_decorator_f8(language):
     # ...
 
 
-def test_arguments_f9():
+@pytest.mark.parametrize( 'language', [
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python),
+    ]
+)
+def test_arguments_f9(language):
     @types('int64[:]')
     def f9(x):
         x += 1
 
-    f = epyccel(f9)
+    f = epyccel(f9, language = language)
 
     x = np.zeros(10, dtype='int64')
     x_expected = x.copy()
@@ -229,12 +234,17 @@ def test_arguments_f9():
     f(x_expected)
     assert np.array_equal(x, x_expected)
 
-def test_arguments_f10():
+@pytest.mark.parametrize( 'language', [
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python),
+    ]
+)
+def test_arguments_f10(language):
     @types('int64[:]')
     def f10(x):
         x[:] += 1
 
-    f = epyccel(f10)
+    f = epyccel(f10, language = language)
 
     x = np.zeros(10, dtype='int64')
     x_expected = x.copy()


### PR DESCRIPTION
As explained in issue #643 the python printer is no longer up to date. Even basic things such as `return` do not work. This is because this code is never tested. In order to avoid problems in psydac we should therefore test translation to python too. This PR makes translating from python to python possible and activates some of the few tests which work.

**Commit Summary**
- Update python Import printer
-  When translating to python stop after code generation and copy file to output location
- Stop pyccel command from overwriting original python file
- Only check for shared library when not translating to python
- Activate some tests
- Group python tests in the workflow