### PR TITLE
Store LiteralInteger value in a private variable

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -260,10 +260,8 @@ class PythonFloat(PyccelAstNode):
     _attribute_nodes = ('_arg',)
 
     def __new__(cls, arg):
-        if isinstance(arg, LiteralFloat):
-            return LiteralFloat(arg, precision = cls._precision)
-        elif isinstance(arg, LiteralInteger):
-            return LiteralFloat(arg.p, precision = cls._precision)
+        if isinstance(arg, (LiteralInteger, LiteralFloat)):
+            return LiteralFloat(arg.python_value, precision = cls._precision)
         else:
             return super().__new__(cls)
 
@@ -291,7 +289,7 @@ class PythonInt(PyccelAstNode):
 
     def __new__(cls, arg):
         if isinstance(arg, LiteralInteger):
-            return LiteralInteger(arg.p, precision = cls._precision)
+            return LiteralInteger(arg.python_value, precision = cls._precision)
         else:
             return super().__new__(cls)
 

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -92,11 +92,11 @@ class LiteralInteger(Literal):
         super().__init__(precision)
         if not isinstance(value, int):
             raise TypeError("A LiteralInteger can only be created with an integer")
-        self.p = value
+        self._value = value
 
     @property
     def python_value(self):
-        return self.p
+        return self._value
 
     def __index__(self):
         return self.python_value

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -129,7 +129,7 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
     if isinstance(expr, LiteralInteger):
         return sp.Integer(expr.python_value)
 
-    elif isinstance(expr, LiteralReal):
+    elif isinstance(expr, LiteralFloat):
         return sp.Float(expr.python_value)
 
     elif isinstance(expr, LiteralComplex):

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -19,7 +19,7 @@ from .builtins  import PythonRange, PythonTuple
 
 from .mathext   import MathCeil
 
-from .literals  import LiteralInteger, LiteralFloat
+from .literals  import LiteralInteger, LiteralFloat, Literal
 
 from .datatypes import NativeInteger
 

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -126,11 +126,8 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
     """
 
     #Constants
-    if isinstance(expr, LiteralInteger):
-        return sp.Integer(expr.p)
-
-    elif isinstance(expr, LiteralFloat):
-        return sp.Float(expr)
+    if isinstance(expr, Literal):
+        return expr.python_value
 
     #Operators
     elif isinstance(expr, PyccelDiv):
@@ -139,7 +136,7 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
 
     elif isinstance(expr, PyccelMul):
         args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
-        return sp.Mul(*args)
+        return args[0] * args[1]
 
     elif isinstance(expr, PyccelMinus):
         args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
@@ -151,11 +148,11 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
 
     elif isinstance(expr, PyccelAdd):
         args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
-        return sp.Add(*args)
+        return args[0] + args[1]
 
     elif isinstance(expr, PyccelPow):
         args = [pyccel_to_sympy(e, symbol_map, used_names) for e in expr.args]
-        return sp.Pow(*args)
+        return args[0] ** args[1]
 
     elif isinstance(expr, PyccelAssociativeParenthesis):
         return pyccel_to_sympy(expr.args[0], symbol_map, used_names)

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -19,7 +19,7 @@ from .builtins  import PythonRange, PythonTuple
 
 from .mathext   import MathCeil
 
-from .literals  import LiteralInteger, LiteralFloat, Literal
+from .literals  import LiteralInteger, LiteralFloat, LiteralComplex
 
 from .datatypes import NativeInteger
 
@@ -126,8 +126,14 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
     """
 
     #Constants
-    if isinstance(expr, Literal):
-        return expr.python_value
+    if isinstance(expr, LiteralInteger):
+        return sp.Integer(expr.python_value)
+
+    elif isinstance(expr, LiteralReal):
+        return sp.Float(expr.python_value)
+
+    elif isinstance(expr, LiteralComplex):
+        return sp.Float(expr.real) + sp.Float(expr.imag) * 1j
 
     #Operators
     elif isinstance(expr, PyccelDiv):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3041,7 +3041,7 @@ class SemanticParser(BasicParser):
         if isinstance(val, (TupleVariable, PythonTuple)) and \
                 not isinstance(val, PythonList):
             if isinstance(length, LiteralInteger):
-                length = length.p
+                length = length.python_value
             if isinstance(val, TupleVariable):
                 return PythonTuple(*(val.get_vars()*length))
             else:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -854,22 +854,10 @@ class SemanticParser(BasicParser):
         return expr
     def _visit_Literal(self, expr, **settings):
         return expr
-    def _visit_Integer(self, expr, **settings):
-        """Visit sympy.Integer"""
-        return LiteralInteger(expr.p)
-    def _visit_Float(self, expr, **settings):
-        """Visit sympy.Integer"""
-        return LiteralFloat(expr)
     def _visit_PythonComplex(self, expr, **settings):
         return expr
     def _visit_Pass(self, expr, **settings):
         return expr
-
-    def _visit_NumberSymbol(self, expr, **settings):
-        return expr.n()
-
-    def _visit_Number(self, expr, **settings):
-        return expr.n()
 
     def _visit_Variable(self, expr, **settings):
         name = expr.name


### PR DESCRIPTION
**Commit Summary**
- Store LiteralInteger value in a private variable
- Remove dead code in parser/semantic.py
- Use operations rather than calling sympy operations directly