### PR TITLE
Remove unused classes in ast/core.py and ast/datatypes.py

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -24,9 +24,7 @@ from sympy.core.function      import _coeff_isneg
 from sympy.core.expr          import Expr, AtomicExpr
 from sympy.logic.boolalg      import And as sp_And, Or as sp_Or
 from sympy.logic.boolalg      import Boolean as sp_Boolean
-from sympy.tensor             import Idx
 
-from sympy.matrices.expressions.matexpr import MatrixSymbol, MatrixElement
 from sympy.utilities.iterables          import iterable
 
 
@@ -39,7 +37,7 @@ from .builtins  import (PythonEnumerate, PythonLen, PythonList, PythonMap,
 from .datatypes import (datatype, DataType, NativeSymbol,
                         NativeBool, NativeRange,
                         NativeTuple, is_iterable_datatype, str_dtype)
-from .internals      import PyccelArraySize, Slice
+from .internals      import Slice
 
 from .literals       import LiteralTrue, LiteralFalse, LiteralInteger, Nil
 from .literals       import LiteralImaginaryUnit, LiteralString
@@ -47,7 +45,7 @@ from .itertoolsext   import Product
 from .functionalexpr import GeneratorComprehension as GC
 from .functionalexpr import FunctionalFor
 
-from .operators import PyccelMul, IfTernaryOperator
+from .operators import PyccelMul, IfTernaryOperator, Relational
 
 from .variable import DottedName, DottedVariable, IndexedElement
 from .variable import ValuedVariable, Variable

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -5,7 +5,6 @@
 # go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
 #------------------------------------------------------------------------------------------#
 
-import importlib
 from collections     import OrderedDict
 
 from sympy import sympify
@@ -20,7 +19,7 @@ from sympy import preorder_traversal
 from sympy.simplify.radsimp   import fraction
 from sympy.core.compatibility import with_metaclass
 from sympy.core.singleton     import Singleton, S
-from sympy.core.function      import Derivative, UndefinedFunction as sp_UndefinedFunction
+from sympy.core.function      import Derivative
 from sympy.core.function      import _coeff_isneg
 from sympy.core.expr          import Expr, AtomicExpr
 from sympy.logic.boolalg      import And as sp_And, Or as sp_Or
@@ -38,8 +37,7 @@ from .basic     import Basic, PyccelAstNode
 from .builtins  import (PythonEnumerate, PythonLen, PythonList, PythonMap,
                         PythonRange, PythonZip, PythonTuple, PythonBool)
 from .datatypes import (datatype, DataType, NativeSymbol,
-                        NativeInteger, NativeBool, NativeReal,
-                        NativeComplex, NativeRange, NativeString,
+                        NativeBool, NativeRange,
                         NativeTuple, is_iterable_datatype, str_dtype)
 from .internals      import PyccelInternalFunction, PyccelArraySize, Slice
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -39,7 +39,7 @@ from .builtins  import (PythonEnumerate, PythonLen, PythonList, PythonMap,
                         PythonRange, PythonZip, PythonTuple, PythonBool)
 from .datatypes import (datatype, DataType, NativeSymbol,
                         NativeInteger, NativeBool, NativeReal,
-                        NativeComplex, NativeRange, NativeTensor, NativeString,
+                        NativeComplex, NativeRange, NativeString,
                         NativeTuple, is_iterable_datatype, str_dtype)
 from .internals      import PyccelInternalFunction, PyccelArraySize, Slice
 
@@ -1654,11 +1654,6 @@ class ForIterator(For):
         if isinstance(it, Variable):
             if isinstance(it.dtype, NativeRange):
                 return 1
-            if isinstance(it.dtype, NativeTensor):
-
-                # TODO must be computed
-
-                return 2
 
             cls_base = it.cls_base
             if not cls_base:

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1188,38 +1188,6 @@ class With(Basic):
         body +=  end.body.body
         return Block('with', [], body)
 
-class Tile(PythonRange):
-
-    """
-    Representes a tile.
-
-    Examples
-    --------
-    >>> from pyccel.ast.core import Variable
-    >>> from pyccel.ast.core import Tile
-    >>> from sympy import Symbol
-    >>> s = Variable('int', 's')
-    >>> e = Symbol('e')
-    >>> Tile(s, e, 1)
-    Tile(0, n, 1)
-    """
-
-    def __new__(cls, start, stop):
-        step = 1
-        return PythonRange.__new__(cls, start, stop, step)
-
-    @property
-    def start(self):
-        return self._args[0]
-
-    @property
-    def stop(self):
-        return self._args[1]
-
-    @property
-    def size(self):
-        return self.stop - self.start
-
 
 # TODO add a name to a block?
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -98,7 +98,6 @@ __all__ = (
     'ModuleHeader',
     'MulOp',
     'NativeOp',
-    'NewLine',
     'ParserResult',
     'Pass',
     'Program',
@@ -3320,29 +3319,6 @@ class EmptyNode(Basic):
 
     def _sympystr(self, printer):
         return ''
-
-
-class NewLine(Basic):
-
-    """Represents a NewLine in the code.
-
-    Parameters
-    ----------
-    text : str
-       the comment line
-
-    Examples
-    --------
-    >>> from pyccel.ast.core import NewLine
-    >>> NewLine()
-
-    """
-
-    def __new__(cls):
-        return Basic.__new__(cls)
-
-    def _sympystr(self, printer):
-        return '\n'
 
 
 class Comment(Basic):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2698,7 +2698,7 @@ class ClassDef(Basic):
         name,
         attributes=(),
         methods=(),
-        options=('public'),
+        options=('public',),
         imports=(),
         parent=(),
         interfaces=(),

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1094,7 +1094,7 @@ class While(Basic):
     While(n > 1, (n := n - 1,))
     """
 
-    def __new__(cls, test, body, local_vars=[]):
+    def __new__(cls, test, body, local_vars=()):
         test = sympify(test, locals=local_sympify)
 
         if PyccelAstNode.stage == 'semantic':
@@ -1300,9 +1300,9 @@ class Module(Basic):
         name,
         variables,
         funcs,
-        interfaces=[],
-        classes=[],
-        imports=[],
+        interfaces=(),
+        classes=(),
+        imports=(),
         ):
         if not isinstance(name, str):
             raise TypeError('name must be a string')
@@ -1449,7 +1449,7 @@ class Program(Basic):
         name,
         variables,
         body,
-        imports=[],
+        imports=(),
         ):
 
         if not isinstance(name, str):
@@ -1558,7 +1558,7 @@ class For(Basic):
         target,
         iter_obj,
         body,
-        local_vars = [],
+        local_vars = (),
         ):
         self._target = self._args[0]
         self._iterable = self._args[1]
@@ -2031,22 +2031,22 @@ class FunctionDef(Basic):
         arguments,
         results,
         body,
-        local_vars=[],
-        global_vars=[],
+        local_vars=(),
+        global_vars=(),
         cls_name=None,
         is_static=False,
-        imports=[],
+        imports=(),
         decorators={},
-        headers=[],
+        headers=(),
         templates={},
         is_recursive=False,
         is_pure=False,
         is_elemental=False,
         is_private=False,
         is_header=False,
-        arguments_inout=[],
-        functions=[],
-        interfaces=[],
+        arguments_inout=(),
+        functions=(),
+        interfaces=(),
         doc_string=None):
 
         if isinstance(name, str):
@@ -2696,12 +2696,12 @@ class ClassDef(Basic):
     def __new__(
         cls,
         name,
-        attributes=[],
-        methods=[],
-        options=['public'],
-        imports=[],
-        parent=[],
-        interfaces=[],
+        attributes=(),
+        methods=(),
+        options=('public'),
+        imports=(),
+        parent=(),
+        interfaces=(),
         ):
 
         # name

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3489,6 +3489,14 @@ class Pass(Basic):
 
     pass
 
+class Exit(Basic):
+
+    """Basic class for exits."""
+
+class ErrorExit(Exit):
+
+    """Exit with error."""
+
 
 class If(Basic):
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -39,16 +39,15 @@ from .builtins  import (PythonEnumerate, PythonLen, PythonList, PythonMap,
 from .datatypes import (datatype, DataType, NativeSymbol,
                         NativeBool, NativeRange,
                         NativeTuple, is_iterable_datatype, str_dtype)
-from .internals      import PyccelInternalFunction, PyccelArraySize, Slice
+from .internals      import PyccelArraySize, Slice
 
 from .literals       import LiteralTrue, LiteralFalse, LiteralInteger, Nil
-from .literals       import LiteralImaginaryUnit, LiteralString, Literal
-from .literals       import Nil
+from .literals       import LiteralImaginaryUnit, LiteralString
 from .itertoolsext   import Product
 from .functionalexpr import GeneratorComprehension as GC
 from .functionalexpr import FunctionalFor
 
-from .operators import PyccelMul
+from .operators import PyccelMul, IfTernaryOperator
 
 from .variable import DottedName, DottedVariable, IndexedElement
 from .variable import ValuedVariable, Variable
@@ -88,7 +87,6 @@ __all__ = (
     'FunctionCall',
     'FunctionDef',
     'If',
-    'IfTernaryOperator',
     'Import',
     'Interface',
     'ModOp',
@@ -107,7 +105,6 @@ __all__ = (
     'SymbolicAssign',
     'SymbolicPrint',
     'SympyFunction',
-    'Tile',
     'ValuedArgument',
     'While',
     'With',

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -36,7 +36,6 @@ __all__ = (
     'NativeReal',
     'NativeString',
     'NativeSymbol',
-    'NativeTensor',
     'NativeVoid',
     'UnionType',
     'VariableType',
@@ -154,9 +153,6 @@ class NativeTuple(DataType):
 
 class NativeRange(DataType):
     _name = 'Range'
-
-class NativeTensor(DataType):
-    _name = 'Tensor'
 
 class NativeParallelRange(NativeRange):
     _name = 'ParallelRange'
@@ -279,7 +275,7 @@ def is_iterable_datatype(dtype):
     """Returns True if dtype is an iterable class."""
     if is_pyccel_datatype(dtype):
         return dtype.is_iterable
-    elif isinstance(dtype, (NativeRange, NativeTensor)):
+    elif isinstance(dtype, NativeRange):
         return True
     else:
         return False

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -31,7 +31,6 @@ __all__ = (
     'NativeInteger',
     'NativeTuple',
 #    'NativeNil',
-#    'NativeParallelRange',
     'NativeRange',
     'NativeReal',
     'NativeString',

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -154,9 +154,6 @@ class NativeTuple(DataType):
 class NativeRange(DataType):
     _name = 'Range'
 
-class NativeParallelRange(NativeRange):
-    _name = 'ParallelRange'
-
 class NativeSymbol(DataType):
     _name = 'Symbol'
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -10,8 +10,10 @@ import numpy
 from sympy           import (Integer as sp_Integer,
                              Rational as sp_Rational, Expr)
 
-from .core           import (ClassDef, FunctionDef, PyccelInternalFunction,
+from .core           import (ClassDef, FunctionDef,
                             process_shape, ValuedArgument)
+
+from .internals      import PyccelInternalFunction
 
 from .operators      import broadcast
 

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -10,7 +10,7 @@ from pyccel.codegen.printing.ccode  import CCodePrinter
 from pyccel.codegen.printing.pycode import PythonCodePrinter
 
 from pyccel.ast.core      import FunctionDef, Module, Program, Interface, ModuleHeader
-from pyccel.ast.core      import EmptyNode, NewLine, Comment, CommentBlock
+from pyccel.ast.core      import EmptyNode, Comment, CommentBlock
 from pyccel.ast.headers   import Header
 from pyccel.errors.errors import Errors
 
@@ -206,7 +206,7 @@ class Codegen(object):
         """Finds the source code kind."""
 
 
-        cls = (Header, EmptyNode, NewLine, Comment, CommentBlock, Module)
+        cls = (Header, EmptyNode, Comment, CommentBlock, Module)
         is_module = all(isinstance(i,cls) for i in self.ast.body)
 
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1318,9 +1318,6 @@ class CCodePrinter(CodePrinter):
     def _print_EmptyNode(self, expr):
         return ''
 
-    def _print_NewLine(self, expr):
-        return '\n'
-
     #=================== OMP ==================
     def _print_OMP_For_Loop(self, expr):
         omp_expr   = str(expr.txt)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -483,9 +483,6 @@ class FCodePrinter(CodePrinter):
     def _print_EmptyNode(self, expr):
         return ''
 
-    def _print_NewLine(self, expr):
-        return '\n'
-
     def _print_AnnotatedComment(self, expr):
         accel = self._print(expr.accel)
         txt   = str(expr.txt)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -428,10 +428,6 @@ class FCodePrinter(CodePrinter):
         code = code.replace("'", '')
         return self._get_statement(code) + '\n'
 
-    def _print_TupleImport(self, expr):
-        code = '\n'.join(self._print(i) for i in expr.imports)
-        return self._get_statement(code) + '\n'
-
     def _print_PythonPrint(self, expr):
         args = []
         for f in expr.expr:
@@ -564,10 +560,6 @@ class FCodePrinter(CodePrinter):
 
     def _print_DottedName(self, expr):
         return ' % '.join(self._print(n) for n in expr.name)
-
-    def _print_Concatenate(self, expr):
-        code = ', '.join(self._print(a) for a in expr.args)
-        return '[' + code + ']'
 
     def _print_Lambda(self, expr):
         return '"{args} -> {expr}"'.format(args=expr.variables, expr=expr.expr)
@@ -1211,7 +1203,7 @@ class FCodePrinter(CodePrinter):
 
         lhs_code = self._print(expr.lhs)
         rhs = expr.rhs
-        # we don't print Range, Tensor
+        # we don't print Range
         # TODO treat the case of iterable classes
         if isinstance(rhs, NINF):
             rhs_code = '-Huge({0})'.format(lhs_code)
@@ -1780,20 +1772,6 @@ class FCodePrinter(CodePrinter):
         start = self._print(expr.start)
         stop  = self._print(expr.stop)
         return '{0}, {1}'.format(start, stop)
-
-
-    def _print_ForAll(self, expr):
-
-        start = self._print(expr.iter.start)
-        end   = self._print(expr.iter.stop)
-        body  = ''.join(self._print(i) for i in expr.body)
-        mask  = self._print(expr.mask)
-        ind   = self._print(expr.target)
-
-        code = 'forall({ind} = {start}:{end}, {mask})\n'
-        code = code.format(ind=ind,start=start,end=end,mask=mask)
-        code = code + body + 'end forall\n'
-        return code
 
     def _print_FunctionalFor(self, expr):
         loops = ''.join(self._print(i) for i in expr.loops)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1768,11 +1768,6 @@ class FCodePrinter(CodePrinter):
         step  = self._print(expr.step)
         return '{0}, {1}, {2}'.format(start, stop, step)
 
-    def _print_Tile(self, expr):
-        start = self._print(expr.start)
-        stop  = self._print(expr.stop)
-        return '{0}, {1}'.format(start, stop)
-
     def _print_FunctionalFor(self, expr):
         loops = ''.join(self._print(i) for i in expr.loops)
         return loops

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -52,7 +52,7 @@ from pyccel.ast.datatypes import is_iterable_datatype, is_with_construct_datatyp
 from pyccel.ast.datatypes import NativeSymbol, NativeString, str_dtype
 from pyccel.ast.datatypes import NativeInteger, NativeBool, NativeReal
 from pyccel.ast.datatypes import iso_c_binding
-from pyccel.ast.datatypes import NativeRange, NativeTensor, NativeTuple
+from pyccel.ast.datatypes import NativeRange, NativeTuple
 from pyccel.ast.datatypes import CustomDataType
 
 from pyccel.ast.internals import Slice
@@ -993,7 +993,7 @@ class FCodePrinter(CodePrinter):
         if isinstance(expr.dtype, NativeSymbol):
             return ''
 
-        if isinstance(expr.dtype, (NativeRange, NativeTensor)):
+        if isinstance(expr.dtype, NativeRange):
             return ''
 
         # meta-variables

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -154,9 +154,6 @@ class PythonCodePrinter(SympyPythonCodePrinter):
     def _print_EmptyNode(self, expr):
         return ''
 
-    def _print_NewLine(self, expr):
-        return '\n'
-
     def _print_DottedName(self, expr):
         return '.'.join(self._print(n) for n in expr.name)
 

--- a/pyccel/complexity/arithmetic.py
+++ b/pyccel/complexity/arithmetic.py
@@ -30,7 +30,7 @@ f =  n**2*(2*ADD + DIV + 2*MUL + 2*POW)
 from sympy import count_ops as sympy_count_ops
 from sympy import Tuple
 
-from pyccel.ast.core     import For, Assign, NewLine, CodeBlock, Comment
+from pyccel.ast.core     import For, Assign, CodeBlock, Comment
 from pyccel.ast.numpyext import NumpyZeros, NumpyOnes
 from pyccel.ast.sympy_helper import pyccel_to_sympy
 from pyccel.complexity.basic import Complexity
@@ -66,7 +66,7 @@ def count_ops(expr, visual=None):
         return sum(count_ops(i, visual) for i in expr)
     elif isinstance(expr, CodeBlock):
         return sum(count_ops(i, visual) for i in expr.body)
-    elif isinstance(expr, (NumpyZeros, NumpyOnes,NewLine, Comment)):
+    elif isinstance(expr, (NumpyZeros, NumpyOnes, Comment)):
         return 0
     else:
         raise NotImplementedError('TODO count_ops for {}'.format(type(expr)))

--- a/pyccel/complexity/memory.py
+++ b/pyccel/complexity/memory.py
@@ -37,7 +37,7 @@ from sympy import Poly, LT
 from sympy.core.expr import Expr
 
 
-from pyccel.ast.core     import For, Assign, NewLine, CodeBlock, Comment
+from pyccel.ast.core     import For, Assign, CodeBlock, Comment
 from pyccel.ast.numpyext import NumpyZeros, NumpyOnes
 from pyccel.ast.sympy_helper import pyccel_to_sympy
 from pyccel.complexity.basic import Complexity
@@ -92,7 +92,7 @@ def count_access(expr, visual=True):
         import numpy as np
         return WRITE*np.prod(expr.shape)
 
-    elif isinstance(expr, (NewLine, Comment)):
+    elif isinstance(expr, Comment):
         return 0
     else:
         raise NotImplementedError('TODO count_access for {}'.format(type(expr)))

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -845,8 +845,6 @@ class SemanticParser(BasicParser):
         return expr
     def _visit_EmptyNode(self, expr, **settings):
         return expr
-    def _visit_NewLine(self, expr, **settings):
-        return expr
     def _visit_Break(self, expr, **settings):
         return expr
     def _visit_Continue(self, expr, **settings):

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -38,7 +38,7 @@ from pyccel.ast.core import While
 from pyccel.ast.core import Del
 from pyccel.ast.core import Assert
 from pyccel.ast.core import PythonTuple
-from pyccel.ast.core import Comment, EmptyNode, NewLine
+from pyccel.ast.core import Comment, EmptyNode
 from pyccel.ast.core import Break, Continue
 from pyccel.ast.core import Argument, ValuedArgument
 from pyccel.ast.core import Import
@@ -222,7 +222,7 @@ class SyntaxParser(BasicParser):
                 n_empty_lines = 0
                 current_file = start
                 current_file.append(v)
-            elif isinstance(v, (NewLine, EmptyNode)):
+            elif isinstance(v, EmptyNode):
                 # EmptyNodes are defined in the same block as the previous line
                 current_file.append(v)
                 n_empty_lines += 1


### PR DESCRIPTION
The following classes existed in ast/core.py and were unused within pyccel. They are therefore removed:
- Tensor
- ParallelBlock
- ForAll
- Void
- VoidFunction
- GetDefaultFunctionArg
- TupleImport - Not used anywhere
- Load
- Subroutine
- Random (we have `NumpyRand` for this)
- SumFunction
- Concatenate (this is handled by `PyccelAdd`)
- Eval
- Tile

In addition, the class `NewLine` is used in a few places but is never instantiated. It is therefore also removed.

The following unused associated classes in ast/datatypes.py are also removed:
- NativeTensor
- NativeParallelRange