### PR TITLE
Handle type casting in array_fill

### DIFF
--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -146,10 +146,10 @@ class NumpyReal(PythonReal):
 PrecisionToDtype = {
     'Int' : {
         4 : NumpyInt32,
-        8 : PythonInt},
+        8 : NumpyInt64},
     'Real' : {
         4 : NumpyFloat32,
-        8 : PythonFloat},
+        8 : NumpyFloat64},
     'Complex' : {
         4 : NumpyComplex64,
         8 : PythonComplex,

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -555,6 +555,15 @@ class NumpyRandint(PyccelInternalFunction):
 
 #==============================================================================
 def process_stype(stype, precision):
+    """
+    returns a cast function from
+    PrecisionToDtype_int, PrecisionToDtype_float, PrecisionToDtype_complex, python_builtin_datatypes
+    by ginving it:
+    stype:
+        supported data type name.
+    precision:
+        describs the precision of stype, to make the returned function more specific.
+    """
     if stype == 'integer':
         return PrecisionToDtype_int[precision]
     if stype == 'real':
@@ -562,7 +571,9 @@ def process_stype(stype, precision):
     if stype == 'complex':
         return PrecisionToDtype_complex[precision]
     if stype == 'bool':
+        from pyccel.codegen.printing.fcode import python_builtin_datatypes
         return python_builtin_datatypes['bool']
+    return None
 
 class NumpyFull(PyccelInternalFunction, NumpyNewArray):
     """
@@ -605,10 +616,11 @@ class NumpyFull(PyccelInternalFunction, NumpyNewArray):
         # Cast fill_value to correct type
         from pyccel.ast.datatypes import str_dtype
         stype = str_dtype(dtype)
-        from pyccel.codegen.printing.fcode import python_builtin_datatypes
-        cast_func  = python_builtin_datatypes[stype]
-        cast_func = process_stype(stype, precision)
-        fill_value = cast_func(fill_value)
+        if fill_value:
+            from pyccel.codegen.printing.fcode import python_builtin_datatypes
+            cast_func  = python_builtin_datatypes[stype]
+            cast_func = process_stype(stype, precision)
+            fill_value = cast_func(fill_value)
         self._shape = shape
         self._rank  = len(self._shape)
         self._dtype = dtype

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -144,38 +144,19 @@ class NumpyReal(PythonReal):
 
 #==============================================================================
 PrecisionToDtype = {
-    'int' : {
+    'Int' : {
         4 : NumpyInt32,
         8 : PythonInt},
-    'float' : {
+    'Real' : {
         4 : NumpyFloat32,
         8 : PythonFloat},
-    'complex' : {
+    'Complex' : {
         4 : NumpyComplex64,
         8 : PythonComplex,
-        16 : NumpyComplex128,}
+        16 : NumpyComplex128,},
+    'Bool':  {
+        4 : PythonBool}
 }
-
-def process_stype(stype, precision):
-    """
-    returns a cast function from
-    PrecisionToDtype_int, PrecisionToDtype_float, PrecisionToDtype_complex, python_builtin_datatypes
-    by ginving it:
-    stype:
-        supported data type name.
-    precision:
-        describs the precision of stype, to make the returned function more specific.
-    """
-    if stype == 'integer':
-        return PrecisionToDtype['int'][precision]
-    if stype == 'real':
-        return PrecisionToDtype['float'][precision]
-    if stype == 'complex':
-        return PrecisionToDtype['complex'][precision]
-    if stype == 'bool':
-        from pyccel.codegen.printing.fcode import python_builtin_datatypes
-        return python_builtin_datatypes['bool']
-    return None
 
 #==============================================================================
 numpy_constants = {
@@ -614,12 +595,8 @@ class NumpyFull(PyccelInternalFunction, NumpyNewArray):
         order = NumpyNewArray._process_order(order)
 
         # Cast fill_value to correct type
-        from pyccel.ast.datatypes import str_dtype
-        stype = str_dtype(dtype)
         if fill_value:
-            from pyccel.codegen.printing.fcode import python_builtin_datatypes
-            cast_func  = python_builtin_datatypes[stype]
-            cast_func = process_stype(stype, precision)
+            cast_func = PrecisionToDtype[dtype.name][precision]
             fill_value = cast_func(fill_value)
         self._shape = shape
         self._rank  = len(self._shape)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -142,21 +142,41 @@ class NumpyReal(PythonReal):
     1.0
     """
 
-PrecisionToDtype_int = {
-    4 : NumpyInt32,
-    8 : PythonInt,
+#==============================================================================
+PrecisionToDtype = {
+    'int' : {
+        4 : NumpyInt32,
+        8 : PythonInt},
+    'float' : {
+        4 : NumpyFloat32,
+        8 : PythonFloat},
+    'complex' : {
+        4 : NumpyComplex64,
+        8 : PythonComplex,
+        16 : NumpyComplex128,}
 }
 
-PrecisionToDtype_float = {
-    4 : NumpyFloat32,
-    8 : PythonFloat,
-}
+def process_stype(stype, precision):
+    """
+    returns a cast function from
+    PrecisionToDtype_int, PrecisionToDtype_float, PrecisionToDtype_complex, python_builtin_datatypes
+    by ginving it:
+    stype:
+        supported data type name.
+    precision:
+        describs the precision of stype, to make the returned function more specific.
+    """
+    if stype == 'integer':
+        return PrecisionToDtype['int'][precision]
+    if stype == 'real':
+        return PrecisionToDtype['float'][precision]
+    if stype == 'complex':
+        return PrecisionToDtype['complex'][precision]
+    if stype == 'bool':
+        from pyccel.codegen.printing.fcode import python_builtin_datatypes
+        return python_builtin_datatypes['bool']
+    return None
 
-PrecisionToDtype_complex = {
-    4 : NumpyComplex64,
-    8 : PythonComplex,
-    16 : NumpyComplex128,
-}
 #==============================================================================
 numpy_constants = {
     'pi': Constant('real', 'pi', value=numpy.pi),
@@ -554,26 +574,6 @@ class NumpyRandint(PyccelInternalFunction):
         return self._low
 
 #==============================================================================
-def process_stype(stype, precision):
-    """
-    returns a cast function from
-    PrecisionToDtype_int, PrecisionToDtype_float, PrecisionToDtype_complex, python_builtin_datatypes
-    by ginving it:
-    stype:
-        supported data type name.
-    precision:
-        describs the precision of stype, to make the returned function more specific.
-    """
-    if stype == 'integer':
-        return PrecisionToDtype_int[precision]
-    if stype == 'real':
-        return PrecisionToDtype_float[precision]
-    if stype == 'complex':
-        return PrecisionToDtype_complex[precision]
-    if stype == 'bool':
-        from pyccel.codegen.printing.fcode import python_builtin_datatypes
-        return python_builtin_datatypes['bool']
-    return None
 
 class NumpyFull(PyccelInternalFunction, NumpyNewArray):
     """

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -143,7 +143,7 @@ class NumpyReal(PythonReal):
     """
 
 #==============================================================================
-PrecisionToDtype = {
+DtypePrecisionToCastFunction = {
     'Int' : {
         4 : NumpyInt32,
         8 : NumpyInt64},
@@ -596,7 +596,7 @@ class NumpyFull(PyccelInternalFunction, NumpyNewArray):
 
         # Cast fill_value to correct type
         if fill_value:
-            cast_func = PrecisionToDtype[dtype.name][precision]
+            cast_func = DtypePrecisionToCastFunction[dtype.name][precision]
             fill_value = cast_func(fill_value)
         self._shape = shape
         self._rank  = len(self._shape)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -593,7 +593,7 @@ class NumpyFull(PyccelInternalFunction, NumpyNewArray):
         order = NumpyNewArray._process_order(order)
 
         # Cast fill_value to correct type
-        if fill_value:
+        if fill_value and not isinstance(fill_value, Nil):
             cast_func = DtypePrecisionToCastFunction[dtype.name][precision]
             fill_value = cast_func(fill_value)
         self._shape = shape

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -433,12 +433,12 @@ class CCodePrinter(CodePrinter):
 
     def _print_PythonFloat(self, expr):
         value = self._print(expr.arg)
-        type_name = self.find_in_dtype_registry('real', default_precision['real'])
+        type_name = self.find_in_dtype_registry('real', expr.precision)
         return '({0})({1})'.format(type_name, value)
 
     def _print_PythonInt(self, expr):
         value = self._print(expr.arg)
-        type_name = self.find_in_dtype_registry('int', default_precision['int'])
+        type_name = self.find_in_dtype_registry('int', expr.precision)
         return '({0})({1})'.format(type_name, value)
 
     def _print_PythonBool(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -462,13 +462,11 @@ class CCodePrinter(CodePrinter):
         self._additional_imports.add("complex")
         if expr.is_cast:
             value = self._print(expr.internal_var)
-            type_name = self.find_in_dtype_registry('complex', expr.precision)
-            return '({0})({1})'.format(type_name, value)
         else:
             value = self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
                             PyccelMul(expr.imag, LiteralImaginaryUnit()))))
-            type_name = self.find_in_dtype_registry('complex', expr.precision)
-            return '({0})({1})'.format(type_name, value)
+        type_name = self.find_in_dtype_registry('complex', expr.precision)
+        return '({0})({1})'.format(type_name, value)
 
     def _print_LiteralImaginaryUnit(self, expr):
         return '_Complex_I'

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -461,10 +461,14 @@ class CCodePrinter(CodePrinter):
     def _print_PythonComplex(self, expr):
         self._additional_imports.add("complex")
         if expr.is_cast:
-            return self._print(expr.internal_var)
+            value = self._print(expr.internal_var)
+            type_name = self.find_in_dtype_registry('complex', expr.precision)
+            return '({0})({1})'.format(type_name, value)
         else:
-            return self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
+            value = self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
                             PyccelMul(expr.imag, LiteralImaginaryUnit()))))
+            type_name = self.find_in_dtype_registry('complex', expr.precision)
+            return '({0})({1})'.format(type_name, value)
 
     def _print_LiteralImaginaryUnit(self, expr):
         return '_Complex_I'

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -2682,7 +2682,6 @@ def test_full_like_order(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="casting to complex is not handled correctly, , see https://github.com/pyccel/pyccel/issues/723"),
             pytest.mark.c]
         )
     )

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -1364,7 +1364,6 @@ def test_full_order(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="casting to complex in not handled correctly"),
             pytest.mark.c]
         )
     )


### PR DESCRIPTION
`array_fill` is a Pyccel builtin function, written in C, which is used to fill an `array`(second argument) with a given `value` (first argument) and return a `value-filled array`. The type of `value` should be the same type of `array` to prevent wrong alignments and even crashes (in case of the data type of `value` greater than the data type of `array`). By fixing we can reactivate the x-failing C tests for `NumpyFull` and `NumpyFullLike` (soon), and fix all kinds of casting in `array_fill`.

Commit summary:
- Handle the casting (including complex casting) in `NumpyFull` class by using more flexible dictionaries and function to handle them;
- Cast dynamically in `_print_PythonComplex`, `_print_PythonFloat`, `_print_PythonInt`;
- Activate the test `test_full_dtype` in test_numpy_functions.py`.