### PR TITLE
Remove Sympy inheritance from printers

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -243,26 +243,15 @@ class CCodePrinter(CodePrinter):
     printmethod = "_ccode"
     language = "C"
 
-    _default_settings = {
-        'order': None,
-        'full_prec': 'auto',
-        'human': True,
-        'precision': 15,
-        'user_functions': {},
-        'dereference': set()
-    }
-
-    def __init__(self, parser, **settings):
+    def __init__(self, parser, prefix_module = None, user_functions = None):
 
         if parser.filename:
             errors.set_target(parser.filename, 'file')
 
-        prefix_module = settings.pop('prefix_module', None)
-        CodePrinter.__init__(self, settings)
+        super().__init__()
         self.known_functions = dict(known_functions)
-        userfuncs = settings.get('user_functions', {})
+        userfuncs = user_functions if user_functions is not None else {}
         self.known_functions.update(userfuncs)
-        self._dereference = set(settings.get('dereference', []))
         self.prefix_module = prefix_module
         self._additional_imports = set(['stdlib'])
         self._parser = parser
@@ -1445,7 +1434,7 @@ class CCodePrinter(CodePrinter):
             return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
     def _print_Variable(self, expr):
-        if expr in self._dereference or self.stored_in_c_pointer(expr):
+        if self.stored_in_c_pointer(expr):
             return '(*{0})'.format(expr.name)
         else:
             return expr.name

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -53,31 +53,6 @@ errors = Errors()
 
 __all__ = ["CCodePrinter", "ccode"]
 
-# dictionary mapping sympy function to (argument_conditions, C_function).
-# Used in CCodePrinter._print_Function(self)
-known_functions = {
-    "Abs": [(lambda x: not x.is_integer, "fabs")],
-    "gamma": "tgamma",
-    "sin"  : "sin",
-    "cos"  : "cos",
-    "tan"  : "tan",
-    "asin" : "asin",
-    "acos" : "acos",
-    "atan" : "atan",
-    "atan2": "atan2",
-    "exp"  : "exp",
-    "log"  : "log",
-    "erf"  : "erf",
-    "sinh" : "sinh",
-    "cosh" : "cosh",
-    "tanh" : "tanh",
-    "asinh": "asinh",
-    "acosh": "acosh",
-    "atanh": "atanh",
-    "floor": "floor",
-    "ceiling": "ceil",
-}
-
 # dictionary mapping numpy function to (argument_conditions, C_function).
 # Used in CCodePrinter._print_NumpyUfuncBase(self, expr)
 numpy_ufunc_to_c_real = {
@@ -243,15 +218,12 @@ class CCodePrinter(CodePrinter):
     printmethod = "_ccode"
     language = "C"
 
-    def __init__(self, parser, prefix_module = None, user_functions = None):
+    def __init__(self, parser, prefix_module = None):
 
         if parser.filename:
             errors.set_target(parser.filename, 'file')
 
         super().__init__()
-        self.known_functions = dict(known_functions)
-        userfuncs = user_functions if user_functions is not None else {}
-        self.known_functions.update(userfuncs)
         self.prefix_module = prefix_module
         self._additional_imports = set(['stdlib'])
         self._parser = parser

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -218,6 +218,10 @@ class CCodePrinter(CodePrinter):
     printmethod = "_ccode"
     language = "C"
 
+    _default_settings = {
+        'tabwidth': 4,
+    }
+
     def __init__(self, parser, prefix_module = None):
 
         if parser.filename:
@@ -1498,7 +1502,7 @@ class CCodePrinter(CodePrinter):
             code_lines = self.indent_code(code.splitlines(True))
             return ''.join(code_lines)
 
-        tab = "    "
+        tab = " "*self._default_settings["tabwidth"]
         inc_token = ('{', '(', '{\n', '(\n')
         dec_token = ('}', ')')
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1553,8 +1553,6 @@ class CCodePrinter(CodePrinter):
             level += increase[n]
         return pretty
 
-    _print_Function = CodePrinter._print_not_supported
-
 def ccode(expr, parser, assign_to=None, **settings):
     """Converts an expr to a string of c code
 

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -7,8 +7,7 @@
 
 
 
-from sympy.core.basic import Basic
-from sympy.printing.str import StrPrinter
+from pyccel.ast.basic import Basic
 
 from pyccel.ast.core      import Assign
 from pyccel.ast.internals import PyccelSymbol

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -54,9 +54,9 @@ class CodePrinter:
         return ''.join(self._format_code(lines))
 
     def _print(self, expr):
-        """Annotates the AST.
+        """Print the AST node in the printer language
 
-        The annotation is done by finding the appropriate function _visit_X
+        The printing is done by finding the appropriate function _visit_X
         for the object expr. X is the type of the object expr. If this function
         does not exist then the method resolution order is used to search for
         other compatible _visit_X functions. If none are found then an error is

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -56,10 +56,10 @@ class CodePrinter:
     def _print(self, expr):
         """Print the AST node in the printer language
 
-        The printing is done by finding the appropriate function _visit_X
+        The printing is done by finding the appropriate function _print_X
         for the object expr. X is the type of the object expr. If this function
         does not exist then the method resolution order is used to search for
-        other compatible _visit_X functions. If none are found then an error is
+        other compatible _print_X functions. If none are found then an error is
         raised
         """
 

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -26,12 +26,6 @@ class CodePrinter:
     The base class for code-printing subclasses.
     """
 
-    _operators = {
-        'and': '&&',
-        'or': '||',
-        'not': '!',
-    }
-
     def doprint(self, expr, assign_to=None):
         """
         Print the expression as code.

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -60,7 +60,23 @@ class CodePrinter(StrPrinter):
         # Format the output
         return ''.join(self._format_code(lines))
 
+    def _print(self, expr):
+        """Annotates the AST.
 
+        The annotation is done by finding the appropriate function _visit_X
+        for the object expr. X is the type of the object expr. If this function
+        does not exist then the method resolution order is used to search for
+        other compatible _visit_X functions. If none are found then an error is
+        raised
+        """
+
+        classes = type(expr).__mro__
+        for cls in classes:
+            print_method = '_print_' + cls.__name__
+            if hasattr(self, print_method):
+                obj = getattr(self, print_method)(expr)
+                return obj
+        return self._print_not_supported(expr)
 
     def _get_statement(self, codestring):
         """Formats a codestring with the proper line ending."""
@@ -84,13 +100,8 @@ class CodePrinter(StrPrinter):
         raise NotImplementedError("This function must be implemented by "
                                   "subclass of CodePrinter.")
 
-
     def _print_NumberSymbol(self, expr):
         return str(expr)
-
-    def _print_Dummy(self, expr):
-        # dummies must be printed as unique symbols
-        return "%s_%i" % (expr.name, expr.dummy_index)  # Dummy
 
     def _print_not_supported(self, expr):
         errors.report(PYCCEL_RESTRICTION_TODO, symbol = expr,
@@ -102,36 +113,3 @@ class CodePrinter(StrPrinter):
     _print_GoldenRatio = _print_NumberSymbol
     _print_Exp1 = _print_NumberSymbol
     _print_Pi = _print_NumberSymbol
-
-    # The following can not be simply translated into C or Fortran
-    _print_Basic = _print_not_supported
-    _print_ComplexInfinity = _print_not_supported
-    _print_Derivative = _print_not_supported
-    _print_dict = _print_not_supported
-    _print_ExprCondPair = _print_not_supported
-    _print_GeometryEntity = _print_not_supported
-    _print_Infinity = _print_not_supported
-    _print_Integral = _print_not_supported
-    _print_Interval = _print_not_supported
-    _print_Limit = _print_not_supported
-    _print_list = _print_not_supported
-    _print_Matrix = _print_not_supported
-    _print_ImmutableMatrix = _print_not_supported
-    _print_MutableDenseMatrix = _print_not_supported
-    _print_MatrixBase = _print_not_supported
-    _print_DeferredVector = _print_not_supported
-    _print_NaN = _print_not_supported
-    _print_NegativeInfinity = _print_not_supported
-    _print_Normal = _print_not_supported
-    _print_Order = _print_not_supported
-    _print_PDF = _print_not_supported
-    _print_RootOf = _print_not_supported
-    _print_RootsOf = _print_not_supported
-    _print_RootSum = _print_not_supported
-    _print_Sample = _print_not_supported
-    _print_SparseMatrix = _print_not_supported
-    _print_tuple = _print_not_supported
-    _print_Uniform = _print_not_supported
-    _print_Unit = _print_not_supported
-    _print_Wild = _print_not_supported
-    _print_WildFunction = _print_not_supported

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -22,7 +22,7 @@ __all__ = ["CodePrinter"]
 
 errors = Errors()
 
-class CodePrinter(StrPrinter):
+class CodePrinter:
     """
     The base class for code-printing subclasses.
     """

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -101,9 +101,16 @@ class CodePrinter:
                                   "subclass of CodePrinter.")
 
     def _print_NumberSymbol(self, expr):
+        """ Print sympy symbols used for constants"""
         return str(expr)
 
+    def _print_str(self, expr):
+        """ Basic print functionality for strings """
+        return expr
+
     def _print_not_supported(self, expr):
+        """ Print an error message if the print function for the type
+        is not implemented """
         errors.report(PYCCEL_RESTRICTION_TODO, symbol = expr,
                 severity='fatal')
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -198,18 +198,16 @@ class FCodePrinter(CodePrinter):
     }
 
 
-    def __init__(self, parser, **settings):
-
-        prefix_module = settings.pop('prefix_module', None)
+    def __init__(self, parser, prefix_module = None, user_functions = None):
 
         if parser.filename:
             errors.set_target(parser.filename, 'file')
 
-        CodePrinter.__init__(self, settings)
+        super().__init__()
         self.parser = parser
         self._namespace = self.parser.namespace
         self.known_functions = dict(known_functions)
-        userfuncs = settings.get('user_functions', {})
+        userfuncs = user_functions if user_functions is not None else {}
         self.known_functions.update(userfuncs)
         self._current_function = None
         self._current_class    = None

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -173,7 +173,7 @@ class FCodePrinter(CodePrinter):
     }
 
 
-    def __init__(self, parser, prefix_module = None)
+    def __init__(self, parser, prefix_module = None):
 
         if parser.filename:
             errors.set_target(parser.filename, 'file')

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -77,11 +77,6 @@ from pyccel.codegen.printing.codeprinter import CodePrinter
 
 __all__ = ["FCodePrinter", "fcode"]
 
-known_functions = {
-    "sign": "sign",       # TODO: move to numpyext
-    "conjugate": "conjg"  # TODO: move to numpyext
-}
-
 numpy_ufunc_to_fortran = {
     'NumpyAbs'  : 'abs',
     'NumpyFabs'  : 'abs',
@@ -174,31 +169,11 @@ class FCodePrinter(CodePrinter):
     language = "Fortran"
 
     _default_settings = {
-        'order': None,
-        'full_prec': 'auto',
-        'precision': 15,
-        'user_functions': {},
-        'human': True,
-        'source_format': 'fixed',
         'tabwidth': 2,
-        'contract': True,
-        'standard': 77
-    }
-
-    _operators = {
-        'and': '.and.',
-        'or': '.or.',
-        'xor': '.neqv.',
-        'equivalent': '.eqv.',
-        'not': '.not. ',
-    }
-
-    _relationals = {
-        '!=': '/=',
     }
 
 
-    def __init__(self, parser, prefix_module = None, user_functions = None):
+    def __init__(self, parser, prefix_module = None)
 
         if parser.filename:
             errors.set_target(parser.filename, 'file')
@@ -206,9 +181,6 @@ class FCodePrinter(CodePrinter):
         super().__init__()
         self.parser = parser
         self._namespace = self.parser.namespace
-        self.known_functions = dict(known_functions)
-        userfuncs = user_functions if user_functions is not None else {}
-        self.known_functions.update(userfuncs)
         self._current_function = None
         self._current_class    = None
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -35,11 +35,6 @@ def _construct_header(func_name, args):
 class PythonCodePrinter(CodePrinter):
     """A printer to convert pyccel expressions to strings of Python code"""
     printmethod = "_pycode"
-    _kf = dict(chain(
-        _known_functions.items(),
-        [(k, '' + v) for k, v in _known_functions_math.items()]
-    ))
-    _kc = {k: ''+v for k, v in _known_constants_math.items()}
 
     def __init__(self, parser=None):
         self.parser = parser

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -41,10 +41,10 @@ class PythonCodePrinter(CodePrinter):
     ))
     _kc = {k: ''+v for k, v in _known_constants_math.items()}
 
-    def __init__(self, parser=None, **settings):
+    def __init__(self, parser=None):
         self.assert_contiguous = settings.pop('assert_contiguous', False)
         self.parser = parser
-        super().__init__(settings=settings)
+        super().__init__()
         self._additional_imports = set()
 
     def _indent_codestring(self, lines):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -35,6 +35,11 @@ def _construct_header(func_name, args):
 class PythonCodePrinter(CodePrinter):
     """A printer to convert pyccel expressions to strings of Python code"""
     printmethod = "_pycode"
+    language = "python"
+
+    _default_settings = {
+        'tabwidth': 4,
+    }
 
     def __init__(self, parser=None):
         self.parser = parser
@@ -42,7 +47,8 @@ class PythonCodePrinter(CodePrinter):
         self._additional_imports = set()
 
     def _indent_codestring(self, lines):
-        return '    '+lines.replace('\n','\n    ')
+        tab = " "*self._default_settings['tabwidth']
+        return tab+lines.replace('\n','\n'+tab)
 
     def _format_code(self, lines):
         return lines

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -42,7 +42,6 @@ class PythonCodePrinter(CodePrinter):
     _kc = {k: ''+v for k, v in _known_constants_math.items()}
 
     def __init__(self, parser=None):
-        self.assert_contiguous = settings.pop('assert_contiguous', False)
         self.parser = parser
         super().__init__()
         self._additional_imports = set()


### PR DESCRIPTION
Remove `sympy.StrPrinter` from the inheritance tree of the printer classes. Remove objects existing due to sympy. Fixes #746