### PR TITLE
Allow negative step in for loops

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1349,9 +1349,14 @@ class CCodePrinter(CodePrinter):
             step  = self._print(expr.iterable.step )
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
-        return ('for ({target} = {start}; {target} < {stop}; {target} += '
+        if (step[0] == "-"):
+            return ('for ({target} = {start}; {target} > {stop}; {target} += '
                 '{step})\n{{\n{body}\n}}').format(target=target, start=start,
                 stop=stop, step=step, body=body)
+        else:
+            return ('for ({target} = {start}; {target} < {stop}; {target} += '
+                    '{step})\n{{\n{body}\n}}').format(target=target, start=start,
+                                                      stop=stop, step=step, body=body)
 
     def _print_CodeBlock(self, expr):
         body_exprs, new_vars = expand_to_loops(expr, self._parser.get_new_variable, language_has_vectors = False)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1350,6 +1350,7 @@ class CCodePrinter(CodePrinter):
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
 
+        test_step = None
         if isinstance(test_step, PyccelUnarySub):
             test_step = expr.iterable.step.args[0]
         else:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1317,8 +1317,7 @@ class CCodePrinter(CodePrinter):
         return '{} = {};'.format(lhs, rhs)
 
     def _print_For(self, expr):
-        loop_counter = self._print(expr.target)
-        loop_counter = self._print(expr.target)
+        counter = self._print(expr.target)
         body  = self._print(expr.body)
         if isinstance(expr.iterable, PythonRange):
             start = self._print(expr.iterable.start)
@@ -1334,13 +1333,13 @@ class CCodePrinter(CodePrinter):
         # testing if the step is a value or an expression
         if isinstance(test_step, Literal):
             op = '>' if isinstance(expr.iterable.step, PyccelUnarySub) else '<'
-            return ('for ({loop_counter} = {start}; {loop_counter} {op} {stop}; {loop_counter} += '
-                        '{step})\n{{\n{body}\n}}').format(loop_counter=loop_counter, start=start, op=op,
+            return ('for ({counter} = {start}; {counter} {op} {stop}; {counter} += '
+                        '{step})\n{{\n{body}\n}}').format(counter=counter, start=start, op=op,
                                                           stop=stop, step=step, body=body)
         else:
             return (
-                'for ({loop_counter} = {start}; ({step} > 0) ? ({loop_counter} < {stop}) : ({loop_counter} > {stop}); {loop_counter} += '
-                '{step})\n{{\n{body}\n}}').format(loop_counter=loop_counter, start=start,
+                'for ({counter} = {start}; ({step} > 0) ? ({counter} < {stop}) : ({counter} > {stop}); {counter} += '
+                '{step})\n{{\n{body}\n}}').format(counter=counter, start=start,
                                                   stop=stop, step=step, body=body)
 
     def _print_CodeBlock(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1317,7 +1317,8 @@ class CCodePrinter(CodePrinter):
         return '{} = {};'.format(lhs, rhs)
 
     def _print_For(self, expr):
-        target = self._print(expr.target)
+        loop_counter = self._print(expr.target)
+        loop_counter = self._print(expr.target)
         body  = self._print(expr.body)
         if isinstance(expr.iterable, PythonRange):
             start = self._print(expr.iterable.start)
@@ -1333,13 +1334,13 @@ class CCodePrinter(CodePrinter):
         # testing if the step is a value or an expression
         if isinstance(test_step, Literal):
             op = '>' if isinstance(expr.iterable.step, PyccelUnarySub) else '<'
-            return ('for ({target} = {start}; {target} {op} {stop}; {target} += '
-                        '{step})\n{{\n{body}\n}}').format(target=target, start=start, op=op,
+            return ('for ({loop_counter} = {start}; {loop_counter} {op} {stop}; {loop_counter} += '
+                        '{step})\n{{\n{body}\n}}').format(loop_counter=loop_counter, start=start, op=op,
                                                           stop=stop, step=step, body=body)
         else:
             return (
-                'for ({target} = {start}; (({step} > 0 ? 1 : -1)*({target})) < (({step} > 0 ? 1 : -1)*({stop})); {target} += '
-                '{step})\n{{\n{body}\n}}').format(target=target, start=start,
+                'for ({loop_counter} = {start}; (({step} > 0 ? 1 : -1)*({loop_counter})) < (({step} > 0 ? 1 : -1)*({stop})); {loop_counter} += '
+                '{step})\n{{\n{body}\n}}').format(loop_counter=loop_counter, start=start,
                                                   stop=stop, step=step, body=body)
 
     def _print_CodeBlock(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1349,14 +1349,9 @@ class CCodePrinter(CodePrinter):
             step  = self._print(expr.iterable.step )
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
-        if isinstance(expr.iterable.step, PyccelUnarySub):
-            return ('for ({target} = {start}; {target} > {stop}; {target} += '
+        return ('for ({target} = {start}; (({step} > 0 ? 1 : -1)*({target})) < (({step} > 0 ? 1 : -1)*({stop})); {target} += '
                 '{step})\n{{\n{body}\n}}').format(target=target, start=start,
                 stop=stop, step=step, body=body)
-        else:
-            return ('for ({target} = {start}; {target} < {stop}; {target} += '
-                    '{step})\n{{\n{body}\n}}').format(target=target, start=start,
-                                                      stop=stop, step=step, body=body)
 
     def _print_CodeBlock(self, expr):
         body_exprs, new_vars = expand_to_loops(expr, self._parser.get_new_variable, language_has_vectors = False)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1350,9 +1350,10 @@ class CCodePrinter(CodePrinter):
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
 
-        test_step = expr.iterable.step
         if isinstance(test_step, PyccelUnarySub):
             test_step = expr.iterable.step.args[0]
+        else:
+            test_step = expr.iterable.step
 
         # testing if the step is a value or an expression
         if isinstance(test_step, Literal):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1339,7 +1339,7 @@ class CCodePrinter(CodePrinter):
                                                           stop=stop, step=step, body=body)
         else:
             return (
-                'for ({loop_counter} = {start}; (({step} > 0 ? 1 : -1)*({loop_counter})) < (({step} > 0 ? 1 : -1)*({stop})); {loop_counter} += '
+                'for ({loop_counter} = {start}; ({step} > 0) ? ({loop_counter} < {stop}) : ({loop_counter} > {stop}); {loop_counter} += '
                 '{step})\n{{\n{body}\n}}').format(loop_counter=loop_counter, start=start,
                                                   stop=stop, step=step, body=body)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1350,11 +1350,9 @@ class CCodePrinter(CodePrinter):
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
 
-        test_step = None
+        test_step = expr.iterable.step
         if isinstance(test_step, PyccelUnarySub):
             test_step = expr.iterable.step.args[0]
-        else:
-            test_step = expr.iterable.step
 
         # testing if the step is a value or an expression
         if isinstance(test_step, Literal):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1349,7 +1349,7 @@ class CCodePrinter(CodePrinter):
             step  = self._print(expr.iterable.step )
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
-        if (step[0] == "-"):
+        if isinstance(expr.iterable.step, PyccelUnarySub):
             return ('for ({target} = {start}; {target} > {stop}; {target} += '
                 '{step})\n{{\n{body}\n}}').format(target=target, start=start,
                 stop=stop, step=step, body=body)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -528,7 +528,6 @@ class CCodePrinter(CodePrinter):
         cond = self._print(expr.cond)
         value_true = self._print(expr.value_true)
         value_false = self._print(expr.value_false)
-        print('here is fine')
         return '{cond} ? {true} : {false}'.format(cond = cond, true =value_true, false = value_false)
 
     def _print_LiteralTrue(self, expr):
@@ -1357,13 +1356,9 @@ class CCodePrinter(CodePrinter):
 
         # testing if the step is a value or an expression
         if isinstance(test_step, Literal):
-            if isinstance(expr.iterable.step, PyccelUnarySub):
-                return ('for ({target} = {start}; {target} > {stop}; {target} += '
-                        '{step})\n{{\n{body}\n}}').format(target=target, start=start,
-                                                          stop=stop, step=step, body=body)
-            else:
-                return ('for ({target} = {start}; {target} < {stop}; {target} += '
-                        '{step})\n{{\n{body}\n}}').format(target=target, start=start,
+            op = '>' if isinstance(expr.iterable.step, PyccelUnarySub) else '<'
+            return ('for ({target} = {start}; {target} {op} {stop}; {target} += '
+                        '{step})\n{{\n{body}\n}}').format(target=target, start=start, op=op,
                                                           stop=stop, step=step, body=body)
         else:
             return (

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1787,8 +1787,10 @@ class FCodePrinter(CodePrinter):
 
     def _print_PythonRange(self, expr):
         start = self._print(expr.start)
-        stop  = self._print(expr.stop) + '-' + self._print(LiteralInteger(1))
         step  = self._print(expr.step)
+        stop = self._print(expr.stop) + '-' + self._print(LiteralInteger(1))
+        if (step[0] == "-"):
+            stop = self._print(expr.stop) + '+' + self._print(LiteralInteger(1))
         return '{0}, {1}, {2}'.format(start, stop, step)
 
     def _print_FunctionalFor(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1795,12 +1795,15 @@ class FCodePrinter(CodePrinter):
 
         # testing if the step is a value or an expression
         if isinstance(test_step, Literal):
-            stop = self._print(expr.stop) + '-' + self._print(LiteralInteger(1))
+            stop = PyccelMinus(expr.stop, LiteralInteger(1))
             if isinstance(expr.step, PyccelUnarySub):
-                stop = self._print(expr.stop) + '+' + self._print(LiteralInteger(1))
+                stop = PyccelAdd(expr.stop, LiteralInteger(1))
         else:
-            stop = self._print(expr.stop) + '- ( (merge('+self._print(LiteralInteger(1))+', '+self._print(LiteralInteger(-1))+', ' + self._print(expr.step) + ' > '+ self._print(LiteralInteger(0)) +')) *' + self._print(LiteralInteger(1)) + ')'
+            stop = IfTernaryOperator(PyccelGt(expr.step, LiteralInteger(0)),
+                                     PyccelMinus(expr.stop, LiteralInteger(1)),
+                                     PyccelAdd(expr.stop, LiteralInteger(1)))
 
+        stop = self._print(stop)
         return '{0}, {1}, {2}'.format(start, stop, step)
 
     def _print_FunctionalFor(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1795,9 +1795,10 @@ class FCodePrinter(CodePrinter):
 
         # testing if the step is a value or an expression
         if isinstance(test_step, Literal):
-            stop = PyccelMinus(expr.stop, LiteralInteger(1))
             if isinstance(expr.step, PyccelUnarySub):
                 stop = PyccelAdd(expr.stop, LiteralInteger(1))
+            else:
+                stop = PyccelMinus(expr.stop, LiteralInteger(1))
         else:
             stop = IfTernaryOperator(PyccelGt(expr.step, LiteralInteger(0)),
                                      PyccelMinus(expr.stop, LiteralInteger(1)),

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1789,7 +1789,7 @@ class FCodePrinter(CodePrinter):
         start = self._print(expr.start)
         step  = self._print(expr.step)
         stop = self._print(expr.stop) + '-' + self._print(LiteralInteger(1))
-        if (step[0] == "-"):
+        if isinstance(expr.step, PyccelUnarySub):
             stop = self._print(expr.stop) + '+' + self._print(LiteralInteger(1))
         return '{0}, {1}, {2}'.format(start, stop, step)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1788,9 +1788,7 @@ class FCodePrinter(CodePrinter):
     def _print_PythonRange(self, expr):
         start = self._print(expr.start)
         step  = self._print(expr.step)
-        stop = self._print(expr.stop) + '-' + self._print(LiteralInteger(1))
-        if isinstance(expr.step, PyccelUnarySub):
-            stop = self._print(expr.stop) + '+' + self._print(LiteralInteger(1))
+        stop = self._print(expr.stop) + '- ( (merge(1_C_INT64_T, -1_C_INT64_T, ' + self._print(expr.step) + ' > 0_C_INT64_T)) *' + self._print(LiteralInteger(1)) + ')'
         return '{0}, {1}, {2}'.format(start, stop, step)
 
     def _print_FunctionalFor(self, expr):

--- a/tests/epyccel/modules/loops.py
+++ b/tests/epyccel/modules/loops.py
@@ -225,6 +225,12 @@ def for_loop1(start, stop, step):
 
 def for_loop2():
     x = 0
-    for i in range(1, 10, -1):
+    for i in range(1, 10, 1):
+        x += i
+    return x
+
+def for_loop3():
+    x = 0
+    for i in range(10, 1, -2):
         x += i
     return x

--- a/tests/epyccel/modules/loops.py
+++ b/tests/epyccel/modules/loops.py
@@ -217,8 +217,14 @@ def while_not_0( n ):
     return n
 
 @types( int, int, int )
-def for_loop(start, stop, step):
+def for_loop1(start, stop, step):
     x = 0
     for i in range(start, stop, step):
+        x += i
+    return x
+
+def for_loop2():
+    x = 0
+    for i in range(1, 10, -1):
         x += i
     return x

--- a/tests/epyccel/modules/loops.py
+++ b/tests/epyccel/modules/loops.py
@@ -215,3 +215,10 @@ def while_not_0( n ):
     while n:
         n -= 1
     return n
+
+@types( int, int, int )
+def for_loop(start, stop, step):
+    x = 0
+    for i in range(start, stop, step):
+        x += i
+    return x

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -185,11 +185,14 @@ def test_loop_on_real_array(language):
     assert np.array_equal( out1, out2 )
 
 def test_for_loops(language):
-    f1 = loops.for_loop
+    f1 = loops.for_loop1
     f2 = epyccel(f1, language=language)
+    f3 = loops.for_loop2
+    f4 = epyccel(f3, language=language)
 
     assert (f1(1,10,1) == f2(1,10,1))
     assert (f1(10,1,-1) == f2(10,1,-1))
+    assert (f3() == f4())
 
 def test_breaks(language):
     f1 = loops.fizzbuzz_search_with_breaks

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -186,13 +186,18 @@ def test_loop_on_real_array(language):
 
 def test_for_loops(language):
     f1 = loops.for_loop1
-    f2 = epyccel(f1, language=language)
+    g1 = epyccel(f1, language=language)
+    f2 = loops.for_loop2
+    g2 = epyccel(f2, language=language)
     f3 = loops.for_loop2
-    f4 = epyccel(f3, language=language)
+    g3 = epyccel(f3, language=language)
 
-    assert (f1(1,10,1) == f2(1,10,1))
-    assert (f1(10,1,-1) == f2(10,1,-1))
-    assert (f3() == f4())
+    assert (f1(1,10,1) == g1(1,10,1))
+    assert (f1(10,1,-1) == g1(10,1,-1))
+    assert (f1(1, 10, 2) == g1(1, 10, 2))
+    assert (f1(10, 1, -3) == g1(10, 1, -3))
+    assert (f2() == g2())
+    assert (f3() == g3())
 
 def test_breaks(language):
     f1 = loops.fizzbuzz_search_with_breaks

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -184,6 +184,13 @@ def test_loop_on_real_array(language):
 
     assert np.array_equal( out1, out2 )
 
+def test_for_loops(language):
+    f1 = loops.for_loop
+    f2 = epyccel(f1, language=language)
+
+    assert (f1(1,10,1) == f2(1,10,1))
+    assert (f1(10,1,-1) == f2(10,1,-1))
+
 def test_breaks(language):
     f1 = loops.fizzbuzz_search_with_breaks
     f2 = epyccel( f1, language = language )


### PR DESCRIPTION
Allow for loops of descending order (with negative step). This fixes #709:

- Fix method `_print_PythonRange` of Fortran printer;
- Fix method `_print_For` of C printer;
- Add tests.