### PR TITLE
Move Nil class from ast.core to ast.literals

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -49,6 +49,7 @@ from .datatypes import (datatype, DataType, CustomDataType, NativeSymbol,
 
 from .literals       import LiteralTrue, LiteralFalse, LiteralInteger
 from .literals       import LiteralImaginaryUnit, LiteralString, Literal
+from .literals       import Nil
 from .itertoolsext   import Product
 from .functionalexpr import GeneratorComprehension as GC
 from .functionalexpr import FunctionalFor
@@ -113,7 +114,6 @@ __all__ = (
     'MulOp',
     'NativeOp',
     'NewLine',
-    'Nil',
     'ParallelBlock',
     'ParallelRange',
     'ParserResult',
@@ -2054,19 +2054,6 @@ class ConstructorCall(AtomicExpr):
             return self.func.name
         else:
             return self.func
-
-
-
-class Nil(Basic):
-
-    """
-    class for None object in the code.
-    """
-
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return sstr('None')
-
 
 class Void(Basic):
 

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -223,6 +223,8 @@ class Nil(Basic):
     class for None object in the code.
     """
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return sstr('None')
+    def __str__(self):
+        """
+        return str ob and 'None' as value
+        """
+        return 'None'

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -224,7 +224,4 @@ class Nil(Basic):
     """
 
     def __str__(self):
-        """
-        return str ob and 'None' as value
-        """
         return 'None'

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -217,3 +217,12 @@ def get_default_literal_value(dtype):
         raise TypeError('Unknown type')
     return value
 
+class Nil(Basic):
+
+    """
+    class for None object in the code.
+    """
+
+    def _sympystr(self, printer):
+        sstr = printer.doprint
+        return sstr('None')

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -14,7 +14,7 @@ from sympy           import (Basic, Function, Tuple, Integer as sp_Integer,
 
 from .core           import (ClassDef, FunctionDef,
                              PythonList, Variable, IndexedElement,
-                             Nil, process_shape, ValuedArgument, Constant)
+                             process_shape, ValuedArgument, Constant)
 
 from .operators      import (PyccelPow, PyccelAssociativeParenthesis, broadcast)
 
@@ -27,6 +27,7 @@ from .datatypes      import (dtype_and_precision_registry as dtype_registry,
 
 from .literals       import LiteralInteger, LiteralFloat, LiteralComplex
 from .literals       import LiteralTrue, LiteralFalse
+from .literals       import Nil
 from .basic          import PyccelAstNode
 
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -1029,7 +1029,7 @@ class PyccelIs(PyccelBooleanOperator):
     Examples
     --------
     >>> from pyccel.ast import PyccelIs
-    >>> from pyccel.ast import Nil
+    >>> from pyccel.literals import Nil
     >>> from sympy.abc import x
     >>> PyccelIs(x, Nil())
     PyccelIs(x, None)
@@ -1061,7 +1061,7 @@ class PyccelIsNot(PyccelIs):
     Examples
     --------
     >>> from pyccel.ast import PyccelIsNot
-    >>> from pyccel.ast import Nil
+    >>> from pyccel.ast.literals import Nil
     >>> from sympy.abc import x
     >>> PyccelIsNot(x, Nil())
     PyccelIsNot(x, None)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -15,7 +15,7 @@ from pyccel.ast.core      import Declare, IndexedVariable, Slice, ValuedVariable
 from pyccel.ast.core      import FuncAddressDeclare, FunctionCall
 from pyccel.ast.core      import Deallocate
 from pyccel.ast.core      import FunctionAddress, PyccelArraySize
-from pyccel.ast.core      import Nil, IfTernaryOperator
+from pyccel.ast.core      import IfTernaryOperator
 from pyccel.ast.core      import Assign, datatype, Variable, Import
 from pyccel.ast.core      import SeparatorComment, VariableAddress
 from pyccel.ast.core      import DottedName
@@ -30,6 +30,7 @@ from pyccel.ast.datatypes import NativeInteger, NativeBool, NativeComplex, Nativ
 
 from pyccel.ast.literals  import LiteralTrue, LiteralImaginaryUnit, LiteralFloat
 from pyccel.ast.literals  import LiteralString, LiteralInteger, Literal
+from pyccel.ast.literals  import Nil
 
 from pyccel.ast.numpyext import NumpyFull, NumpyArray
 from pyccel.ast.numpyext import NumpyReal, NumpyImag, NumpyFloat

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -12,11 +12,12 @@ import numpy as np
 from pyccel.codegen.printing.ccode import CCodePrinter
 
 from pyccel.ast.literals  import LiteralTrue, LiteralInteger, LiteralString
+from pyccel.ast.literals  import Nil
 
 from pyccel.ast.builtins import PythonPrint
 
 from pyccel.ast.core import Variable, ValuedVariable, Assign, AliasAssign, FunctionDef, FunctionAddress
-from pyccel.ast.core import If, Nil, Return, FunctionCall
+from pyccel.ast.core import If, Return, FunctionCall
 from pyccel.ast.core import create_incremented_string, SeparatorComment
 from pyccel.ast.core import VariableAddress, Import, IfTernaryOperator
 from pyccel.ast.core import AugAssign

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -27,7 +27,6 @@ from sympy.logic.boolalg import Not
 
 from pyccel.ast.core import get_iterable_ranges
 from pyccel.ast.core import AddOp, MulOp, SubOp, DivOp
-from pyccel.ast.core import Nil
 from pyccel.ast.core import SeparatorComment, Comment
 from pyccel.ast.core import ConstructorCall
 from pyccel.ast.core import ErrorExit, FunctionAddress
@@ -58,6 +57,7 @@ from pyccel.ast.datatypes import NativeRange, NativeTensor, NativeTuple
 from pyccel.ast.datatypes import CustomDataType
 from pyccel.ast.literals  import LiteralInteger, LiteralFloat
 from pyccel.ast.literals  import LiteralTrue
+from pyccel.ast.literals import Nil
 
 from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -28,7 +28,6 @@ from pyccel.ast.basic import PyccelAstNode
 
 from pyccel.ast.core import Allocate, Deallocate
 from pyccel.ast.core import Constant
-from pyccel.ast.core import Nil
 from pyccel.ast.core import Variable
 from pyccel.ast.core import TupleVariable
 from pyccel.ast.core import DottedName, DottedVariable
@@ -69,6 +68,7 @@ from pyccel.ast.datatypes import NativeInteger, NativeBool, NativeReal, NativeSt
 
 from pyccel.ast.literals import LiteralTrue, LiteralFalse
 from pyccel.ast.literals import LiteralInteger, LiteralFloat
+from pyccel.ast.literals import Nil
 
 from pyccel.ast.headers import FunctionHeader, ClassHeader, MethodHeader
 from pyccel.ast.headers import MacroFunction, MacroVariable

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -26,7 +26,6 @@ from sympy.core import cache
 from pyccel.ast.basic import PyccelAstNode
 
 from pyccel.ast.core import ParserResult
-from pyccel.ast.core import Nil
 from pyccel.ast.core import DottedName
 from pyccel.ast.core import Assign
 from pyccel.ast.core import AugAssign
@@ -66,6 +65,7 @@ from pyccel.ast.builtins import PythonPrint
 from pyccel.ast.headers  import Header, MetaVariable
 from pyccel.ast.literals import LiteralInteger, LiteralFloat, LiteralComplex
 from pyccel.ast.literals import LiteralFalse, LiteralTrue, LiteralString
+from pyccel.ast.literals import Nil
 from pyccel.ast.functionalexpr import FunctionalSum, FunctionalMax, FunctionalMin
 
 from pyccel.parser.extend_tree import extend_tree


### PR DESCRIPTION
According to wikipedia:

> In computer science, a literal is a notation for representing a fixed value in source code.

so moving Nil class to literals.py makes more sense, and it will fix a cyclic import in https://github.com/pyccel/pyccel/pull/651.