### PR TITLE
Remove unused valgrind installation from macOS

### DIFF
--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -10,8 +10,3 @@ runs:
         ln -s /usr/local/bin/gfortran-8 /usr/local/bin/gfortran
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash
-    - name: Install Valgrind
-      run: |
-        brew tap 'LouisBrunner/valgrind'
-        brew install --HEAD 'LouisBrunner/valgrind/valgrind'
-      shell: bash


### PR DESCRIPTION
Valgrind installation on macOS has errors when an OS update occurs. Since we are not running any memory checks on this platform, it is safe to remove Valgrind's installation from our tests' pipeline.