### PR TITLE
Reduce sympy dependence

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -44,16 +44,6 @@ __all__ = (
 )
 
 #==============================================================================
-# TODO [YG, 06.03.2020]: avoid core duplication between builtins and core
-local_sympify = {
-    'N'    : Symbol('N'),
-    'S'    : Symbol('S'),
-    'zeros': Symbol('zeros'),
-    'ones' : Symbol('ones'),
-    'Point': Symbol('Point')
-}
-
-#==============================================================================
 class PythonComplexProperty(PyccelInternalFunction):
     """Represents a call to the .real or .imag property
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -8,8 +8,6 @@
 from collections     import OrderedDict
 
 from sympy import Integral, Symbol
-from sympy import Integer as sp_Integer
-from sympy import Float as sp_Float
 from sympy import preorder_traversal
 
 from sympy.simplify.radsimp   import fraction
@@ -3879,8 +3877,6 @@ def process_shape(shape):
     for s in shape:
         if isinstance(s,(LiteralInteger, Variable, Slice, PyccelAstNode, FunctionCall)):
             new_shape.append(s)
-        elif isinstance(s, sp_Integer):
-            new_shape.append(LiteralInteger(s.p))
         elif isinstance(s, int):
             new_shape.append(LiteralInteger(s))
         else:

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1642,8 +1642,8 @@ class ValuedArgument(Basic):
 
         if isinstance(value, (bool, int, float, complex, str)):
             value = convert_to_literal(value)
-        elif not isinstance(value, PyccelAstNode):
-            raise TypeError("Expecting a pyccel object")
+        elif not isinstance(value, (Basic, Symbol)):
+            raise TypeError("Expecting a pyccel object not {}".format(type(value)))
 
         if not isinstance(kwonly, bool):
             raise TypeError("kwonly must be a bool")

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -7,11 +7,9 @@
 
 from collections     import OrderedDict
 
-from sympy import Add as sp_Add, Mul as sp_Mul, Pow as sp_Pow
-from sympy import Eq as sp_Eq, Ne as sp_Ne, Lt as sp_Lt, Le as sp_Le, Gt as sp_Gt, Ge as sp_Ge
 from sympy import Integral, Symbol
 from sympy import Integer as sp_Integer
-from sympy import Float as sp_Float, Rational as sp_Rational
+from sympy import Float as sp_Float
 from sympy import preorder_traversal
 
 from sympy.simplify.radsimp   import fraction
@@ -19,9 +17,8 @@ from sympy.core.compatibility import with_metaclass
 from sympy.core.singleton     import Singleton, S
 from sympy.core.function      import Derivative
 from sympy.core.function      import _coeff_isneg
-from sympy.core.expr          import Expr, AtomicExpr
-from sympy.logic.boolalg      import And as sp_And, Or as sp_Or
-from sympy.logic.boolalg      import Boolean as sp_Boolean
+from sympy.core.expr          import Expr
+from sympy.logic.boolalg      import And as sp_And
 
 from sympy.utilities.iterables          import iterable
 
@@ -30,20 +27,18 @@ from pyccel.errors.errors import Errors
 from pyccel.errors.messages import RECURSIVE_RESULTS_REQUIRED
 
 from .basic     import Basic, PyccelAstNode
-from .builtins  import (PythonEnumerate, PythonLen, PythonList, PythonMap,
-                        PythonRange, PythonZip, PythonTuple, PythonBool, Lambda)
+from .builtins  import (PythonEnumerate, PythonLen, PythonMap,
+                        PythonRange, PythonZip, PythonBool, Lambda)
 from .datatypes import (datatype, DataType, NativeSymbol,
                         NativeBool, NativeRange,
                         NativeTuple, is_iterable_datatype, str_dtype)
 from .internals      import Slice
 
-from .literals       import LiteralTrue, LiteralFalse, LiteralInteger, Nil
-from .literals       import LiteralImaginaryUnit, LiteralString
+from .literals       import LiteralInteger, Nil
 from .itertoolsext   import Product
-from .functionalexpr import GeneratorComprehension as GC
 from .functionalexpr import FunctionalFor
 
-from .operators import PyccelMul, IfTernaryOperator, Relational
+from .operators import PyccelMul, Relational
 
 from .variable import DottedName, DottedVariable, IndexedElement
 from .variable import ValuedVariable, Variable

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -109,7 +109,6 @@ __all__ = (
     'get_iterable_ranges',
     'inline',
     'int2float',
-#    'is_simple_assign',
 #    'operator',
 #    'op_registry',
     'process_shape',
@@ -3424,19 +3423,6 @@ class StarredArguments(Basic):
     @property
     def args_var(self):
         return self._starred_obj
-
-
-def is_simple_assign(expr):
-    if not isinstance(expr, Assign):
-        return False
-
-    assignable = [Variable, IndexedElement]
-    assignable += [sp_Integer, sp_Float]
-    assignable = tuple(assignable)
-    if isinstance(expr.rhs, assignable):
-        return True
-    else:
-        return False
 
 
 # ...

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -32,7 +32,7 @@ from .datatypes import (datatype, DataType, NativeSymbol,
                         NativeTuple, is_iterable_datatype, str_dtype)
 from .internals      import Slice
 
-from .literals       import LiteralInteger, Nil
+from .literals       import LiteralInteger, Nil, convert_to_literal
 from .itertoolsext   import Product
 from .functionalexpr import FunctionalFor
 
@@ -1639,6 +1639,14 @@ class ValuedArgument(Basic):
 
         if not isinstance(expr, (Symbol, Argument)):
             raise TypeError('Expecting an argument')
+
+        if isinstance(value, (bool, int, float, complex, str)):
+            value = convert_to_literal(value)
+        elif not isinstance(value, PyccelAstNode):
+            raise TypeError("Expecting a pyccel object")
+
+        if not isinstance(kwonly, bool):
+            raise TypeError("kwonly must be a bool")
 
         self._expr   = expr
         self._value  = value

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -103,12 +103,10 @@ __all__ = (
 #    'allocatable_like',
     'create_variable',
     'create_incremented_string',
-#    'float2int',
     'get_assigned_symbols',
     'get_initial_value',
     'get_iterable_ranges',
     'inline',
-    'int2float',
 #    'operator',
 #    'op_registry',
     'process_shape',
@@ -318,13 +316,6 @@ def inline(func, args):
     body = func.body
     body = subs(body, zip(func.arguments, args))
     return Block(str(func.name), local_vars, body)
-
-
-def int2float(expr):
-    return expr
-
-def float2int(expr):
-    return expr
 
 def create_incremented_string(forbidden_exprs, prefix = 'Dummy', counter = 1):
     """This function takes a prefix and a counter and uses them to construct

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -7,7 +7,6 @@
 
 from collections     import OrderedDict
 
-from sympy import sympify
 from sympy import Add as sp_Add, Mul as sp_Mul, Pow as sp_Pow
 from sympy import Eq as sp_Eq, Ne as sp_Ne, Lt as sp_Lt, Le as sp_Le, Gt as sp_Gt, Ge as sp_Ge
 from sympy import Integral, Symbol
@@ -117,7 +116,6 @@ __all__ = (
     'inline',
     'int2float',
 #    'is_simple_assign',
-    'local_sympify',
 #    'operator',
 #    'op_registry',
     'process_shape',
@@ -129,13 +127,6 @@ __all__ = (
 )
 
 #==============================================================================
-local_sympify = {
-    'N'    : Symbol('N'),
-    'S'    : Symbol('S'),
-    'zeros': Symbol('zeros'),
-    'ones' : Symbol('ones'),
-    'Point': Symbol('Point')
-}
 
 # TODO - add EmptyStmt => empty lines
 #      - update code examples
@@ -150,7 +141,7 @@ def apply(func, args, kwargs):return func(*args, **kwargs)
 #==============================================================================
 def subs(expr, new_elements):
     """
-    Substitutes old for new in an expression after sympifying args.
+    Substitutes old for new in an expression.
 
     Parameters
     ----------
@@ -359,7 +350,7 @@ def extract_subexpressions(expr):
             for i in expr:
                 args.append(substitute(i))
 
-            return PythonList(*args, sympify=False)
+            return PythonList(*args)
 
         elif isinstance(expr, (tuple, list)):
             args = []
@@ -1090,14 +1081,13 @@ class While(Basic):
     """
 
     def __init__(self, test, body, local_vars=()):
-        test = sympify(test, locals=local_sympify)
 
         if PyccelAstNode.stage == 'semantic':
             if test.dtype is not NativeBool():
                 test = PythonBool(test)
 
         if iterable(body):
-            body = CodeBlock((sympify(i, locals=local_sympify) for i in body))
+            body = CodeBlock(body)
         elif not isinstance(body,CodeBlock):
             raise TypeError('body must be an iterable or a CodeBlock')
 
@@ -1146,10 +1136,9 @@ class With(Basic):
         test,
         body,
         ):
-        test = sympify(test, locals=local_sympify)
 
         if iterable(body):
-            body = CodeBlock((sympify(i, locals=local_sympify) for i in body))
+            body = CodeBlock(body)
         elif not isinstance(body,CodeBlock):
             raise TypeError('body must be an iterable')
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3880,6 +3880,6 @@ def process_shape(shape):
         elif isinstance(s, int):
             new_shape.append(LiteralInteger(s))
         else:
-            raise TypeError('shape elements cannot be '+str(type(s))+'. They must be one of the following types: Integer(pyccel), Variable, Slice, PyccelAstNode, Integer(sympy), int, FunctionCall')
+            raise TypeError('shape elements cannot be '+str(type(s))+'. They must be one of the following types: LiteralInteger, Variable, Slice, PyccelAstNode, int, FunctionCall')
     return tuple(new_shape)
 

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -6,14 +6,12 @@
 
 from sympy.utilities.iterables import iterable
 from sympy.core import Symbol
-from sympy import sympify
 
 from ..errors.errors import Errors
 from ..errors.messages import TEMPLATE_IN_UNIONTYPE
 from .core import Basic
 from .core import ValuedArgument
 from .core import FunctionDef, Interface, FunctionAddress
-from .core import local_sympify
 from .datatypes import datatype, DataTypeFactory, UnionType
 from .macros import Macro, MacroShape, construct_macro
 from .variable import DottedName, DottedVariable
@@ -589,9 +587,6 @@ class MacroFunction(Header):
         # master can be a string or FunctionDef
         if not isinstance(master, (str, FunctionDef, Interface)):
             raise ValueError('Expecting a master name of FunctionDef')
-
-        if not(results is None):
-            results = [sympify(a, locals=local_sympify) for a in results]
 
         self._name             = name
         self._arguments        = args

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -222,3 +222,54 @@ def get_default_literal_value(dtype):
     else:
         raise TypeError('Unknown type')
     return value
+
+#------------------------------------------------------------------------------
+
+def convert_to_literal(value, dtype = None, precision = None):
+    """ Convert a python value to a pyccel Literal
+
+    Parameters
+    ----------
+    value     : int/float/complex/bool/str
+                The python value
+    dtype     : DataType
+                The datatype of the python value
+                Default : Matches type of 'value'
+    precision : int
+                The precision of the value in the generated code
+                Default : python precision (see default_precision)
+    """
+    if dtype is None:
+        if isinstance(value, int):
+            dtype = NativeInteger()
+        elif isinstance(value, float):
+            dtype = NativeReal()
+        elif isinstance(value, complex):
+            dtype = NativeComplex()
+        elif isinstance(value, bool):
+            dtype = NativeBool()
+        elif isinstance(value, str):
+            dtype = NativeString()
+        else:
+            raise TypeError('Unknown type')
+
+    if precision is None and dtype is not NativeString():
+        precision = default_precision[str(dtype)]
+
+    if isinstance(dtype, NativeInteger):
+        value = LiteralInteger(value, precision)
+    elif isinstance(dtype, NativeReal):
+        value = LiteralFloat(value, precision)
+    elif isinstance(dtype, NativeComplex):
+        value = LiteralComplex(value.real, value.imag, precision)
+    elif isinstance(dtype, NativeBool):
+        if value:
+            value = LiteralTrue(precision)
+        else:
+            value = LiteralFalse(precision)
+    elif isinstance(dtype, NativeString):
+        value = LiteralString(value)
+    else:
+        raise TypeError('Unknown type')
+
+    return value

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -238,6 +238,12 @@ def convert_to_literal(value, dtype = None, precision = None):
     precision : int
                 The precision of the value in the generated code
                 Default : python precision (see default_precision)
+
+    Returns
+    -------
+    literal_val : Literal
+                  The python value 'value' expressed as a literal
+                  with the specified dtype and precision
     """
     if dtype is None:
         if isinstance(value, int):
@@ -257,19 +263,19 @@ def convert_to_literal(value, dtype = None, precision = None):
         precision = default_precision[str(dtype)]
 
     if isinstance(dtype, NativeInteger):
-        value = LiteralInteger(value, precision)
+        literal_val = LiteralInteger(value, precision)
     elif isinstance(dtype, NativeReal):
-        value = LiteralFloat(value, precision)
+        literal_val = LiteralFloat(value, precision)
     elif isinstance(dtype, NativeComplex):
-        value = LiteralComplex(value.real, value.imag, precision)
+        literal_val = LiteralComplex(value.real, value.imag, precision)
     elif isinstance(dtype, NativeBool):
         if value:
-            value = LiteralTrue(precision)
+            literal_val = LiteralTrue(precision)
         else:
-            value = LiteralFalse(precision)
+            literal_val = LiteralFalse(precision)
     elif isinstance(dtype, NativeString):
-        value = LiteralString(value)
+        literal_val = LiteralString(value)
     else:
         raise TypeError('Unknown type')
 
-    return value
+    return literal_val

--- a/pyccel/ast/macros.py
+++ b/pyccel/ast/macros.py
@@ -7,7 +7,7 @@
 """
 This module contains all classes and functions used for handling macros.
 """
-
+from sympy import Symbol
 from sympy.core.expr import AtomicExpr
 
 from .basic          import PyccelAstNode
@@ -28,7 +28,8 @@ class Macro(AtomicExpr, PyccelAstNode):
     _name = '__UNDEFINED__'
 
     def __init__(self, argument):
-        # TODO add verification
+        if not isinstance(argument, Symbol):
+            raise TypeError("Argument must be a symbol not {}".format(type(argument)))
 
         self._argument = argument
         super().__init__()

--- a/pyccel/ast/macros.py
+++ b/pyccel/ast/macros.py
@@ -9,10 +9,8 @@ This module contains all classes and functions used for handling macros.
 """
 
 from sympy.core.expr import AtomicExpr
-from sympy import sympify
 
 from .basic          import PyccelAstNode
-from .core           import local_sympify
 from .datatypes      import default_precision
 from .datatypes      import NativeInteger, NativeGeneric
 
@@ -104,7 +102,6 @@ def construct_macro(name, argument, parameter=None):
     if not isinstance(name, str):
         raise TypeError('name must be of type str')
 
-    argument = sympify(argument, locals=local_sympify)
     if name == 'shape':
         return MacroShape(argument, index=parameter)
     elif name == 'dtype':

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -7,8 +7,7 @@
 
 import numpy
 
-from sympy           import (Integer as sp_Integer,
-                             Rational as sp_Rational, Expr)
+from sympy           import Expr
 
 from .core           import (ClassDef, FunctionDef,
                             process_shape, ValuedArgument)
@@ -437,7 +436,7 @@ class NumpyLinspace(NumpyNewArray):
 
 
         _valid_args = (Variable, IndexedElement, LiteralFloat,
-                       sp_Integer, sp_Rational)
+                       LiteralInteger)
 
         for arg in (start, stop, size):
             if not isinstance(arg, _valid_args):

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -7,7 +7,6 @@
 
 import inspect
 
-from sympy import Not
 from numpy import pi
 
 import pyccel.decorators as pyccel_decorators
@@ -52,9 +51,6 @@ def builtin_function(expr, args=None):
 
     if name in dic.keys() :
         return dic[name](*args)
-
-    if name == 'Not':
-        return Not(*args)
 
     if name == 'map':
         func = str(expr.args[0].name)

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -226,8 +226,8 @@ class Variable(Symbol, PyccelAstNode):
             elif s is None or isinstance(s, PyccelAstNode):
                 new_shape.append(PyccelArraySize(self, LiteralInteger(i)))
             else:
-                raise TypeError('shape elements cannot be '+str(type(s))+'. They must be one of the following types: Integer(pyccel),'
-                                'Variable, Slice, PyccelAstNode, Integer(sympy), int, Function')
+                raise TypeError('shape elements cannot be '+str(type(s))+'. They must be one of the following types: LiteralInteger,'
+                                'Variable, Slice, PyccelAstNode, int, Function')
         return tuple(new_shape)
 
     @property

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -9,7 +9,6 @@
 
 from sympy.core.basic import Basic
 from sympy.core.symbol import Symbol
-from sympy.core.sympify import _sympify
 from sympy.printing.str import StrPrinter
 
 from pyccel.ast.core import Assign
@@ -54,8 +53,6 @@ class CodePrinter(StrPrinter):
 
         if assign_to:
             expr = Assign(assign_to, expr)
-        else:
-            expr = _sympify(expr)
 
         # Do the actual printing
         lines = self._print(expr).splitlines(True)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -21,8 +21,6 @@ from sympy.core import Symbol
 from sympy.core.numbers import NegativeInfinity as NINF
 from sympy.core.numbers import Infinity as INF
 
-from sympy.logic.boolalg import Not
-
 from pyccel.ast.core import get_iterable_ranges
 from pyccel.ast.core import AddOp, MulOp, SubOp, DivOp
 from pyccel.ast.core import SeparatorComment, Comment
@@ -32,12 +30,12 @@ from pyccel.ast.internals    import PyccelInternalFunction
 from pyccel.ast.itertoolsext import Product
 from pyccel.ast.core import (Assign, AliasAssign, Declare,
                              CodeBlock, Dlist, AsName,
-                             If)
+                             If, IfSection)
 from pyccel.ast.variable  import (Variable, TupleVariable,
                              IndexedElement,
                              DottedName, PyccelArraySize)
 
-from pyccel.ast.operators      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus
+from pyccel.ast.operators      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus, PyccelNot
 
 from pyccel.ast.operators      import PyccelUnarySub, PyccelLt, PyccelGt, IfTernaryOperator
 
@@ -2237,7 +2235,7 @@ class FCodePrinter(CodePrinter):
         DEBUG = True
 
         err = ErrorExit()
-        args = [(Not(expr.test), [PythonPrint(["'Assert Failed'"]), err])]
+        args = [IfSection(PyccelNot(expr.test), [PythonPrint(["'Assert Failed'"]), err])]
 
         if DEBUG:
             args.append((True, PythonPrint(["'PASSED'"])))

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -97,8 +97,6 @@ from pyccel.errors.errors import PyccelSemanticError
 
 # TODO - remove import * and only import what we need
 #      - use OrderedDict whenever it is possible
-# TODO move or delete extract_subexpressions when we introduce
-#   Functional programming
 from pyccel.errors.messages import *
 
 from pyccel.parser.base      import BasicParser, Scope
@@ -1162,10 +1160,6 @@ class SemanticParser(BasicParser):
             severity='fatal', blocker=True)
 
     def _visit_PyccelOperator(self, expr, **settings):
-        #stmts, expr = extract_subexpressions(expr)
-        #stmts = []
-        #if stmts:
-        #    stmts = [self._visit(i, **settings) for i in stmts]
         args     = [self._visit(a, **settings) for a in expr.args]
         try:
             expr_new = expr.func(*args)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -35,7 +35,6 @@ from pyccel.ast.core import If, IfSection
 from pyccel.ast.core import While
 from pyccel.ast.core import Del
 from pyccel.ast.core import Assert
-from pyccel.ast.core import PythonTuple
 from pyccel.ast.core import Comment, EmptyNode
 from pyccel.ast.core import Break, Continue
 from pyccel.ast.core import Argument, ValuedArgument
@@ -43,7 +42,6 @@ from pyccel.ast.core import Import
 from pyccel.ast.core import AsName
 from pyccel.ast.core import CommentBlock
 from pyccel.ast.core import With
-from pyccel.ast.core import PythonList
 from pyccel.ast.core import StarredArguments
 from pyccel.ast.core import CodeBlock
 from pyccel.ast.core import IndexedElement
@@ -58,6 +56,7 @@ from pyccel.ast.operators import PyccelUnary, PyccelUnarySub
 from pyccel.ast.operators import PyccelIs, PyccelIsNot
 from pyccel.ast.operators import IfTernaryOperator
 
+from pyccel.ast.builtins import PythonTuple, PythonList
 from pyccel.ast.builtins import PythonPrint, Lambda
 from pyccel.ast.headers  import Header, MetaVariable
 from pyccel.ast.literals import LiteralInteger, LiteralFloat, LiteralComplex

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -409,7 +409,7 @@ class MacroStmt(BasicStmt):
     @property
     def expr(self):
         name = str(self.macro)
-        arg  = str(self.arg)
+        arg  = Symbol(str(self.arg))
         parameter = self.parameter
         return construct_macro(name, arg, parameter=parameter)
 
@@ -448,6 +448,8 @@ class FunctionMacroStmt(BasicStmt):
 
         self.dotted_name = tuple(kwargs.pop('dotted_name'))
         self.results = kwargs.pop('results',None)
+        if self.results:
+            self.results = [Symbol(r) for r in self.results]
         self.args = kwargs.pop('args')
         self.master_name = tuple(kwargs.pop('master_name'))
         self.master_args = kwargs.pop('master_args')

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -8,7 +8,6 @@
 from os.path import join, dirname
 
 from sympy.core import Symbol
-from sympy import sympify
 
 from textx.metamodel import metamodel_from_file
 
@@ -391,8 +390,6 @@ class MacroArg(BasicStmt):
         if not(value is None):
             if isinstance(value, (MacroStmt,StringStmt)):
                 value = value.expr
-            else:
-                value = sympify(str(value),locals={'N':Symbol('N'),'S':Symbol('S')})
             return ValuedArgument(arg, value)
         return arg
 


### PR DESCRIPTION
Remove all calls to sympify and remove places where sympy is imported and used unnecessarily. Fixes #686 

**Commit Summary**
- Remove calls to sympify
- Remove unused functions
    - extract_subexpressions
    - is_simple_assign
    - float2int
    - int2float
- Use PyccelNot instead of Not (this is an operator, not a function)
- Remove unnecessary references to sympy types
- Add type checks to macro types
- Ensure that symbols in macros are stored in symbols not strings
- Add `convert_to_literal` function (discussed in issue #564) to automatically handle basic types