### PR TITLE
Raise correct error when pointer variable should own data

### DIFF
--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -136,6 +136,7 @@ INVALID_PYTHON_SYNTAX = 'Python syntax error'
 # ARRAY ERRORS
 ASSIGN_ARRAYS_ONE_ANOTHER = 'Arrays which own their data cannot become views on other arrays'
 ARRAY_ALREADY_IN_USE = 'Attempt to reallocate an array which is being used by another variable'
+INVALID_POINTER_REASSIGN = 'Attempt to give data ownership to a pointer'
 
 # warnings
 UNDEFINED_INIT_METHOD = 'Undefined `__init__` method'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1508,6 +1508,12 @@ class SemanticParser(BasicParser):
                             self._current_fst_node.col_offset),
                                 severity='error', symbol=var.name)
 
+                elif var.is_ndarray and var.is_pointer and isinstance(rhs, NumpyNewArray):
+                    errors.report(INVALID_POINTER_REASSIGN,
+                        bounding_box=(self._current_fst_node.lineno,
+                            self._current_fst_node.col_offset),
+                                severity='error', symbol=var.name)
+
                 elif var.is_ndarray and var.is_pointer:
                     # we allow pointers to be reassigned multiple times
                     # pointers reassigning need to call free_pointer func


### PR DESCRIPTION
Raise the correct error in the semantic stage when trying to reassign a pointer with a new data block. Fixes #678.