### PR TITLE
[BUGFIX] Break infinite recursion

### DIFF
--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -106,7 +106,6 @@ class Basic(sp_Basic):
                requested type which contain self
         """
         if self._recursion_in_progress:
-            self._recursion_in_progress = False
             return []
 
         if len(self._user_nodes) == 0:
@@ -140,7 +139,6 @@ class Basic(sp_Basic):
                requested type which exist in self
         """
         if self._recursion_in_progress:
-            self._recursion_in_progress = False
             return
         self._recursion_in_progress = True
 
@@ -186,7 +184,6 @@ class Basic(sp_Basic):
                       Types for which substitute should not be called
         """
         if self._recursion_in_progress:
-            self._recursion_in_progress = False
             return
         self._recursion_in_progress = True
 

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -105,10 +105,7 @@ class Basic(sp_Basic):
         list : List containing all objects of the
                requested type which contain self
         """
-        if self._recursion_in_progress:
-            return []
-
-        if len(self._user_nodes) == 0:
+        if self._recursion_in_progress or len(self._user_nodes) == 0:
             return []
         else:
             self._recursion_in_progress = True
@@ -139,7 +136,7 @@ class Basic(sp_Basic):
                requested type which exist in self
         """
         if self._recursion_in_progress:
-            return
+            return []
         self._recursion_in_progress = True
 
         results = []

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -199,11 +199,12 @@ class Basic(sp_Basic):
 
         def prepare_sub(found_node):
             idx = original.index(found_node)
+            rep = replacement[idx]
             if not self.ignore(found_node):
                 found_node.remove_user_node(self)
-            if not self.ignore(replacement[idx]):
-                replacement[idx].set_current_user_node(self)
-            return replacement[idx]
+            if not self.ignore(rep):
+                rep.set_current_user_node(self)
+            return rep
 
         for n in self._attribute_nodes:
             v = getattr(self, n)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2679,8 +2679,8 @@ class SemanticParser(BasicParser):
                     functions = sub_funcs,
                     interfaces = func_interfaces,
                     doc_string = doc_string)
-            func.body.substitute(recursive_func_obj, func)
-            recursive_func_obj.invalidate_node()
+            if recursive_func_obj not in body.get_attribute_nodes(FunctionDef):
+                recursive_func_obj.invalidate_node()
 
             if cls_name:
                 cls = self.get_class(cls_name)

--- a/tests/ast/scripts/cyclic_dependence.py
+++ b/tests/ast/scripts/cyclic_dependence.py
@@ -1,7 +1,7 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring, unused-variable
 
 def fib_caller(x : int):
-    @types('int', results='int')
-    def fib(n):
+    def fib(n : int) -> int:
         if n < 2:
             return n
         i = fib(n-1)

--- a/tests/ast/scripts/cyclic_dependence.py
+++ b/tests/ast/scripts/cyclic_dependence.py
@@ -1,0 +1,12 @@
+
+def fib_caller(x : int):
+    @types('int', results='int')
+    def fib(n):
+        if n < 2:
+            return n
+        i = fib(n-1)
+        j = fib(n-2)
+        return i + j
+
+    m = fib(x)
+    return m

--- a/tests/ast/test_basic.py
+++ b/tests/ast/test_basic.py
@@ -5,7 +5,7 @@ from pyccel.parser.parser   import Parser
 from pyccel.errors.errors   import Errors
 
 from pyccel.ast.basic       import Basic
-from pyccel.ast.core        import Assign, Return
+from pyccel.ast.core        import Assign, Return, FunctionDef
 from pyccel.ast.literals    import LiteralInteger
 from pyccel.ast.operators   import PyccelAdd, PyccelMinus
 from pyccel.ast.variable    import Variable, ValuedVariable
@@ -165,3 +165,19 @@ def test_substitute_exclude():
     new_parents = set(new_var.get_user_nodes(Basic))
     assert(len(new_parents.difference(old_parents))==0)
     assert(len(old_parents.difference(new_parents))==1)
+
+def test_recursive():
+    filename = os.path.join(path_dir, "cyclic_dependence.py")
+
+    fst = get_functions(filename)[0]
+
+    atts = fst.get_attribute_nodes(PyccelMinus)
+    assert(len(set(atts))==2)
+
+    var = atts[0].args[0]
+
+    atts = var.get_user_nodes(FunctionDef)
+    assert(len(set(atts))==2) # The actual FunctionDef + the signature version
+
+    fst.substitute(LiteralInteger(2), LiteralInteger(3))
+


### PR DESCRIPTION
Keep function signature in recursive function call instead of replacing it with the complete function definition. Fixes #743

In addition an attribute `_recursion_in_progress` is added to `pyccel.ast.basic.Basic` to break any future accidental recursion