### PR TITLE
Skip GPU tests due to compiler problems

### DIFF
--- a/tests/epyccel/test_epyccel_openmp.py
+++ b/tests/epyccel/test_epyccel_openmp.py
@@ -143,13 +143,14 @@ def test_modules_13(language):
 
     assert f1() >= 0
 
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = [
-            pytest.mark.xfail(sys.platform == 'darwin', reason="omp_get_num_devices and omp_get_default_device unrecognized in C !"),
-            pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
-    ]
-)
+#@pytest.mark.parametrize( 'language', [
+#        pytest.param("c", marks = [
+#            pytest.mark.xfail(sys.platform == 'darwin', reason="omp_get_num_devices and omp_get_default_device unrecognized in C !"),
+#            pytest.mark.c]),
+#        pytest.param("fortran", marks = pytest.mark.fortran)
+#    ]
+#)
+@pytest.mark.skip("Compiling is not fully managed for GPU commands")
 def test_modules_14_0(language):
     f1 = epyccel(openmp.test_omp_set_get_default_device, accelerator='openmp', language=language)
     f2 = epyccel(openmp.test_omp_get_num_devices, accelerator='openmp', language=language)
@@ -158,38 +159,41 @@ def test_modules_14_0(language):
     assert f1(2) == 2
     assert f2() >= 0
 
+@pytest.mark.skip("Compiling is not fully managed for GPU commands")
 def test_modules_14_1(language):
     f3 = epyccel(openmp.test_omp_is_initial_device, accelerator='openmp', language=language)
-    f4 = epyccel(openmp.test_omp_get_initial_device, accelerator='openmp') #Needs a non-host device to test the function properly
+    f4 = epyccel(openmp.test_omp_get_initial_device, accelerator='openmp', language=language) #Needs a non-host device to test the function properly
 
     assert f3() == 1
     assert f4() == 0
 
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="omp_get_team_num() return a wrong result!"),
-            pytest.mark.c]),
-        pytest.param("fortran", marks = [
-            pytest.mark.xfail(reason="Compilation fails on github action"),
-            pytest.mark.fortran])
-
-    ]
-)
+#@pytest.mark.parametrize( 'language', [
+#        pytest.param("c", marks = [
+#            pytest.mark.xfail(reason="omp_get_team_num() return a wrong result!"),
+#            pytest.mark.c]),
+#        pytest.param("fortran", marks = [
+#            pytest.mark.xfail(reason="Compilation fails on github action"),
+#            pytest.mark.fortran])
+#
+#    ]
+#)
+@pytest.mark.skip("Compiling is not fully managed for GPU commands")
 def test_modules_15(language):
     f1 = epyccel(openmp.test_omp_get_team_num, accelerator='openmp', language=language)
 
     assert f1(0) == 0
     assert f1(1) == 1
 
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="omp_get_num_teams() return a wrong result!"),
-            pytest.mark.c]),
-        pytest.param("fortran", marks = [
-            pytest.mark.xfail(reason="Compilation fails on github action"),
-            pytest.mark.fortran])
-    ]
-)
+#@pytest.mark.parametrize( 'language', [
+#        pytest.param("c", marks = [
+#            pytest.mark.xfail(reason="omp_get_num_teams() return a wrong result!"),
+#            pytest.mark.c]),
+#        pytest.param("fortran", marks = [
+#            pytest.mark.xfail(reason="Compilation fails on github action"),
+#            pytest.mark.fortran])
+#    ]
+#)
+@pytest.mark.skip("Compiling is not fully managed for GPU commands")
 def test_modules_15_1(language):
     f1 = epyccel(openmp.test_omp_get_num_teams, accelerator='openmp', language=language)
 

--- a/tests/epyccel/test_epyccel_openmp.py
+++ b/tests/epyccel/test_epyccel_openmp.py
@@ -150,7 +150,7 @@ def test_modules_13(language):
 #        pytest.param("fortran", marks = pytest.mark.fortran)
 #    ]
 #)
-@pytest.mark.skip("Compiling is not fully managed for GPU commands")
+@pytest.mark.skip("Compiling is not fully managed for GPU commands. See #798")
 def test_modules_14_0(language):
     f1 = epyccel(openmp.test_omp_set_get_default_device, accelerator='openmp', language=language)
     f2 = epyccel(openmp.test_omp_get_num_devices, accelerator='openmp', language=language)
@@ -159,7 +159,7 @@ def test_modules_14_0(language):
     assert f1(2) == 2
     assert f2() >= 0
 
-@pytest.mark.skip("Compiling is not fully managed for GPU commands")
+@pytest.mark.skip("Compiling is not fully managed for GPU commands. See #798")
 def test_modules_14_1(language):
     f3 = epyccel(openmp.test_omp_is_initial_device, accelerator='openmp', language=language)
     f4 = epyccel(openmp.test_omp_get_initial_device, accelerator='openmp', language=language) #Needs a non-host device to test the function properly
@@ -177,7 +177,7 @@ def test_modules_14_1(language):
 #
 #    ]
 #)
-@pytest.mark.skip("Compiling is not fully managed for GPU commands")
+@pytest.mark.skip("Compiling is not fully managed for GPU commands. See #798")
 def test_modules_15(language):
     f1 = epyccel(openmp.test_omp_get_team_num, accelerator='openmp', language=language)
 
@@ -193,7 +193,7 @@ def test_modules_15(language):
 #            pytest.mark.fortran])
 #    ]
 #)
-@pytest.mark.skip("Compiling is not fully managed for GPU commands")
+@pytest.mark.skip("Compiling is not fully managed for GPU commands. See #798")
 def test_modules_15_1(language):
     f1 = epyccel(openmp.test_omp_get_num_teams, accelerator='openmp', language=language)
 


### PR DESCRIPTION
Some of the OpenMP tests use GPU commands. Additional compiler flags are required for these cases. There are 4 tests for these GPU commands, which test the following functions:
- omp_set_default_device
- omp_get_default_device
- omp_get_num_devices
- omp_is_initial_device
- omp_get_initial_device
- omp_get_team_num
- omp_get_num_teams

Of these tests, only 1 is working reliably, but a recent update to gfortran (github actions are now using gfortran 9.3 instead of gfortran 7.4) has broken that test too.

This PR therefore skips the GPU tests and leaves them for issue #798 .

cc: @nhamidn 