### PR TITLE
Remove `strict` argument which causes `sympify` to be called

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1721,6 +1721,7 @@ class For(Basic):
         if strict:
             target = sympify(target, locals=local_sympify)
 
+        if PyccelAstNode.stage == "semantic":
             cond_iter = iterable(iter_obj)
             cond_iter = cond_iter or isinstance(iter_obj, (PythonRange, Product,
                     PythonEnumerate, PythonZip, PythonMap))

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -20,7 +20,6 @@ from sympy import preorder_traversal
 from sympy.simplify.radsimp   import fraction
 from sympy.core.compatibility import with_metaclass
 from sympy.core.singleton     import Singleton, S
-from sympy.core.function      import Function
 from sympy.core.function      import Derivative, UndefinedFunction as sp_UndefinedFunction
 from sympy.core.function      import _coeff_isneg
 from sympy.core.expr          import Expr, AtomicExpr

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1716,11 +1716,7 @@ class For(Basic):
         iter_obj,
         body,
         local_vars = (),
-        strict=True,
         ):
-        if strict:
-            target = sympify(target, locals=local_sympify)
-
         if PyccelAstNode.stage == "semantic":
             cond_iter = iterable(iter_obj)
             cond_iter = cond_iter or isinstance(iter_obj, (PythonRange, Product,
@@ -1745,7 +1741,6 @@ class For(Basic):
         iter_obj,
         body,
         local_vars = [],
-        strict=True,
         ):
         self._target = self._args[0]
         self._iterable = self._args[1]
@@ -1812,12 +1807,11 @@ class ForIterator(For):
         target,
         iterable,
         body,
-        strict=True,
         ):
 
         if isinstance(iterable, Symbol):
             iterable = PythonRange(PythonLen(iterable))
-        return For.__new__(cls, target, iterable, body, strict)
+        return For.__new__(cls, target, iterable, body)
 
     # TODO uncomment later when we intriduce iterators
     # @property

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -609,10 +609,6 @@ class Assign(Basic):
         a Matrix type can be assigned to MatrixSymbol, but not to Symbol, as
         the dimensions will not align.
 
-    strict: bool
-        if True, we do some verifications. In general, this can be more
-        complicated and is treated in pyccel.syntax.
-
     status: None, str
         if lhs is not allocatable, then status is None.
         otherwise, status is {'allocated', 'unallocated'}
@@ -642,41 +638,9 @@ class Assign(Basic):
         cls,
         lhs,
         rhs,
-        strict=False,
         status=None,
         like=None,
         ):
-        cls._strict = strict
-
-        if strict:
-            lhs = sympify(lhs, locals=local_sympify)
-            rhs = sympify(rhs, locals=local_sympify)
-
-            # Tuple of things that can be on the lhs of an assignment
-
-            assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed,
-                          Idx)
-
-            # if not isinstance(lhs, assignable):
-            #    raise TypeError("Cannot assign to lhs of type %s." % type(lhs))
-            # Indexed types implement shape, but don't define it until later. This
-            # causes issues in assignment validation. For now, matrices are defined
-            # as anything with a shape that is not an Indexed
-
-            lhs_is_mat = hasattr(lhs, 'shape') and not isinstance(lhs,
-                    Indexed)
-            rhs_is_mat = hasattr(rhs, 'shape') and not isinstance(rhs,
-                    Indexed)
-
-            # If lhs and rhs have same structure, then this assignment is ok
-
-            if lhs_is_mat:
-                if not rhs_is_mat:
-                    raise ValueError('Cannot assign a scalar to a matrix.')
-                elif lhs.shape != rhs.shape:
-                    raise ValueError("Dimensions of lhs and rhs don't align.")
-            elif rhs_is_mat and not lhs_is_mat:
-                raise ValueError('Cannot assign a matrix to a scalar.')
         return Basic.__new__(cls, lhs, rhs, status, like)
 
     def _sympystr(self, printer):
@@ -704,10 +668,6 @@ class Assign(Basic):
     @property
     def like(self):
         return self._args[3]
-
-    @property
-    def strict(self):
-        return self._strict
 
     @property
     def is_alias(self):
@@ -1060,10 +1020,6 @@ class AugAssign(Assign):
         a Matrix type can be assigned to MatrixSymbol, but not to Symbol, as
         the dimensions will not align.
 
-    strict: bool
-        if True, we do some verifications. In general, this can be more
-        complicated and is treated in pyccel.syntax.
-
     status: None, str
         if lhs is not allocatable, then status is None.
         otherwise, status is {'allocated', 'unallocated'}
@@ -1086,42 +1042,9 @@ class AugAssign(Assign):
         lhs,
         op,
         rhs,
-        strict=False,
         status=None,
         like=None,
         ):
-        cls._strict = strict
-        if strict:
-            lhs = sympify(lhs, locals=local_sympify)
-            rhs = sympify(rhs, locals=local_sympify)
-
-            # Tuple of things that can be on the lhs of an assignment
-
-            assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed)
-            if not isinstance(lhs, assignable):
-                raise TypeError('Cannot assign to lhs of type %s.'
-                                % type(lhs))
-
-            # Indexed types implement shape, but don't define it until later. This
-            # causes issues in assignment validation. For now, matrices are defined
-            # as anything with a shape that is not an Indexed
-
-            lhs_is_mat = hasattr(lhs, 'shape') and not isinstance(lhs,
-                    Indexed)
-            rhs_is_mat = hasattr(rhs, 'shape') and not isinstance(rhs,
-                    Indexed)
-
-            # If lhs and rhs have same structure, then this assignment is ok
-
-            if lhs_is_mat:
-                if not rhs_is_mat:
-                    raise ValueError('Cannot assign a scalar to a matrix.'
-                            )
-                elif lhs.shape != rhs.shape:
-                    raise ValueError("Dimensions of lhs and rhs don't align."
-                            )
-            elif rhs_is_mat and not lhs_is_mat:
-                raise ValueError('Cannot assign a matrix to a scalar.')
 
         if isinstance(op, str):
             op = operator(op)
@@ -1161,10 +1084,6 @@ class AugAssign(Assign):
     @property
     def like(self):
         return self._args[4]
-
-    @property
-    def strict(self):
-        return self._strict
 
 
 class While(Basic):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1207,7 +1207,6 @@ class FCodePrinter(CodePrinter):
             return '\n'.join(self._print_Assign(
                         Assign(lhs,
                                 rhs,
-                                strict=expr.strict,
                                 status=expr.status,
                                 like=expr.like,
                                 )
@@ -1756,7 +1755,6 @@ class FCodePrinter(CodePrinter):
         lhs    = expr.lhs
         op     = expr.op
         rhs    = expr.rhs
-        strict = expr.strict
         status = expr.status
         like   = expr.like
 
@@ -1772,7 +1770,7 @@ class FCodePrinter(CodePrinter):
         else:
             raise ValueError('Unrecognized operation', op)
 
-        stmt = Assign(lhs, rhs, strict=strict, status=status, like=like)
+        stmt = Assign(lhs, rhs, status=status, like=like)
         return self._print_Assign(stmt)
 
     def _print_PythonRange(self, expr):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1919,7 +1919,7 @@ class SemanticParser(BasicParser):
             func  = FunctionCall(func, args)
             body  = [Assign(var, func)]
             body[0].set_fst(fst)
-            body  = For(index, range_, body, strict=False)
+            body  = For(index, range_, body)
             body  = self._visit_For(body, **settings)
             body  = [alloc , body]
             return CodeBlock(body)
@@ -2449,7 +2449,7 @@ class SemanticParser(BasicParser):
 #            args[index_arg] = vec_arg[index]
 #            body_vec        = Assign(args[index_arg], Function(name)(*args))
 #            body_vec.set_fst(expr.fst)
-#            body_vec   = [For(index, range_, [body_vec], strict=False)]
+#            body_vec   = [For(index, range_, [body_vec])]
 #            header_vec = header.vectorize(index_arg)
 #            vec_func   = expr.vectorize(body_vec, header_vec)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1987,12 +1987,11 @@ class SemanticParser(BasicParser):
 
     def _visit_For(self, expr, **settings):
 
-
         self.create_new_loop_scope()
 
         # treatment of the index/indices
         iterable = self._visit(expr.iterable, **settings)
-        body     = list(expr.body)
+        body     = list(expr.body.body)
         iterator = expr.target
 
         if isinstance(iterable, Variable):
@@ -2188,7 +2187,7 @@ class SemanticParser(BasicParser):
             if (step != 1):
                 size = ceiling(size)
 
-            body = body.body[0]
+            body = body.body.body[0]
             dims.append((size, step, start, stop))
 
         # we now calculate the size of the array which will be allocated

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -943,7 +943,7 @@ class SyntaxParser(BasicParser):
         iterator = self._visit(stmt.target)
         iterable = self._visit(stmt.iter)
         body = self._visit(stmt.body)
-        expr = For(iterator, iterable, body, strict=False)
+        expr = For(iterator, iterable, body)
         expr.set_fst(stmt)
         return expr
 
@@ -951,7 +951,7 @@ class SyntaxParser(BasicParser):
 
         iterator = self._visit(stmt.target)
         iterable = self._visit(stmt.iter)
-        expr = For(iterator, iterable, [], strict=False)
+        expr = For(iterator, iterable, [])
         expr.set_fst(stmt)
         return expr
 

--- a/pyccel/symbolic/lambdify.py
+++ b/pyccel/symbolic/lambdify.py
@@ -69,7 +69,7 @@ def cse(expr):
             var = Symbol(name)
             stmt = Assign(var, Function('empty')(size[0]))
             allocate.append(stmt)
-            stmts[i] = For(ind[0], Function('range')(size[0]), [stmts[i]], strict=False)
+            stmts[i] = For(ind[0], Function('range')(size[0]), [stmts[i]])
     lhs = create_variable(expr)
     stmts[-1] = Assign(lhs, stmts[-1])
     imports = [Import('empty', 'numpy')]
@@ -87,7 +87,7 @@ def pyccel_sum(expr):
     index = expr.args[1]
     target = Function('range')(index[1], index[2])
     body = AugAssign(lhs, '+', expr.args[0])
-    stmt = For(index[0], target, [body], strict=False)
+    stmt = For(index[0], target, [body])
     stmt = FunctionalSum([stmt], expr.args[0], lhs)
 
     return stmt


### PR DESCRIPTION
The classes `Assign`, `AugAssign`, and `For` each have a `strict` argument. The value passed for this argument is almost always `False`. When it is `True` the function `sympify` is called which could result in pyccel objects being replaced by sympy objects

**Commit Summary**
- Remove unused strict argument from `Assign` and `AugAssign`
- Always store For body in `CodeBlock`
- Remove `sympify` call from `For`
- Add `insert2body` function to `CodeBlock`
- Correct `CodeBlock` fst setter
- Always test for iterable `iter_obj` at semantic stage for class `For`
- Remove `strict` argument from `For` class (previously only 1 call had `strict=True`)
