### PR TITLE
Document Pyccel container image usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,16 @@ Pyccel comes with a selection of **extensions** allowing you to convert calls to
 - mpi4py
 - h5py (not available yet)
 
+Pyccel Installation Methods
+***************************
+
+Pyccel can be installed / deployed in different ways:
+
+1. using Pypi
+2. using containers
+3. from source
+
+  
 Getting Started
 ===============
 

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,27 @@ Pyccel comes with a selection of **extensions** allowing you to convert calls to
 - mpi4py
 - h5py (not available yet)
 
+Getting Started
+===============
+
+Pyccel container images are available through both Docker Hub (docker.io) and GitHub Container Registry (ghcr.io).
+
+Image tags match pyccel releases.
+
+In order to implement your pyccel accelerated code, you can use a host based volume during the pyccel container creation
+
+For example::
+  docker pull pyccel/pyccel:v1.0.0
+  docker run -it -v $PWD:/data:rwz  pyccel/pyccel:v1.0.0 bash
+
+About Pyccel Container Images
+*****************************
+
+The image is :
+- based on ubuntu:latest
+- uses distro packaged python3, gcc, gfortran, blas and openmpi
+
+
 Requirements
 ============
 
@@ -55,6 +76,8 @@ Finally, Pyccel supports distributed-memory parallel programming through the Mes
 We recommend using GFortran/Gcc and Open-MPI.
 
 Pyccel also depends on several Python3 packages, which are automatically downloaded by pip, the Python Package Installer, during the installation process. In addition to these, unit tests require the *scipy*, *mpi4py*, *pytest* and *coverage* packages, while building the documentation requires Sphinx <http://www.sphinx-doc.org/>.
+
+
 
 Linux Debian/Ubuntu/Mint
 ************************

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ Image tags match pyccel releases.
 In order to implement your pyccel accelerated code, you can use a host based volume during the pyccel container creation
 
 For example::
+
   docker pull pyccel/pyccel:v1.0.0
   docker run -it -v $PWD:/data:rwz  pyccel/pyccel:v1.0.0 bash
 
@@ -41,6 +42,7 @@ About Pyccel Container Images
 *****************************
 
 The image is :
+
 - based on ubuntu:latest
 - uses distro packaged python3, gcc, gfortran, blas and openmpi
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Pyccel container images are available through both Docker Hub (docker.io) and Gi
 
 Image tags match pyccel releases.
 
-In order to implement your pyccel accelerated code, you can use a host based volume during the pyccel container creation
+In order to implement your pyccel accelerated code, you can use a host based volume during the pyccel container creation.
 
 For example::
 
@@ -41,10 +41,10 @@ For example::
 About Pyccel Container Images
 *****************************
 
-The image is :
+The images :
 
-- based on ubuntu:latest
-- uses distro packaged python3, gcc, gfortran, blas and openmpi
+- are based on ubuntu:latest
+- use distro packaged python3, gcc, gfortran, blas and openmpi
 
 
 Requirements

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,12 @@ In order to implement your pyccel accelerated code, you can use a host based vol
 For example::
 
   docker pull pyccel/pyccel:v1.0.0
-  docker run -it -v $PWD:/data:rwz  pyccel/pyccel:v1.0.0 bash
+  docker run -it -v $PWD:/data:rw  pyccel/pyccel:v1.0.0 bash
+
+If you are using SELinux, you will need to set the right context for your host based volume.
+Alternatively you may have docker or podman set the context using -v $PWD:/data:rwz instead of -v $PWD:/data:rw .
+
+
 
 About Pyccel Container Images
 *****************************
@@ -45,7 +50,7 @@ The images :
 
 - are based on ubuntu:latest
 - use distro packaged python3, gcc, gfortran, blas and openmpi
-
+- support all pyccel releases except the legacy "0.1"
 
 Requirements
 ============


### PR DESCRIPTION
This PR documents Pyccel container image usage based on https://github.com/noushi/pyccel-docker generated images.
As of now, images are available on Docker Hub ( https://hub.docker.com/r/pyccel/pyccel/ ) and GitHub Container Registry ( ghcr.io , private at the moment).