### PR TITLE
Add `__index__` magic method to `LiteralInteger`

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -359,8 +359,6 @@ class PythonTuple(PyccelAstNode):
             self._shape     = (LiteralInteger(len(args)), ) + args[0].shape
 
     def __getitem__(self,i):
-        if isinstance(i, LiteralInteger):
-            i = i.p
         return self._args[i]
 
     def __add__(self,other):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -96,6 +96,9 @@ class LiteralInteger(Literal, Basic):
     def python_value(self):
         return self.p
 
+    def __index__(self):
+        return self.python_value
+
 #------------------------------------------------------------------------------
 class LiteralFloat(Literal, sp_Float):
     """Represents a float literal in python"""

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -591,8 +591,6 @@ class TupleVariable(Variable):
                        wish to collect
         """
         assert(not self._is_homogeneous)
-        if isinstance(variable_idx, LiteralInteger):
-            variable_idx = variable_idx.p
         return self._vars[variable_idx]
 
     def rename_var(self, variable_idx, new_name):

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -618,8 +618,6 @@ class TupleVariable(Variable):
             else:
                 sub_idx = []
 
-            if isinstance(idx, LiteralInteger):
-                idx = idx.p
             var = self.get_var(idx)
 
             if len(sub_idx) > 0:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3070,8 +3070,6 @@ class SemanticParser(BasicParser):
         var = self._visit(name)
         assert(var.rank==1)
         size = var.shape[0]
-        if isinstance(size, LiteralInteger):
-            size = size.p
         return StarredArguments([self._visit(Indexed(name,i)) for i in range(size)])
 
 #==============================================================================


### PR DESCRIPTION
Allow instances of class `LiteralInteger` to be used for indexing lists/tuples/etc.:
- Add magic method `__index__` to `LiteralInteger`;
- Remove unnecessary checks and simplify expressions.