### PR TITLE
Add short traceback to generated errors in developer mode

### DIFF
--- a/pyccel/epyccel.py
+++ b/pyccel/epyccel.py
@@ -16,7 +16,7 @@ from types import ModuleType, FunctionType
 from importlib.machinery import ExtensionFileLoader
 
 from pyccel.codegen.pipeline import execute_pyccel
-from pyccel.errors.errors import PyccelError
+from pyccel.errors.errors import PyccelError, ErrorsMode
 
 __all__ = ['random_string', 'get_source_function', 'epyccel_seq', 'epyccel']
 
@@ -221,6 +221,11 @@ def epyccel( python_function_or_module, **kwargs ):
     comm  = kwargs.pop('comm', None)
     root  = kwargs.pop('root', 0)
     bcast = kwargs.pop('bcast', True)
+    if kwargs.pop('developer_mode', None):
+        # this will initialize the singleton ErrorsMode
+        # making this settings available everywhere
+        err_mode = ErrorsMode()
+        err_mode.set_mode('developer')
 
     # Parallel version
     if comm is not None:

--- a/pyccel/epyccel.py
+++ b/pyccel/epyccel.py
@@ -222,8 +222,8 @@ def epyccel( python_function_or_module, **kwargs ):
     root  = kwargs.pop('root', 0)
     bcast = kwargs.pop('bcast', True)
     if kwargs.pop('developer_mode', None):
-        # this will initialize the singleton ErrorsMode
-        # making this settings available everywhere
+        # This will initialize the singleton ErrorsMode
+        # making this setting available everywhere
         err_mode = ErrorsMode()
         err_mode.set_mode('developer')
 

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -118,7 +118,7 @@ class ErrorInfo:
             'location': '',
             'message' : self.message,
             'symbol'  : '',
-            'traceback': '{}\n'.format(self.traceback) if self.traceback else ''
+            'traceback': self.traceback or ''
         }
 
         if self.line:

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -128,7 +128,10 @@ class ErrorInfo:
                 info['location'] = ' [{line}]'.format(line=self.line)
 
         if self.symbol:
-            info['symbol'] = ' ({})'.format(self.symbol)
+            if self.traceback:
+                info['symbol'] = ' ({})'.format(repr(self.symbol))
+            else:
+                info['symbol'] = ' ({})'.format(self.symbol)
 
         return pattern.format(**info)
 

--- a/pyccel/errors/errors.py
+++ b/pyccel/errors/errors.py
@@ -9,6 +9,7 @@ that could be shown by pyccel.
 """
 import ast
 import sys
+import traceback as tb
 
 from collections import OrderedDict
 from os.path import basename
@@ -84,7 +85,8 @@ class ErrorInfo:
                  severity=None,
                  message='',
                  symbol=None,
-                 blocker=False):
+                 blocker=False,
+                 traceback=None):
         # The parser stage
         self.stage = stage
         # The source file that was the source of this error.
@@ -103,17 +105,20 @@ class ErrorInfo:
         self.symbol = symbol
         # If True, we should halt build after the file that generated this error.
         self.blocker = blocker or (severity == 'fatal')
+        # The traceback at the moment that the error was raised
+        self.traceback = traceback
 
     def __str__(self):
 
-        pattern = '|{severity} [{stage}]: {filename}{location}| {message}{symbol}'
+        pattern = '{traceback}|{severity} [{stage}]: {filename}{location}| {message}{symbol}'
         info = {
             'stage'   : self.stage,
             'severity': _severity_registry[self.severity],
             'filename': self.filename,
             'location': '',
             'message' : self.message,
-            'symbol'  : ''
+            'symbol'  : '',
+            'traceback': '{}\n'.format(self.traceback) if self.traceback else ''
         }
 
         if self.line:
@@ -152,7 +157,7 @@ class Errors(metaclass = Singleton):
         self.error_info_map = None
         self._target = None
         self._parser_stage = None
-        self._mode = ErrorsMode().value
+        self._mode = ErrorsMode()
 
         self.initialize()
 
@@ -166,7 +171,7 @@ class Errors(metaclass = Singleton):
 
     @property
     def mode(self):
-        return self._mode
+        return self._mode.value
 
     def initialize(self):
         self.error_info_map = OrderedDict()
@@ -244,6 +249,10 @@ class Errors(metaclass = Singleton):
             line   = fst.lineno
             column = fst.col_offset
 
+        traceback = None
+        if self.mode == 'developer':
+            traceback = ''.join(tb.format_stack(limit=5))
+
         info = ErrorInfo(stage=self._parser_stage,
                          filename=filename,
                          line=line,
@@ -251,7 +260,8 @@ class Errors(metaclass = Singleton):
                          severity=severity,
                          message=message,
                          symbol=symbol,
-                         blocker=blocker)
+                         blocker=blocker,
+                         traceback=traceback)
 
         if verbose: print(info)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2391,8 +2391,8 @@ class SemanticParser(BasicParser):
                         severity='warning')
         for hd in headers:
             if (args_number != len(hd.dtypes)):
-                msg = 'The number of arguments in the function {} ({}) does not match the number\
-                        of types in decorator/header ({}).'.format(name ,args_number, len(hd.dtypes))
+                msg = """The number of arguments in the function {} ({}) does not match the number
+                        of types in decorator/header ({}).'.format(name ,args_number, len(hd.dtypes))"""
                 if (args_number < len(hd.dtypes)):
                     errors.report(msg, symbol=expr.arguments, severity='warning')
                 else:

--- a/tests/epyccel/conftest.py
+++ b/tests/epyccel/conftest.py
@@ -41,3 +41,12 @@ def pytest_runtest_teardown(item, nextitem):
     marks = [m.name for m in item.own_markers ]
     if 'parallel' not in marks:
         teardown()
+
+def pytest_addoption(parser):
+    parser.addoption("--developer-mode", action="store_true", default=False, help="Show tracebacks when pyccel errors are raised")
+
+def pytest_sessionstart(session):
+    # setup_stuff
+    if session.config.option.developer_mode:
+        from pyccel.errors.errors import ErrorsMode
+        ErrorsMode().set_mode('developer')


### PR DESCRIPTION
Pyccel has a `--developer-mode` option which does nothing. This PR modifies the error messages if Pyccel is run in developer mode. Instead of just printing the error, it also prints the last 5 calls on the stack.

E.g. The following file:
```
import numpy
import numpy

from pyccel.decorators import types

@unknown
@types('int', 'int')
def func(n):
    return n
```
when compiled with `pyccel test.py` produces the following output:
```
pyccel:
 |warning [semantic]: warn_central.py| Duplicated import  (numpy)
 |warning [semantic]: warn_central.py| Decorator(s) not used (unknown)
 |warning [semantic]: warn_central.py| The number of arguments in the function {} ({}) does not match the number
                        of types in decorator/header ({}).'.format(name ,args_number, len(hd.dtypes)) ((<pyccel.ast.core.Argument object at 0x7f5f07c9e0a0>,))
```
but when run with `pyccel test.py --developer-mode`, it produces the following output:
```
pyccel:
   File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 837, in <listcomp>
    ls = [self._visit(i, **settings) for i in expr.body]
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 801, in _visit
    obj = getattr(self, annotation_method)(expr, **settings)
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 2881, in _visit_Import
    _insert_obj('variables', source_target, imports)
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 2864, in _insert_obj
    errors.report(FOUND_DUPLICATED_IMPORT,
  File "/home/emily/Code/pyccel/pyccel/errors/errors.py", line 254, in report
    traceback = ''.join(tb.format_stack(limit=5))
|warning [semantic]: warn_central.py| Duplicated import  (numpy)
   File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 837, in _visit_CodeBlock
    ls = [self._visit(i, **settings) for i in expr.body]
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 837, in <listcomp>
    ls = [self._visit(i, **settings) for i in expr.body]
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 801, in _visit
    obj = getattr(self, annotation_method)(expr, **settings)
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 2372, in _visit_FunctionDef
    errors.report(UNUSED_DECORATORS, symbol=', '.join(not_used), severity='warning')
  File "/home/emily/Code/pyccel/pyccel/errors/errors.py", line 254, in report
    traceback = ''.join(tb.format_stack(limit=5))
|warning [semantic]: warn_central.py| Decorator(s) not used (unknown)
   File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 837, in _visit_CodeBlock
    ls = [self._visit(i, **settings) for i in expr.body]
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 837, in <listcomp>
    ls = [self._visit(i, **settings) for i in expr.body]
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 801, in _visit
    obj = getattr(self, annotation_method)(expr, **settings)
  File "/home/emily/Code/pyccel/pyccel/parser/semantic.py", line 2397, in _visit_FunctionDef
    errors.report(msg, symbol=expr.arguments, severity='warning')
  File "/home/emily/Code/pyccel/pyccel/errors/errors.py", line 254, in report
    traceback = ''.join(tb.format_stack(limit=5))
|warning [semantic]: warn_central.py| The number of arguments in the function {} ({}) does not match the number
                        of types in decorator/header ({}).'.format(name ,args_number, len(hd.dtypes)) ((<pyccel.ast.core.Argument object at 0x7f2a42160070>,))
```

**Commit Summary**

- Save `ErrorsMode` object not `ErrorsMode().value` in `Errors()` so initialisation order doesn't matter
- Collect traceback when reporting errors if in developer mode
- Print traceback at start of ErrorInfo when it is provided
- Add `developer_mode` to epyccel kwargs
- [BUG_FIX] Use a multiline string for error message, not a single line string with a line continuation character
- Add `--developer-mode` to pytest options in the tests/epyccel folder to help with debugging
- Use `repr` instead of `str` to print symbol when printing errors in developer mode to get as much information as possible