### PR TITLE
Use mutable objects in classes instead of indexing _args

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -476,19 +476,20 @@ class PythonRange(Basic):
 
     def __init__(self, *args):
         # Define default values
+        n = len(args)
 
-        if len(args) == 1:
+        if n == 1:
             self._start = LiteralInteger(0)
-            self._stop = args[0]
+            self._stop  = args[0]
             self._step  = LiteralInteger(1)
-        elif len(args) == 2:
+        elif n == 2:
             self._start = args[0]
-            self._stop = args[1]
+            self._stop  = args[1]
             self._step  = LiteralInteger(1)
-        elif len(args) == 3:
+        elif n == 3:
             self._start = args[0]
-            self._stop = args[1]
-            self._step = args[2]
+            self._stop  = args[1]
+            self._step  = args[2]
         else:
             raise ValueError('Range has at most 3 arguments')
 

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -475,25 +475,22 @@ class PythonRange(Basic):
     """
 
     def __init__(self, *args):
-        start = LiteralInteger(0)
-        stop = None
-        step = LiteralInteger(1)
+        # Define default values
+        self._start = LiteralInteger(0)
+        self._step  = LiteralInteger(1)
 
         if len(args) == 1:
-            stop = args[0]
+            self._stop = args[0]
         elif len(args) == 2:
-            start = args[0]
-            stop = args[1]
+            self._start = args[0]
+            self._stop = args[1]
         elif len(args) == 3:
-            start = args[0]
-            stop = args[1]
-            step = args[2]
+            self._start = args[0]
+            self._stop = args[1]
+            self._step = args[2]
         else:
             raise ValueError('Range has at most 3 arguments')
 
-        self._start = start
-        self._stop  = stop
-        self._step  = step
         super().__init__()
 
     @property

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -420,9 +420,6 @@ class PythonList(PythonTuple):
     """
     _order = 'C'
     _is_homogeneous = True
-    """ Represent lists in the code with dynamic memory management."""
-    def __init__(self, *args):
-        super().__init__(*args)
 
 #==============================================================================
 class PythonMap(Basic):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -476,14 +476,15 @@ class PythonRange(Basic):
 
     def __init__(self, *args):
         # Define default values
-        self._start = LiteralInteger(0)
-        self._step  = LiteralInteger(1)
 
         if len(args) == 1:
+            self._start = LiteralInteger(0)
             self._stop = args[0]
+            self._step  = LiteralInteger(1)
         elif len(args) == 2:
             self._start = args[0]
             self._stop = args[1]
+            self._step  = LiteralInteger(1)
         elif len(args) == 3:
             self._start = args[0]
             self._stop = args[1]

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -421,7 +421,7 @@ class PythonList(PythonTuple):
     _order = 'C'
     _is_homogeneous = True
     """ Represent lists in the code with dynamic memory management."""
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args):
         super().__init__(*args)
 
 #==============================================================================

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -482,22 +482,17 @@ class PythonRange(Basic):
         stop = None
         step = LiteralInteger(1)
 
-        if isinstance(args, (tuple, list)):
-            if len(args) == 1:
-                stop = args[0]
-            elif len(args) == 2:
-                start = args[0]
-                stop = args[1]
-            elif len(args) == 3:
-                start = args[0]
-                stop = args[1]
-                step = args[2]
-            else:
-                raise ValueError('Range has at most 3 arguments')
-        elif isinstance(args, PyccelAstNode):
-            stop = args
-        elif PyccelAstNode.stage != "syntactic":
-            raise TypeError('expecting a list or valid stop')
+        if len(args) == 1:
+            stop = args[0]
+        elif len(args) == 2:
+            start = args[0]
+            stop = args[1]
+        elif len(args) == 3:
+            start = args[0]
+            stop = args[1]
+            step = args[2]
+        else:
+            raise ValueError('Range has at most 3 arguments')
 
         self._start = start
         self._stop  = stop

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -112,7 +112,7 @@ dtype_and_precision_registry = { 'real':('real',default_precision['float']),
                                  'pythonbool' :('bool',default_precision['bool'])}
 
 
-class DataType(with_metaclass(Singleton, Basic)):
+class DataType(with_metaclass(Singleton)):
     """Base class representing native datatypes"""
     _name = '__UNDEFINED__'
 
@@ -224,12 +224,13 @@ dtype_registry = {'bool': Bool,
 
 class UnionType(Basic):
 
-    def __new__(cls, args):
-        return Basic.__new__(cls, args)
+    def __init__(self, args):
+        self._args = args
+        super().__init__()
 
     @property
     def args(self):
-        return self._args[0]
+        return self._args
 
 
 def DataTypeFactory(name, argnames=["_name"],

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -5,10 +5,11 @@
 #------------------------------------------------------------------------------------------#
 """
 File containing basic classes which are used throughout pyccel.
-To avoid circular imports this file should only import from basic and datatypes
+To avoid circular imports this file should only import from basic, datatypes, and literals
 """
-from .basic import Basic, PyccelAstNode
+from .basic     import Basic, PyccelAstNode
 from .datatypes import NativeInteger, default_precision
+from .literals  import LiteralInteger
 
 __all__ = (
     'PyccelInternalFunction',
@@ -50,6 +51,11 @@ class PyccelArraySize(PyccelInternalFunction):
                                 tuple,
                                 PyccelAstNode)):
             raise TypeError('Unknown type of  %s.' % type(arg))
+
+        if isinstance(index, int):
+            index = LiteralInteger(index)
+        elif not isinstance(index, PyccelAstNode):
+            raise TypeError('Unknown type of  %s.' % type(index))
 
         PyccelInternalFunction.__init__(self, arg, index)
         self._arg   = arg

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -32,6 +32,7 @@ class Literal(PyccelAstNode):
     _shape     = ()
 
     def __init__(self, precision):
+        super().__init__()
         if not isinstance(precision, int):
             raise TypeError("precision must be an integer")
         self._precision = precision
@@ -51,43 +52,36 @@ class Literal(PyccelAstNode):
         return printer.doprint(self.python_value)
 
 #------------------------------------------------------------------------------
-class LiteralTrue(Literal, Basic):
+class LiteralTrue(Literal):
     """Represents the python value True"""
     _dtype     = NativeBool()
-    def __new__(cls, precision = default_precision['bool']):
-        return Basic.__new__(cls, precision)
 
     def __init__(self, precision = default_precision['bool']):
-        Literal.__init__(self, precision)
+        super().__init__(precision)
 
     @property
     def python_value(self):
         return True
 
 #------------------------------------------------------------------------------
-class LiteralFalse(Literal, Basic):
+class LiteralFalse(Literal):
     """Represents the python value False"""
     _dtype     = NativeBool()
-    def __new__(cls, precision = default_precision['bool']):
-        return Basic.__new__(cls, precision)
 
     def __init__(self,precision = default_precision['bool']):
-        Literal.__init__(self, precision)
+        super().__init__(precision)
 
     @property
     def python_value(self):
         return False
 
 #------------------------------------------------------------------------------
-class LiteralInteger(Literal, Basic):
+class LiteralInteger(Literal):
     """Represents an integer literal in python"""
     _dtype     = NativeInteger()
-    def __new__(cls, value, precision = default_precision['integer']):
-        return Basic.__new__(cls, value)
 
     def __init__(self, value, precision = default_precision['integer']):
-        Basic.__init__(self)
-        Literal.__init__(self, precision)
+        super().__init__(precision)
         if not isinstance(value, int):
             raise TypeError("A LiteralInteger can only be created with an integer")
         self.p = value
@@ -117,23 +111,22 @@ class LiteralFloat(Literal, sp_Float):
 
 
 #------------------------------------------------------------------------------
-class LiteralComplex(Literal, Basic):
+class LiteralComplex(Literal):
     """Represents a complex literal in python"""
     _dtype     = NativeComplex()
 
     def __new__(cls, real, imag, precision = default_precision['complex']):
         if cls is LiteralImaginaryUnit:
-            return Basic.__new__(cls, real, imag)
+            return super().__new__(cls, real, imag)
         real_part = cls._collect_python_val(real)
         imag_part = cls._collect_python_val(imag)
         if real_part == 0 and imag_part == 1:
             return LiteralImaginaryUnit()
         else:
-            return Basic.__new__(cls, real, imag)
+            return super().__new__(cls, real, imag)
 
     def __init__(self, real, imag, precision = default_precision['complex']):
-        Basic.__init__(self)
-        Literal.__init__(self, precision)
+        super().__init__(precision)
         self._real_part = LiteralFloat(self._collect_python_val(real))
         self._imag_part = LiteralFloat(self._collect_python_val(imag))
 
@@ -164,25 +157,22 @@ class LiteralComplex(Literal, Basic):
 class LiteralImaginaryUnit(LiteralComplex):
     """Represents the python value j"""
     def __new__(cls):
-        return LiteralComplex.__new__(cls, 0, 1)
+        return super().__new__(cls, 0, 1)
 
     def __init__(self, real=0, imag=1, precision = default_precision['complex']):
-        LiteralComplex.__init__(self, 0, 1)
+        super().__init__(0, 1)
 
     @property
     def python_value(self):
         return 1j
 
 #------------------------------------------------------------------------------
-class LiteralString(Literal, Basic):
+class LiteralString(Literal):
     """Represents a string literal in python"""
     _dtype     = NativeString()
     _precision = 0
-    def __new__(cls, arg):
-        return Basic.__new__(cls, arg)
-
     def __init__(self, arg):
-        Basic.__init__(self)
+        super().__init__(self._precision)
         if not isinstance(arg, str):
             raise TypeError('arg must be of type str')
         self._string = arg

--- a/pyccel/ast/macros.py
+++ b/pyccel/ast/macros.py
@@ -11,7 +11,7 @@ This module contains all classes and functions used for handling macros.
 from sympy.core.expr import AtomicExpr
 from sympy import sympify
 
-from .basic          import Basic, PyccelAstNode
+from .basic          import PyccelAstNode
 from .core           import local_sympify
 from .datatypes      import default_precision
 from .datatypes      import NativeInteger, NativeGeneric

--- a/pyccel/ast/macros.py
+++ b/pyccel/ast/macros.py
@@ -29,15 +29,15 @@ class Macro(AtomicExpr, PyccelAstNode):
     """."""
     _name = '__UNDEFINED__'
 
-    def __new__(cls, argument):
+    def __init__(self, argument):
         # TODO add verification
 
-        argument = sympify(argument, locals=local_sympify)
-        return Basic.__new__(cls, argument)
+        self._argument = argument
+        super().__init__()
 
     @property
     def argument(self):
-        return self._args[0]
+        return self._argument
 
     @property
     def name(self):
@@ -52,11 +52,9 @@ class MacroShape(Macro):
     _dtype     = NativeInteger()
     _precision = default_precision['integer']
 
-    def __new__(cls, argument, index=None):
-        return Macro.__new__(cls, argument)
-
     def __init__(self, argument, index=None):
         self._index = index
+        super().__init__(argument)
 
     @property
     def index(self):
@@ -79,9 +77,6 @@ class MacroType(Macro):
     _shape     = ()
     _precision = 0
 
-    def __new__(cls, argument):
-        return Macro.__new__(cls, argument)
-
     def _sympystr(self, printer):
         sstr = printer.doprint
         return 'MacroType({})'.format(sstr(self.argument))
@@ -94,9 +89,6 @@ class MacroCount(Macro):
     _shape     = ()
     _dtype     = NativeInteger()
     _precision = default_precision['integer']
-
-    def __new__(cls, argument):
-        return Macro.__new__(cls, argument)
 
     def _sympystr(self, printer):
         sstr = printer.doprint

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -136,7 +136,6 @@ class NumpyArray(NumpyNewArray):
     """
 
     def __init__(self, arg, dtype=None, order='C'):
-        NumpyNewArray.__init__(self)
 
         if not isinstance(arg, (PythonTuple, PythonList, Variable)):
             raise TypeError('Unknown type of  %s.' % type(arg))
@@ -168,6 +167,7 @@ class NumpyArray(NumpyNewArray):
         self._dtype = dtype
         self._order = order
         self._precision = prec
+        super().__init__()
 
     def _sympystr(self, printer):
         return self.arg
@@ -198,7 +198,6 @@ class NumpyArange(NumpyNewArray):
     """
 
     def __init__(self, start, stop = None, step = None, dtype = None):
-        NumpyNewArray.__init__(self)
 
         if stop is None:
             self._start = LiteralInteger(0)
@@ -208,21 +207,20 @@ class NumpyArange(NumpyNewArray):
             self._stop = stop
         self._step = step if step is not None else LiteralInteger(1)
 
-        self._arg = [self._start, self._stop, self._step]
-
         if dtype is None:
-            self._dtype = max([i.dtype for i in self._arg], key = NativeNumeric.index)
-            self._precision = max([i.precision for i in self._arg])
+            self._dtype = max([i.dtype for i in self.arg], key = NativeNumeric.index)
+            self._precision = max([i.precision for i in self.arg])
         else:
             self._dtype, self._precision = process_dtype(dtype)
 
         self._rank = 1
         self._shape = (MathCeil(PyccelDiv(PyccelMinus(self._stop, self._start), self._step)))
         self._shape = process_shape(self._shape)
+        super().__init__()
 
     @property
     def arg(self):
-        return self._arg
+        return (self._start, self._stop, self._step)
 
     @property
     def start(self):
@@ -247,8 +245,8 @@ class NumpySum(PyccelInternalFunction):
     def __init__(self, arg):
         if not isinstance(arg, (list, tuple, PythonTuple, PythonList,
                             Variable, Expr)):
-            raise TypeError('Uknown type of  %s.' % type(arg))
-        PyccelInternalFunction.__init__(self, arg)
+            raise TypeError('Unknown type of  %s.' % type(arg))
+        super().__init__(arg)
         self._dtype = arg.dtype
         self._rank  = 0
         self._shape = ()
@@ -268,8 +266,8 @@ class NumpyProduct(PyccelInternalFunction):
     def __init__(self, arg):
         if not isinstance(arg, (list, tuple, PythonTuple, PythonList,
                                 Variable, Expr)):
-            raise TypeError('Uknown type of  %s.' % type(arg))
-        PyccelInternalFunction.__init__(self, arg)
+            raise TypeError('Unknown type of  %s.' % type(arg))
+        super().__init__(arg)
         self._dtype = arg.dtype
         self._rank  = 0
         self._shape = ()
@@ -293,7 +291,7 @@ class NumpyMatmul(PyccelInternalFunction):
         if not isinstance(b, (list, tuple, PythonTuple, PythonList,
                                 Variable, Expr)):
             raise TypeError('Unknown type of  %s.' % type(a))
-        PyccelInternalFunction.__init__(self, a, b)
+        super().__init__(a, b)
 
         args      = (a, b)
         integers  = [e for e in args if e.dtype is NativeInteger() or a.dtype is NativeBool()]
@@ -390,7 +388,7 @@ class NumpyLinspace(NumpyNewArray):
         self._stop  = stop
         self._size  = size
         self._shape = (self.size,)
-        NumpyNewArray.__init__(self)
+        super().__init__()
 
     @property
     def start(self):
@@ -424,7 +422,7 @@ class NumpyWhere(PyccelInternalFunction):
     """ Represents a call to  numpy.where """
 
     def __init__(self, mask):
-        PyccelInternalFunction.__init__(self, mask)
+        super().__init__(mask)
 
 
     @property
@@ -448,7 +446,7 @@ class NumpyRand(PyccelInternalFunction):
     _precision = default_precision['real']
 
     def __init__(self, *args):
-        PyccelInternalFunction.__init__(self)
+        super().__init__(*args)
         self._shape = args
         self._rank  = len(self.shape)
 
@@ -468,7 +466,6 @@ class NumpyRandint(PyccelInternalFunction):
     _order = 'C'
 
     def __init__(self, low, high = None, size = None):
-        PyccelInternalFunction.__init__(self)
         if size is None:
             size = ()
         if not hasattr(size,'__iter__'):
@@ -479,6 +476,7 @@ class NumpyRandint(PyccelInternalFunction):
         self._rand    = NumpyRand(*size)
         self._low     = low
         self._high    = high
+        super().__init__()
 
     @property
     def rand_expr(self):
@@ -564,7 +562,7 @@ class NumpyAutoFill(NumpyFull):
         if (dtype is None) or isinstance(dtype, Nil):
             raise TypeError("Data type must be provided")
 
-        NumpyFull.__init__(self, shape, None, dtype, order)
+        super().__init__(shape, Nil(), dtype, order)
 
 #==============================================================================
 class NumpyEmpty(NumpyAutoFill):
@@ -677,7 +675,7 @@ class NumpyNorm(PyccelInternalFunction):
         else:
             self._shape = ()
         self._rank = len(self._shape)
-        PyccelInternalFunction.__init__(self, arg, dim)
+        super().__init__(arg, dim)
 
     @property
     def arg(self):

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -97,6 +97,9 @@ class Variable(Symbol, PyccelAstNode):
     matrix.n_rows
     """
 
+    def __new__( cls, *args, **kwargs ):
+        return PyccelAstNode.__new__(cls, *args, **kwargs)
+
     def __init__(
         self,
         dtype,
@@ -117,7 +120,7 @@ class Variable(Symbol, PyccelAstNode):
         is_kwonly=False,
         allows_negative_indexes=False
         ):
-        Symbol.__init__(self, name)
+        Symbol.__init__(self)
 
         # ------------ PyccelAstNode Properties ---------------
         if isinstance(dtype, str) or str(dtype) == '*':

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1303,7 +1303,9 @@ class CCodePrinter(CodePrinter):
         target = self._print(expr.target)
         body  = self._print(expr.body)
         if isinstance(expr.iterable, PythonRange):
-            start, stop, step = [self._print(e) for e in expr.iterable.args]
+            start = self._print(expr.iterable.start)
+            stop  = self._print(expr.iterable.stop )
+            step  = self._print(expr.iterable.step )
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
         return ('for ({target} = {start}; {target} < {stop}; {target} += '

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -768,10 +768,13 @@ class FCodePrinter(CodePrinter):
     def _print_PyccelArraySize(self, expr):
         init_value = self._print(expr.arg)
         prec = self.print_kind(expr)
+
         if expr.arg.order == 'C':
-            index = self._print(expr.arg.rank - expr.index)
+            index = PyccelMinus(LiteralInteger(expr.arg.rank), expr.index)
+            index = self._print(index)
         else:
-            index = self._print(expr.index + 1)
+            index = PyccelAdd(expr.index, LiteralInteger(1))
+            index = self._print(index)
 
         if expr.arg.rank == 1:
             return 'size({0}, kind={1})'.format(init_value, prec)


### PR DESCRIPTION
Fixes #660.
This PR makes the classes in the following files mutable:

- builtins.py
- datatypes.py
- literals.py
- macros.py
- numpyext.py
- variable.py

In addition the following improvements are made to the above files:
- Use `super.__init__()` where possible. This means that the call does not necessarily need updating if the inheritance changes
- Simplify PythonList by using PythonTuple inheritance
-  Convert `int` indexes to `LiteralInteger`s in the constructor of `IndexedElement`
- Use PyccelNot in place of SympyNot.
- Remove unnecessary __new__ functions
- Correct a bug in `PythonBool` where `PythonBool.__init__` was not called
- Remove unnecessary inheritance
- Correct typos
- Remove unnecessary sympy objects