### PR TITLE
Fix bugs in numpy.prod

### DIFF
--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -343,8 +343,7 @@ class NumpyProduct(PyccelInternalFunction):
             raise TypeError('Unknown type of  %s.' % type(arg))
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
-        self._arg = PythonInt(self._arg) if (isinstance(arg.dtype, NativeBool) or \
-                    isinstance(arg.dtype, NativeInteger)) else self._arg
+        self._arg = PythonInt(self._arg) if isinstance(arg.dtype, (NativeInteger, NativeBool)) else self._arg
         self._dtype = self._arg.dtype
         self._rank  = 0
         self._shape = ()

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -343,7 +343,7 @@ class NumpyProduct(PyccelInternalFunction):
             raise TypeError('Unknown type of  %s.' % type(arg))
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
-        self._arg = PythonInt(self._arg) if isinstance(arg.dtype, NativeBool) else self._arg
+        self._arg = PythonInt(self._arg) if (isinstance(arg.dtype, NativeBool) or (isinstance(arg.dtype, NativeInteger) and self._arg.precision < 8)) else self._arg
         self._dtype = self._arg.dtype
         self._rank  = 0
         self._shape = ()

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -342,14 +342,16 @@ class NumpyProduct(PyccelInternalFunction):
         if not isinstance(arg, PyccelAstNode):
             raise TypeError('Unknown type of  %s.' % type(arg))
         super().__init__(arg)
-        self._dtype = arg.dtype
+        self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
+        self._arg = PythonInt(self._arg) if isinstance(arg.dtype, NativeBool) else self._arg
+        self._dtype = self._arg.dtype
         self._rank  = 0
         self._shape = ()
         self._precision = default_precision[str_dtype(self._dtype)]
 
     @property
     def arg(self):
-        return self._args[0]
+        return self._arg
 
 
 #==============================================================================

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -344,7 +344,7 @@ class NumpyProduct(PyccelInternalFunction):
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
         self._arg = PythonInt(self._arg) if (isinstance(arg.dtype, NativeBool) or \
-                    (isinstance(arg.dtype, NativeInteger) and self._arg.precision < default_precision['int'])\
+                    (isinstance(arg.dtype, NativeInteger) and self._arg.precision < default_precision['int']))\
                     else self._arg
         self._dtype = self._arg.dtype
         self._rank  = 0

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -343,7 +343,9 @@ class NumpyProduct(PyccelInternalFunction):
             raise TypeError('Unknown type of  %s.' % type(arg))
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
-        self._arg = PythonInt(self._arg) if isinstance(arg.dtype, (NativeInteger, NativeBool)) else self._arg
+        self._arg = PythonInt(self._arg) if (isinstance(arg.dtype, NativeBool) or \
+                    (isinstance(arg.dtype, NativeInteger) and self._arg.precision < default_precision['int'])\
+                    else self._arg
         self._dtype = self._arg.dtype
         self._rank  = 0
         self._shape = ()

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -343,7 +343,8 @@ class NumpyProduct(PyccelInternalFunction):
             raise TypeError('Unknown type of  %s.' % type(arg))
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
-        self._arg = PythonInt(self._arg) if (isinstance(arg.dtype, NativeBool) or (isinstance(arg.dtype, NativeInteger) and self._arg.precision < 8)) else self._arg
+        self._arg = PythonInt(self._arg) if (isinstance(arg.dtype, NativeBool) or \
+            (isinstance(arg.dtype, NativeInteger) and self._arg.precision < 8)) else self._arg
         self._dtype = self._arg.dtype
         self._rank  = 0
         self._shape = ()

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -344,7 +344,7 @@ class NumpyProduct(PyccelInternalFunction):
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
         self._arg = PythonInt(self._arg) if (isinstance(arg.dtype, NativeBool) or \
-            (isinstance(arg.dtype, NativeInteger) and self._arg.precision < 8)) else self._arg
+                    isinstance(arg.dtype, NativeInteger)) else self._arg
         self._dtype = self._arg.dtype
         self._rank  = 0
         self._shape = ()

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4790,3 +4790,290 @@ def test_numpy_complex128_scalar(language):
 
     assert f_fl64_output == test_float64_output
     assert type(f_fl64_output) == type(test_float64_output.item())
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="Prod function not supported in C"),
+            pytest.mark.c]
+        )
+    )
+)
+
+# Not all arguments are supported
+
+def test_numpy_prod_scalar(language):
+
+    @types('bool')
+    @types('int')
+    @types('int8')
+    @types('int16')
+    @types('int32')
+    @types('int64')
+    @types('float')
+    @types('float32')
+    @types('float64')
+    @types('complex64')
+    @types('complex128')
+    def get_prod(a):
+        from numpy import prod
+        b = prod(a)
+        return b
+
+    integer8 = randint(min_int8, max_int8, dtype=np.int8)
+    integer16 = randint(min_int16, max_int16, dtype=np.int16)
+    integer = randint(min_int, max_int, dtype=np.int)
+    integer32 = randint(min_int32, max_int32, dtype=np.int32)
+    integer64 = randint(min_int64, max_int64, dtype=np.int64)
+
+    fl = uniform(min_int / 2, max_int / 2)
+    fl32 = uniform(min_int, max_int)
+    fl32 = np.float32(fl32)
+    fl64 = uniform(min_int / 2, max_int / 2)
+
+    cmplx128_from_float32 = uniform(low=min_float32 / 2, high=max_float32 / 2) + uniform(low=min_float32 / 2, high=max_float32 / 2) * 1j
+    # the result of the last operation is a Python complex type which has 8 bytes in the alignment,
+    # that's why we need to convert it to a numpy.complex64 the needed type.
+    cmplx64 = np.complex64(cmplx128_from_float32)
+    cmplx128 = uniform(low=min_float64 / 2, high=max_float64 / 2) + uniform(low=min_float64 / 2, high=max_float64 / 2) * 1j
+
+    f_bl = epyccel(get_prod, language=language)
+
+    f_bl_true_output = f_bl(True)
+    test_bool_true_output = get_prod(True)
+
+    f_bl_false_output = f_bl(False)
+    test_bool_false_output = get_prod(False)
+
+    assert f_bl_true_output == test_bool_true_output
+    assert f_bl_false_output == test_bool_false_output
+
+    assert (type(f_bl_true_output) == type(test_bool_false_output.item()))
+
+    f_integer = epyccel(get_prod, language=language)
+    f_integer8 = epyccel(get_prod, language=language)
+    f_integer16 = epyccel(get_prod, language=language)
+    f_integer32 = epyccel(get_prod, language=language)
+    f_integer64 = epyccel(get_prod, language=language)
+
+    f_integer_output = f_integer(integer)
+    test_int_output  = get_prod(integer)
+
+    assert f_integer_output == test_int_output
+    assert type(f_integer_output) == type(test_int_output.item())
+
+    f_integer8_output = f_integer8(integer8)
+    test_int8_output = get_prod(integer8)
+
+    assert f_integer8_output == test_int8_output
+    assert type(f_integer8_output) == type(test_int8_output.item())
+
+    f_integer16_output = f_integer16(integer16)
+    test_int16_output = get_prod(integer16)
+
+    assert f_integer16_output == test_int16_output
+    assert type(f_integer16_output) == type(test_int16_output.item())
+
+    f_integer32_output = f_integer32(integer32)
+    test_int32_output = get_prod(integer32)
+
+    assert f_integer32_output == test_int32_output
+    assert type(f_integer32_output) == type(test_int32_output.item())
+
+    f_integer64_output = f_integer64(integer64)
+    test_int64_output = get_prod(integer64)
+
+    assert f_integer64_output == test_int64_output
+    assert type(f_integer64_output) == type(test_int64_output.item())
+
+    f_fl = epyccel(get_prod, language=language)
+    f_fl32 = epyccel(get_prod, language=language)
+    f_fl64 = epyccel(get_prod, language=language)
+
+    f_fl_output = f_fl(fl)
+    test_float_output = get_prod(fl)
+
+    assert f_fl_output == test_float_output
+    assert type(f_fl_output) == type(test_float_output.item())
+
+    f_fl32_output = f_fl32(fl32)
+    test_float32_output = get_prod(fl32)
+
+    assert f_fl32_output == test_float32_output
+    assert type(f_fl32_output) == type(test_float32_output.item())
+
+    f_fl64_output = f_fl64(fl64)
+    test_float64_output = get_prod(fl64)
+
+    assert f_fl64_output == test_float64_output
+    assert type(f_fl64_output) == type(test_float64_output.item())
+
+    f_complex64 = epyccel(get_prod, language=language)
+    f_complex128 = epyccel(get_prod, language=language)
+
+    f_complex64_output = f_complex64(cmplx64)
+    test_complex64_output = get_prod(cmplx64)
+
+    assert f_complex64_output == test_complex64_output
+    assert (type(f_complex64_output) == type(test_complex64_output.item()))
+
+    f_complex128_output = f_complex128(cmplx128)
+    test_complex128_output = get_prod(cmplx128)
+
+    assert f_complex128_output == test_complex128_output
+    assert (type(f_complex64_output) == type(test_complex64_output.item()))
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="Prod function not supported in C"),
+            pytest.mark.c]
+        )
+    )
+)
+
+def test_numpy_prod_array_like_1d(language):
+
+    @types('bool[:]')
+    @types('int[:]')
+    @types('int8[:]')
+    @types('int16[:]')
+    @types('int32[:]')
+    @types('int64[:]')
+    @types('float[:]')
+    @types('float32[:]')
+    @types('float64[:]')
+    @types('complex64[:]')
+    @types('complex128[:]')
+    def get_prod(arr):
+        from numpy import prod
+        a = prod(arr)
+        return a
+
+    bl = randint(0, 1, size=(5), dtype= bool)
+
+    integer8 = randint(min_int8, max_int8, size=(5), dtype=np.int8)
+    integer16 = randint(min_int16, max_int16, size=(5), dtype=np.int16)
+    integer = randint(min_int, max_int, size=(5), dtype=np.int)
+    integer32 = randint(min_int32, max_int32, size=(5), dtype=np.int32)
+    integer64 = randint(min_int64, max_int64, size=(5), dtype=np.int64)
+
+    fl = uniform(min_float / 2, max_float / 2, size=(5))
+    fl32 = uniform(min_float32, max_float32, size=(5))
+    fl32 = np.float32(fl32)
+    fl64 = uniform(min_float64 / 2, max_float64 / 2, size=(5))
+
+    cmplx128_from_float32 = uniform(low=min_float32 / 2, high=max_float32 / 2, size=5) + uniform(low=min_float32 / 2, high=max_float32 / 2, size=5) * 1j
+    # the result of the last operation is a Python complex type which has 8 bytes in the alignment,
+    # that's why we need to convert it to a numpy.complex64 the needed type.
+    cmplx64 = np.complex64(cmplx128_from_float32)
+    cmplx128 = uniform(low=min_float64 / 2, high=max_float64 / 2, size=5) + uniform(low=min_float64 / 2, high=max_float64 / 2, size=5) * 1j
+
+    f_bl = epyccel(get_prod, language=language)
+
+    assert (f_bl(bl) == get_prod(bl))
+
+    f_integer8 = epyccel(get_prod, language=language)
+    f_integer16 = epyccel(get_prod, language=language)
+    f_integer = epyccel(get_prod, language=language)
+    f_integer32 = epyccel(get_prod, language=language)
+
+    assert (f_integer8(integer8) == get_prod(integer8))
+    assert (f_integer16(integer16) == get_prod(integer16))
+    assert (f_integer(integer) == get_prod(integer))
+    assert (f_integer32(integer32) == get_prod(integer32))
+
+    f_integer64 = epyccel(get_prod, language=language)
+    assert (f_integer64(integer64) == get_prod(integer64))
+
+    f_fl = epyccel(get_prod, language=language)
+    f_fl32 = epyccel(get_prod, language=language)
+    f_fl64 = epyccel(get_prod, language=language)
+
+    assert (f_fl(fl) == get_prod(fl))
+    assert (f_fl32(fl32) == get_prod(fl32))
+    assert (f_fl64(fl64) == get_prod(fl64))
+
+    f_complex64 = epyccel(get_prod, language=language)
+    f_complex128 = epyccel(get_prod, language=language)
+
+    assert (f_complex64(cmplx64) == get_prod(cmplx64))
+    assert (f_complex128(cmplx128) == get_prod(cmplx128))
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="Prod function not supported in C"),
+            pytest.mark.c]
+        )
+    )
+)
+
+
+def test_numpy_prod_array_like_2d(language):
+
+    @types('bool[:]')
+    @types('int[:]')
+    @types('int8[:]')
+    @types('int16[:]')
+    @types('int32[:]')
+    @types('int64[:]')
+    @types('float[:]')
+    @types('float32[:]')
+    @types('float64[:]')
+    @types('complex64[:]')
+    @types('complex128[:]')
+    def get_prod(arr):
+        from numpy import prod
+        a = prod(arr)
+        return a
+
+    bl = randint(0, 1, size=(2, 5), dtype= bool)
+
+    integer8 = randint(min_int8, max_int8, size=(2, 5), dtype=np.int8)
+    integer16 = randint(min_int16, max_int16, size=(2, 5), dtype=np.int16)
+    integer = randint(min_int, max_int, size=(2, 5), dtype=np.int)
+    integer32 = randint(min_int32, max_int32, size=(2, 5), dtype=np.int32)
+    integer64 = randint(min_int64, max_int64, size=(2, 5), dtype=np.int64)
+
+    fl = uniform(min_float / 2, max_float / 2, size=(2, 5))
+    fl32 = uniform(min_float32, max_float32, size=(2, 5))
+    fl32 = np.float32(fl32)
+    fl64 = uniform(min_float64 / 2, max_float64 / 2, size=(2, 5))
+
+    cmplx128_from_float32 = uniform(low=min_float32 / 2, high=max_float32 / 2, size=(2, 5)) + uniform(low=min_float32 / 2, high=max_float32 / 2, size=(2, 5)) * 1j
+    # the result of the last operation is a Python complex type which has 8 bytes in the alignment,
+    # that's why we need to convert it to a numpy.complex64 the needed type.
+    cmplx64 = np.complex64(cmplx128_from_float32)
+    cmplx128 = uniform(low=min_float64 / 2, high=max_float64 / 2, size=(2, 5)) + uniform(low=min_float64 / 2, high=max_float64 / 2, size=(2, 5)) * 1j
+
+    f_bl = epyccel(get_prod, language=language)
+
+    assert (f_bl(bl) == get_prod(bl))
+
+    f_integer8 = epyccel(get_prod, language=language)
+    f_integer16 = epyccel(get_prod, language=language)
+    f_integer = epyccel(get_prod, language=language)
+    f_integer32 = epyccel(get_prod, language=language)
+
+    assert (f_integer8(integer8) == get_prod(integer8))
+    assert (f_integer16(integer16) == get_prod(integer16))
+    assert (f_integer(integer) == get_prod(integer))
+    assert (f_integer32(integer32) == get_prod(integer32))
+
+    f_integer64 = epyccel(get_prod, language=language)
+    assert (f_integer64(integer64) == get_prod(integer64))
+
+    f_fl = epyccel(get_prod, language=language)
+    f_fl32 = epyccel(get_prod, language=language)
+    f_fl64 = epyccel(get_prod, language=language)
+
+    assert (f_fl(fl) == get_prod(fl))
+    assert (f_fl32(fl32) == get_prod(fl32))
+    assert (f_fl64(fl64) == get_prod(fl64))
+
+    f_complex64 = epyccel(get_prod, language=language)
+    f_complex128 = epyccel(get_prod, language=language)
+
+    assert (f_complex64(cmplx64) == get_prod(cmplx64))
+    assert (f_complex128(cmplx128) == get_prod(cmplx128))

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4949,25 +4949,27 @@ def test_numpy_prod_array_like_1d(language):
         from numpy import prod
         a = prod(arr)
         return a
+    
+    size = 5
 
-    bl = randint(0, 1, size=(5), dtype= bool)
+    bl = randint(0, 1, size = size, dtype= bool)
 
-    integer8 = randint(min_int8, max_int8, size=(5), dtype=np.int8)
-    integer16 = randint(min_int16, max_int16, size=(5), dtype=np.int16)
-    integer = randint(min_int, max_int, size=(5), dtype=np.int)
-    integer32 = randint(min_int32, max_int32, size=(5), dtype=np.int32)
-    integer64 = randint(min_int64, max_int64, size=(5), dtype=np.int64)
+    integer8 = randint(min_int8, max_int8, size = size, dtype=np.int8)
+    integer16 = randint(min_int16, max_int16, size = size, dtype=np.int16)
+    integer = randint(min_int, max_int, size = size, dtype=np.int)
+    integer32 = randint(min_int32, max_int32, size = size, dtype=np.int32)
+    integer64 = randint(min_int64, max_int64, size = size, dtype=np.int64)
 
-    fl = uniform(min_float / 2, max_float / 2, size=(5))
-    fl32 = uniform(min_float32, max_float32, size=(5))
+    fl = uniform(min_float / 2, max_float / 2, size = size)
+    fl32 = uniform(min_float32, max_float32, size = size)
     fl32 = np.float32(fl32)
-    fl64 = uniform(min_float64 / 2, max_float64 / 2, size=(5))
+    fl64 = uniform(min_float64 / 2, max_float64 / 2, size = size)
 
-    cmplx128_from_float32 = uniform(low=min_float32 / 2, high=max_float32 / 2, size=5) + uniform(low=min_float32 / 2, high=max_float32 / 2, size=5) * 1j
+    cmplx128_from_float32 = uniform(low=-((-min_float32) ** (1/5)), high=(max_float32 ** (1/5)), size = size) + uniform(low=-((-min_float32) ** (1/5)), high=(max_float32 ** (1/5)), size = size) * 1j
     # the result of the last operation is a Python complex type which has 8 bytes in the alignment,
     # that's why we need to convert it to a numpy.complex64 the needed type.
     cmplx64 = np.complex64(cmplx128_from_float32)
-    cmplx128 = uniform(low=min_float64 / 2, high=max_float64 / 2, size=5) + uniform(low=min_float64 / 2, high=max_float64 / 2, size=5) * 1j
+    cmplx128 = uniform(low=-((-min_float64) ** (1/5)), high=(max_float64 ** (1/5)), size = size) + uniform(low=-((-min_float64) ** (1/5)), high=(max_float64 ** (1/5)), size = size) * 1j
 
     f_bl = epyccel(get_prod, language=language)
 
@@ -5012,40 +5014,42 @@ def test_numpy_prod_array_like_1d(language):
 
 def test_numpy_prod_array_like_2d(language):
 
-    @types('bool[:]')
-    @types('int[:]')
-    @types('int8[:]')
-    @types('int16[:]')
-    @types('int32[:]')
-    @types('int64[:]')
-    @types('float[:]')
-    @types('float32[:]')
-    @types('float64[:]')
-    @types('complex64[:]')
-    @types('complex128[:]')
+    @types('bool[:,:]')
+    @types('int[:,:]')
+    @types('int8[:,:]')
+    @types('int16[:,:]')
+    @types('int32[:,:]')
+    @types('int64[:,:]')
+    @types('float[:,:]')
+    @types('float32[:,:]')
+    @types('float64[:,:]')
+    @types('complex64[:,:]')
+    @types('complex128[:,:]')
     def get_prod(arr):
         from numpy import prod
         a = prod(arr)
         return a
 
-    bl = randint(0, 1, size=(2, 5), dtype= bool)
+    size = (2, 5)
 
-    integer8 = randint(min_int8, max_int8, size=(2, 5), dtype=np.int8)
-    integer16 = randint(min_int16, max_int16, size=(2, 5), dtype=np.int16)
-    integer = randint(min_int, max_int, size=(2, 5), dtype=np.int)
-    integer32 = randint(min_int32, max_int32, size=(2, 5), dtype=np.int32)
-    integer64 = randint(min_int64, max_int64, size=(2, 5), dtype=np.int64)
+    bl = randint(0, 1, size = size, dtype= bool)
 
-    fl = uniform(min_float / 2, max_float / 2, size=(2, 5))
-    fl32 = uniform(min_float32, max_float32, size=(2, 5))
+    integer8 = randint(min_int8, max_int8, size = size, dtype=np.int8)
+    integer16 = randint(min_int16, max_int16, size = size, dtype=np.int16)
+    integer = randint(min_int, max_int, size = size, dtype=np.int)
+    integer32 = randint(min_int32, max_int32, size = size, dtype=np.int32)
+    integer64 = randint(min_int64, max_int64, size = size, dtype=np.int64)
+
+    fl = uniform(min_float / 2, max_float / 2, size = size)
+    fl32 = uniform(min_float32, max_float32, size = size)
     fl32 = np.float32(fl32)
-    fl64 = uniform(min_float64 / 2, max_float64 / 2, size=(2, 5))
+    fl64 = uniform(min_float64 / 2, max_float64 / 2, size = size)
 
-    cmplx128_from_float32 = uniform(low=min_float32 / 2, high=max_float32 / 2, size=(2, 5)) + uniform(low=min_float32 / 2, high=max_float32 / 2, size=(2, 5)) * 1j
+    cmplx128_from_float32 = uniform(low=-((-min_float32) ** (1/10)), high=(max_float32 ** (1/10)), size = size) + uniform(low=-((-min_float32) ** (1/10)), high=(max_float32 ** (1/10)), size = size) * 1j
     # the result of the last operation is a Python complex type which has 8 bytes in the alignment,
     # that's why we need to convert it to a numpy.complex64 the needed type.
     cmplx64 = np.complex64(cmplx128_from_float32)
-    cmplx128 = uniform(low=min_float64 / 2, high=max_float64 / 2, size=(2, 5)) + uniform(low=min_float64 / 2, high=max_float64 / 2, size=(2, 5)) * 1j
+    cmplx128 = uniform(low=-((-min_float64) ** (1/10)), high=(max_float64 ** (1/10)), size = size) + uniform(low=-((-min_float64) ** (1/10)), high=(max_float64 ** (1/10)), size = size) * 1j
 
     f_bl = epyccel(get_prod, language=language)
 

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4880,11 +4880,13 @@ def test_numpy_prod_scalar(language):
     assert f_integer32_output == test_int32_output
     assert type(f_integer32_output) == type(test_int32_output.item())
 
-    f_integer64_output = f_integer64(integer64)
-    test_int64_output = get_prod(integer64)
+    # the if block shoud be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
+    if sys.platform != 'win32':
+        f_integer64_output = f_integer64(integer64)
+        test_int64_output = get_prod(integer64)
 
-    assert f_integer64_output == test_int64_output
-    assert type(f_integer64_output) == type(test_int64_output.item())
+        assert f_integer64_output == test_int64_output
+        assert type(f_integer64_output) == type(test_int64_output.item())
 
     f_fl = epyccel(get_prod, language=language)
     f_fl32 = epyccel(get_prod, language=language)
@@ -4949,7 +4951,7 @@ def test_numpy_prod_array_like_1d(language):
         from numpy import prod
         a = prod(arr)
         return a
-    
+
     size = 5
 
     bl = randint(0, 1, size = size, dtype= bool)
@@ -4985,8 +4987,10 @@ def test_numpy_prod_array_like_1d(language):
     assert (f_integer(integer) == get_prod(integer))
     assert (f_integer32(integer32) == get_prod(integer32))
 
-    f_integer64 = epyccel(get_prod, language=language)
-    assert (f_integer64(integer64) == get_prod(integer64))
+    # the if block shoud be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
+    if sys.platform != 'win32':
+        f_integer64 = epyccel(get_prod, language=language)
+        assert (f_integer64(integer64) == get_prod(integer64))
 
     f_fl = epyccel(get_prod, language=language)
     f_fl32 = epyccel(get_prod, language=language)
@@ -5065,8 +5069,10 @@ def test_numpy_prod_array_like_2d(language):
     assert (f_integer(integer) == get_prod(integer))
     assert (f_integer32(integer32) == get_prod(integer32))
 
-    f_integer64 = epyccel(get_prod, language=language)
-    assert (f_integer64(integer64) == get_prod(integer64))
+    # the if block shoud be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
+    if sys.platform != 'win32':
+        f_integer64 = epyccel(get_prod, language=language)
+        assert (f_integer64(integer64) == get_prod(integer64))
 
     f_fl = epyccel(get_prod, language=language)
     f_fl32 = epyccel(get_prod, language=language)


### PR DESCRIPTION
Currently `Numpy.prod` does not accept scalar arguments or arguments of `bool` type, and it gives wrong results when passing arrays with int8, int16, int32 types. This pull request should fix this:

- Fix scalar arguments bug by converting it to list, and cast the argument if it is a bool;
- Cast `arg` to `int64` in NumpyProd if it is `int` and its precision is less than 8;
- Add tests.