### PR TITLE
Use numpy cast functions to cast arrays

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -151,6 +151,8 @@ class PythonComplex(PyccelAstNode):
     _rank = 0
     _shape = ()
     _order = None
+    _real_cast = PythonReal
+    _imag_cast = PythonImag
     _attribute_nodes = ('_real_part', '_imag_part', '_internal_var')
 
     def __new__(cls, arg0, arg1=LiteralFloat(0)):
@@ -189,8 +191,8 @@ class PythonComplex(PyccelAstNode):
                         isinstance(arg1, Literal) and arg1.python_value == 0
 
         if self._is_cast:
-            self._real_part = PythonReal(arg0)
-            self._imag_part = PythonImag(arg0)
+            self._real_part = self._real_cast(arg0)
+            self._imag_part = self._imag_cast(arg0)
             self._internal_var = arg0
 
         else:
@@ -199,20 +201,20 @@ class PythonComplex(PyccelAstNode):
             if arg0.dtype is NativeComplex() and \
                     not (isinstance(arg1, Literal) and arg1.python_value == 0):
                 # first arg is complex. Second arg is non-0
-                self._real_part = PythonReal(arg0)
-                self._imag_part = PyccelAdd(PythonImag(arg0), arg1)
+                self._real_part = self._real_cast(arg0)
+                self._imag_part = PyccelAdd(self._imag_cast(arg0), arg1)
             elif arg1.dtype is NativeComplex():
                 if isinstance(arg0, Literal) and arg0.python_value == 0:
                     # second arg is complex. First arg is 0
-                    self._real_part = PyccelUnarySub(PythonImag(arg1))
-                    self._imag_part = PythonReal(arg1)
+                    self._real_part = PyccelUnarySub(self._imag_cast(arg1))
+                    self._imag_part = self._real_cast(arg1)
                 else:
                     # Second arg is complex. First arg is non-0
-                    self._real_part = PyccelMinus(arg0, PythonImag(arg1))
-                    self._imag_part = PythonReal(arg1)
+                    self._real_part = PyccelMinus(arg0, self._imag_cast(arg1))
+                    self._imag_part = self._real_cast(arg1)
             else:
-                self._real_part = PythonInt(arg0) if isinstance(arg0.dtype, NativeBool) else arg0
-                self._imag_part = PythonInt(arg1) if isinstance(arg1.dtype, NativeBool) else arg1
+                self._real_part = self._real_cast(arg0)
+                self._imag_part = self._real_cast(arg1)
         super().__init__()
 
     @property

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -329,7 +329,14 @@ class PythonTuple(PyccelAstNode):
     def __init__(self, *args):
         self._args = args
         super().__init__()
-        if self.stage == 'syntactic' or len(args) == 0:
+        if self.stage == 'syntactic':
+            return
+        elif len(args) == 0:
+            self._dtype = NativeGeneric()
+            self._precision = 0
+            self._rank = 0
+            self._shape = ()
+            self._is_homogeneous = False
             return
         is_homogeneous = all(a.dtype is not NativeGeneric() and \
                              args[0].dtype == a.dtype and \

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -113,9 +113,12 @@ class PythonImag(PythonComplexProperty):
 class PythonBool(PyccelAstNode):
     """ Represents a call to Python's native bool() function.
     """
-    __slots__ = ('_arg','_shape','_rank','_order')
+    __slots__ = ('_arg',)
     _dtype = NativeBool()
     _precision = default_precision['bool']
+    _rank = 0
+    _shape = ()
+    _order = None
     _attribute_nodes = ('_arg',)
 
     def __new__(cls, arg):
@@ -128,9 +131,6 @@ class PythonBool(PyccelAstNode):
 
     def __init__(self, arg):
         self._arg = arg
-        self._shape = arg.shape
-        self._rank  = len(self._shape)
-        self._order = arg.order
         super().__init__()
 
     @property
@@ -264,9 +264,12 @@ class PythonEnumerate(Basic):
 class PythonFloat(PyccelAstNode):
     """ Represents a call to Python's native float() function.
     """
-    __slots__ = ('_arg','_shape','_rank','_order')
+    __slots__ = ('_arg')
     _dtype = NativeReal()
     _precision = default_precision['real']
+    _rank = 0
+    _shape = ()
+    _order = None
     _attribute_nodes = ('_arg',)
 
     def __new__(cls, arg):
@@ -278,9 +281,6 @@ class PythonFloat(PyccelAstNode):
 
     def __init__(self, arg):
         self._arg = arg
-        self._shape = arg.shape
-        self._rank  = len(self._shape)
-        self._order = arg.order
         super().__init__()
 
     @property
@@ -288,16 +288,19 @@ class PythonFloat(PyccelAstNode):
         return self._arg
 
     def __str__(self):
-        return 'LiteralFloat({0})'.format(str(self.arg))
+        return 'float({0})'.format(str(self.arg))
 
 #==============================================================================
 class PythonInt(PyccelAstNode):
     """ Represents a call to Python's native int() function.
     """
 
-    __slots__ = ('_arg','_shape','_rank','_order')
+    __slots__ = ('_arg')
     _dtype = NativeInteger()
     _precision = default_precision['integer']
+    _rank = 0
+    _shape = ()
+    _order = None
     _attribute_nodes  = ('_arg',)
 
     def __new__(cls, arg):
@@ -308,9 +311,6 @@ class PythonInt(PyccelAstNode):
 
     def __init__(self, arg):
         self._arg = arg
-        self._shape = arg.shape
-        self._rank  = len(self._shape)
-        self._order = arg.order
         super().__init__()
 
     @property

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -190,6 +190,12 @@ class NumpyReal(PythonReal):
     1.0
     """
     __slots__ = ('_rank','_shape','_order')
+    def __new__(cls, arg):
+        if isinstance(arg.dtype, NativeBool):
+            return NumpyInt(arg)
+        else:
+            return super().__new__(cls, arg)
+
     def __init__(self, arg):
         super().__init__(arg)
         self._precision = arg.precision

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -215,10 +215,10 @@ DtypePrecisionToCastFunction = {
         8 : NumpyFloat64},
     'Complex' : {
         4 : NumpyComplex64,
-        8 : PythonComplex,
+        8 : NumpyComplex,
         16 : NumpyComplex128,},
     'Bool':  {
-        4 : PythonBool}
+        4 : NumpyBool}
 }
 
 #==============================================================================
@@ -415,7 +415,7 @@ class NumpyProduct(PyccelInternalFunction):
             raise TypeError('Unknown type of  %s.' % type(arg))
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
-        self._arg = PythonInt(self._arg) if (isinstance(arg.dtype, NativeBool) or \
+        self._arg = NumpyInt(self._arg) if (isinstance(arg.dtype, NativeBool) or \
                     (isinstance(arg.dtype, NativeInteger) and self._arg.precision < default_precision['int']))\
                     else self._arg
         self._dtype = self._arg.dtype
@@ -843,7 +843,7 @@ class NumpyNorm(PyccelInternalFunction):
     def __init__(self, arg, axis=None):
         super().__init__(arg, axis)
         if not isinstance(arg.dtype, (NativeComplex, NativeReal)):
-            arg = PythonFloat(arg)
+            arg = NumpyFloat(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else arg
         self._precision = arg.precision
         if self.axis is not None:
@@ -1027,8 +1027,8 @@ class NumpyMod(NumpyUfuncBinary):
 
     def __init__(self, x1, x2):
         super().__init__(x1, x2)
-        x1 = PythonInt(x1) if isinstance(x1.dtype, NativeBool) else x1
-        x2 = PythonInt(x2) if isinstance(x2.dtype, NativeBool) else x2
+        x1 = NumpyInt(x1) if isinstance(x1.dtype, NativeBool) else x1
+        x2 = NumpyInt(x2) if isinstance(x2.dtype, NativeBool) else x2
         self._args = (x1, x2)
 
     def _set_shape_rank(self, x1, x2):

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -92,7 +92,14 @@ __all__ = (
 class NumpyComplex(PythonComplex):
     """ Represents a call to numpy.complex() function.
     """
-    __slots__ = ()
+    __slots__ = ('_rank','_shape','_order')
+    def __init__(self, arg0, arg1 = None):
+        if arg1 is not None:
+            raise NotImplementedError("Use builtin complex function not deprecated np.complex")
+        self._shape = arg0.shape
+        self._rank  = arg0.rank
+        self._order = arg0.order
+        super().__init__(arg0)
 
 class NumpyComplex64(NumpyComplex):
     """ Represents a call to numpy.complex64() function.
@@ -110,7 +117,12 @@ class NumpyComplex128(NumpyComplex):
 class NumpyFloat(PythonFloat):
     """ Represents a call to numpy.float() function.
     """
-    __slots__ = ()
+    __slots__ = ('_rank','_shape','_order')
+    def __init__(self, arg):
+        self._shape = arg.shape
+        self._rank  = arg.rank
+        self._order = arg.order
+        super().__init__(arg)
 
 class NumpyFloat32(NumpyFloat):
     """ Represents a call to numpy.float32() function.
@@ -128,17 +140,24 @@ class NumpyFloat64(NumpyFloat):
 class NumpyBool(PythonBool):
     """ Represents a call to numpy.bool() function.
     """
-    def __new__(cls, arg=None, base=10):
-        return super().__new__(cls, arg)
+    __slots__ = ('_shape','_rank','_order')
+    def __init__(self, arg):
+        self._shape = arg.shape
+        self._rank  = arg.rank
+        self._order = arg.order
+        super().__init__(arg)
 
 #=======================================================================================
 # TODO [YG, 13.03.2020]: handle case where base != 10
 class NumpyInt(PythonInt):
     """ Represents a call to numpy.int() function.
     """
-    __slots__ = ()
-    def __new__(cls, arg=None, base=10):
-        return super().__new__(cls, arg)
+    __slots__ = ('_shape','_rank','_order')
+    def __init__(self, arg=None, base=10):
+        self._shape = arg.shape
+        self._rank  = arg.rank
+        self._order = arg.order
+        super().__init__(arg)
 
 class NumpyInt8(NumpyInt):
     """ Represents a call to numpy.int8() function.

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -8,7 +8,7 @@
 import functools
 import operator
 
-from pyccel.ast.builtins  import PythonRange, PythonFloat, PythonComplex
+from pyccel.ast.builtins  import PythonRange, PythonComplex
 
 from pyccel.ast.core      import Declare
 from pyccel.ast.core      import FuncAddressDeclare, FunctionCall, FunctionDef
@@ -564,9 +564,9 @@ class CCodePrinter(CodePrinter):
             return "{} % {}".format(first, second)
 
         if expr.args[0].dtype is NativeInteger():
-            first = self._print(PythonFloat(expr.args[0]))
+            first = self._print(NumpyFloat(expr.args[0]))
         if expr.args[1].dtype is NativeInteger():
-            second = self._print(PythonFloat(expr.args[1]))
+            second = self._print(NumpyFloat(expr.args[1]))
         return "fmod({}, {})".format(first, second)
 
     def _print_PyccelPow(self, expr):
@@ -580,8 +580,8 @@ class CCodePrinter(CodePrinter):
             return 'cpow({}, {})'.format(b, e)
 
         self._additional_imports.add("math")
-        b = self._print(b if b.dtype is NativeReal() else PythonFloat(b))
-        e = self._print(e if e.dtype is NativeReal() else PythonFloat(e))
+        b = self._print(b if b.dtype is NativeReal() else NumpyFloat(b))
+        e = self._print(e if e.dtype is NativeReal() else NumpyFloat(e))
         code = 'pow({}, {})'.format(b, e)
         if expr.dtype is NativeInteger():
             dtype = self._print(expr.dtype)
@@ -1021,7 +1021,7 @@ class CCodePrinter(CodePrinter):
         args = []
         for arg in expr.args:
             if arg.dtype != NativeReal() and not func_name.startswith("pyc"):
-                args.append(self._print(PythonFloat(arg)))
+                args.append(self._print(NumpyFloat(arg)))
             else:
                 args.append(self._print(arg))
         code_args = ', '.join(args)
@@ -1037,7 +1037,7 @@ class CCodePrinter(CodePrinter):
         self._additional_imports.add('math')
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
-            code_arg = self._print(PythonFloat(arg))
+            code_arg = self._print(NumpyFloat(arg))
         else:
             code_arg = self._print(arg)
         return "isfinite({})".format(code_arg)
@@ -1049,7 +1049,7 @@ class CCodePrinter(CodePrinter):
         self._additional_imports.add('math')
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
-            code_arg = self._print(PythonFloat(arg))
+            code_arg = self._print(NumpyFloat(arg))
         else:
             code_arg = self._print(arg)
         return "isinf({})".format(code_arg)
@@ -1061,7 +1061,7 @@ class CCodePrinter(CodePrinter):
         self._additional_imports.add('math')
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
-            code_arg = self._print(PythonFloat(arg))
+            code_arg = self._print(NumpyFloat(arg))
         else:
             code_arg = self._print(arg)
         return "isnan({})".format(code_arg)
@@ -1073,7 +1073,7 @@ class CCodePrinter(CodePrinter):
         self._additional_imports.add('math')
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
-            code_arg = self._print(PythonFloat(arg))
+            code_arg = self._print(NumpyFloat(arg))
         else:
             code_arg = self._print(arg)
         return "trunc({})".format(code_arg)
@@ -1231,7 +1231,7 @@ class CCodePrinter(CodePrinter):
 
     def _print_PyccelDiv(self, expr):
         if all(a.dtype is NativeInteger() for a in expr.args):
-            args = [PythonFloat(a) for a in expr.args]
+            args = [NumpyFloat(a) for a in expr.args]
         else:
             args = expr.args
         return  ' / '.join(self._print(a) for a in args)
@@ -1242,7 +1242,7 @@ class CCodePrinter(CodePrinter):
         # type, if all arguments are integers the result is integer otherwise
         # the result type is float
         need_to_cast = all(a.dtype is NativeInteger() for a in expr.args)
-        code = ' / '.join(self._print(a if a.dtype is NativeReal() else PythonFloat(a)) for a in expr.args)
+        code = ' / '.join(self._print(a if a.dtype is NativeReal() else NumpyFloat(a)) for a in expr.args)
         if (need_to_cast):
             cast_type = self.find_in_dtype_registry('int', expr.precision)
             return "({})floor({})".format(cast_type, code)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2339,7 +2339,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_PyccelDiv(self, expr):
         if all(a.dtype is NativeInteger() for a in expr.args):
-            args = [PythonFloat(a) for a in expr.args]
+            args = [NumpyFloat(a) for a in expr.args]
         else:
             args = expr.args
         return ' / '.join(self._print(a) for a in args)
@@ -2349,7 +2349,7 @@ class FCodePrinter(CodePrinter):
 
         def correct_type_arg(a):
             if is_real and a.dtype is NativeInteger():
-                return PythonFloat(a)
+                return NumpyFloat(a)
             else:
                 return a
 
@@ -2368,7 +2368,7 @@ class FCodePrinter(CodePrinter):
         for b in expr.args[1:]:
             bdtype    = b.dtype
             if adtype is NativeInteger() and bdtype is NativeInteger():
-                b = PythonFloat(b)
+                b = NumpyFloat(b)
             c = self._print(b)
             adtype = bdtype
             code = 'FLOOR({}/{},{})'.format(code, c, self.print_kind(expr))
@@ -2534,7 +2534,7 @@ class FCodePrinter(CodePrinter):
         # add necessary include
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
-            code_arg = self._print(PythonFloat(arg))
+            code_arg = self._print(NumpyFloat(arg))
         else:
             code_arg = self._print(arg)
         return "ceiling({})".format(code_arg)
@@ -2545,7 +2545,7 @@ class FCodePrinter(CodePrinter):
         # add necessary include
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
-            code_arg = self._print(PythonFloat(arg))
+            code_arg = self._print(NumpyFloat(arg))
         else:
             code_arg = self._print(arg)
         return "isnan({})".format(code_arg)
@@ -2556,7 +2556,7 @@ class FCodePrinter(CodePrinter):
         # add necessary include
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
-            code_arg = self._print(PythonFloat(arg))
+            code_arg = self._print(NumpyFloat(arg))
         else:
             code_arg = self._print(arg)
         return "dint({})".format(code_arg)
@@ -2572,7 +2572,7 @@ class FCodePrinter(CodePrinter):
     def _print_NumpySqrt(self, expr):
         arg = expr.args[0]
         if arg.dtype is NativeInteger() or arg.dtype is NativeBool():
-            arg = PythonFloat(arg)
+            arg = NumpyFloat(arg)
         code_args = self._print(arg)
         code = 'sqrt({})'.format(code_args)
         return self._get_statement(code)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -235,7 +235,7 @@ class PythonCodePrinter(CodePrinter):
 
     def _print_PythonInt(self, expr):
         type_name = type(expr).__name__.lower()
-        is_numpy  = type_name[-1].isdigit()
+        is_numpy  = type_name.startswith('numpy')
         precision = str(expr.precision*8) if is_numpy else ''
         name = 'int{}'.format(precision)
         if is_numpy:
@@ -244,7 +244,7 @@ class PythonCodePrinter(CodePrinter):
 
     def _print_PythonFloat(self, expr):
         type_name = type(expr).__name__.lower()
-        is_numpy  = type_name[-1].isdigit()
+        is_numpy  = type_name.startswith('numpy')
         precision = str(expr.precision*8) if is_numpy else ''
         name = 'float{}'.format(precision)
         if is_numpy:

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -54,20 +54,13 @@ ATOL32 = 1e-7
 def matching_types(pyccel_result, python_result):
     """  Returns True if the types match, False otherwise
     """
+    if type(pyccel_result) is type(python_result):
+        return True
     if isinstance(pyccel_result, np.generic):
-        python_type_alignment = np.dtype(type(pyccel_result.item())).alignment
-        returned_type_alignment = np.dtype(type(pyccel_result)).alignment
-        if python_type_alignment != returned_type_alignment:
-            return isinstance(pyccel_result, type(python_result))
-        else:
-            return isinstance(pyccel_result, type(python_result)) or \
-                    isinstance(pyccel_result.item(), type(python_result))
+        return isinstance(pyccel_result.item(), type(python_result))
     else:
-        if isinstance(python_result, np.generic):
-            #TODO: Remove when #735 is fixed
-            return isinstance(pyccel_result, (type(python_result.item()), type(python_result)))
-        else:
-            return isinstance(pyccel_result, type(python_result))
+        #TODO: Remove when #735 is fixed
+        return isinstance(python_result, np.generic) and isinstance(pyccel_result, (type(python_result.item()), type(python_result)))
 
 #-------------------------------- Fabs function ------------------------------#
 def test_fabs_call_r(language):

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -54,11 +54,20 @@ ATOL32 = 1e-7
 def matching_types(pyccel_result, python_result):
     """  Returns True if the types match, False otherwise
     """
-    if isinstance(python_result, np.generic):
-        #TODO: Remove when #735 is fixed
-        return isinstance(pyccel_result, (type(python_result.item()), type(python_result)))
+    if isinstance(pyccel_result, np.generic):
+        python_type_alignment = np.dtype(type(pyccel_result.item())).alignment
+        returned_type_alignment = np.dtype(type(pyccel_result)).alignment
+        if python_type_alignment != returned_type_alignment:
+            return isinstance(pyccel_result, type(python_result))
+        else:
+            return isinstance(pyccel_result, type(python_result)) or \
+                    isinstance(pyccel_result.item(), type(python_result))
     else:
-        return isinstance(pyccel_result, type(python_result))
+        if isinstance(python_result, np.generic):
+            #TODO: Remove when #735 is fixed
+            return isinstance(pyccel_result, (type(python_result.item()), type(python_result)))
+        else:
+            return isinstance(pyccel_result, type(python_result))
 
 #-------------------------------- Fabs function ------------------------------#
 def test_fabs_call_r(language):

--- a/tests/epyccel/recognised_functions/test_numpy_types.py
+++ b/tests/epyccel/recognised_functions/test_numpy_types.py
@@ -991,6 +991,16 @@ def get_complex128(a):
     b = complex128(a)
     return b
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
+        pytest.param("c", marks = [pytest.mark.c]),
+        pytest.param("python", marks = [
+            pytest.mark.skip(reason=("complex handles types in __new__ so it "
+                "cannot be used in a translated interface in python. See #802")),
+            pytest.mark.python]
+        )
+    )
+)
 @pytest.mark.parametrize( 'get_complex', [get_complex128, get_complex64])
 def test_numpy_complex_scalar(language, get_complex):
 
@@ -1141,7 +1151,7 @@ def get_complex64_arr_2d(arr):
         ),
         pytest.param("python", marks = [
             pytest.mark.skip(reason=("complex handles types in __new__ so it "
-                "cannot be used in a translated interface in python")),
+                "cannot be used in a translated interface in python. See #802")),
             pytest.mark.python]
         )
     )
@@ -1186,7 +1196,7 @@ def test_numpy_complex_array_like_1d(language, get_complex):
         ),
         pytest.param("python", marks = [
             pytest.mark.skip(reason=("complex handles types in __new__ so it "
-                "cannot be used in a translated interface in python")),
+                "cannot be used in a translated interface in python. See #802")),
             pytest.mark.python]
         )
     )

--- a/tests/epyccel/recognised_functions/test_numpy_types.py
+++ b/tests/epyccel/recognised_functions/test_numpy_types.py
@@ -1085,22 +1085,22 @@ def get_complex128_arr_1d(arr):
     from numpy import complex128, shape
     a = complex128(arr)
     s = shape(a)
-    return len(s), s[0], s[1], a[0,0], a[0,1]
+    return len(s), s[0], a[0], a[1]
 
-@types('bool[:,:]')
-@types('int[:,:]')
-@types('int8[:,:]')
-@types('int16[:,:]')
-@types('int32[:,:]')
-@types('int64[:,:]')
-@types('float[:,:]')
-@types('float32[:,:]')
-@types('float64[:,:]')
+@types('bool[:]')
+@types('int[:]')
+@types('int8[:]')
+@types('int16[:]')
+@types('int32[:]')
+@types('int64[:]')
+@types('float[:]')
+@types('float32[:]')
+@types('float64[:]')
 def get_complex64_arr_1d(arr):
     from numpy import complex64, shape
     a = complex64(arr)
     s = shape(a)
-    return len(s), s[0], s[1], a[0,0], a[0,1]
+    return len(s), s[0], a[0], a[1]
 
 @types('bool[:,:]')
 @types('int[:,:]')
@@ -1132,22 +1132,20 @@ def get_complex64_arr_2d(arr):
     s = shape(a)
     return len(s), s[0], s[1], a[0,0], a[0,1]
 
+
 @pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="AttributeError: _dtype"),
-            pytest.mark.fortran]
-        ),
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="Arrays not handled yet."),
+            pytest.mark.skip(reason="Tuples not handled yet."),
             pytest.mark.c]
         ),
         pytest.param("python", marks = [
-            pytest.mark.skip(reason="AttributeError: _dtype"),
+            pytest.mark.skip(reason=("complex handles types in __new__ so it "
+                "cannot be used in a translated interface in python")),
             pytest.mark.python]
         )
     )
 )
-
 @pytest.mark.parametrize( 'get_complex', [get_complex128_arr_1d, get_complex64_arr_1d])
 def test_numpy_complex_array_like_1d(language, get_complex):
 
@@ -1181,21 +1179,18 @@ def test_numpy_complex_array_like_1d(language, get_complex):
     assert epyccel_func(fl32) == get_complex(fl32)
 
 @pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="AttributeError: _dtype"),
-            pytest.mark.fortran]
-        ),
+        pytest.param("fortran", marks = [pytest.mark.fortran]),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="Arrays not handled yet."),
+            pytest.mark.skip(reason="Tuples not handled yet."),
             pytest.mark.c]
         ),
         pytest.param("python", marks = [
-            pytest.mark.skip(reason="AttributeError: _dtype"),
+            pytest.mark.skip(reason=("complex handles types in __new__ so it "
+                "cannot be used in a translated interface in python")),
             pytest.mark.python]
         )
     )
 )
-
 @pytest.mark.parametrize( 'get_complex', [get_complex128_arr_2d, get_complex64_arr_2d])
 def test_numpy_complex_array_like_2d(language, get_complex):
 


### PR DESCRIPTION
Python's builtin functions cannot be called with arrays as arguments. Internally pyccel's AST allows this in order to facilitate casting. However this sometimes leads to confusion. In python numpy also has casting functions which can be called on arrays and have the expected behaviour. This PR therefore restores the classes `PythonInt`, `PythonFloat`, `PythonComplex` and `PythonBool` to classes which only handle scalars, ensures that all Numpy casting functions handle arrays, and calls the numpy casting functions instead of the pure python casting functions. This fixes #809 

**Commit Summary**
- [BUGFIX] Correctly set dtype etc for empty tuples
- Ensure that all numpy casting functions accept arrays as arguments (fixes #809)
- Use numpy casting instead of python casting when casting internally