### PR TITLE
Improve setup_X.py file

### DIFF
--- a/pyccel/codegen/cwrapper.py
+++ b/pyccel/codegen/cwrapper.py
@@ -50,7 +50,7 @@ def create_c_setup(mod_name,
             A string containing the contents of the setup file
     """
 
-    code  = "from setuptools import Extension, setup\n"
+    code  = "from distutils.core import Extension, setup\n"
     code += "import numpy\n"
     code += "\n"
 

--- a/pyccel/codegen/cwrapper.py
+++ b/pyccel/codegen/cwrapper.py
@@ -5,6 +5,7 @@
 """ Functions necessary for creating the setup_X.py file which
 uses python setuptools to compile a c file and generate the
 corresponding shared library file"""
+from numpy import get_include as get_numpy_include
 
 def print_list(l):
     """ Convert a list of strings to a string that contains the
@@ -51,7 +52,6 @@ def create_c_setup(mod_name,
     """
 
     code  = "from distutils.core import Extension, setup\n"
-    code += "import numpy\n"
     code += "\n"
 
     wrapper_file = "[ r'{0}' ]".format(wrapper_file)
@@ -64,9 +64,10 @@ def create_c_setup(mod_name,
                    if deps else None)
 
     if include is None:
-        include_str = 'include_dirs = [numpy.get_include()]'
+        include_str = 'include_dirs = {0}'.format(print_list([get_numpy_include()]))
     else:
-        include_str = ('include_dirs = [{0}, numpy.get_include()]'.format(print_list(include)[1:-1])
+        include.append(get_numpy_include())
+        include_str = ('include_dirs = {0}'.format(print_list(include))
                        if include else None)
 
     libs_str    = ('libraries = {0}'.format(print_list(libs))


### PR DESCRIPTION
Minor improvements to generated `setup_X.py` file which make pyccel run faster.

**Commit Summary**
- Use `distutils.core` instead of `setuptools`
- Print numpy includes not a call to `numpy.get_include()` (numpy takes time to import)