### PR TITLE
Handle `if n:` for an optional argument `n`

### DIFF
--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -1,0 +1,232 @@
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
+#------------------------------------------------------------------------------------------#
+"""
+Module handling all python builtin operators
+These operators all have a precision as detailed here:
+    https://docs.python.org/3/reference/expressions.html#operator-precedence
+They also have specific rules to determine the dtype, precision, rank, shape
+"""
+from .builtins     import PythonInt
+from .datatypes    import (NativeBool, NativeInteger, NativeReal,
+                           NativeComplex, NativeString)
+from .operators     import PyccelUnaryOperator, PyccelOperator
+
+__all__ = (
+    'PyccelRShift',
+    'PyccelLShift',
+    'PyccelBitXor',
+    'PyccelBitOr',
+    'PyccelBitAnd',
+    'PyccelInvert',
+)
+
+#==============================================================================
+
+class PyccelInvert(PyccelUnaryOperator):
+    """
+    Class representing a call to the python bitwise not operator.
+    I.e:
+        ~a
+    is equivalent to:
+        PyccelInvert(a)
+
+    Parameters
+    ----------
+    arg: PyccelAstNode
+        The argument passed to the operator
+    """
+    _precedence = 14
+    _dtype     = NativeInteger()
+
+    def _set_dtype(self):
+        a = self._args[0]
+        if a.dtype not in (NativeInteger(), NativeBool()):
+            raise TypeError('unsupported operand type(s): {}'.format(self))
+
+        self._args      = (PythonInt(a) if a.dtype is NativeBool() else a,)
+
+        self._precision = a.precision
+
+    def __repr__(self):
+        return '~{}'.format(repr(self.args[0]))
+
+#==============================================================================
+
+class PyccelBitOperator(PyccelOperator):
+    """ Abstract superclass representing a python
+    bitwise operator with two arguments
+
+    Parameters
+    ----------
+    arg1: PyccelAstNode
+        The first argument passed to the operator
+    arg2: PyccelAstNode
+        The second argument passed to the operator
+    """
+    _rank = 0
+    _shape = ()
+
+    def _set_dtype(self):
+        """ Sets the dtype and precision
+
+        If one argument is a string then all arguments must be strings
+
+        If the arguments are numeric then the dtype and precision
+        match the broadest type and the largest precision
+        e.g.
+            1 + 2j -> PyccelAdd(LiteralInteger, LiteralComplex) -> complex
+        """
+        integers  = [a for a in self._args if a.dtype in (NativeInteger(),NativeBool())]
+        reals     = [a for a in self._args if a.dtype is NativeReal()]
+        complexes = [a for a in self._args if a.dtype is NativeComplex()]
+        strs      = [a for a in self._args if a.dtype is NativeString()]
+
+        if strs or complexes or reals:
+            raise TypeError('unsupported operand type(s): {}'.format(self))
+        elif integers:
+            self._handle_integer_type(integers)
+        else:
+            raise TypeError('cannot determine the type of {}'.format(self))
+
+    def _set_shape_rank(self):
+        pass
+
+    def _handle_integer_type(self, integers):
+        self._dtype     = NativeInteger()
+        self._precision = max(a.precision for a in integers)
+        self._args = [PythonInt(a) if a.dtype is NativeBool() else a for a in integers]
+
+#==============================================================================
+
+class PyccelRShift(PyccelBitOperator):
+    """
+    Class representing a call to the python right shift operator.
+    I.e:
+        a >> b
+    is equivalent to:
+        PyccelRShift(a, b)
+
+    Parameters
+    ----------
+    arg1: PyccelAstNode
+        The first argument passed to the operator
+    arg2: PyccelAstNode
+        The second argument passed to the operator
+    """
+    _precedence = 11
+
+    def __repr__(self):
+        return '{} >> {}'.format(self.args[0], self.args[1])
+
+#==============================================================================
+
+class PyccelLShift(PyccelBitOperator):
+    """
+    Class representing a call to the python right shift operator.
+    I.e:
+        a << b
+    is equivalent to:
+        PyccelRShift(a, b)
+
+    Parameters
+    ----------
+    arg1: PyccelAstNode
+        The first argument passed to the operator
+    arg2: PyccelAstNode
+        The second argument passed to the operator
+    """
+    _precedence = 11
+
+    def __repr__(self):
+        return '{} << {}'.format(self.args[0], self.args[1])
+
+#==============================================================================
+
+class PyccelBitComparisonOperator(PyccelBitOperator):
+    """ Abstract superclass representing a python
+    bitwise comparison operator with two arguments
+
+    Parameters
+    ----------
+    arg1: PyccelAstNode
+        The first argument passed to the operator
+    arg2: PyccelAstNode
+        The second argument passed to the operator
+    """
+    def _handle_integer_type(self, integers):
+        if all(a.dtype is NativeInteger() for a in integers):
+            self._dtype = NativeInteger()
+        elif all(a.dtype is NativeBool() for a in integers):
+            self._dtype = NativeBool()
+        else:
+            self._dtype = NativeInteger()
+            self._args = [PythonInt(a) if a.dtype is NativeBool() else a for a in integers]
+        self._precision = max(a.precision for a in integers)
+
+#==============================================================================
+
+class PyccelBitXor(PyccelBitComparisonOperator):
+    """
+    Class representing a call to the python bitwise XOR operator.
+    I.e:
+        a ^ b
+    is equivalent to:
+        PyccelBitXor(a, b)
+
+    Parameters
+    ----------
+    arg1: PyccelAstNode
+        The first argument passed to the operator
+    arg2: PyccelAstNode
+        The second argument passed to the operator
+    """
+    _precedence = 9
+
+    def __repr__(self):
+        return '{} ^ {}'.format(self.args[0], self.args[1])
+
+#==============================================================================
+
+class PyccelBitOr(PyccelBitComparisonOperator):
+    """
+    Class representing a call to the python bitwise OR operator.
+    I.e:
+        a | b
+    is equivalent to:
+        PyccelBitOr(a, b)
+
+    Parameters
+    ----------
+    arg1: PyccelAstNode
+        The first argument passed to the operator
+    arg2: PyccelAstNode
+        The second argument passed to the operator
+    """
+    _precedence = 8
+
+    def __repr__(self):
+        return '{} | {}'.format(self.args[0], self.args[1])
+
+#==============================================================================
+
+class PyccelBitAnd(PyccelBitComparisonOperator):
+    """
+    Class representing a call to the python bitwise AND operator.
+    I.e:
+        a & b
+    is equivalent to:
+        PyccelBitAnd(a, b)
+
+    Parameters
+    ----------
+    arg1: PyccelAstNode
+        The first argument passed to the operator
+    arg2: PyccelAstNode
+        The second argument passed to the operator
+    """
+    _precedence = 10
+
+    def __repr__(self):
+        return '{} & {}'.format(self.args[0], self.args[1])

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -21,9 +21,9 @@ from .datatypes import (NativeInteger, NativeBool, NativeReal,
                         NativeComplex, NativeString, str_dtype,
                         NativeGeneric, default_precision)
 from .internals import PyccelInternalFunction
-from .literals  import LiteralInteger, LiteralFloat, LiteralComplex
+from .literals  import LiteralInteger, LiteralFloat, LiteralComplex, Nil
 from .literals  import Literal, LiteralImaginaryUnit, get_default_literal_value
-from .operators import PyccelAnd, PyccelMul
+from .operators import PyccelAnd, PyccelMul, PyccelIsNot
 from .operators import PyccelMinus, PyccelUnarySub
 
 __all__ = (
@@ -128,7 +128,10 @@ class PythonBool(Expr, PyccelAstNode):
     _dtype = NativeBool()
 
     def __new__(cls, arg):
-        return Expr.__new__(cls, arg)
+        if getattr(arg, 'is_optional', None):
+            return PyccelAnd(PyccelIsNot(arg, Nil()), Expr.__new__(cls, arg))
+        else:
+            return Expr.__new__(cls, arg)
 
     @property
     def arg(self):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -23,7 +23,7 @@ from .datatypes import (NativeInteger, NativeBool, NativeReal,
 from .internals import PyccelInternalFunction
 from .literals  import LiteralInteger, LiteralFloat, LiteralComplex, Nil
 from .literals  import Literal, LiteralImaginaryUnit, get_default_literal_value
-from .operators import PyccelAnd, PyccelMul, PyccelIsNot
+from .operators import PyccelAdd, PyccelAnd, PyccelMul, PyccelIsNot
 from .operators import PyccelMinus, PyccelUnarySub
 
 __all__ = (

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -23,6 +23,8 @@ from .datatypes import (NativeInteger, NativeBool, NativeReal,
 from .internals import PyccelInternalFunction
 from .literals  import LiteralInteger, LiteralFloat, LiteralComplex
 from .literals  import Literal, LiteralImaginaryUnit, get_default_literal_value
+from .operators import PyccelAnd, PyccelMul
+from .operators import PyccelMinus, PyccelUnarySub
 
 __all__ = (
     'PythonReal',
@@ -173,7 +175,6 @@ class PythonComplex(Expr, PyccelAstNode):
 
         # Split arguments depending on their type to ensure that the arguments are
         # either a complex and LiteralFloat(0) or 2 floats
-        from .operators import PyccelAdd, PyccelMul
 
         if arg0.dtype is NativeComplex() and arg1.dtype is NativeComplex():
             # both args are complex
@@ -190,7 +191,6 @@ class PythonComplex(Expr, PyccelAstNode):
             self._internal_var = arg0
 
         else:
-            from .operators import PyccelAdd, PyccelMinus, PyccelUnarySub
 
             if arg0.dtype is NativeComplex() and \
                     not (isinstance(arg1, Literal) and arg1.python_value == 0):

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -14,8 +14,6 @@ from ..errors.errors        import Errors, PyccelSemanticError
 
 from .basic                 import PyccelAstNode
 
-from .builtins              import PythonInt
-
 from .datatypes             import (NativeBool, NativeInteger, NativeReal,
                                     NativeComplex, NativeString, default_precision,
                                     NativeNumeric)
@@ -44,12 +42,6 @@ __all__ = (
     'PyccelAnd',
     'PyccelOr',
     'PyccelNot',
-    'PyccelRShift',
-    'PyccelLShift',
-    'PyccelBitXor',
-    'PyccelBitOr',
-    'PyccelBitAnd',
-    'PyccelInvert',
     'PyccelAssociativeParenthesis',
     'PyccelUnary',
     'PyccelUnarySub',
@@ -287,36 +279,6 @@ class PyccelNot(PyccelUnaryOperator):
 
     def __repr__(self):
         return 'not {}'.format(repr(self.args[0]))
-
-#==============================================================================
-
-class PyccelInvert(PyccelUnaryOperator):
-    """
-    Class representing a call to the python bitwise not operator.
-    I.e:
-        ~a
-    is equivalent to:
-        PyccelInvert(a)
-
-    Parameters
-    ----------
-    arg: PyccelAstNode
-        The argument passed to the operator
-    """
-    _precedence = 14
-    _dtype     = NativeInteger()
-
-    def _set_dtype(self):
-        a = self._args[0]
-        if a.dtype not in (NativeInteger(), NativeBool()):
-            raise TypeError('unsupported operand type(s): {}'.format(self))
-
-        self._args      = (PythonInt(a) if a.dtype is NativeBool() else a,)
-
-        self._precision = a.precision
-
-    def __repr__(self):
-        return '~{}'.format(repr(self.args[0]))
 
 #==============================================================================
 
@@ -644,185 +606,6 @@ class PyccelFloorDiv(PyccelArithmeticOperator):
 
     def __repr__(self):
         return '{} // {}'.format(self.args[0], self.args[1])
-
-#==============================================================================
-
-class PyccelBitOperator(PyccelOperator):
-    """ Abstract superclass representing a python
-    bitwise operator with two arguments
-
-    Parameters
-    ----------
-    arg1: PyccelAstNode
-        The first argument passed to the operator
-    arg2: PyccelAstNode
-        The second argument passed to the operator
-    """
-    _rank = 0
-    _shape = ()
-
-    def _set_dtype(self):
-        """ Sets the dtype and precision
-
-        If one argument is a string then all arguments must be strings
-
-        If the arguments are numeric then the dtype and precision
-        match the broadest type and the largest precision
-        e.g.
-            1 + 2j -> PyccelAdd(LiteralInteger, LiteralComplex) -> complex
-        """
-        integers  = [a for a in self._args if a.dtype in (NativeInteger(),NativeBool())]
-        reals     = [a for a in self._args if a.dtype is NativeReal()]
-        complexes = [a for a in self._args if a.dtype is NativeComplex()]
-        strs      = [a for a in self._args if a.dtype is NativeString()]
-
-        if strs or complexes or reals:
-            raise TypeError('unsupported operand type(s): {}'.format(self))
-        elif integers:
-            self._handle_integer_type(integers)
-        else:
-            raise TypeError('cannot determine the type of {}'.format(self))
-
-    def _set_shape_rank(self):
-        pass
-
-    def _handle_integer_type(self, integers):
-        self._dtype     = NativeInteger()
-        self._precision = max(a.precision for a in integers)
-        self._args = [PythonInt(a) if a.dtype is NativeBool() else a for a in integers]
-
-#==============================================================================
-
-class PyccelRShift(PyccelBitOperator):
-    """
-    Class representing a call to the python right shift operator.
-    I.e:
-        a >> b
-    is equivalent to:
-        PyccelRShift(a, b)
-
-    Parameters
-    ----------
-    arg1: PyccelAstNode
-        The first argument passed to the operator
-    arg2: PyccelAstNode
-        The second argument passed to the operator
-    """
-    _precedence = 11
-
-    def __repr__(self):
-        return '{} >> {}'.format(self.args[0], self.args[1])
-
-#==============================================================================
-
-class PyccelLShift(PyccelBitOperator):
-    """
-    Class representing a call to the python right shift operator.
-    I.e:
-        a << b
-    is equivalent to:
-        PyccelRShift(a, b)
-
-    Parameters
-    ----------
-    arg1: PyccelAstNode
-        The first argument passed to the operator
-    arg2: PyccelAstNode
-        The second argument passed to the operator
-    """
-    _precedence = 11
-
-    def __repr__(self):
-        return '{} << {}'.format(self.args[0], self.args[1])
-
-#==============================================================================
-
-class PyccelBitComparisonOperator(PyccelBitOperator):
-    """ Abstract superclass representing a python
-    bitwise comparison operator with two arguments
-
-    Parameters
-    ----------
-    arg1: PyccelAstNode
-        The first argument passed to the operator
-    arg2: PyccelAstNode
-        The second argument passed to the operator
-    """
-    def _handle_integer_type(self, integers):
-        if all(a.dtype is NativeInteger() for a in integers):
-            self._dtype = NativeInteger()
-        elif all(a.dtype is NativeBool() for a in integers):
-            self._dtype = NativeBool()
-        else:
-            self._dtype = NativeInteger()
-            self._args = [PythonInt(a) if a.dtype is NativeBool() else a for a in integers]
-        self._precision = max(a.precision for a in integers)
-
-#==============================================================================
-
-class PyccelBitXor(PyccelBitComparisonOperator):
-    """
-    Class representing a call to the python bitwise XOR operator.
-    I.e:
-        a ^ b
-    is equivalent to:
-        PyccelBitXor(a, b)
-
-    Parameters
-    ----------
-    arg1: PyccelAstNode
-        The first argument passed to the operator
-    arg2: PyccelAstNode
-        The second argument passed to the operator
-    """
-    _precedence = 9
-
-    def __repr__(self):
-        return '{} ^ {}'.format(self.args[0], self.args[1])
-
-#==============================================================================
-
-class PyccelBitOr(PyccelBitComparisonOperator):
-    """
-    Class representing a call to the python bitwise OR operator.
-    I.e:
-        a | b
-    is equivalent to:
-        PyccelBitOr(a, b)
-
-    Parameters
-    ----------
-    arg1: PyccelAstNode
-        The first argument passed to the operator
-    arg2: PyccelAstNode
-        The second argument passed to the operator
-    """
-    _precedence = 8
-
-    def __repr__(self):
-        return '{} | {}'.format(self.args[0], self.args[1])
-
-#==============================================================================
-
-class PyccelBitAnd(PyccelBitComparisonOperator):
-    """
-    Class representing a call to the python bitwise AND operator.
-    I.e:
-        a & b
-    is equivalent to:
-        PyccelBitAnd(a, b)
-
-    Parameters
-    ----------
-    arg1: PyccelAstNode
-        The first argument passed to the operator
-    arg2: PyccelAstNode
-        The second argument passed to the operator
-    """
-    _precedence = 10
-
-    def __repr__(self):
-        return '{} & {}'.format(self.args[0], self.args[1])
 
 #==============================================================================
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -52,7 +52,11 @@ __all__ = (
     'PyccelInvert',
     'PyccelAssociativeParenthesis',
     'PyccelUnary',
-    'Relational'
+    'PyccelUnarySub',
+    'Relational',
+    'PyccelIs',
+    'PyccelIsNot',
+    'IfTernaryOperator'
 )
 
 #==============================================================================

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -51,7 +51,7 @@ from pyccel.ast.core import CodeBlock
 from pyccel.ast.core import _atomic
 from pyccel.ast.core import create_variable
 
-from pyccel.ast.operators import PyccelRShift, PyccelLShift, PyccelBitXor, PyccelBitOr, PyccelBitAnd, PyccelInvert
+from pyccel.ast.bitwise_operators import PyccelRShift, PyccelLShift, PyccelBitXor, PyccelBitOr, PyccelBitAnd, PyccelInvert
 from pyccel.ast.operators import PyccelPow, PyccelAdd, PyccelMul, PyccelDiv, PyccelMod, PyccelFloorDiv
 from pyccel.ast.operators import PyccelEq,  PyccelNe,  PyccelLt,  PyccelLe,  PyccelGt,  PyccelGe
 from pyccel.ast.operators import PyccelAnd, PyccelOr,  PyccelNot, PyccelMinus

--- a/tests/epyccel/modules/base.py
+++ b/tests/epyccel/modules/base.py
@@ -213,3 +213,9 @@ def pass2_if(b):
     else:
         c = 2
     return c
+
+def use_optional(a : int = None):
+    b = 3
+    if a:
+        b += a
+    return b

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -200,3 +200,8 @@ def test_pass2_if(language):
     test = epyccel_test(base.pass2_if, lang=language)
     test.compare_epyccel(True)
     test.compare_epyccel(False)
+
+def test_use_optional(language):
+    test = epyccel_test(base.use_optional, lang=language)
+    test.compare_epyccel()
+    test.compare_epyccel(6)


### PR DESCRIPTION
As mentioned in the discussion of issue #700, optional arguments are only tested for existence when we write `n is None` explicitly, however it should also be tested if the argument is cast to a bool (as in the expression `if n:`). This PR fixes this

**Commit Summary**
- Split pyccel.ast.operators into 2 files to avoid circular imports between pyccel.ast.operators and  pyccel.ast.builtins
    - The new file pyccel.ast.bitwise_operators is created
    - It requires the `PythonInt` cast
- Add missing classes to pyccel.ast.operators.__all__
- Handle boolean cast of optional argument in `PythonBool.__new__`
    - When the argument of `PythonBool` is an optional object the `__new__` function modifies the result to check that the argument exists:
    `bool(a)`->`a is not None and bool(a)`
    - Handling this in the `__new__` function ensures that operator precedence is handled with minimal parentheses even when the `PythonBool` is created in the constructor of `pyccel.ast.core.If`
- Add a test