### PR TITLE
Handle bool arguments in numpy.mod 

### DIFF
--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -875,6 +875,12 @@ class NumpyFloor(NumpyUfuncUnary):
 
 class NumpyMod(NumpyUfuncBinary):
 
+    def __init__(self, x1, x2):
+        super().__init__(x1, x2)
+        x1 = PythonInt(x1) if isinstance(x1.dtype, NativeBool) else x1
+        x2 = PythonInt(x2) if isinstance(x2.dtype, NativeBool) else x2
+        self._args = (x1, x2)
+
     def _set_shape_rank(self, x1, x2):
         args   = (x1, x2)
         shapes = [a.shape for a in args]

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -5035,11 +5035,13 @@ def test_numpy_mod_scalar(language):
     assert f_integer32_output == test_int32_output
     assert type(f_integer32_output) == type(test_int32_output.item())
 
-    f_integer64_output = f_integer64(integer64)
-    test_int64_output = get_mod(integer64)
+    # the if block shoud be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
+    if sys.platform != 'win32':
+        f_integer64_output = f_integer64(integer64)
+        test_int64_output = get_mod(integer64)
 
-    assert f_integer64_output == test_int64_output
-    assert type(f_integer64_output) == type(test_int64_output.item())
+        assert f_integer64_output == test_int64_output
+        assert type(f_integer64_output) == type(test_int64_output.item())
 
     f_fl = epyccel(get_mod, language=language)
     f_fl32 = epyccel(get_mod, language=language)
@@ -5116,8 +5118,10 @@ def test_numpy_mod_array_like_1d(language):
     assert (f_integer(integer) == get_mod(integer))
     assert (f_integer32(integer32) == get_mod(integer32))
 
-    f_integer64 = epyccel(get_mod, language=language)
-    assert (f_integer64(integer64) == get_mod(integer64))
+    # the if block shoud be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
+    if sys.platform != 'win32':
+        f_integer64 = epyccel(get_mod, language=language)
+        assert (f_integer64(integer64) == get_mod(integer64))
 
     f_fl = epyccel(get_mod, language=language)
     f_fl32 = epyccel(get_mod, language=language)
@@ -5180,8 +5184,10 @@ def test_numpy_mod_array_like_2d(language):
     assert (f_integer(integer) == get_mod(integer))
     assert (f_integer32(integer32) == get_mod(integer32))
 
-    f_integer64 = epyccel(get_mod, language=language)
-    assert (f_integer64(integer64) == get_mod(integer64))
+    # the if block shoud be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
+    if sys.platform != 'win32':
+        f_integer64 = epyccel(get_mod, language=language)
+        assert (f_integer64(integer64) == get_mod(integer64))
 
     f_fl = epyccel(get_mod, language=language)
     f_fl32 = epyccel(get_mod, language=language)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4954,3 +4954,239 @@ def test_numpy_complex128_scalar(language):
 
     assert f_fl64_output == test_float64_output
     assert type(f_fl64_output) == type(test_float64_output.item())
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="Mod function not supported in C"),
+            pytest.mark.c]
+        )
+    )
+)
+
+# Not all the arguments supported
+
+def test_numpy_mod_scalar(language):
+
+    @types('bool')
+    @types('int')
+    @types('int8')
+    @types('int16')
+    @types('int32')
+    @types('int64')
+    @types('float')
+    @types('float32')
+    @types('float64')
+    def get_mod(a):
+        from numpy import mod
+        b = mod(a, a)
+        return b
+
+    integer8 = randint(min_int8, max_int8, dtype=np.int8)
+    integer16 = randint(min_int16, max_int16, dtype=np.int16)
+    integer = randint(min_int, max_int, dtype=np.int)
+    integer32 = randint(min_int32, max_int32, dtype=np.int32)
+    integer64 = randint(min_int64, max_int64, dtype=np.int64)
+
+    fl = uniform(min_int / 2, max_int / 2)
+    fl32 = uniform(min_int, max_int)
+    fl32 = np.float32(fl32)
+    fl64 = uniform(min_int / 2, max_int / 2)
+
+
+    f_bl = epyccel(get_mod, language=language)
+
+    f_bl_true_output = f_bl(True)
+    test_bool_true_output = get_mod(True)
+
+    f_bl_false_output = f_bl(False)
+    test_bool_false_output = get_mod(False)
+
+    assert f_bl_true_output == test_bool_true_output
+    assert f_bl_false_output == test_bool_false_output
+
+    f_integer = epyccel(get_mod, language=language)
+    f_integer8 = epyccel(get_mod, language=language)
+    f_integer16 = epyccel(get_mod, language=language)
+    f_integer32 = epyccel(get_mod, language=language)
+    f_integer64 = epyccel(get_mod, language=language)
+
+    f_integer_output = f_integer(integer)
+    test_int_output  = get_mod(integer)
+
+    assert f_integer_output == test_int_output
+    assert type(f_integer_output) == type(test_int_output.item())
+
+    f_integer8_output = f_integer8(integer8)
+    test_int8_output = get_mod(integer8)
+
+    assert f_integer8_output == test_int8_output
+    assert type(f_integer8_output) == type(test_int8_output.item())
+
+    f_integer16_output = f_integer16(integer16)
+    test_int16_output = get_mod(integer16)
+
+    assert f_integer16_output == test_int16_output
+    assert type(f_integer16_output) == type(test_int16_output.item())
+
+    f_integer32_output = f_integer32(integer32)
+    test_int32_output = get_mod(integer32)
+
+    assert f_integer32_output == test_int32_output
+    assert type(f_integer32_output) == type(test_int32_output.item())
+
+    f_integer64_output = f_integer64(integer64)
+    test_int64_output = get_mod(integer64)
+
+    assert f_integer64_output == test_int64_output
+    assert type(f_integer64_output) == type(test_int64_output.item())
+
+    f_fl = epyccel(get_mod, language=language)
+    f_fl32 = epyccel(get_mod, language=language)
+    f_fl64 = epyccel(get_mod, language=language)
+
+    f_fl_output = f_fl(fl)
+    test_float_output = get_mod(fl)
+
+    assert f_fl_output == test_float_output
+    assert type(f_fl_output) == type(test_float_output.item())
+
+    f_fl32_output = f_fl32(fl32)
+    test_float32_output = get_mod(fl32)
+
+    assert f_fl32_output == test_float32_output
+    assert type(f_fl32_output) == type(test_float32_output.item())
+
+    f_fl64_output = f_fl64(fl64)
+    test_float64_output = get_mod(fl64)
+
+    assert f_fl64_output == test_float64_output
+    assert type(f_fl64_output) == type(test_float64_output.item())
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="Mod function not supported in C"),
+            pytest.mark.c]
+        )
+    )
+)
+
+def test_numpy_mod_array_like_1d(language):
+
+    @types('bool[:]')
+    @types('int[:]')
+    @types('int8[:]')
+    @types('int16[:]')
+    @types('int32[:]')
+    @types('int64[:]')
+    @types('float[:]')
+    @types('float32[:]')
+    @types('float64[:]')
+    def get_mod(arr):
+        from numpy import mod, shape
+        a = mod(arr, arr)
+        s = shape(a)
+        return len(s), s[0], a[0]
+
+    bl = randint(0, 1, size=(5), dtype= bool)
+
+    integer8 = randint(min_int8, max_int8, size=(5), dtype=np.int8)
+    integer16 = randint(min_int16, max_int16, size=(5), dtype=np.int16)
+    integer = randint(min_int, max_int, size=(5), dtype=np.int)
+    integer32 = randint(min_int32, max_int32, size=(5), dtype=np.int32)
+    integer64 = randint(min_int64, max_int64, size=(5), dtype=np.int64)
+
+    fl = uniform(min_float / 2, max_float / 2, size=(5))
+    fl32 = uniform(min_float32, max_float32, size=(5))
+    fl32 = np.float32(fl32)
+    fl64 = uniform(min_float64 / 2, max_float64 / 2, size=(5))
+
+    f_bl = epyccel(get_mod, language=language)
+
+    assert (f_bl(bl) == get_mod(bl))
+
+    f_integer8 = epyccel(get_mod, language=language)
+    f_integer16 = epyccel(get_mod, language=language)
+    f_integer = epyccel(get_mod, language=language)
+    f_integer32 = epyccel(get_mod, language=language)
+
+    assert (f_integer8(integer8) == get_mod(integer8))
+    assert (f_integer16(integer16) == get_mod(integer16))
+    assert (f_integer(integer) == get_mod(integer))
+    assert (f_integer32(integer32) == get_mod(integer32))
+
+    f_integer64 = epyccel(get_mod, language=language)
+    assert (f_integer64(integer64) == get_mod(integer64))
+
+    f_fl = epyccel(get_mod, language=language)
+    f_fl32 = epyccel(get_mod, language=language)
+    f_fl64 = epyccel(get_mod, language=language)
+
+    assert (f_fl(fl) == get_mod(fl))
+    assert (f_fl32(fl32) == get_mod(fl32))
+    assert (f_fl64(fl64) == get_mod(fl64))
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="Mod function not supported in C"),
+            pytest.mark.c]
+        )
+    )
+)
+
+def test_numpy_mod_array_like_2d(language):
+
+    @types('bool[:,:]')
+    @types('int[:,:]')
+    @types('int8[:,:]')
+    @types('int16[:,:]')
+    @types('int32[:,:]')
+    @types('int64[:,:]')
+    @types('float[:,:]')
+    @types('float32[:,:]')
+    @types('float64[:,:]')
+    def get_mod(arr):
+        from numpy import mod, shape
+        a = mod(arr, arr)
+        s = shape(a)
+        return len(s), s[0], s[1], a[0,1], a[1,0]
+
+    bl = randint(0, 1, size=(2, 5), dtype= bool)
+
+    integer8 = randint(min_int8, max_int8, size=(2, 5), dtype=np.int8)
+    integer16 = randint(min_int16, max_int16, size=(2, 5), dtype=np.int16)
+    integer = randint(min_int, max_int, size=(2, 5), dtype=np.int)
+    integer32 = randint(min_int32, max_int32, size=(2, 5), dtype=np.int32)
+    integer64 = randint(min_int64, max_int64, size=(2, 5), dtype=np.int64)
+
+    fl = uniform(min_float / 2, max_float / 2, size=(2, 5))
+    fl32 = uniform(min_float32, max_float32, size=(2, 5))
+    fl32 = np.float32(fl32)
+    fl64 = uniform(min_float64 / 2, max_float64 / 2, size=(2, 5))
+
+    f_bl = epyccel(get_mod, language=language)
+
+    assert (f_bl(bl) == get_mod(bl))
+
+    f_integer8 = epyccel(get_mod, language=language)
+    f_integer16 = epyccel(get_mod, language=language)
+    f_integer = epyccel(get_mod, language=language)
+    f_integer32 = epyccel(get_mod, language=language)
+
+    assert (f_integer8(integer8) == get_mod(integer8))
+    assert (f_integer16(integer16) == get_mod(integer16))
+    assert (f_integer(integer) == get_mod(integer))
+    assert (f_integer32(integer32) == get_mod(integer32))
+
+    f_integer64 = epyccel(get_mod, language=language)
+    assert (f_integer64(integer64) == get_mod(integer64))
+
+    f_fl = epyccel(get_mod, language=language)
+    f_fl32 = epyccel(get_mod, language=language)
+    f_fl64 = epyccel(get_mod, language=language)
+
+    assert (f_fl(fl) == get_mod(fl))
+    assert (f_fl32(fl32) == get_mod(fl32))
+    assert (f_fl64(fl64) == get_mod(fl64))


### PR DESCRIPTION
Commit summary:
- Create NumpyMod constructor, and cast NumpyMod arguments to int type whenever they are booleans.
- Add tests