### PR TITLE
Remove `sympy.Function` from pyccel

### DIFF
--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -4,7 +4,10 @@
 #------------------------------------------------------------------------------------------#
 
 """
-This module contains two classes. Basic that provides a python AST and PyccelAstNode which describes each PyccelAstNode
+This module contains classes from which all pyccel nodes inherit.
+They are:
+- Basic, which provides a python AST
+--PyccelAstNode which describes each PyccelAstNode
 """
 
 from sympy.core.basic import Basic as sp_Basic

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -17,7 +17,9 @@ class Basic(sp_Basic):
     _fst = None
 
     def __new__(cls, *args, **kwargs):
-        return sp_Basic.__new__(cls, *args, *kwargs.values())
+        hashable_args  = [a if not isinstance(a, list) else tuple(a) for a in args]
+        hashable_args += [a if not isinstance(a, list) else tuple(a) for a in kwargs.values()]
+        return sp_Basic.__new__(cls, *hashable_args)
 
     def set_fst(self, fst):
         """Sets the python.ast fst."""

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -21,7 +21,6 @@ class Basic(sp_Basic):
 
     def __new__(cls, *args, **kwargs):
         hashable_args  = [a if not isinstance(a, list) else tuple(a) for a in args]
-        hashable_args += [a if not isinstance(a, list) else tuple(a) for a in kwargs.values()]
         return sp_Basic.__new__(cls, *hashable_args)
 
     def set_fst(self, fst):

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -7,7 +7,7 @@
 This module contains classes from which all pyccel nodes inherit.
 They are:
 - Basic, which provides a python AST
---PyccelAstNode which describes each PyccelAstNode
+- PyccelAstNode which describes each PyccelAstNode
 """
 
 from sympy.core.basic import Basic as sp_Basic
@@ -33,6 +33,8 @@ class Basic(sp_Basic):
         return self._fst
 
 class PyccelAstNode(Basic):
+    """Class from which all nodes containing objects inherit
+    """
     stage      = None
     _shape     = None
     _rank      = None
@@ -42,22 +44,31 @@ class PyccelAstNode(Basic):
 
     @property
     def shape(self):
+        """ Tuple containing the length of each dimension
+        of the object """
         return self._shape
 
     @property
     def rank(self):
+        """ Number of dimensions of the object
+        """
         return self._rank
 
     @property
     def dtype(self):
+        """ Datatype of the object """
         return self._dtype
 
     @property
     def precision(self):
+        """ Precision of the datatype of the object """
         return self._precision
 
     @property
     def order(self):
+        """ Indicates whether the data is stored in
+        row-major ('C') or column-major ('F') format.
+        This is only relevant if rank > 1 """
         return self._order
 
     def copy_attributes(self, x):

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -16,6 +16,9 @@ class Basic(sp_Basic):
     """Basic class for Pyccel AST."""
     _fst = None
 
+    def __new__(cls, *args, **kwargs):
+        return sp_Basic.__new__(cls, *args, *kwargs.values())
+
     def set_fst(self, fst):
         """Sets the python.ast fst."""
         self._fst = fst
@@ -24,7 +27,7 @@ class Basic(sp_Basic):
     def fst(self):
         return self._fst
 
-class PyccelAstNode:
+class PyccelAstNode(Basic):
     stage      = None
     _shape     = None
     _rank      = None

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -395,7 +395,7 @@ class PythonLen(PyccelInternalFunction):
     _dtype     = NativeInteger()
 
     def __init__(self, arg):
-         PyccelInternalFunction.__init__(self, arg)
+        PyccelInternalFunction.__init__(self, arg)
 
     @property
     def arg(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1859,21 +1859,37 @@ class For(Basic):
 
         return Basic.__new__(cls, target, iter_obj, body, local_vars)
 
+    def __init__(
+        self,
+        target,
+        iter_obj,
+        body,
+        local_vars = [],
+        strict=True,
+        ):
+        self._target = self._args[0]
+        self._iterable = self._args[1]
+        if strict:
+            self._body = self._args[2]
+        else:
+            self._body = body
+        self._local_vars = self._args[3]
+
     @property
     def target(self):
-        return self._args[0]
+        return self._target
 
     @property
     def iterable(self):
-        return self._args[1]
+        return self._iterable
 
     @property
     def body(self):
-        return self._args[2]
+        return self._body
 
     @property
     def local_vars(self):
-        return self._args[3]
+        return self._local_vars
 
     def insert2body(self, stmt):
         self.body.append(stmt)

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -551,9 +551,6 @@ class DottedName(Basic):
     pyccel.stdlib.parallel
     """
 
-    def __new__(cls, *args):
-        return Basic.__new__(cls, *args)
-
     @property
     def name(self):
         return self._args
@@ -816,9 +813,6 @@ class Allocate(Basic):
     mutable Variable object.
 
     """
-    def __new__(cls, *args, **kwargs):
-
-        return Basic.__new__(cls)
 
     # ...
     def __init__(self, variable, *, shape, order, status):
@@ -899,9 +893,6 @@ class Deallocate(Basic):
     mutable Variable object.
 
     """
-    def __new__(cls, *args, **kwargs):
-
-        return Basic.__new__(cls)
 
     # ...
     def __init__(self, variable):
@@ -1419,7 +1410,7 @@ class Tensor(Basic):
 
         args = list(args) + [name]
 
-        return Basic.__new__(cls, *args)
+        return Basic.__new__(cls, *args, **kwargs)
 
     @property
     def name(self):
@@ -1605,9 +1596,6 @@ class Module(Basic):
     >>> Module('my_module', [], [incr, decr], classes = [Point])
     Module(my_module, [], [FunctionDef(), FunctionDef()], [], [ClassDef(Point, (x, y), (FunctionDef(),), [public], (), [], [])], ())
     """
-
-    def __new__(cls, *args, **kwargs):
-        return Basic.__new__(cls)
 
     def __init__(
         self,
@@ -2145,8 +2133,8 @@ class Variable(Symbol, PyccelAstNode):
     matrix.n_rows
     """
 
-    def __new__( cls, *args, **kwargs ):
-        return Basic.__new__(cls)
+    def __new__(cls, *args, **kwargs):
+        return Basic.__new__(cls, *args, **kwargs)
 
     def __init__(
         self,
@@ -2684,8 +2672,6 @@ class ValuedArgument(Basic):
     >>> n
     n=4
     """
-    def __new__(cls, *args, **kwargs):
-        return Basic.__new__(cls)
 
     def __init__(self, expr, value, *, kwonly = False):
         if isinstance(expr, str):
@@ -2750,13 +2736,6 @@ class FunctionCall(PyccelAstNode):
 
     """Represents a function call in the code.
     """
-    def __new__(
-        cls,
-        *args,
-        **kwargs
-        ):
-        return Basic.__new__(cls)
-
 
     def __init__(self, func, args, current_function=None):
 
@@ -2984,17 +2963,6 @@ class FunctionDef(Basic):
     >>> FunctionDef('incr', args, results, body)
     FunctionDef(incr, (x, n=4), (y,), [y := 1 + x], [], [], None, False, function, [])
     """
-
-    def __new__(
-        cls,
-        name,
-        arguments,
-        results,
-        body,
-        *args,
-        **kwargs
-        ):
-        return Basic.__new__(cls)
 
     def __init__(
         self,
@@ -3371,9 +3339,6 @@ class Interface(Basic):
     >>> f = FunctionDef('F', [], [], [])
     >>> Interface('I', [f])
     """
-
-    def __new__( cls, *args, **kwargs ):
-        return Basic.__new__(cls)
 
     def __init__(
         self,
@@ -4188,9 +4153,6 @@ class FuncAddressDeclare(Basic):
     >>> y = Variable('real', 'y')
     >>> FuncAddressDeclare(FunctionAddress('f', [x], [y], []))
     """
-
-    def __new__( cls, *args, **kwargs ):
-        return Basic.__new__(cls)
 
     def __init__(
         self,
@@ -5586,14 +5548,6 @@ def get_iterable_ranges(it, var_name=None):
     return [PythonRange(s, e, 1) for (s, e) in zip(starts, ends)]
 
 class ParserResult(Basic):
-    def __new__(
-        cls,
-        program   = None,
-        module    = None,
-        mod_name  = None,
-        prog_name = None,
-        ):
-        return Basic.__new__(cls)
 
     def __init__(
         self,

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3564,7 +3564,6 @@ class SympyFunction(FunctionDef):
                              self.body, cls_name=self.cls_name)
 
 
-# TODO: [EB 06.01.2021] Is this class used? What for?
 class PythonFunction(FunctionDef):
 
     """Represents a Python-Function definition."""

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3318,9 +3318,10 @@ class FunctionDef(Basic):
     def __str__(self):
         result = 'None' if len(self.results) == 0 else \
                     ', '.join(str(r) for r in self.results)
+        args = ', '.join(str(a) for a in self.arguments)
         return '{name}({args}) -> {result}'.format(
                 name   = self.name,
-                args   = ', '.join(self.args),
+                args   = args,
                 result = result)
 
 class Interface(Basic):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -46,6 +46,7 @@ from .datatypes import (datatype, DataType, CustomDataType, NativeSymbol,
                         NativeInteger, NativeBool, NativeReal,
                         NativeComplex, NativeRange, NativeTensor, NativeString,
                         NativeGeneric, NativeTuple, default_precision, is_iterable_datatype)
+from .internals      import PyccelInternalFunction, PyccelArraySize
 
 from .literals       import LiteralTrue, LiteralFalse, LiteralInteger
 from .literals       import LiteralImaginaryUnit, LiteralString, Literal
@@ -4349,18 +4350,7 @@ class Raise(Basic):
     pass
 
 
-class PyccelInternalFunction(PyccelAstNode):
-    """ Abstract class used by function calls
-    which are translated to Pyccel objects
-    """
-    def __init__(self, *args):
-        self._args   = tuple(args)
-
-    @property
-    def args(self):
-        return self._args
-
-# TODO: improve with __new__ from Function and add example
+# TODO: add example
 
 class Random(PyccelInternalFunction):
 
@@ -5705,34 +5695,3 @@ def process_shape(shape):
             raise TypeError('shape elements cannot be '+str(type(s))+'. They must be one of the following types: Integer(pyccel), Variable, Slice, PyccelAstNode, Integer(sympy), int, FunctionCall')
     return tuple(new_shape)
 
-
-class PyccelArraySize(PyccelInternalFunction):
-    def __new__(cls, arg, index):
-        if not isinstance(arg, (list,
-                                tuple,
-                                Tuple,
-                                PythonTuple,
-                                PythonList,
-                                Variable,
-                                IndexedElement,
-                                IndexedBase)):
-            raise TypeError('Uknown type of  %s.' % type(arg))
-
-        return Basic.__new__(cls, arg, index)
-
-    def __init__(self, arg, index):
-        self._dtype = NativeInteger()
-        self._rank  = 0
-        self._shape = ()
-        self._precision = default_precision['integer']
-
-    @property
-    def arg(self):
-        return self._args[0]
-
-    @property
-    def index(self):
-        return self._args[1]
-
-    def _sympystr(self, printer):
-        return 'Shape({},{})'.format(str(self.arg), str(self.index))

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -606,7 +606,7 @@ class AsName(Basic):
         return hash(self.target)
 
 
-class Dlist(Basic, PyccelAstNode):
+class Dlist(PyccelAstNode):
 
     """ this is equivalent to the zeros function of numpy arrays for the python list.
 
@@ -2723,7 +2723,7 @@ class ValuedArgument(Basic):
         value = sstr(self.value)
         return '{0}={1}'.format(argument, value)
 
-class VariableAddress(Basic, PyccelAstNode):
+class VariableAddress(PyccelAstNode):
 
     """Represents the address of a variable.
     E.g. In C
@@ -2746,7 +2746,7 @@ class VariableAddress(Basic, PyccelAstNode):
     def variable(self):
         return self._variable
 
-class FunctionCall(Basic, PyccelAstNode):
+class FunctionCall(PyccelAstNode):
 
     """Represents a function call in the code.
     """
@@ -4373,7 +4373,7 @@ class Random(PyccelInternalFunction):
 
 # TODO: improve with __new__ from Function and add example
 
-class SumFunction(Basic, PyccelAstNode):
+class SumFunction(PyccelAstNode):
 
     """Represents a Sympy Sum Function.
 
@@ -4887,7 +4887,7 @@ class IndexedElement(Expr, PyccelAstNode):
         return self._indices
 
 
-class Concatenate(Basic, PyccelAstNode):
+class Concatenate(PyccelAstNode):
 
     """Represents the String concatination operation.
 
@@ -4936,7 +4936,7 @@ class Concatenate(Basic, PyccelAstNode):
 
 
 
-class Slice(Basic, PyccelOperator):
+class Slice(PyccelOperator):
 
     """Represents a slice in the code.
 
@@ -5116,7 +5116,7 @@ class If(Basic):
         return b
 
 
-class IfTernaryOperator(Basic, PyccelAstNode):
+class IfTernaryOperator(PyccelAstNode):
     """Represent a ternary conditional operator in the code, of the form (a if cond else b)
 
     Parameters

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2802,7 +2802,7 @@ class FunctionCall(PyccelAstNode):
         self._func_name     = func.name
 
     @property
-    def arguments(self):
+    def args(self):
         return self._arguments
 
     @property

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5767,3 +5767,14 @@ class PyccelArraySize(Function, PyccelAstNode):
 
     def _sympystr(self, printer):
         return 'Shape({},{})'.format(str(self.arg), str(self.index))
+
+class PyccelInternalFunction(PyccelAstNode):
+    """ Abstract class used by function calls
+    which are translated to Pyccel objects
+    """
+    def __init__(self, *args):
+        self._args   = tuple(args)
+
+    @property
+    def args(self):
+        return self._args

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2964,6 +2964,11 @@ class FunctionDef(Basic):
     FunctionDef(incr, (x, n=4), (y,), [y := 1 + x], [], [], None, False, function, [])
     """
 
+    def __new__(cls, *args, **kwargs):
+        kwargs.pop('decorators', None)
+        kwargs.pop('templates', None)
+        return super().__new__(cls, *args, **kwargs)
+
     def __init__(
         self,
         name,
@@ -5304,7 +5309,7 @@ def get_assigned_symbols(expr):
     elif isinstance(expr, FunctionCall):
         f = expr.funcdef
         symbols = []
-        for func_arg, inout in zip(expr.arguments,f.arguments_inout):
+        for func_arg, inout in zip(expr.args,f.arguments_inout):
             if inout:
                 symbols.append(func_arg)
         return symbols

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2851,6 +2851,12 @@ class FunctionCall(Basic, PyccelAstNode):
 
     def __init__(self, func, args, current_function=None):
 
+        if self.stage == "syntactic":
+            self._interface = None
+            self._funcdef   = func
+            self._arguments = args
+            return
+
         # ...
         if not isinstance(func, (FunctionDef, Interface)):
             raise TypeError('> expecting a FunctionDef or an Interface')

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -30,6 +30,18 @@ class PyccelInternalFunction(PyccelAstNode):
 
 
 class PyccelArraySize(PyccelInternalFunction):
+    """
+    Class representing a call to a function which would
+    return the shape of an object in a given dimension
+
+    Parameters
+    ==========
+    arg   : PyccelAstNode
+            A PyccelAstNode of unknown shape
+    index : int
+            The dimension along which the shape is
+            provided
+    """
 
     def __init__(self, arg, index):
         if not isinstance(arg, (list,
@@ -47,11 +59,15 @@ class PyccelArraySize(PyccelInternalFunction):
 
     @property
     def arg(self):
+        """ Object whose size is investigated
+        """
         return self._arg
 
     @property
     def index(self):
+        """ Dimension along which the size is calculated
+        """
         return self._index
 
-    def _sympystr(self, printer):
+    def __str__(self):
         return 'Shape({},{})'.format(str(self.arg), str(self.index))

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -18,6 +18,7 @@ class PyccelInternalFunction(PyccelAstNode):
     """
     def __init__(self, *args):
         self._args   = tuple(args)
+        PyccelAstNode.__init__(self, *args)
 
     @property
     def args(self):

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
+#------------------------------------------------------------------------------------------#
+from .basic import PyccelAstNode
+
+__all__ = (
+    'PyccelInternalFunction',
+    'PyccelArraySize'
+)
+
+
+class PyccelInternalFunction(PyccelAstNode):
+    """ Abstract class used by function calls
+    which are translated to Pyccel objects
+    """
+    def __init__(self, *args):
+        self._args   = tuple(args)
+
+    @property
+    def args(self):
+        return self._args
+
+
+class PyccelArraySize(PyccelInternalFunction):
+
+    def __init__(self, arg, index):
+        if not isinstance(arg, (list,
+                                tuple,
+                                PyccelAstNode)):
+            raise TypeError('Unknown type of  %s.' % type(arg))
+
+        PyccelInternalFunction.__init__(self, arg, index)
+        self._arg   = arg
+        self._index = index
+        self._dtype = NativeInteger()
+        self._rank  = 0
+        self._shape = ()
+        self._precision = default_precision['integer']
+
+    @property
+    def arg(self):
+        return self._arg
+
+    @property
+    def index(self):
+        return self._index
+
+    def _sympystr(self, printer):
+        return 'Shape({},{})'.format(str(self.arg), str(self.index))

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -3,6 +3,10 @@
 # This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
 # go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
 #------------------------------------------------------------------------------------------#
+"""
+File containing basic classes which are used throughout pyccel.
+To avoid circular imports this file should only import from basic and datatypes
+"""
 from .basic import PyccelAstNode
 from .datatypes import NativeInteger, default_precision
 
@@ -17,6 +21,7 @@ class PyccelInternalFunction(PyccelAstNode):
     which are translated to Pyccel objects
     """
     def __init__(self, *args):
+        PyccelAstNode.__init__(self)
         self._args   = tuple(args)
 
     @property

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -26,6 +26,8 @@ class PyccelInternalFunction(PyccelAstNode):
 
     @property
     def args(self):
+        """ The arguments passed to the function
+        """
         return self._args
 
 

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -18,7 +18,6 @@ class PyccelInternalFunction(PyccelAstNode):
     """
     def __init__(self, *args):
         self._args   = tuple(args)
-        PyccelAstNode.__init__(self, *args)
 
     @property
     def args(self):

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -4,6 +4,7 @@
 # go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
 #------------------------------------------------------------------------------------------#
 from .basic import PyccelAstNode
+from .datatypes import NativeInteger, default_precision
 
 __all__ = (
     'PyccelInternalFunction',

--- a/pyccel/ast/mathext.py
+++ b/pyccel/ast/mathext.py
@@ -4,9 +4,8 @@
 #------------------------------------------------------------------------------------------#
 
 import math
-from sympy import Function
 
-from pyccel.ast.basic     import PyccelAstNode
+from pyccel.ast.core      import PyccelInternalFunction
 from pyccel.ast.core      import Constant
 from pyccel.ast.datatypes import (NativeInteger, NativeBool, NativeReal,
                                   default_precision)
@@ -85,7 +84,7 @@ math_constants = {
 #==============================================================================
 # Base classes
 #==============================================================================
-class MathFunctionBase(Function, PyccelAstNode):
+class MathFunctionBase(PyccelInternalFunction):
     """Abstract base class for the Math Functions"""
     _shape = ()
     _rank  = 0

--- a/pyccel/ast/mathext.py
+++ b/pyccel/ast/mathext.py
@@ -5,7 +5,7 @@
 
 import math
 
-from pyccel.ast.core      import PyccelInternalFunction
+from pyccel.ast.internals import PyccelInternalFunction
 from pyccel.ast.core      import Constant
 from pyccel.ast.datatypes import (NativeInteger, NativeBool, NativeReal,
                                   default_precision)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -618,11 +618,6 @@ class NumpyNorm(PyccelInternalFunction):
     def dim(self):
         return self._args[1]
 
-#=====================================================
-class Sqrt:
-    def __new__(cls, base):
-        return PyccelPow(PyccelAssociativeParenthesis(base), LiteralFloat(0.5))
-
 #====================================================
 
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -321,7 +321,7 @@ class NumpyLinspace(NumpyNewArray):
         self._stop  = stop
         self._size  = size
         self._shape = (self.size,)
-        NumpyNewArray.__init__(self, start, stop, size)
+        NumpyNewArray.__init__(self)
 
     @property
     def start(self):
@@ -479,7 +479,7 @@ class NumpyFull(PyccelInternalFunction, NumpyNewArray):
         self._precision = precision
 
         PyccelInternalFunction.__init__(self, fill_value)
-        NumpyNewArray.__init__(self, shape, fill_value, dtype, order)
+        NumpyNewArray.__init__(self)
 
     #--------------------------------------------------------------------------
     @property

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -14,7 +14,7 @@ from .core           import (ClassDef, FunctionDef, PyccelInternalFunction,
                              PythonList, Variable, IndexedElement,
                              process_shape, ValuedArgument, Constant)
 
-from .operators      import (PyccelPow, PyccelAssociativeParenthesis, broadcast)
+from .operators      import (PyccelAssociativeParenthesis, broadcast)
 
 from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
                              PythonComplex, PythonReal, PythonImag)
@@ -717,6 +717,7 @@ class NumpyFloor(NumpyUfuncUnary):
 class NumpyMod(NumpyUfuncBinary):
 
     def _set_shape_rank(self, x1, x2):
+        args   = (x1, x2)
         shapes = [a.shape for a in args]
 
         if all(sh is not None for sh in shapes):

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -321,6 +321,7 @@ class NumpyLinspace(NumpyNewArray):
         self._stop  = stop
         self._size  = size
         self._shape = (self.size,)
+        NumpyNewArray.__init__(self, start, stop, size)
 
     @property
     def start(self):
@@ -354,7 +355,7 @@ class NumpyWhere(PyccelInternalFunction):
     """ Represents a call to  numpy.where """
 
     def __init__(self, mask):
-        return PyccelInternalFunction.__init__(self, mask)
+        PyccelInternalFunction.__init__(self, mask)
 
 
     @property
@@ -478,6 +479,7 @@ class NumpyFull(PyccelInternalFunction, NumpyNewArray):
         self._precision = precision
 
         PyccelInternalFunction.__init__(self, fill_value)
+        NumpyNewArray.__init__(self, shape, fill_value, dtype, order)
 
     #--------------------------------------------------------------------------
     @property

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -14,7 +14,7 @@ from .core           import (ClassDef, FunctionDef, PyccelInternalFunction,
                              PythonList, Variable, IndexedElement,
                              process_shape, ValuedArgument, Constant)
 
-from .operators      import (PyccelAssociativeParenthesis, broadcast)
+from .operators      import broadcast
 
 from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
                              PythonComplex, PythonReal, PythonImag)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -633,12 +633,18 @@ class NumpyUfuncUnary(NumpyUfuncBase):
     """Numpy's universal function with one argument.
     """
     def __init__(self, x):
-        self._shape      = x.shape
-        self._rank       = x.rank
-        self._dtype      = x.dtype if x.dtype is NativeComplex() else NativeReal()
-        self._precision  = default_precision[str_dtype(self._dtype)]
+        self._set_dtype_precision(x)
+        self._set_shape_rank(x)
         self._order      = x.order
         super().__init__(x)
+
+    def _set_shape_rank(self, x):
+        self._shape      = x.shape
+        self._rank       = x.rank
+
+    def _set_dtype_precision(self, x):
+        self._dtype      = x.dtype if x.dtype is NativeComplex() else NativeReal()
+        self._precision  = default_precision[str_dtype(self._dtype)]
 
 #------------------------------------------------------------------------------
 class NumpyUfuncBinary(NumpyUfuncBase):
@@ -688,22 +694,14 @@ class NumpyArctanh(NumpyUfuncUnary) : pass
 #=======================================================================================
 
 class NumpyAbs(NumpyUfuncUnary):
-    def __init__(self, x):
-        self._shape     = x.shape
-        self._rank      = x.rank
+    def _set_dtype_precision(self, x):
         self._dtype     = NativeInteger() if x.dtype is NativeInteger() else NativeReal()
         self._precision = default_precision[str_dtype(self._dtype)]
-        self._order     = x.order
-        PyccelInternalFunction.__init__(self, x)
-
 
 class NumpyFloor(NumpyUfuncUnary):
-    def __init__(self, x):
-        self._shape     = x.shape
-        self._rank      = x.rank
+    def _set_dtype_precision(self, x):
         self._dtype     = NativeReal()
         self._precision = default_precision[str_dtype(self._dtype)]
-        PyccelInternalFunction.__init__(self, x)
 
 class NumpyMod(NumpyUfuncBinary):
     def __init__(self, x1, x2):
@@ -742,20 +740,22 @@ class NumpyMod(NumpyUfuncBinary):
         PyccelInternalFunction.__init__(self, x1, x2)
 
 class NumpyMin(NumpyUfuncUnary):
-    def __init__(self, x):
+    def _set_shape_rank(self, x):
         self._shape     = ()
         self._rank      = 0
+
+    def _set_dtype_precision(self, x):
         self._dtype     = x.dtype
         self._precision = x.precision
-        PyccelInternalFunction.__init__(self, x)
 
 class NumpyMax(NumpyUfuncUnary):
-    def __init__(self, x):
+    def _set_shape_rank(self, x):
         self._shape     = ()
         self._rank      = 0
+
+    def _set_dtype_precision(self, x):
         self._dtype     = x.dtype
         self._precision = x.precision
-        PyccelInternalFunction.__init__(self, x)
 
 
 #=======================================================================================

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -7,8 +7,7 @@
 
 import inspect
 
-from sympy.core.function import Application
-from sympy import Not, Function
+from sympy import Not
 from numpy import pi
 
 import pyccel.decorators as pyccel_decorators
@@ -59,7 +58,7 @@ def builtin_function(expr, args=None):
         return Not(*args)
 
     if name == 'map':
-        func = Function(str(expr.args[0].name))
+        func = str(expr.args[0].name)
         args = [func]+list(args[1:])
         return PythonMap(*args)
 

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -16,7 +16,8 @@ from pyccel.symbolic import lambdify
 from pyccel.errors.errors import Errors
 
 from .core     import (AsName, Import, FunctionDef, Constant,
-                       Variable, IndexedVariable, ValuedVariable)
+                       Variable, IndexedVariable, ValuedVariable,
+                       FunctionCall)
 
 from .builtins      import builtin_functions_dict, PythonMap
 from .itertoolsext  import Product
@@ -42,12 +43,12 @@ scipy_constants = {
 def builtin_function(expr, args=None):
     """Returns a builtin-function call applied to given arguments."""
 
-    if isinstance(expr, Application):
-        name = str(type(expr).__name__)
+    if isinstance(expr, FunctionCall):
+        name = str(expr.funcdef)
     elif isinstance(expr, str):
         name = expr
     else:
-        raise TypeError('expr must be of type str or Function')
+        raise TypeError('expr must be of type str or FunctionCall')
 
     dic = builtin_functions_dict
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -289,6 +289,9 @@ class CCodePrinter(CodePrinter):
     def _print_LiteralInteger(self, expr):
         return str(expr.p)
 
+    def _print_LiteralFloat(self, expr):
+        return CodePrinter._print_Float(self, expr)
+
     def _print_LiteralComplex(self, expr):
         if expr.real == LiteralFloat(0):
             return self._print(PyccelAssociativeParenthesis(PyccelMul(expr.imag, LiteralImaginaryUnit())))

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -965,7 +965,7 @@ class CCodePrinter(CodePrinter):
         func = expr.funcdef
          # Ensure the correct syntax is used for pointers
         args = []
-        for a, f in zip(expr.arguments, func.arguments):
+        for a, f in zip(expr.args, func.arguments):
             if isinstance(a, Variable) and self.stored_in_c_pointer(f):
                 args.append(VariableAddress(a))
             elif f.is_optional and not isinstance(a, Nil):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1270,7 +1270,7 @@ class FCodePrinter(CodePrinter):
             if isinstance(expr.lhs, (tuple, list, Tuple, PythonTuple)):
 
                 rhs_code = rhs.funcdef.name
-                args = rhs.arguments
+                args = rhs.args
                 code_args = [self._print(i) for i in args]
                 func = rhs.funcdef
                 output_names = func.results
@@ -2756,7 +2756,7 @@ class FCodePrinter(CodePrinter):
     def _print_FunctionCall(self, expr):
         func = expr.funcdef
         f_name = self._print(expr.func_name if not expr.interface else expr.interface_name)
-        args = [a for a in expr.arguments if not isinstance(a, Nil)]
+        args = [a for a in expr.args if not isinstance(a, Nil)]
         results = func.results
 
         if len(results) == 1:
@@ -2816,7 +2816,7 @@ class FCodePrinter(CodePrinter):
                 self._namespace.variables[var.name] = var
 
             self._additional_code = self._additional_code + self._print(Assign(var,expr.prefix)) + '\n'
-            expr = DottedFunctionCall(expr.funcdef, expr.arguments, var)
+            expr = DottedFunctionCall(expr.funcdef, expr.args, var)
         return self._print_FunctionCall(expr)
 
 #=======================================================================================

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -19,7 +19,6 @@ import operator
 
 from sympy.core import Symbol
 from sympy.core import Tuple
-from sympy.core.function import Application
 from sympy.core.numbers import NegativeInfinity as NINF
 from sympy.core.numbers import Infinity as INF
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2823,7 +2823,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_PyccelInternalFunction(self, expr):
         if isinstance(expr, NumpyNewArray):
-            errors.report(FORTRAN_ALLOCATABLE_IN_EXPRESSION,
+            return errors.report(FORTRAN_ALLOCATABLE_IN_EXPRESSION,
                           symbol=expr, severity='fatal')
         else:
             return self._print_not_supported(expr)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -31,6 +31,7 @@ from pyccel.ast.core import Nil
 from pyccel.ast.core import SeparatorComment, Comment
 from pyccel.ast.core import ConstructorCall
 from pyccel.ast.core import ErrorExit, FunctionAddress
+from pyccel.ast.internals    import PyccelInternalFunction
 from pyccel.ast.itertoolsext import Product
 from pyccel.ast.core import (Assign, AliasAssign, Variable,
                              VariableAddress,
@@ -2618,10 +2619,10 @@ class FCodePrinter(CodePrinter):
             base = expr.base.internal_variable
         else:
             base = expr.base
-        if isinstance(base, Application) and not isinstance(base, PythonTuple):
+        if isinstance(base, PyccelInternalFunction) and not isinstance(base, PythonTuple):
             indexed_type = base.dtype
             if isinstance(indexed_type, PythonTuple):
-                base = self._print_Function(expr.base.base)
+                base = self._print_PyccelInternalFunction(expr.base.base)
             else:
                 if (not self._additional_code):
                     self._additional_code = ''
@@ -2820,7 +2821,7 @@ class FCodePrinter(CodePrinter):
 
 #=======================================================================================
 
-    def _print_Application(self, expr):
+    def _print_PyccelInternalFunction(self, expr):
         if isinstance(expr, NumpyNewArray):
             errors.report(FORTRAN_ALLOCATABLE_IN_EXPRESSION,
                           symbol=expr, severity='fatal')

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1626,7 +1626,7 @@ class SemanticParser(BasicParser):
         lhs = expr.lhs
 
         if isinstance(rhs, FunctionCall):
-            name = type(rhs).__name__
+            name = rhs.funcdef
             macro = self.get_macro(name)
             if macro is None:
                 rhs = self._visit(rhs, **settings)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1064,7 +1064,7 @@ class SemanticParser(BasicParser):
 
                 if isinstance(rhs, FunctionCall):
                     # If object is a function
-                    args  = self._handle_function_args(rhs.args, **settings)
+                    args  = self._handle_function_args(rhs.arguments, **settings)
                     func  = first[rhs_name]
                     if new_name != rhs_name:
                         func  = func.clone(new_name)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1919,7 +1919,7 @@ class SemanticParser(BasicParser):
             alloc.set_fst(fst)
             index_name = self.get_new_name(expr)
             index = Variable('int',index_name)
-            range_ = FunctionCall('range', (FunctionCall('len', lhs,)),))
+            range_ = FunctionCall('range', (FunctionCall('len', lhs,),))
             name  = _get_name(lhs)
             var   = IndexedBase(name)[index]
             args  = rhs.args[1:]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -257,7 +257,7 @@ class SemanticParser(BasicParser):
         """
         code = expr
         if not isinstance(expr.body[-1], Return):
-            code = expr.body + [Deallocate(i) for i in self._allocs[-1]]
+            code = expr.body + tuple(Deallocate(i) for i in self._allocs[-1])
             code = CodeBlock(code)
         self._allocs.pop()
         return code

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1064,7 +1064,7 @@ class SemanticParser(BasicParser):
 
                 if isinstance(rhs, FunctionCall):
                     # If object is a function
-                    args  = self._handle_function_args(rhs.arguments, **settings)
+                    args  = self._handle_function_args(rhs.args, **settings)
                     func  = first[rhs_name]
                     if new_name != rhs_name:
                         func  = func.clone(new_name)
@@ -1266,10 +1266,10 @@ class SemanticParser(BasicParser):
 
         func     = self.get_function(name)
 
-        args = self._handle_function_args(expr.arguments, **settings)
+        args = self._handle_function_args(expr.args, **settings)
 
         if name == 'lambdify':
-            args = self.get_symbolic_function(str(expr.arguments[0]))
+            args = self.get_symbolic_function(str(expr.args[0]))
         F = pyccel_builtin_function(expr, args)
 
         if F is not None:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1314,10 +1314,9 @@ class SemanticParser(BasicParser):
             else:
                 func = self.get_function(name)
             if func is None:
-                # TODO [SH, 25.02.2020] Report error
-                errors.report(UNDEFINED_FUNCTION, symbol=name,
-                bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
-                severity='fatal', blocker=self.blocking)
+                return errors.report(UNDEFINED_FUNCTION, symbol=name,
+                        bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
+                        severity='fatal', blocker=self.blocking)
             else:
                 return self._handle_function(func, args, **settings)
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -921,10 +921,10 @@ class SyntaxParser(BasicParser):
             if str(f_name) == "print":
                 func = PythonPrint(PythonTuple(*args))
             else:
-                func = FunctionCall(f_name)(*args)
+                func = FunctionCall(f_name, args)
         elif isinstance(func, DottedName):
             f_name = func.name[-1]
-            func_attr = FunctionCall(f_name)(*args)
+            func_attr = FunctionCall(f_name, args)
             func = DottedName(*func.name[:-1], func_attr)
         else:
             raise NotImplementedError(' Unknown function type {}'.format(str(type(func))))

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -667,7 +667,7 @@ class SyntaxParser(BasicParser):
             if stmt.returns:
                 returns = ValuedArgument(Symbol('results'),self._visit(stmt.returns))
                 annotated_args.append(returns)
-            decorators['types'] = [Function('types')(*annotated_args)]
+            decorators['types'] = [FunctionCall('types', annotated_args)]
 
         for d in self._visit(stmt.decorator_list):
             tmp_var = str(d) if isinstance(d, Symbol) else str(d.funcdef)
@@ -917,13 +917,13 @@ class SyntaxParser(BasicParser):
         func = self._visit(stmt.func)
 
         if isinstance(func, Symbol):
-            f_name = func.name
-            if str(f_name) == "print":
+            f_name = str(func.name)
+            if f_name == "print":
                 func = PythonPrint(PythonTuple(*args))
             else:
                 func = FunctionCall(f_name, args)
         elif isinstance(func, DottedName):
-            f_name = func.name[-1]
+            f_name = str(func.name[-1])
             func_attr = FunctionCall(f_name, args)
             func = DottedName(*func.name[:-1], func_attr)
         else:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -742,7 +742,7 @@ class SyntaxParser(BasicParser):
 
                 cache.clear_cache()
                 results = []
-                ls = comb_types.arguments
+                ls = comb_types.args
 
                 if len(ls) > 0 and isinstance(ls[-1], ValuedArgument):
                     arg_name = ls[-1].name


### PR DESCRIPTION
Replace `sympy.Function` with FunctionCall and a new class `PyccelInternalFunction`. This is the first step in the epic #665, as such it closes #655 

**Commit Summary**
- Add different handling to allow the use of FunctionCall in syntactic stage
- Use FunctionCall instead of sympy's Function
    - `_visit_Application`->`_visit_FunctionCall`
    - Ensure that `funcdef` property is a string at syntactic stage
    - Remove references to `sympy.Application` and `sympy.UndefinedFunction`
    - Remove references to `sympy.Function`
- Create `PyccelInternalFunction` class to replace Sympy's Function for numpy/math inheritance
- Move PyccelInternalFunction and PyccelArraySize to new file ast.internals to avoid circular imports (these are needed in lots of places)
- Add `__new__` to Basic to ensure all args and kwargs are stored to avoid sympy singleton bugs. Make `PyccelAstNode` inherit from `Basic`
    - Remove useless `__new__` calls
    - Ensure only hashable types are passed to sympy
    - Use mutable objects in addition to sympy storage where necessary
- Add `_print_LiteralFloat` to `CCodePrinter`

**Codacy Commits**
- Remove duplicate class (`NumpySqrt` and `Sqrt` exist)
- Ensure that new `__init__` methods call parent `__init__`
     - Use overridable functions instead of separate `__init__` to avoid codacy non-parent-init-called in ast.numpyext
- Return fatal `errors.report` to avoid "inconsistent-return-statements"