### PR TITLE
Remove Sympy inheritance from AST nodes

### DIFF
--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -292,14 +292,6 @@ class Basic:
         """
         return len(self._user_nodes)==0
 
-    def __eq__(self, other):
-        #TODO: Remove with sympy inheritance
-        return id(self) == id(other)
-
-    def __hash__(self):
-        #TODO: Remove with sympy inheritance
-        return id(self)
-
 class PyccelAstNode(Basic):
     """Class from which all nodes containing objects inherit
     """

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -29,9 +29,6 @@ class Basic:
     _fst = None
     _ignored_types = (Immutable, type)
 
-    def __new__(cls, *args, **kwargs):
-        hashable_args  = [a if not isinstance(a, list) else tuple(a) for a in args]
-
     def __init__(self):
         self._user_nodes = []
         self._fst = []

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -46,8 +46,8 @@ class Basic:
                 c = convert_to_literal(c)
                 setattr(self, c_name, c)
 
-            elif isinstance(c, iterable_types):
-                if any(isinstance(ci, iterable_types) for ci in c):
+            elif iterable(c):
+                if any(iterable(ci) for ci in c):
                     raise TypeError("Basic child cannot be a tuple of tuples")
                 c = tuple(ci if (not isinstance(ci, (int, float, complex, str, bool)) \
                                  or self.ignore(ci)) \
@@ -180,8 +180,8 @@ class Basic:
             return
         self._recursion_in_progress = True
 
-        if isinstance(original, iterable_types):
-            assert(isinstance(replacement, iterable_types))
+        if iterable(original):
+            assert(iterable(replacement))
             assert(len(original) == len(replacement))
         else:
             original = (original,)
@@ -192,7 +192,7 @@ class Basic:
             rep = replacement[idx]
             if not self.ignore(found_node):
                 found_node.remove_user_node(self)
-            if isinstance(rep, iterable_types):
+            if iterable(rep):
                 for r in rep:
                     if not self.ignore(r):
                         r.set_current_user_node(self)
@@ -219,7 +219,7 @@ class Basic:
                             new_vi = prepare_sub(vi)
                         elif not self.ignore(vi):
                             vi.substitute(original, replacement, excluded_nodes)
-                    if isinstance(new_vi, iterable_types):
+                    if iterable(new_vi):
                         new_v.extend(new_vi)
                     else:
                         new_v.append(new_vi)

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -10,13 +10,13 @@ They are:
 - PyccelAstNode which describes each PyccelAstNode
 """
 import ast
-from sympy.core.basic import Basic as sp_Basic
 
 __all__ = ('Basic', 'PyccelAstNode')
 
 dict_keys   = type({}.keys())
 dict_values = type({}.values())
 iterable_types = (list, tuple, dict_keys, dict_values)
+iterable = lambda x : isinstance(x, iterable_types)
 
 #==============================================================================
 class Immutable:
@@ -24,14 +24,13 @@ class Immutable:
     from Basic """
 
 #==============================================================================
-class Basic(sp_Basic):
+class Basic:
     """Basic class for Pyccel AST."""
     _fst = None
     _ignored_types = (Immutable, type)
 
     def __new__(cls, *args, **kwargs):
         hashable_args  = [a if not isinstance(a, list) else tuple(a) for a in args]
-        return sp_Basic.__new__(cls, *hashable_args)
 
     def __init__(self):
         self._user_nodes = []

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -439,8 +439,8 @@ class PythonPrint(Basic):
 
     """Represents a print function in the code.
 
-    expr : sympy expr
-        The expression to return.
+    expr : PyccelAstNode
+        The expression to print
 
     Examples
 

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -532,7 +532,7 @@ class PythonZip(PyccelInternalFunction):
             raise TypeError('args must be a list or tuple')
         elif len(args) < 2:
             raise ValueError('args must be of length > 2')
-        super().__init__(args)
+        super().__init__(*args)
         if PyccelAstNode.stage == 'syntactic':
             self._length = None
             return

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -134,9 +134,6 @@ class PythonBool(PyccelAstNode):
     def __str__(self):
         return 'Bool({})'.format(str(self.arg))
 
-    def _sympystr(self, printer):
-        return self.__str__()
-
 #==============================================================================
 class PythonComplex(PyccelAstNode):
     """ Represents a call to Python's native complex() function.
@@ -282,9 +279,6 @@ class PythonFloat(PyccelAstNode):
 
     def __str__(self):
         return 'LiteralFloat({0})'.format(str(self.arg))
-
-    def _sympystr(self, printer):
-        return self.__str__()
 
 #==============================================================================
 class PythonInt(PyccelAstNode):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -436,6 +436,8 @@ class PythonMap(Basic):
 
     @property
     def args(self):
+        """ Arguments of the map
+        """
         return self._args
 
 #==============================================================================

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -85,7 +85,7 @@ class PythonReal(PythonComplexProperty):
         elif not isinstance(arg.dtype, NativeComplex):
             return arg
         else:
-            return super().__new__(cls, arg)
+            return super().__new__(cls)
 
 #==============================================================================
 class PythonImag(PythonComplexProperty):
@@ -102,7 +102,7 @@ class PythonImag(PythonComplexProperty):
         if arg.dtype is not NativeComplex():
             return get_default_literal_value(arg.dtype)
         else:
-            return super().__new__(cls, arg)
+            return super().__new__(cls)
 
 
 #==============================================================================
@@ -115,11 +115,11 @@ class PythonBool(PyccelAstNode):
 
     def __new__(cls, arg):
         if getattr(arg, 'is_optional', None):
-            bool_expr = super().__new__(cls, arg)
+            bool_expr = super().__new__(cls)
             bool_expr.__init__(arg)
             return PyccelAnd(PyccelIsNot(arg, Nil()), bool_expr)
         else:
-            return super().__new__(cls, arg)
+            return super().__new__(cls)
 
     def __init__(self, arg):
         self._arg = arg
@@ -177,7 +177,7 @@ class PythonComplex(PyccelAstNode):
         if arg0.dtype is NativeComplex() and arg1.dtype is NativeComplex():
             # both args are complex
             return PyccelAdd(arg0, PyccelMul(arg1, LiteralImaginaryUnit()))
-        return super().__new__(cls, arg0, arg1)
+        return super().__new__(cls)
 
     def __init__(self, arg0, arg1 = LiteralFloat(0)):
         self._is_cast = arg0.dtype is NativeComplex() and \
@@ -268,7 +268,7 @@ class PythonFloat(PyccelAstNode):
         elif isinstance(arg, LiteralInteger):
             return LiteralFloat(arg.p, precision = cls._precision)
         else:
-            return super().__new__(cls, arg)
+            return super().__new__(cls)
 
     def __init__(self, arg):
         self._arg = arg
@@ -299,7 +299,7 @@ class PythonInt(PyccelAstNode):
         if isinstance(arg, LiteralInteger):
             return LiteralInteger(arg.p, precision = cls._precision)
         else:
-            return super().__new__(cls, arg)
+            return super().__new__(cls)
 
     def __init__(self, arg):
         self._arg = arg

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -232,7 +232,7 @@ class PythonComplex(PyccelAstNode):
         return self._internal_var
 
     def __str__(self):
-        return "complex({}, {})".format(str(self._args[0]), str(self._args[1]))
+        return "complex({}, {})".format(str(self.real), str(self.imag))
 
 #==============================================================================
 class PythonEnumerate(Basic):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -534,7 +534,7 @@ class PythonZip(Basic):
             self._length = None
             return
         else:
-            lengths = [a.shape[0] for a in self.args if not isinstance(a.shape[0], PyccelArraySize)]
+            lengths = [a.shape[0].python_value for a in self.args if isinstance(a.shape[0], LiteralInteger)]
             if lengths:
                 self._length = max(lengths)
             else:

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -15,7 +15,7 @@ from .basic     import Basic, PyccelAstNode
 from .datatypes import (NativeInteger, NativeBool, NativeReal,
                         NativeComplex, NativeString, str_dtype,
                         NativeGeneric, default_precision)
-from .internals import PyccelInternalFunction, PyccelArraySize
+from .internals import PyccelInternalFunction
 from .literals  import LiteralInteger, LiteralFloat, LiteralComplex, Nil
 from .literals  import Literal, LiteralImaginaryUnit, get_default_literal_value
 from .operators import PyccelAdd, PyccelAnd, PyccelMul, PyccelIsNot
@@ -392,6 +392,8 @@ class PythonTuple(PyccelAstNode):
 
     @property
     def args(self):
+        """ Arguments of the tuple
+        """
         return self._args
 
 #==============================================================================
@@ -515,7 +517,7 @@ class PythonRange(Basic):
 
 
 #==============================================================================
-class PythonZip(Basic):
+class PythonZip(PyccelInternalFunction):
 
     """
     Represents a zip stmt.
@@ -528,24 +530,21 @@ class PythonZip(Basic):
             raise TypeError('args must be a list or tuple')
         elif len(args) < 2:
             raise ValueError('args must be of length > 2')
-        self._args = args
-        super().__init__()
+        super().__init__(args)
         if PyccelAstNode.stage == 'syntactic':
             self._length = None
             return
         else:
             lengths = [a.shape[0].python_value for a in self.args if isinstance(a.shape[0], LiteralInteger)]
             if lengths:
-                self._length = max(lengths)
+                self._length = min(lengths)
             else:
                 self._length = self.args[0].shape[0]
 
     @property
-    def args(self):
-        return self._args
-
-    @property
     def length(self):
+        """ Length of the shortest zip argument
+        """
         return self._length
 
 #==============================================================================

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -284,9 +284,8 @@ class AsName(Basic):
     def target(self):
         return self._target
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return '{0} as {1}'.format(sstr(self.name), sstr(self.target))
+    def __str__(self):
+        return '{0} as {1}'.format(str(self.name), str(self.target))
 
     def __eq__(self, string):
         if isinstance(string, str):
@@ -391,9 +390,8 @@ class Assign(Basic):
         self._like = like
         super().__init__()
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return '{0} := {1}'.format(sstr(self.lhs), sstr(self.rhs))
+    def __str__(self):
+        return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
 
     @property
     def lhs(self):
@@ -529,10 +527,9 @@ class Allocate(Basic):
     def status(self):
         return self._status
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
+    def __str__(self):
         return 'Allocate({}, shape={}, order={}, status={})'.format(
-                sstr(self.variable), sstr(self.shape), sstr(self.order), sstr(self.status))
+                str(self.variable), str(self.shape), str(self.order), str(self.status))
 
     def __eq__(self, other):
         if isinstance(other, Allocate):
@@ -689,9 +686,8 @@ class AliasAssign(Basic):
         self._rhs = rhs
         super().__init__()
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return '{0} := {1}'.format(sstr(self.lhs), sstr(self.rhs))
+    def __str__(self):
+        return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
 
     @property
     def lhs(self):
@@ -730,9 +726,8 @@ class SymbolicAssign(Basic):
         self._rhs = rhs
         super().__init__()
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return '{0} := {1}'.format(sstr(self.lhs), sstr(self.rhs))
+    def __str__(self):
+        return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
 
     @property
     def lhs(self):
@@ -850,10 +845,9 @@ class AugAssign(Assign):
 
         super().__init__(lhs, rhs, status, like)
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return '{0} {1}= {2}'.format(sstr(self.lhs), self.op._symbol,
-                sstr(self.rhs))
+    def __str__(self):
+        return '{0} {1}= {2}'.format(str(self.lhs), self.op._symbol,
+                str(self.rhs))
 
     @property
     def op(self):
@@ -1471,12 +1465,11 @@ class ConstructorCall(Basic):
         self._arguments = arguments
         super().__init__()
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        name = sstr(self.name)
+    def __str__(self, printer):
+        name = str(self.name)
         args = ''
         if not self.arguments is None:
-            args = ', '.join(sstr(i) for i in self.arguments)
+            args = ', '.join(str(i) for i in self.arguments)
         return '{0}({1})'.format(name, args)
 
     @property
@@ -1584,11 +1577,9 @@ class ValuedArgument(Basic):
     def is_kwonly(self):
         return self._kwonly
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-
-        argument = sstr(self.argument)
-        value = sstr(self.value)
+    def __str__(self):
+        argument = str(self.argument)
+        value = str(self.value)
         return '{0}={1}'.format(argument, value)
 
 class FunctionCall(PyccelAstNode):
@@ -2781,13 +2772,12 @@ class Import(Basic):
             raise TypeError('to_ignore must be a boolean.')
         self._ignore_at_print = to_ignore
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        source = sstr(self.source)
+    def __str__(self):
+        source = str(self.source)
         if len(self.target) == 0:
             return 'import {source}'.format(source=source)
         else:
-            target = ', '.join([sstr(i) for i in self.target])
+            target = ', '.join([str(i) for i in self.target])
             return 'from {source} import {target}'.format(source=source,
                     target=target)
 
@@ -3083,7 +3073,7 @@ class EmptyNode(Basic):
     """
     _attribute_nodes = ()
 
-    def _sympystr(self, printer):
+    def __str__(self, printer):
         return ''
 
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -628,6 +628,27 @@ class CodeBlock(Basic):
     def __str__(self):
         return 'CodeBlock({})'.format(self.body)
 
+    def __reduce_ex__(self, i):
+        """ Used by pickle to create an object of this class.
+
+          Parameters
+          ----------
+
+          i : int
+           protocol
+
+          Results
+          -------
+
+          out : tuple
+           A tuple of two elements
+           a callable function that can be called
+           to create the initial version of the object
+           and its arguments.
+        """
+        kwargs = dict(body = self.body)
+        return (apply, (self.__class__, (), kwargs))
+
 class AliasAssign(Basic):
 
     """Represents aliasing for code generation. An alias is any statement of the
@@ -3091,9 +3112,29 @@ class Comment(Basic):
     def text(self):
         return self._text
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return '# {0}'.format(sstr(self.text))
+    def __str__(self):
+        return '# {0}'.format(str(self.text))
+
+    def __reduce_ex__(self, i):
+        """ Used by pickle to create an object of this class.
+
+          Parameters
+          ----------
+
+          i : int
+           protocol
+
+          Results
+          -------
+
+          out : tuple
+           A tuple of two elements
+           a callable function that can be called
+           to create the initial version of the object
+           and its arguments.
+        """
+        kwargs = dict(text = self.text)
+        return (apply, (self.__class__, (), kwargs))
 
 
 class SeparatorComment(Comment):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -304,7 +304,7 @@ class Dlist(PyccelAstNode):
     Parameters
     ----------
     value : PyccelAstNode
-           a sympy expression which represents the initilized value of the list
+           an expression which represents the initilized value of the list
 
     shape : the shape of the array
     """
@@ -738,7 +738,7 @@ class SymbolicAssign(Basic):
         return self._rhs
 
 
-# The following are defined to be sympy approved nodes. If there is something
+# The following were defined to be sympy approved nodes. If there is something
 # smaller that could be used, that would be preferable. We only use them as
 # tokens.
 
@@ -864,9 +864,9 @@ class While(Basic):
 
     Parameters
     ----------
-    test : expression
-        test condition given as a sympy expression
-    body : sympy expr
+    test : PyccelAstNode
+        test condition given as an expression
+    body : list of Pyccel objects
         list of statements representing the body of the While statement.
 
     Examples
@@ -918,9 +918,9 @@ class With(Basic):
 
     Parameters
     ----------
-    test : expression
-        test condition given as a sympy expression
-    body : sympy expr
+    test : PyccelAstNode
+        test condition given as an expression
+    body : list of Pyccel objects
         list of statements representing the body of the With statement.
 
     Examples
@@ -1304,11 +1304,11 @@ class For(Basic):
 
     Parameters
     ----------
-    target : symbol
+    target : symbol / Variable
         symbol representing the iterator
     iter : iterable
         iterable object. for the moment only Range is used
-    body : sympy expr
+    body : list of pyccel objects
         list of statements representing the body of the For statement.
 
     Examples
@@ -1721,7 +1721,7 @@ class Return(Basic):
 
     Parameters
     ----------
-    expr : sympy expr
+    expr : PyccelAstNode
         The expression to return.
 
     stmts :represent assign stmts in the case of expression return
@@ -2988,8 +2988,8 @@ class SymbolicPrint(Basic):
 
     Parameters
     ----------
-    expr : sympy expr
-        The expression to return.
+    expr : PyccelAstNode
+        The expression to print
 
     Examples
     --------
@@ -3584,7 +3584,6 @@ def get_iterable_ranges(it, var_name=None):
         cls_base = it.this.cls_base
 
         # arguments[0] is 'self'
-        # TODO must be improved in syntax, so that a['value'] is a sympy object
 
         args = []
         kwargs = {}

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -7,13 +7,13 @@
 
 from collections     import OrderedDict
 
-from sympy.core.compatibility import with_metaclass
-from sympy.core.singleton     import Singleton
 from sympy.logic.boolalg      import And as sp_And
 
 
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import RECURSIVE_RESULTS_REQUIRED
+
+from pyccel.utilities.metaclasses import Singleton
 
 from .basic     import Basic, PyccelAstNode, iterable
 from .builtins  import (PythonEnumerate, PythonLen, PythonMap, PythonTuple,
@@ -747,7 +747,7 @@ class SymbolicAssign(Basic):
 # smaller that could be used, that would be preferable. We only use them as
 # tokens.
 
-class NativeOp(with_metaclass(Singleton)):
+class NativeOp(metaclass=Singleton):
 
     """Base type for native operands."""
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1465,7 +1465,7 @@ class ConstructorCall(Basic):
         self._arguments = arguments
         super().__init__()
 
-    def __str__(self, printer):
+    def __str__(self):
         name = str(self.name)
         args = ''
         if not self.arguments is None:

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -7,20 +7,15 @@
 
 from collections     import OrderedDict
 
-from sympy import preorder_traversal
-
 from sympy.core.compatibility import with_metaclass
 from sympy.core.singleton     import Singleton
-from sympy.core.expr          import Expr
 from sympy.logic.boolalg      import And as sp_And
-
-from sympy.utilities.iterables          import iterable
 
 
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import RECURSIVE_RESULTS_REQUIRED
 
-from .basic     import Basic, PyccelAstNode
+from .basic     import Basic, PyccelAstNode, iterable
 from .builtins  import (PythonEnumerate, PythonLen, PythonMap, PythonTuple,
                         PythonRange, PythonZip, PythonBool, Lambda)
 from .datatypes import (datatype, DataType, NativeSymbol,
@@ -169,44 +164,11 @@ def subs(expr, new_elements):
         new_expr = expr.subs(new_elements)
         new_expr.set_fst(expr.fst)
         return new_expr
-    elif isinstance(expr, Expr):
+    elif isinstance(expr, PyccelAstNode):
         return expr.subs(new_elements)
 
     else:
         return expr
-
-
-
-#def collect_vars(ast):
-#    """ collect variables in order to be declared"""
-#    #TODO use the namespace to get the declared variables
-#    variables = {}
-#    def collect(stmt):
-#
-#        if isinstance(stmt, Variable):
-#            if not isinstance(stmt.name, DottedName):
-#                variables[stmt.name] = stmt
-#        elif isinstance(stmt, (tuple, list)):
-#            for i in stmt:
-#                collect(i)
-#        if isinstance(stmt, For):
-#            collect(stmt.target)
-#            collect(stmt.body)
-#        elif isinstance(stmt, FunctionalFor):
-#            collect(stmt.lhs)
-#            collect(stmt.loops)
-#        elif isinstance(stmt, If):
-#            collect(stmt.bodies)
-#        elif isinstance(stmt, (While, CodeBlock)):
-#            collect(stmt.body)
-#        elif isinstance(stmt, (Assign, AliasAssign, AugAssign)):
-#            collect(stmt.lhs)
-#            if isinstance(stmt.rhs, (Linspace, Diag, Where)):
-#                collect(stmt.rhs.index)
-#
-#
-#    collect(ast)
-#    return variables.values()
 
 def inline(func, args):
     local_vars = func.local_vars
@@ -342,7 +304,7 @@ class Dlist(PyccelAstNode):
 
     Parameters
     ----------
-    value : Expr
+    value : PyccelAstNode
            a sympy expression which represents the initilized value of the list
 
     shape : the shape of the array
@@ -372,7 +334,7 @@ class Assign(Basic):
 
     Parameters
     ----------
-    lhs : Expr
+    lhs : PyccelAstNode
         In the syntactic stage:
            Object representing the lhs of the expression. These should be
            singular objects, such as one would use in writing code. Notable types
@@ -381,7 +343,7 @@ class Assign(Basic):
         In the semantic stage:
            Variable or IndexedElement
 
-    rhs : Expr
+    rhs : PyccelAstNode
         In the syntactic stage:
           Object representing the rhs of the expression
         In the semantic stage :
@@ -814,7 +776,7 @@ class AugAssign(Assign):
 
     Parameters
     ----------
-    lhs : Expr
+    lhs : PyccelAstNode
         In the syntactic stage:
            Object representing the lhs of the expression. These should be
            singular objects, such as one would use in writing code. Notable types
@@ -826,7 +788,7 @@ class AugAssign(Assign):
     op : str
         Operator (+, -, /, \*, %).
 
-    rhs : Expr
+    rhs : PyccelAstNode
         In the syntactic stage:
           Object representing the rhs of the expression
         In the semantic stage :
@@ -2843,7 +2805,7 @@ class FuncAddressDeclare(Basic):
         An instance of FunctionAddress.
     intent: None, str
         one among {'in', 'out', 'inout'}
-    value: Expr
+    value: PyccelAstNode
         variable value
     static: bool
         True for a static declaration of an array.
@@ -2922,7 +2884,7 @@ class Declare(Basic):
         Variables must be of the same type.
     intent: None, str
         one among {'in', 'out', 'inout'}
-    value: Expr
+    value: PyccelAstNode
         variable value
     static: bool
         True for a static declaration of an array.
@@ -3265,7 +3227,7 @@ class Assert(Basic):
 
     Parameters
     ----------
-    test: Expr
+    test: PyccelAstNode
         boolean expression to check
 
     Examples

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3073,7 +3073,7 @@ class EmptyNode(Basic):
     """
     _attribute_nodes = ()
 
-    def __str__(self, printer):
+    def __str__(self):
         return ''
 
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1821,11 +1821,6 @@ class FunctionDef(Basic):
                  '_interfaces'
                  )
 
-    def __new__(cls, *args, **kwargs):
-        kwargs.pop('decorators', None)
-        kwargs.pop('templates', None)
-        return super().__new__(cls, *args, **kwargs)
-
     def __init__(
         self,
         name,
@@ -2386,10 +2381,6 @@ class ValuedFunctionAddress(FunctionAddress):
     """
     _attribute_nodes = (*FunctionAddress._attribute_nodes, '_value')
 
-    def __new__(cls, *args, **kwargs):
-        kwargs.pop('value', Nil())
-        return super().__new__(cls, *args, **kwargs)
-
     def __init__(self, *args, **kwargs):
         self._value = kwargs.pop('value', Nil())
         super().__init__(*args, **kwargs)
@@ -2425,8 +2416,6 @@ class BindCFunctionDef(FunctionDef):
         The function from which the c-compatible version was created
     """
     _attribute_nodes = (*FunctionDef._attribute_nodes, '_original_function')
-    def __new__(cls, *args, original_function, **kwargs):
-        return super().__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, original_function, **kwargs):
         self._original_function = original_function

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2692,9 +2692,6 @@ class ClassDef(Basic):
         else:
             return self.is_iterable or self.is_with_construct
 
-    def _eval_subs(self, old , new):
-        return self
-
     @property
     def is_unused(self):
         return False

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -9,12 +9,11 @@
 Classes and methods that handle supported datatypes in C/Fortran.
 """
 
-from .basic import Basic
-
-from sympy.core.singleton import Singleton
-from sympy.core.compatibility import with_metaclass
-
 import numpy
+
+from pyccel.utilities.metaclasses import Singleton
+
+from .basic import Basic
 
 # TODO [YG, 12.03.2020] verify why we need all these types
 # NOTE: symbols not used in pyccel are commented out
@@ -112,7 +111,7 @@ dtype_and_precision_registry = { 'real':('real',default_precision['float']),
                                  'pythonbool' :('bool',default_precision['bool'])}
 
 
-class DataType(with_metaclass(Singleton)):
+class DataType(metaclass=Singleton):
     """Base class representing native datatypes"""
     _name = '__UNDEFINED__'
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -92,6 +92,7 @@ default_precision = {'real': 8,
                     'float':8}
 dtype_and_precision_registry = { 'real':('real',default_precision['float']),
                                  'double':('real',default_precision['float']),
+                                 'float':('real',default_precision['float']),
                                  'pythonfloat':('real',default_precision['float']), # built-in float
                                  'float32':('real',4),
                                  'float64':('real',8),

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -92,7 +92,6 @@ default_precision = {'real': 8,
                     'float':8}
 dtype_and_precision_registry = { 'real':('real',default_precision['float']),
                                  'double':('real',default_precision['float']),
-                                 'float':('real',default_precision['float']),       # sympy.Float
                                  'pythonfloat':('real',default_precision['float']), # built-in float
                                  'float32':('real',4),
                                  'float64':('real',8),
@@ -290,9 +289,9 @@ def is_with_construct_datatype(dtype):
 def datatype(arg):
     """Returns the datatype singleton for the given dtype.
 
-    arg : str or sympy expression
+    arg : str or pyccel expression
         If a str ('bool', 'int', 'real','complex', or 'void'), return the
-        singleton for the corresponding dtype. If a sympy expression, return
+        singleton for the corresponding dtype. If a pyccel expression, return
         the datatype that best fits the expression. This is determined from the
         assumption system. For more control, use the `DataType` class directly.
 
@@ -314,7 +313,7 @@ def datatype(arg):
 def str_dtype(dtype):
 
     """
-    This function takes a datatype and returns a sympy datatype as a string
+    This function takes a datatype and returns a pyccel datatype as a string
 
     Example
     -------

--- a/pyccel/ast/functionalexpr.py
+++ b/pyccel/ast/functionalexpr.py
@@ -58,24 +58,22 @@ class FunctionalFor(Basic):
         return self._index
 
 #==============================================================================
-class GeneratorComprehension(Basic):
-    _attribute_nodes = ()
+class GeneratorComprehension(FunctionalFor):
+    """ Super class for all functions which reduce generator expressions to scalars
+    """
 
 #==============================================================================
-class FunctionalSum(GeneratorComprehension, FunctionalFor):
-    _attribute_nodes = FunctionalFor._attribute_nodes
+class FunctionalSum(GeneratorComprehension):
     name = 'sum'
 
 #==============================================================================
-class FunctionalMax(GeneratorComprehension, FunctionalFor):
-    _attribute_nodes = FunctionalFor._attribute_nodes
+class FunctionalMax(GeneratorComprehension):
     name = 'max'
 #==============================================================================
 
-class FunctionalMin(GeneratorComprehension, FunctionalFor):
-    _attribute_nodes = FunctionalFor._attribute_nodes
+class FunctionalMin(GeneratorComprehension):
     name = 'min'
 
 #==============================================================================
-class FunctionalMap(GeneratorComprehension, FunctionalFor):
-    _attribute_nodes = FunctionalFor._attribute_nodes
+class FunctionalMap(GeneratorComprehension):
+    pass

--- a/pyccel/ast/functionalexpr.py
+++ b/pyccel/ast/functionalexpr.py
@@ -6,7 +6,6 @@
 #------------------------------------------------------------------------------------------#
 
 from .basic import Basic
-from sympy.core.expr  import AtomicExpr
 
 __all__ = (
     'FunctionalFor',
@@ -59,7 +58,7 @@ class FunctionalFor(Basic):
         return self._index
 
 #==============================================================================
-class GeneratorComprehension(AtomicExpr, Basic):
+class GeneratorComprehension(Basic):
     _attribute_nodes = ()
 
 #==============================================================================

--- a/pyccel/ast/functionalexpr.py
+++ b/pyccel/ast/functionalexpr.py
@@ -63,21 +63,21 @@ class GeneratorComprehension(FunctionalFor):
 
 #==============================================================================
 class FunctionalSum(GeneratorComprehension):
-    name = 'sum'
     """ Represents a call to sum for a list argument
     >>> sum([i in range(5)])
     """
+    name = 'sum'
 
 #==============================================================================
 class FunctionalMax(GeneratorComprehension):
-    name = 'max'
     """ Represents a call to max for a list argument
     >>> max([i in range(5)])
     """
+    name = 'max'
 #==============================================================================
 
 class FunctionalMin(GeneratorComprehension):
-    name = 'min'
     """ Represents a call to min for a list argument
     >>> min([i in range(5)])
     """
+    name = 'min'

--- a/pyccel/ast/functionalexpr.py
+++ b/pyccel/ast/functionalexpr.py
@@ -65,14 +65,23 @@ class GeneratorComprehension(FunctionalFor):
 #==============================================================================
 class FunctionalSum(GeneratorComprehension):
     name = 'sum'
+    """ Represents a call to sum for a list argument
+    >>> sum([i in range(5)])
+    """
 
 #==============================================================================
 class FunctionalMax(GeneratorComprehension):
     name = 'max'
+    """ Represents a call to max for a list argument
+    >>> max([i in range(5)])
+    """
 #==============================================================================
 
 class FunctionalMin(GeneratorComprehension):
     name = 'min'
+    """ Represents a call to min for a list argument
+    >>> min([i in range(5)])
+    """
 
 #==============================================================================
 class FunctionalMap(GeneratorComprehension):

--- a/pyccel/ast/functionalexpr.py
+++ b/pyccel/ast/functionalexpr.py
@@ -9,7 +9,6 @@ from .basic import Basic
 
 __all__ = (
     'FunctionalFor',
-    'FunctionalMap',
     'FunctionalMax',
     'FunctionalMin',
     'FunctionalSum',
@@ -82,7 +81,3 @@ class FunctionalMin(GeneratorComprehension):
     """ Represents a call to min for a list argument
     >>> min([i in range(5)])
     """
-
-#==============================================================================
-class FunctionalMap(GeneratorComprehension):
-    pass

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -4,20 +4,18 @@
 # go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
 #------------------------------------------------------------------------------------------#
 
-from sympy.utilities.iterables import iterable
-
-from ..errors.errors import Errors
-from ..errors.messages import TEMPLATE_IN_UNIONTYPE
-from .core import Basic
-from .core import ValuedArgument
-from .core import FunctionDef, Interface, FunctionAddress
-from .core import create_incremented_string
-from .datatypes import datatype, DataTypeFactory, UnionType
-from .macros import Macro, MacroShape, construct_macro
-from .variable import DottedName, DottedVariable
-from .variable import Variable
-from .variable import ValuedVariable
-from .internals import PyccelSymbol
+from ..errors.errors    import Errors
+from ..errors.messages  import TEMPLATE_IN_UNIONTYPE
+from .basic             import Basic, iterable
+from .core              import ValuedArgument
+from .core              import FunctionDef, Interface, FunctionAddress
+from .core              import create_incremented_string
+from .datatypes         import datatype, DataTypeFactory, UnionType
+from .internals         import PyccelSymbol
+from .macros            import Macro, MacroShape, construct_macro
+from .variable          import DottedName, DottedVariable
+from .variable          import Variable
+from .variable          import ValuedVariable
 
 __all__ = (
     'ClassHeader',

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -186,7 +186,7 @@ class Template(Header):
            to create the initial version of the object
            and its arguments
            """
-        return (self.__class__, (self.name, self.args))
+        return (self.__class__, (self.name, self.dtypes))
 
 #==============================================================================
 class FunctionHeader(Header):

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -152,9 +152,6 @@ class Template(Header):
     >>> T = Template('T', [d_var0, d_var1])
     """
 
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(cls)
-
     def __init__(self, name, dtypes):
         super().__init__()
         self._name = name

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -156,19 +156,6 @@ class Slice(Basic):
         """
         return self._step
 
-    def _sympystr(self, printer):
-        """ sympy equivalent of __str__"""
-        sstr = printer.doprint
-        if self.start is None:
-            start = ''
-        else:
-            start = sstr(self.start)
-        if self.stop is None:
-            stop = ''
-        else:
-            stop = sstr(self.stop)
-        return '{0} : {1}'.format(start, stop)
-
     def __str__(self):
         if self.start is None:
             start = ''

--- a/pyccel/ast/itertoolsext.py
+++ b/pyccel/ast/itertoolsext.py
@@ -25,7 +25,7 @@ class Product(Basic):
         elif len(args) < 2:
             return args[0]
         else:
-            return super().__new__(cls, *args)
+            return super().__new__(cls)
 
     def __init__(self, *args):
         self._elements = args

--- a/pyccel/ast/itertoolsext.py
+++ b/pyccel/ast/itertoolsext.py
@@ -17,7 +17,7 @@ class Product(Basic):
 
     arg : list, tuple
     """
-    _attribute_nodes = ('_args',)
+    _attribute_nodes = ('_elements',)
 
     def __new__(cls, *args):
         if not isinstance(args, (tuple, list)):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -47,11 +47,8 @@ class Literal(PyccelAstNode):
     def python_value(self):
         """ Get python literal represented by this instance """
 
-    def __repr__(self):
-        return repr(self.python_value)
-
-    def _sympystr(self, printer):
-        return printer.doprint(self.python_value)
+    def __str__(self):
+        return str(self.python_value)
 
     def __eq__(self, other):
         if isinstance(other, PyccelAstNode):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -112,7 +112,7 @@ class LiteralFloat(Literal):
         if not isinstance(value, (int, float, LiteralFloat)):
             raise TypeError("A LiteralFloat can only be created with an integer or a float")
         Literal.__init__(self, precision)
-        self._value = value
+        self._value = float(value)
 
     @property
     def python_value(self):

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -4,7 +4,6 @@
 #------------------------------------------------------------------------------------------#
 """ This module contains all literal types
 """
-from sympy               import Float as sp_Float
 
 from .basic              import PyccelAstNode, Basic
 from .datatypes          import (NativeInteger, NativeBool, NativeReal,
@@ -105,20 +104,19 @@ class LiteralInteger(Literal):
         return self.python_value
 
 #------------------------------------------------------------------------------
-class LiteralFloat(Literal, sp_Float):
+class LiteralFloat(Literal):
     """Represents a float literal in python"""
     _dtype     = NativeReal()
-    def __new__(cls, value, *, precision = default_precision['float']):
-        return sp_Float.__new__(cls, value)
 
     def __init__(self, value, *, precision = default_precision['float']):
         if not isinstance(value, (int, float, LiteralFloat)):
             raise TypeError("A LiteralFloat can only be created with an integer or a float")
         Literal.__init__(self, precision)
+        self._value = value
 
     @property
     def python_value(self):
-        return float(self)
+        return self._value
 
 
 #------------------------------------------------------------------------------

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -126,13 +126,13 @@ class LiteralComplex(Literal):
 
     def __new__(cls, real, imag, precision = default_precision['complex']):
         if cls is LiteralImaginaryUnit:
-            return super().__new__(cls, real, imag)
+            return super().__new__(cls)
         real_part = cls._collect_python_val(real)
         imag_part = cls._collect_python_val(imag)
         if real_part == 0 and imag_part == 1:
             return LiteralImaginaryUnit()
         else:
-            return super().__new__(cls, real, imag)
+            return super().__new__(cls)
 
     def __init__(self, real, imag, precision = default_precision['complex']):
         super().__init__(precision)

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -4,6 +4,7 @@
 #------------------------------------------------------------------------------------------#
 """ This module contains all literal types
 """
+from pyccel.utilities.metaclasses import Singleton, ArgumentSingleton
 
 from .basic              import PyccelAstNode, Basic
 from .datatypes          import (NativeInteger, NativeBool, NativeReal,
@@ -62,7 +63,7 @@ class Literal(PyccelAstNode):
         return hash(self.python_value)
 
 #------------------------------------------------------------------------------
-class LiteralTrue(Literal):
+class LiteralTrue(Literal, metaclass = ArgumentSingleton):
     """Represents the python value True"""
     _dtype     = NativeBool()
 
@@ -74,7 +75,7 @@ class LiteralTrue(Literal):
         return True
 
 #------------------------------------------------------------------------------
-class LiteralFalse(Literal):
+class LiteralFalse(Literal, metaclass = ArgumentSingleton):
     """Represents the python value False"""
     _dtype     = NativeBool()
 
@@ -207,7 +208,7 @@ class LiteralString(Literal):
 
 #------------------------------------------------------------------------------
 
-class Nil(Basic):
+class Nil(Basic, metaclass=Singleton):
 
     """
     class for None object in the code.
@@ -221,8 +222,6 @@ class Nil(Basic):
         return False
 
     def __eq__(self, other):
-        #TODO [EB 7.2.2021] Make Nil singleton. See https://stackoverflow.com/questions/6760685/creating-a-singleton-in-python method 3
-        #                   Blocked by issue 662
         return isinstance(other, Nil)
 
 #------------------------------------------------------------------------------

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -112,7 +112,10 @@ class LiteralFloat(Literal):
         if not isinstance(value, (int, float, LiteralFloat)):
             raise TypeError("A LiteralFloat can only be created with an integer or a float")
         Literal.__init__(self, precision)
-        self._value = float(value)
+        if isinstance(value, LiteralFloat):
+            self._value = value.python_value
+        else:
+            self._value = float(value)
 
     @property
     def python_value(self):

--- a/pyccel/ast/macros.py
+++ b/pyccel/ast/macros.py
@@ -7,8 +7,6 @@
 """
 This module contains all classes and functions used for handling macros.
 """
-from sympy.core.expr import AtomicExpr
-
 from .basic          import PyccelAstNode
 from .datatypes      import default_precision
 from .datatypes      import NativeInteger, NativeGeneric
@@ -24,7 +22,7 @@ __all__ = (
 )
 
 #==============================================================================
-class Macro(AtomicExpr, PyccelAstNode):
+class Macro(PyccelAstNode):
     """."""
     _name = '__UNDEFINED__'
     _attribute_nodes = ()

--- a/pyccel/ast/macros.py
+++ b/pyccel/ast/macros.py
@@ -59,13 +59,12 @@ class MacroShape(Macro):
     def index(self):
         return self._index
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
+    def __str__(self):
         if self.index is None:
-            return 'MacroShape({})'.format(sstr(self.argument))
+            return 'MacroShape({})'.format(str(self.argument))
         else:
-            return 'MacroShape({}, {})'.format(sstr(self.argument),
-                                               sstr(self.index))
+            return 'MacroShape({}, {})'.format(str(self.argument),
+                                               str(self.index))
 
 #==============================================================================
 class MacroType(Macro):
@@ -76,9 +75,8 @@ class MacroType(Macro):
     _shape     = ()
     _precision = 0
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return 'MacroType({})'.format(sstr(self.argument))
+    def __str__(self):
+        return 'MacroType({})'.format(str(self.argument))
 
 #==============================================================================
 class MacroCount(Macro):
@@ -89,9 +87,8 @@ class MacroCount(Macro):
     _dtype     = NativeInteger()
     _precision = default_precision['integer']
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        return 'MacroCount({})'.format(sstr(self.argument))
+    def __str__(self):
+        return 'MacroCount({})'.format(str(self.argument))
 
 
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -7,6 +7,7 @@
 
 import numpy
 
+from .basic          import PyccelAstNode
 from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
                              PythonComplex, PythonReal, PythonImag, PythonList)
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -244,8 +244,8 @@ class NumpyArray(NumpyNewArray):
         self._precision = prec
         super().__init__()
 
-    def _sympystr(self, printer):
-        return self.arg
+    def __str__(self, printer):
+        return str(self.arg)
 
     @property
     def arg(self):
@@ -473,11 +473,10 @@ class NumpyLinspace(NumpyNewArray):
     def step(self):
         return (self.stop - self.start) / (self.size - 1)
 
-    def _sympystr(self, printer):
-        sstr = printer.doprint
-        code = 'linspace({}, {}, {})',format(sstr(self.start),
-                                             sstr(self.stop),
-                                             sstr(self.size))
+    def __str__(self):
+        code = 'linspace({}, {}, {})',format(str(self.start),
+                                             str(self.stop),
+                                             str(self.size))
         return code
 
 #==============================================================================

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -7,8 +7,6 @@
 
 import numpy
 
-from sympy           import Expr
-
 from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
                              PythonComplex, PythonReal, PythonImag, PythonList)
 
@@ -320,8 +318,7 @@ class NumpySum(PyccelInternalFunction):
     """
 
     def __init__(self, arg):
-        if not isinstance(arg, (list, tuple, PythonTuple, PythonList,
-                            Variable, Expr)):
+        if not isinstance(arg, PyccelAstNode):
             raise TypeError('Unknown type of  %s.' % type(arg))
         super().__init__(arg)
         self._dtype = arg.dtype
@@ -341,8 +338,7 @@ class NumpyProduct(PyccelInternalFunction):
     """
 
     def __init__(self, arg):
-        if not isinstance(arg, (list, tuple, PythonTuple, PythonList,
-                                Variable, Expr)):
+        if not isinstance(arg, PyccelAstNode):
             raise TypeError('Unknown type of  %s.' % type(arg))
         super().__init__(arg)
         self._dtype = arg.dtype
@@ -362,11 +358,9 @@ class NumpyMatmul(PyccelInternalFunction):
     """
 
     def __init__(self, a ,b):
-        if not isinstance(a, (list, tuple, PythonTuple, PythonList,
-                                Variable, Expr)):
+        if not isinstance(a, PyccelAstNode):
             raise TypeError('Unknown type of  %s.' % type(a))
-        if not isinstance(b, (list, tuple, PythonTuple, PythonList,
-                                Variable, Expr)):
+        if not isinstance(b, PyccelAstNode):
             raise TypeError('Unknown type of  %s.' % type(a))
         super().__init__(a, b)
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -116,7 +116,7 @@ class NumpyInt(PythonInt):
     """ Represents a call to numpy.int() function.
     """
     def __new__(cls, arg=None, base=10):
-        return PythonInt.__new__(cls, arg)
+        return super().__new__(cls, arg)
 
 class NumpyInt32(NumpyInt):
     """ Represents a call to numpy.int32() function.

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -244,7 +244,7 @@ class NumpyArray(NumpyNewArray):
         self._precision = prec
         super().__init__()
 
-    def __str__(self, printer):
+    def __str__(self):
         return str(self.arg)
 
     @property
@@ -474,7 +474,7 @@ class NumpyLinspace(NumpyNewArray):
         return (self.stop - self.start) / (self.size - 1)
 
     def __str__(self):
-        code = 'linspace({}, {}, {})',format(str(self.start),
+        code = 'linspace({}, {}, {})'.format(str(self.start),
                                              str(self.stop),
                                              str(self.size))
         return code

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -831,9 +831,10 @@ class PyccelIs(PyccelBooleanOperator):
 
     Examples
     --------
-    >>> from pyccel.ast import PyccelIs
-    >>> from pyccel.literals import Nil
-    >>> from sympy.abc import x
+    >>> from pyccel.ast.operators import PyccelIs
+    >>> from pyccel.ast.literals  import Nil
+    >>> from pyccel.ast.internals import PyccelSymbol
+    >>> x = PyccelSymbol('x')
     >>> PyccelIs(x, Nil())
     PyccelIs(x, None)
     """
@@ -863,9 +864,10 @@ class PyccelIsNot(PyccelIs):
 
     Examples
     --------
-    >>> from pyccel.ast import PyccelIsNot
-    >>> from pyccel.ast.literals import Nil
-    >>> from sympy.abc import x
+    >>> from pyccel.ast.operators import PyccelIsNot
+    >>> from pyccel.ast.literals  import Nil
+    >>> from pyccel.ast.internals import PyccelSymbol
+    >>> x = PyccelSymbol('x')
     >>> PyccelIsNot(x, Nil())
     PyccelIsNot(x, None)
     """

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -178,6 +178,8 @@ class PyccelOperator(PyccelAstNode):
 
     @property
     def args(self):
+        """ Arguments of the operator
+        """
         return self._args
 
 #==============================================================================

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -176,6 +176,10 @@ class PyccelOperator(PyccelAstNode):
         else:
             self._order = 'C'
 
+    @property
+    def args(self):
+        return self._args
+
 #==============================================================================
 
 class PyccelUnaryOperator(PyccelOperator):

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -473,7 +473,7 @@ class PyccelAdd(PyccelArithmeticOperator):
            arg1.real == LiteralFloat(0):
             return LiteralComplex(arg2, arg1.imag)
         else:
-            return PyccelArithmeticOperator.__new__(cls, arg1, arg2)
+            return super().__new__(cls)
 
     def _handle_str_type(self, strs):
         self._dtype = NativeString()
@@ -532,7 +532,7 @@ class PyccelMinus(PyccelArithmeticOperator):
            arg1.real == LiteralFloat(0):
             return LiteralComplex(-arg2.python_value, arg1.imag)
         else:
-            return PyccelArithmeticOperator.__new__(cls, arg1, arg2)
+            return super().__new__(cls)
 
     def __repr__(self):
         return '{} - {}'.format(repr(self.args[0]), repr(self.args[1]))

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -8,7 +8,6 @@ These operators all have a precision as detailed here:
     https://docs.python.org/3/reference/expressions.html#operator-precedence
 They also have specific rules to determine the dtype, precision, rank, shape
 """
-from sympy.core.expr        import Expr
 
 from ..errors.errors        import Errors, PyccelSemanticError
 
@@ -94,7 +93,7 @@ def broadcast(shape_1, shape_2):
 
 #==============================================================================
 
-class PyccelOperator(Expr, PyccelAstNode):
+class PyccelOperator(PyccelAstNode):
     """
     Abstract superclass for all builtin operators.
     The __init__ function is common

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -44,7 +44,7 @@ class Variable(PyccelAstNode):
         or a str (bool, int, real).
 
     name : str, list, DottedName
-        The sympy object the variable represents. This can be either a string
+        The name of the variable represented. This can be either a string
         or a dotted name, when using a Class attribute.
 
     rank : int
@@ -454,10 +454,6 @@ class Variable(PyccelAstNode):
         out =  (apply, (Variable, args, kwargs))
         return out
 
-    def _eval_subs(self, old, new):
-        """ Overrides sympy method to indicate an atom"""
-        return self
-
     def __getitem__(self, *args):
 
         if len(args) == 1 and isinstance(args[0], (tuple, list)):
@@ -686,10 +682,10 @@ class IndexedElement(PyccelAstNode):
 
     Examples
     --------
-    >>> from sympy import symbols, Idx
     >>> from pyccel.ast.core import Variable, IndexedElement
-    >>> i, j = symbols('i j', cls=Idx)
-    >>> A = Variable('A', dtype='int')
+    >>> A = Variable('A', dtype='int', shape=(2,3), rank=2)
+    >>> i = Variable('i', dtype='int')
+    >>> j = Variable('j', dtype='int')
     >>> IndexedElement(A, i, j)
     IndexedElement(A, i, j)
     >>> IndexedElement(A, i, j) == A[i, j]

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -366,11 +366,6 @@ class Variable(PyccelAstNode):
     def __hash__(self):
         return hash((type(self).__name__, self._name))
 
-    def _sympystr(self, printer):
-        """ sympy equivalent of __str__"""
-        sstr = printer.doprint
-        return '{}'.format(sstr(self.name))
-
     def inspect(self):
         """inspects the variable."""
 
@@ -507,11 +502,6 @@ class DottedName(Basic):
     def __str__(self):
         return """.""".join(str(n) for n in self.name)
 
-    def _sympystr(self, printer):
-        """ sympy equivalent of __str__"""
-        sstr = printer.doprint
-        return """.""".join(sstr(n) for n in self.name)
-
 class ValuedVariable(Variable):
 
     """Represents a valued variable in the code.
@@ -544,12 +534,9 @@ class ValuedVariable(Variable):
         """
         return self._value
 
-    def _sympystr(self, printer):
-        """ sympy equivalent of __str__"""
-        sstr = printer.doprint
-
-        name = sstr(self.name)
-        value = sstr(self.value)
+    def __str__(self):
+        name = str(self.name)
+        value = str(self.value)
         return '{0}={1}'.format(name, value)
 
 class TupleVariable(Variable):

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -173,7 +173,7 @@ class Codegen(object):
         errors = Errors()
         errors.set_parser_stage('codegen')
         # set the code printer
-        self._printer = code_printer(self.parser, settings)
+        self._printer = code_printer(self.parser, **settings)
 
     def get_printer_imports(self):
         """return the imports of the current codeprinter"""

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -449,7 +449,7 @@ class CCodePrinter(CodePrinter):
         return str(expr.p)
 
     def _print_LiteralFloat(self, expr):
-        return CodePrinter._print_Float(self, expr)
+        return repr(expr)
 
     def _print_LiteralComplex(self, expr):
         if expr.real == LiteralFloat(0):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -445,11 +445,8 @@ class CCodePrinter(CodePrinter):
         value = self._print(expr.arg)
         return '({} != 0)'.format(value)
 
-    def _print_LiteralInteger(self, expr):
-        return str(expr.p)
-
-    def _print_LiteralFloat(self, expr):
-        return repr(expr)
+    def _print_Literal(self, expr):
+        return repr(expr.python_value)
 
     def _print_LiteralComplex(self, expr):
         if expr.real == LiteralFloat(0):
@@ -636,20 +633,6 @@ class CCodePrinter(CodePrinter):
             return '#include <{0}.h>'.format(source)
         else:
             return '#include "{0}.h"'.format(source)
-
-    def _print_LiteralString(self, expr):
-        format_str = format(expr.arg)
-        format_str = format_str.replace("\\", "\\\\")\
-                               .replace('\a', '\\a')\
-                               .replace('\b', '\\b')\
-                               .replace('\f', '\\f')\
-                               .replace("\n", "\\n")\
-                               .replace('\r', '\\r')\
-                               .replace('\t', '\\t')\
-                               .replace('\v', '\\v')\
-                               .replace('"', '\\"')\
-                               .replace("'", "\\'")
-        return '"{}"'.format(format_str)
 
     def get_print_format_and_arg(self, var):
         type_to_format = {('real',8)    : '%.12lf',

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1559,4 +1559,4 @@ def ccode(expr, parser, assign_to=None, **settings):
         For example, if ``dereference=[a]``, the resulting code would print
         ``(*a)`` instead of ``a``.
     """
-    return CCodePrinter(parser, settings).doprint(expr, assign_to)
+    return CCodePrinter(parser, **settings).doprint(expr, assign_to)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -252,17 +252,17 @@ class CCodePrinter(CodePrinter):
         'dereference': set()
     }
 
-    def __init__(self, parser, settings=None):
+    def __init__(self, parser, **settings):
 
         if parser.filename:
             errors.set_target(parser.filename, 'file')
 
-        prefix_module = None if settings is None else settings.pop('prefix_module', None)
+        prefix_module = settings.pop('prefix_module', None)
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
-        userfuncs = {} if settings is None else settings.get('user_functions', {})
+        userfuncs = settings.get('user_functions', {})
         self.known_functions.update(userfuncs)
-        self._dereference = set([] if settings is None else settings.get('dereference', []))
+        self._dereference = set(settings.get('dereference', []))
         self.prefix_module = prefix_module
         self._additional_imports = set(['stdlib'])
         self._parser = parser

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -634,6 +634,20 @@ class CCodePrinter(CodePrinter):
         else:
             return '#include "{0}.h"'.format(source)
 
+    def _print_LiteralString(self, expr):
+        format_str = format(expr.arg)
+        format_str = format_str.replace("\\", "\\\\")\
+                               .replace('\a', '\\a')\
+                               .replace('\b', '\\b')\
+                               .replace('\f', '\\f')\
+                               .replace("\n", "\\n")\
+                               .replace('\r', '\\r')\
+                               .replace('\t', '\\t')\
+                               .replace('\v', '\\v')\
+                               .replace('"', '\\"')\
+                               .replace("'", "\\'")
+        return '"{}"'.format(format_str)
+
     def get_print_format_and_arg(self, var):
         type_to_format = {('real',8)    : '%.12lf',
                           ('real',4)    : '%.12f',

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -54,8 +54,8 @@ dtype_registry = {('pyobject'     , 0) : 'PyObject',
 class CWrapperCodePrinter(CCodePrinter):
     """A printer to convert a python module to strings of c code creating
     an interface between python and an implementation of the module in c"""
-    def __init__(self, parser, target_language, settings=None):
-        CCodePrinter.__init__(self, parser,settings)
+    def __init__(self, parser, target_language, **settings):
+        CCodePrinter.__init__(self, parser, **settings)
         self._target_language = target_language
         self._cast_functions_dict = OrderedDict()
         self._to_free_PyObject_list = []
@@ -1020,4 +1020,4 @@ def cwrappercode(expr, parser, target_language, assign_to=None, **settings):
         ``(*a)`` instead of ``a``.
     """
 
-    return CWrapperCodePrinter(parser, target_language, settings).doprint(expr, assign_to)
+    return CWrapperCodePrinter(parser, target_language, **settings).doprint(expr, assign_to)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1842,7 +1842,7 @@ class FCodePrinter(CodePrinter):
                                            prolog, epilog)
 
         elif isinstance(expr.iterable, PythonZip):
-            itr_ = PythonRange(expr.iterable.element.shape[0])
+            itr_ = PythonRange(expr.iterable.length)
             prolog, epilog = _do_range(expr.target, itr_, \
                                        prolog, epilog)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2936,4 +2936,4 @@ def fcode(expr, parser, assign_to=None, **settings):
         for examples.
     """
 
-    return FCodePrinter(parser, settings).doprint(expr, assign_to)
+    return FCodePrinter(parser, **settings).doprint(expr, assign_to)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2593,6 +2593,12 @@ class FCodePrinter(CodePrinter):
         printed = repr(expr.python_value)
         return "{}_{}".format(printed, self.print_kind(expr))
 
+    def _print_LiteralTrue(self, expr):
+        return ".True._{}".format(self.print_kind(expr))
+
+    def _print_LiteralFalse(self, expr):
+        return ".False._{}".format(self.print_kind(expr))
+
     def _print_LiteralComplex(self, expr):
         real_str = self._print(expr.real)
         imag_str = self._print(expr.imag)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1404,12 +1404,6 @@ class FCodePrinter(CodePrinter):
     def _print_DataType(self, expr):
         return self._print(expr.name)
 
-    def _print_LiteralTrue(self, expr):
-        return '.True._{}'.format(self.print_kind(expr))
-
-    def _print_LiteralFalse(self, expr):
-        return '.False._{}'.format(self.print_kind(expr))
-
     def _print_LiteralString(self, expr):
         sp_chars = ['\a', '\b', '\f', '\r', '\t', '\v', "'", '\n']
         sub_str = ''
@@ -2595,17 +2589,14 @@ class FCodePrinter(CodePrinter):
     def _print_int(self, expr):
         return str(expr)
 
-    def _print_LiteralFloat(self, expr):
-        printed = repr(expr)
+    def _print_Literal(self, expr):
+        printed = repr(expr.python_value)
         return "{}_{}".format(printed, self.print_kind(expr))
 
     def _print_LiteralComplex(self, expr):
         real_str = self._print(expr.real)
         imag_str = self._print(expr.imag)
         return "({}, {})".format(real_str, imag_str)
-
-    def _print_LiteralInteger(self, expr):
-        return "{0}_{1}".format(str(expr.p), self.print_kind(expr))
 
     def _print_IndexedElement(self, expr):
         base = expr.base

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -198,7 +198,7 @@ class FCodePrinter(CodePrinter):
     }
 
 
-    def __init__(self, parser, settings={}):
+    def __init__(self, parser, **settings):
 
         prefix_module = settings.pop('prefix_module', None)
 
@@ -1833,7 +1833,7 @@ class FCodePrinter(CodePrinter):
                                        prolog, epilog)
 
         elif isinstance(expr.iterable, Product):
-            for i, a in zip(expr.target, expr.iterable.args):
+            for i, a in zip(expr.target, expr.iterable.elements):
                 if isinstance(a, PythonRange):
                     itr_ = a
                 else:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2596,7 +2596,7 @@ class FCodePrinter(CodePrinter):
         return str(expr)
 
     def _print_LiteralFloat(self, expr):
-        printed = CodePrinter._print_Float(self, expr)
+        printed = repr(expr)
         return "{}_{}".format(printed, self.print_kind(expr))
 
     def _print_LiteralComplex(self, expr):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -33,6 +33,8 @@ def _construct_header(func_name, args):
 
 #==============================================================================
 class PythonCodePrinter(CodePrinter):
+    """A printer to convert pyccel expressions to strings of Python code"""
+    printmethod = "_pycode"
     _kf = dict(chain(
         _known_functions.items(),
         [(k, '' + v) for k, v in _known_functions_math.items()]
@@ -107,7 +109,7 @@ class PythonCodePrinter(CodePrinter):
                 for func in f:
                     args = func.args
                     if args:
-                        args = ', '.join("{}".format(self._print(i)) for i in args)
+                        args = ', '.join(self._print(i) for i in args)
                         dec += '@{name}({args})\n'.format(name=n, args=args)
 
                     else:
@@ -268,8 +270,8 @@ class PythonCodePrinter(CodePrinter):
                 lines.append(self._print(e))
         return "\n".join(lines)
 
-    def _print_LiteralString(self, expr):
-        return '"{}"'.format(self._print(expr.arg))
+    def _print_Literal(self, expr):
+        return repr(expr.python_value)
 
     def _print_Shape(self, expr):
         arg = self._print(expr.arg)
@@ -288,10 +290,10 @@ class PythonCodePrinter(CodePrinter):
 
             elif isinstance(f, tuple):
                 for i in f:
-                    args.append("{}".format(self._print(i)))
+                    args.append(self._print(i))
 
             else:
-                args.append("{}".format(self._print(f)))
+                args.append(self._print(f))
 
         fs = ', '.join(i for i in args)
 

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -12,7 +12,9 @@ import sys
 
 from collections import OrderedDict
 from os.path import basename
+
 from pyccel.ast.basic import Basic
+from pyccel.utilities.metaclasses import Singleton
 
 # ...
 #ERROR = 'error'
@@ -126,20 +128,7 @@ class ErrorInfo:
         return pattern.format(**info)
 
 
-def _singleton(cls):
-    """
-    A Class representing a singleton. Python does not offer this pattern.
-    """
-    instances = {}
-    def getinstance():
-        if cls not in instances:
-            instances[cls] = cls() # Line 5
-        return instances[cls]
-    return getinstance
-
-
-@_singleton
-class ErrorsMode:
+class ErrorsMode(metaclass = Singleton):
     """Developper or User mode.
     pyccel command line will set it.
     """
@@ -155,8 +144,7 @@ class ErrorsMode:
         self._mode = mode
 
 
-@_singleton
-class Errors:
+class Errors(metaclass = Singleton):
     """Container for compile errors.
     """
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -46,7 +46,7 @@ from pyccel.ast.variable import ValuedVariable
 from pyccel.ast.core import ValuedArgument
 from pyccel.ast.core import Import
 from pyccel.ast.core import AsName
-from pyccel.ast.core import With, Block
+from pyccel.ast.core import With
 from pyccel.ast.builtins import PythonList
 from pyccel.ast.core import Dlist
 from pyccel.ast.core import StarredArguments

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1164,7 +1164,7 @@ class SemanticParser(BasicParser):
     def _visit_PyccelOperator(self, expr, **settings):
         args     = [self._visit(a, **settings) for a in expr.args]
         try:
-            expr_new = expr.func(*args)
+            expr_new = type(expr)(*args)
         except PyccelSemanticError as err:
             msg = str(err)
             errors.report(msg, symbol=expr,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2302,8 +2302,10 @@ class SemanticParser(BasicParser):
         return If(*args)
 
     def _visit_IfTernaryOperator(self, expr, **settings):
-        args = [self._visit(i, **settings) for i in expr.args]
-        return expr.func(*args)
+        cond        = self._visit(expr.cond, **settings)
+        value_true  = self._visit(expr.value_true, **settings)
+        value_false = self._visit(expr.value_false, **settings)
+        return IfTernaryOperator(cond, value_true, value_false)
 
     def _visit_VariableHeader(self, expr, **settings):
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -50,7 +50,6 @@ from pyccel.ast.core import With, Block
 from pyccel.ast.builtins import PythonList
 from pyccel.ast.core import Dlist
 from pyccel.ast.core import StarredArguments
-from pyccel.ast.core import subs
 from pyccel.ast.core import get_assigned_symbols
 from pyccel.ast.operators import PyccelIs, PyccelIsNot, IfTernaryOperator
 from pyccel.ast.itertoolsext import Product
@@ -1719,22 +1718,6 @@ class SemanticParser(BasicParser):
                 i.set_fst(fst)
             rhs = self._visit_FunctionDef(rhs, **settings)
             return rhs
-
-        elif isinstance(rhs, Block):
-            #case of inline
-            results = rhs.get_attribute_nodes(rhs.body,Return)
-            sub = list(zip(results,[EmptyNode()]*len(results)))
-            body = rhs.body
-            body = subs(body,sub)
-            results = [i.expr for i in results]
-            lhs = expr.lhs
-            if isinstance(lhs ,(list, tuple, PythonTuple)):
-                sub = [list(zip(i,lhs)) for i in results]
-            else:
-                sub = [(i[0],lhs) for i in results]
-            body = subs(body,sub)
-            expr = Block(rhs.name, rhs.variables, body)
-            return expr
 
         elif isinstance(rhs, CodeBlock):
             if len(rhs.body)>1 and isinstance(rhs.body[1], FunctionalFor):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1198,14 +1198,14 @@ class SemanticParser(BasicParser):
     def _visit_Lambda(self, expr, **settings):
 
 
-        expr_names = set(map(str, expr.expr.atoms(PyccelSymbol, Argument)))
+        expr_names = set(map(str, expr.expr.get_attribute_nodes((PyccelSymbol, Argument))))
         var_names = map(str, expr.variables)
         missing_vars = expr_names.difference(var_names)
         if len(missing_vars) > 0:
             errors.report(UNDEFINED_LAMBDA_VARIABLE, symbol = missing_vars,
                 bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                 severity='fatal', blocker=True)
-        funcs = expr.expr.atoms(FunctionCall)
+        funcs = expr.expr.get_attribute_nodes(FunctionCall)
         for func in funcs:
             name = _get_name(func)
             f = self.get_symbolic_function(name)
@@ -3043,8 +3043,8 @@ class SemanticParser(BasicParser):
     def _visit_Dlist(self, expr, **settings):
         # Arguments have been treated in PyccelMul
 
-        val = expr.args[0]
-        length = expr.args[1]
+        val = expr.val
+        length = expr.length
         if isinstance(val, (TupleVariable, PythonTuple)) and \
                 not isinstance(val, PythonList):
             if isinstance(length, LiteralInteger):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2011,7 +2011,7 @@ class SemanticParser(BasicParser):
         elif isinstance(iterable, PythonEnumerate):
             indx   = iterator.args[0]
             var    = iterator.args[1]
-            assign = Assign(var, IndexedElement(iterable.args[0], indx))
+            assign = Assign(var, IndexedElement(iterable.element, indx))
             assign.set_fst(expr.fst)
             iterator = indx
             body     = [assign] + body

--- a/pyccel/utilities/metaclasses.py
+++ b/pyccel/utilities/metaclasses.py
@@ -1,0 +1,32 @@
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
+#------------------------------------------------------------------------------------------#
+""" Module containing metaclasses which are useful for the rest of pyccel
+"""
+
+
+__all__ = (
+    'Singleton',
+    'ArgumentSingleton',
+)
+
+class Singleton(type):
+    """ Indicates that there is only one instance of the class
+    """
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+class ArgumentSingleton(type):
+    """ Indicates that there is only one instance of the class
+    for any given set of arguments
+    """
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        index = (cls, *args, *kwargs.values())
+        if index not in cls._instances:
+            cls._instances[index] = super().__call__(*args, **kwargs)
+        return cls._instances[index]

--- a/pyccel/utilities/metaclasses.py
+++ b/pyccel/utilities/metaclasses.py
@@ -26,7 +26,7 @@ class ArgumentSingleton(type):
     """
     _instances = {}
     def __call__(cls, *args, **kwargs):
-        index = (cls, *args, *kwargs.values())
+        index = (cls, *args, *sorted(kwargs.items()))
         if index not in cls._instances:
             cls._instances[index] = super().__call__(*args, **kwargs)
         return cls._instances[index]

--- a/tests/epyccel/test_parallel_epyccel.py
+++ b/tests/epyccel/test_parallel_epyccel.py
@@ -5,15 +5,6 @@ import numpy as np
 
 from pyccel.epyccel import epyccel
 
-@pytest.fixture(params=[
-    pytest.param('fortran', marks = pytest.mark.fortran),
-    pytest.param('c'      , marks = [pytest.mark.c,
-        pytest.mark.xfail(message='Arrays not implemented in C')])
-    ]
-)
-def language(request):
-    return request.param
-
 #==============================================================================
 @pytest.mark.parallel
 def test_module_1(language):

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -458,6 +458,7 @@ def test_hope_benchmarks( test_file ):
     pyccel_test(test_file)
 
 #------------------------------------------------------------------------------
+@pytest.mark.c
 @pytest.mark.parametrize( "test_file", ["scripts/hope_benchmarks/hope_fib.py",
                                         pytest.param("scripts/hope_benchmarks/quicksort.py",
                                             marks = pytest.mark.skip(reason="len not implemented in c")),


### PR DESCRIPTION
Remove sympy inheritance from pyccel AST nodes. Fixes #661. Fixes #662.
Remove unnecessary references to sympy. Fixes #666 

**Commit Summary**
- remove sympy inheritance
- replace references to `Expr` with `PyccelAstNode`
- Change `PyCodePrinter` inheritance to match `FCodePrinter` and `CCodePrinter`
- Use `kwargs` for dictionaries to avoid dangerous default value
- Add `__reduce_ex__` functions to `CodeBlock` and `Comment`
- Add `Singleton` class and `ArgumentSingleton` to replace sympy's singleton
- Remove handling of assignment where rhs is `Block` (i.e `With` etc)
- Add `length` property to `PythonZip`
- Clean functionexpr inheritance
- Remove `_sympystr` methods