### PR TITLE
Follow C style convention for include syntax

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -199,7 +199,7 @@ math_function_to_c = {
     'MathLcm'       : 'pyc_lcm',
 }
 
-c_library_headers = [
+c_library_headers = (
     "complex",
     "ctype",
     "float",
@@ -211,7 +211,7 @@ c_library_headers = [
     "stdio",
     "stdlib",
     "tgmath",
-]
+)
 
 dtype_registry = {('real',8)    : 'double',
                   ('real',4)    : 'float',

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -200,36 +200,19 @@ math_function_to_c = {
 }
 
 c_library_headers = [
-    "assert",
     "complex",
     "ctype",
-    "errno",
-    "fenv",
     "float",
-    "inttypes",
-    "iso646",
-    "limits",
-    "locale",
     "math",
-    "setjmp",
-    "signal",
-    "stdalign",
     "stdarg",
-    "stdatomic",
     "stdbool",
     "stddef",
     "stdint",
     "stdio",
     "stdlib",
-    "stdnoreturn",
-    "string",
     "tgmath",
-    "threads",
-    "time",
-    "uchar",
-    "wchar",
-    "wctype"
 ]
+
 dtype_registry = {('real',8)    : 'double',
                   ('real',4)    : 'float',
                   ('complex',8) : 'double complex',

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -199,6 +199,37 @@ math_function_to_c = {
     'MathLcm'       : 'pyc_lcm',
 }
 
+c_library_headers = [
+    "assert",
+    "complex",
+    "ctype",
+    "errno",
+    "fenv",
+    "float",
+    "inttypes",
+    "iso646",
+    "limits",
+    "locale",
+    "math",
+    "setjmp",
+    "signal",
+    "stdalign",
+    "stdarg",
+    "stdatomic",
+    "stdbool",
+    "stddef",
+    "stdint",
+    "stdio",
+    "stdlib",
+    "stdnoreturn",
+    "string",
+    "tgmath",
+    "threads",
+    "time",
+    "uchar",
+    "wchar",
+    "wctype"
+]
 dtype_registry = {('real',8)    : 'double',
                   ('real',4)    : 'float',
                   ('complex',8) : 'double complex',
@@ -472,8 +503,10 @@ class CCodePrinter(CodePrinter):
 
         if source is None:
             return ''
-        else:
+        if str(expr.source) in c_library_headers:
             return '#include <{0}.h>'.format(source)
+        else:
+            return '#include "{0}.h"'.format(source)
 
     def _print_LiteralString(self, expr):
         format_str = format(expr.arg)


### PR DESCRIPTION
All the headers in the `c_library_header` list will be printed inside the arrows (`<`,`>`), while our local files will be double-quoted. In order to print a C header file inside arrows it should be added to the list, otherwise it will be double-quoted. This fixes #482.