### PR TITLE
Add casting to get_index when needed.

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -843,11 +843,11 @@ class CCodePrinter(CodePrinter):
         return "%s.%s[get_index(%s, %s)]" % (base_name, dtype, base_name, ", ".join(inds))
 
     def _cast_to(self, expr, dtype, precision):
-        """ add cast to an expresion when needed
+        """ add cast to an expression when needed
         parameters
         ----------
             expr      : PyccelAstNode
-                the expression to be casted
+                the expression to be cast
             dtype     : Datatype
                 base type of the cast
             precision : integer

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -722,7 +722,7 @@ class CCodePrinter(CodePrinter):
                         inds[i] = Slice(ind, PyccelAdd(ind, LiteralInteger(1)), LiteralInteger(1))
                 inds = [self._print(i) for i in inds]
                 return "array_slicing(%s, %s, %s)" % (base_name, expr.rank, ", ".join(inds))
-            inds = [self._cast_to(i, NativeInteger(), 8) for i in inds]
+            inds = [self._cast_to(i, NativeInteger(), 8).format(self._print(i)) for i in inds]
         else:
             raise NotImplementedError(expr)
         return "%s.%s[get_index(%s, %s)]" % (base_name, dtype, base_name, ", ".join(inds))
@@ -731,9 +731,9 @@ class CCodePrinter(CodePrinter):
         """ add cast to an expresion when needed
         parameters
         ----------
-            expr :
+            expr      : PyccelAstNode
                 the expression to be casted
-            dtype : Datatype
+            dtype     : Datatype
                 base type of the cast
             precision : integer
                 precision of the base type of the cast
@@ -744,10 +744,9 @@ class CCodePrinter(CodePrinter):
                 Return string that contains the expression casted to the desired type
         """
         if (expr.dtype != dtype or expr.precision != precision):
-            cast=self.find_in_dtype_registry(self._print(expr.dtype), precision)
-            expr = self._print(expr)
-            return '({cast}){expr}'.format(cast=cast, expr=expr)
-        return self._print(expr)
+            cast=self.find_in_dtype_registry(self._print(dtype), precision)
+            return '({}){{}}'.format(cast)
+        return '{}'
     def _print_DottedVariable(self, expr):
         """convert dotted Variable to their C equivalent"""
         return '{}.{}'.format(self._print(expr.lhs), self._print(expr.name))

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -741,7 +741,7 @@ class CCodePrinter(CodePrinter):
         Return
         ------
             String
-                Return string that contains the expression casted to the desired type
+                Return format string that contains the desired cast type
         """
         if (expr.dtype != dtype or expr.precision != precision):
             cast=self.find_in_dtype_registry(self._print(dtype), precision)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -728,7 +728,7 @@ class CCodePrinter(CodePrinter):
         return "%s.%s[get_index(%s, %s)]" % (base_name, dtype, base_name, ", ".join(inds))
 
     def _cast_to(self, expr, dtype, precision):
-        """ add cast to an expresion
+        """ add cast to an expresion when needed
         parameters
         ----------
             expr :

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -696,11 +696,17 @@ class CCodePrinter(CodePrinter):
                         inds[i] = Slice(ind, PyccelAdd(ind, LiteralInteger(1)), LiteralInteger(1))
                 inds = [self._print(i) for i in inds]
                 return "array_slicing(%s, %s, %s)" % (base_name, expr.rank, ", ".join(inds))
-            inds = [self._print(i) for i in inds]
+            inds = [self._cast_to(i, NativeInteger(), 8) for i in inds]
         else:
             raise NotImplementedError(expr)
         return "%s.%s[get_index(%s, %s)]" % (base_name, dtype, base_name, ", ".join(inds))
 
+    def _cast_to(self, expr, dtype, precision):
+        if (expr.dtype == dtype and expr.precision != precision):
+            cast=self.find_in_dtype_registry(self._print(expr.dtype), precision)
+            expr = self._print(expr)
+            return '({cast}){expr}'.format(cast=cast, expr=expr)
+        return self._print(expr)
     def _print_DottedVariable(self, expr):
         """convert dotted Variable to their C equivalent"""
         return '{}.{}'.format(self._print(expr.lhs), self._print(expr.name))

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -728,7 +728,22 @@ class CCodePrinter(CodePrinter):
         return "%s.%s[get_index(%s, %s)]" % (base_name, dtype, base_name, ", ".join(inds))
 
     def _cast_to(self, expr, dtype, precision):
-        if (expr.dtype == dtype and expr.precision != precision):
+        """ add cast to an expresion
+        parameters
+        ----------
+            expr : 
+                the expression to be casted
+            dtype : Datatype
+                base type of the cast
+            precision : integer
+                precision of the base type of the cast
+
+        Return
+        ------
+            String
+                Return string that contains the expression casted to the desired type
+        """
+        if (expr.dtype != dtype and expr.precision != precision):
             cast=self.find_in_dtype_registry(self._print(expr.dtype), precision)
             expr = self._print(expr)
             return '({cast}){expr}'.format(cast=cast, expr=expr)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -743,7 +743,7 @@ class CCodePrinter(CodePrinter):
             String
                 Return string that contains the expression casted to the desired type
         """
-        if (expr.dtype != dtype and expr.precision != precision):
+        if (expr.dtype != dtype or expr.precision != precision):
             cast=self.find_in_dtype_registry(self._print(expr.dtype), precision)
             expr = self._print(expr)
             return '({cast}){expr}'.format(cast=cast, expr=expr)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -731,7 +731,7 @@ class CCodePrinter(CodePrinter):
         """ add cast to an expresion
         parameters
         ----------
-            expr : 
+            expr :
                 the expression to be casted
             dtype : Datatype
                 base type of the cast

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -137,6 +137,7 @@ INVALID_PYTHON_SYNTAX = 'Python syntax error'
 ASSIGN_ARRAYS_ONE_ANOTHER = 'Arrays which own their data cannot become views on other arrays'
 ARRAY_ALREADY_IN_USE = 'Attempt to reallocate an array which is being used by another variable'
 INVALID_POINTER_REASSIGN = 'Attempt to give data ownership to a pointer'
+INVALID_INDICES = 'only integers, slices (`:`) , booleans are valid indices'
 
 # warnings
 UNDEFINED_INIT_METHOD = 'Undefined `__init__` method'

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -137,7 +137,7 @@ INVALID_PYTHON_SYNTAX = 'Python syntax error'
 ASSIGN_ARRAYS_ONE_ANOTHER = 'Arrays which own their data cannot become views on other arrays'
 ARRAY_ALREADY_IN_USE = 'Attempt to reallocate an array which is being used by another variable'
 INVALID_POINTER_REASSIGN = 'Attempt to give data ownership to a pointer'
-INVALID_INDICES = 'only integers, slices (`:`) , booleans are valid indices'
+INVALID_INDICES = 'only integers and slices (`:`) are valid indices'
 
 # warnings
 UNDEFINED_INIT_METHOD = 'Undefined `__init__` method'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -944,7 +944,7 @@ class SemanticParser(BasicParser):
                 bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                 severity='error', blocker=self.blocking)
 
-        for arg in var[args]._indices:
+        for arg in var[args].indices:
             if not isinstance(arg, (Slice, LiteralInteger)) and not \
                 (isinstance(arg, Variable) and isinstance(arg.dtype, (NativeBool, NativeInteger))):
                 errors.report(INVALID_INDICES, symbol=var[args],

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -945,8 +945,8 @@ class SemanticParser(BasicParser):
                 severity='error', blocker=self.blocking)
 
         for arg in var[args].indices:
-            if not isinstance(arg, (Slice, LiteralInteger)) and not \
-                (isinstance(arg, Variable) and isinstance(arg.dtype, (NativeBool, NativeInteger))):
+            if not isinstance(arg, Slice) and not \
+                (hasattr(arg, 'dtype') and isinstance(arg.dtype, NativeInteger)):
                 errors.report(INVALID_INDICES, symbol=var[args],
                 bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                 severity='error', blocker=self.blocking)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -944,6 +944,12 @@ class SemanticParser(BasicParser):
                 bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                 severity='error', blocker=self.blocking)
 
+        for arg in var[args]._indices:
+            if not isinstance(arg, (Slice, LiteralInteger)) and not \
+                (isinstance(arg, Variable) and isinstance(arg.dtype, (NativeBool, NativeInteger))):
+                errors.report(INVALID_INDICES, symbol=var[args],
+                bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
+                severity='error', blocker=self.blocking)
         return var[args]
 
     def _visit_IndexedElement(self, expr, **settings):

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -260,7 +260,7 @@ void        alias_assign(t_ndarray *dest, t_ndarray src)
 ** indexing
 */
 
-int32_t     get_index(t_ndarray arr, ...)
+int64_t     get_index(t_ndarray arr, ...)
 {
     va_list va;
     int32_t index;

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -269,7 +269,7 @@ int32_t     get_index(t_ndarray arr, ...)
     index = 0;
     for (int32_t i = 0; i < arr.nd; i++)
     {
-        index += va_arg(va, int32_t) * arr.strides[i];
+        index += va_arg(va, int64_t) * arr.strides[i];
     }
     va_end(va);
     return (index);

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -110,7 +110,7 @@ int32_t         free_array(t_ndarray dump);
 int32_t         free_pointer(t_ndarray dump);
 
 /* indexing */
-int32_t         get_index(t_ndarray arr, ...);
+int64_t         get_index(t_ndarray arr, ...);
 
 /* data converting between numpy and ndarray */
 int64_t     *numpy_to_ndarray_strides(int64_t *np_strides, int type_size, int nd);

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -1640,6 +1640,20 @@ def arrs_1d_negative_index_2():
     b = a[1:-1] + a[2:]
     return np.shape(b)[0], np.sum(b)
 
+def arrs_1d_int32_index():
+    import numpy as np
+    i = np.int32(1)
+    a = np.ones(10)
+    b = a[i] + a[i + 2]
+    return b
+
+def arrs_1d_int64_index():
+    import numpy as np
+    i = np.int64(1)
+    a = np.ones(10)
+    b = a[i] + a[i + 2]
+    return b
+
 def arrs_1d_negative_index_negative_step():
     import numpy as np
     a = np.ones(10)

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -2662,6 +2662,16 @@ def test_arrs_1d_negative_index_2():
     f2 = epyccel(f1)
     assert np.array_equal(f1(), f2())
 
+def test_arrs_1d_int32_index(language):
+    f1 = arrays.arrs_1d_int32_index
+    f2 = epyccel(f1, language=language)
+    assert np.array_equal(f1(), f2())
+
+def test_arrs_1d_int64_index(language):
+    f1 = arrays.arrs_1d_int64_index
+    f2 = epyccel(f1, language=language)
+    assert np.array_equal(f1(), f2())
+
 def test_arrs_1d_negative_index_negative_step():
     f1 = arrays.arrs_1d_negative_index_negative_step
     f2 = epyccel(f1)


### PR DESCRIPTION
- Add func `_cast_to` to help with casting to the correct type when needed;
- Raise error when passing non integer/slice to an `indexedElement`;
- Add tests for indexing with `int64` and `int32`.