### PR TITLE
Fix min / max functions

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -613,9 +613,13 @@ class PythonMax(PyccelInternalFunction):
     _shape = ()
     _order = None
 
-    def __init__(self, x):
-        if not isinstance(x, (list, tuple, PythonTuple, PythonList)):
+    def __init__(self, *x):
+        if isinstance(x, (list, tuple)):
+            x = PythonTuple(*x)
+        elif not isinstance(x, (PythonTuple, PythonList)):
             raise TypeError('Unknown type of  %s.' % type(x))
+        if not x.is_homogeneous:
+            raise NotImplementedError("Cannot determine dtype of min({})".format(x))
         self._dtype     = x.dtype
         self._precision = x.precision
         super().__init__(x)
@@ -631,7 +635,13 @@ class PythonMin(PyccelInternalFunction):
     _rank  = 0
     _shape = ()
     _order = None
-    def __init__(self, x):
+    def __init__(self, *x):
+        if isinstance(x, (list, tuple)):
+            x = PythonTuple(*x)
+        elif not isinstance(x, (PythonTuple, PythonList)):
+            raise TypeError('Unknown type of  %s.' % type(x))
+        if not x.is_homogeneous:
+            raise NotImplementedError("Cannot determine dtype of min({})".format(x))
         self._dtype     = x.dtype
         self._precision = x.precision
         super().__init__(x)

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -619,7 +619,7 @@ class PythonMax(PyccelInternalFunction):
         elif not isinstance(x, (PythonTuple, PythonList)):
             raise TypeError('Unknown type of  %s.' % type(x))
         if not x.is_homogeneous:
-            raise NotImplementedError("Cannot determine dtype of min({})".format(x))
+            raise NotImplementedError("Cannot determine dtype of max({})".format(x))
         self._dtype     = x.dtype
         self._precision = x.precision
         super().__init__(x)

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -614,12 +614,15 @@ class PythonMax(PyccelInternalFunction):
     _order = None
 
     def __init__(self, *x):
+        if len(x)==1:
+            x = x[0]
+
         if isinstance(x, (list, tuple)):
             x = PythonTuple(*x)
         elif not isinstance(x, (PythonTuple, PythonList)):
             raise TypeError('Unknown type of  %s.' % type(x))
         if not x.is_homogeneous:
-            raise NotImplementedError("Cannot determine dtype of max({})".format(x))
+            raise NotImplementedError("Cannot determine dtype of max call with inhomogeneous arguments : {}".format(x))
         self._dtype     = x.dtype
         self._precision = x.precision
         super().__init__(x)
@@ -636,12 +639,15 @@ class PythonMin(PyccelInternalFunction):
     _shape = ()
     _order = None
     def __init__(self, *x):
+        if len(x)==1:
+            x = x[0]
+
         if isinstance(x, (list, tuple)):
             x = PythonTuple(*x)
         elif not isinstance(x, (PythonTuple, PythonList)):
             raise TypeError('Unknown type of  %s.' % type(x))
         if not x.is_homogeneous:
-            raise NotImplementedError("Cannot determine dtype of min({})".format(x))
+            raise NotImplementedError("Cannot determine dtype of min call with inhomogeneous arguments : {}".format(x))
         self._dtype     = x.dtype
         self._precision = x.precision
         super().__init__(x)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -414,7 +414,7 @@ class CCodePrinter(CodePrinter):
             return "fmin({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         else:
-            return errors.report("min not yet supported in C", symbol=expr,
+            return errors.report("min in C is only supported for 2 float arguments", symbol=expr,
                     severity='fatal')
 
     def _print_PythonMax(self, expr):
@@ -424,7 +424,7 @@ class CCodePrinter(CodePrinter):
             return "fmax({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         else:
-            return errors.report("max not yet supported in C", symbol=expr,
+            return errors.report("max in C is only supported for 2 float arguments", symbol=expr,
                     severity='fatal')
 
     def _print_PythonFloat(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -407,6 +407,26 @@ class CCodePrinter(CodePrinter):
             func = "labs"
         return "{}({})".format(func, self._print(expr.arg))
 
+    def _print_PythonMin(self, expr):
+        arg = expr.args[0]
+        if arg.dtype is NativeReal() and len(arg) == 2:
+            self._additional_imports.add("math")
+            return "fmin({}, {})".format(self._print(arg[0]),
+                                         self._print(arg[1]))
+        else:
+            errors.report("min not yet supported in C", symbol=expr,
+                    severity='fatal')
+
+    def _print_PythonMax(self, expr):
+        arg = expr.args[0]
+        if arg.dtype is NativeReal() and len(arg) == 2:
+            self._additional_imports.add("math")
+            return "fmax({}, {})".format(self._print(arg[0]),
+                                         self._print(arg[1]))
+        else:
+            errors.report("max not yet supported in C", symbol=expr,
+                    severity='fatal')
+
     def _print_PythonFloat(self, expr):
         value = self._print(expr.arg)
         type_name = self.find_in_dtype_registry('real', expr.precision)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -404,7 +404,7 @@ class CCodePrinter(CodePrinter):
             self._additional_imports.add("complex")
             func = "cabs"
         else:
-            func = "abs"
+            func = "labs"
         return "{}({})".format(func, self._print(expr.arg))
 
     def _print_PythonFloat(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -414,7 +414,7 @@ class CCodePrinter(CodePrinter):
             return "fmin({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         else:
-            errors.report("min not yet supported in C", symbol=expr,
+            return errors.report("min not yet supported in C", symbol=expr,
                     severity='fatal')
 
     def _print_PythonMax(self, expr):
@@ -424,7 +424,7 @@ class CCodePrinter(CodePrinter):
             return "fmax({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         else:
-            errors.report("max not yet supported in C", symbol=expr,
+            return errors.report("max not yet supported in C", symbol=expr,
                     severity='fatal')
 
     def _print_PythonFloat(self, expr):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -230,6 +230,15 @@ class PythonCodePrinter(CodePrinter):
     def _print_PythonAbs(self, expr):
         return 'abs({})'.format(self._print(expr.arg))
 
+    def _print_PythonMin(self, expr):
+        return 'min({})'.format(self._print(expr.args[0]))
+
+    def _print_PythonMax(self, expr):
+        return 'max({})'.format(self._print(expr.args[0]))
+
+    def _print_PythonSum(self, expr):
+        return 'sum({})'.format(self._print(expr.args[0]))
+
     def _print_PythonBool(self, expr):
         return 'bool({})'.format(self._print(expr.arg))
 

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -48,8 +48,8 @@ else:
     RTOL = 1e-14
     ATOL = 1e-15
 
-RTOL32 = 1e-6
-ATOL32 = 1e-7
+RTOL32 = 1e-5
+ATOL32 = 1e-6
 
 def matching_types(pyccel_result, python_result):
     """  Returns True if the types match, False otherwise

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -71,7 +71,7 @@ def test_abs_c(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.skip(reason="min not implemented in C for integers"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -79,22 +79,30 @@ def test_abs_c(language):
 )
 def test_min_2_args(language):
     @types('int','int')
-    @types('float','float')
     def f(x, y):
         return min(x, y)
 
     epyc_f = epyccel(f, language=language)
 
     int_args = [randint(min_int, max_int) for _ in range(2)]
-    float_args = [uniform(min_float/2, max_float/2) for _ in range(2)]
 
     assert epyc_f(*int_args) == f(*int_args)
+
+def test_min_2_args(language):
+    @types('float','float')
+    def f(x, y):
+        return min(x, y)
+
+    epyc_f = epyccel(f, language=language)
+
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(2)]
+
     assert epyc_f(*float_args) == f(*float_args)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.skip(reason="min not implemented in C for more than 2 args"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -117,7 +125,7 @@ def test_min_3_args(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.skip(reason="min not implemented in C for more than 2 args"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -140,7 +148,7 @@ def test_min_list(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.skip(reason="min not implemented in C for more than 2 args"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -163,30 +171,38 @@ def test_min_tuple(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="max not implemented in C"),
+            pytest.mark.skip(reason="max not implemented in C for integers"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
     )
 )
-def test_max_2_args(language):
+def test_max_2_args_i(language):
     @types('int','int')
-    @types('float','float')
     def f(x, y):
         return max(x, y)
 
     epyc_f = epyccel(f, language=language)
 
     int_args = [randint(min_int, max_int) for _ in range(2)]
-    float_args = [uniform(min_float/2, max_float/2) for _ in range(2)]
 
     assert epyc_f(*int_args) == f(*int_args)
+
+def test_max_2_args_f(language):
+    @types('float','float')
+    def f(x, y):
+        return max(x, y)
+
+    epyc_f = epyccel(f, language=language)
+
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(2)]
+
     assert epyc_f(*float_args) == f(*float_args)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="max not implemented in C"),
+            pytest.mark.skip(reason="max not implemented in C for more than 2 args"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -209,7 +225,7 @@ def test_max_3_args(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.skip(reason="max not implemented in C for more than 2 args"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -232,7 +248,7 @@ def test_max_list(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.skip(reason="max not implemented in C for more than 2 args"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -77,7 +77,7 @@ def test_abs_c(language):
         pytest.param("python", marks = pytest.mark.python)
     )
 )
-def test_min_2_args(language):
+def test_min_2_args_i(language):
     @types('int','int')
     def f(x, y):
         return min(x, y)
@@ -88,7 +88,7 @@ def test_min_2_args(language):
 
     assert epyc_f(*int_args) == f(*int_args)
 
-def test_min_2_args(language):
+def test_min_2_args_f(language):
     @types('float','float')
     def f(x, y):
         return min(x, y)

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 import pytest
 from numpy.random import randint, uniform
-from numpy import isclose, iinfo, finfo
+from numpy import iinfo, finfo
 import numpy as np
 
 from pyccel.epyccel import epyccel

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -269,7 +269,7 @@ def test_sum_matching_types(language):
 
     epyc_f = epyccel(f, language=language)
 
-    int_args = [randint(min_int, max_int) for _ in range(2)]
+    int_args = [randint(min_int/2, max_int/2) for _ in range(2)]
     float_args = [uniform(min_float/2, max_float/2) for _ in range(2)]
     complex_args = [uniform(min_float/2, max_float/2) + 1j*uniform(min_float/2, max_float/2)
                     for _ in range(2)]

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
+from numpy.random import randint
 
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
@@ -39,3 +40,88 @@ def test_abs_c(language):
     assert f1(5j + 0) == f2(5j + 0)
     assert f1(0j + 5) == f2(0j + 5)
     assert f1(0j + 0) == f2(0j + 0)
+
+def test_min_2_args(language):
+    @types('int','int')
+    @types('float','float')
+    @types('complex','complex')
+    def f(x, y):
+        return min(x, y)
+
+    a = randint(100)
+    b = randint(100)
+    epyc_f = epyccel(f, language=language)
+    assert epyc_f(a,b) == f(a,b)
+    assert epyc_f(float(a),float(b)) == f(float(a),float(b))
+    assert epyc_f(complex(a),complex(b)) == f(complex(a),complex(b))
+
+def test_min_3_args(language):
+    @types('int','int','int')
+    @types('float','float','float')
+    @types('complex','complex','complex')
+    def f(x, y):
+        return min(x, y)
+
+    a = randint(100)
+    b = randint(100)
+    c = randint(100)
+    epyc_f = epyccel(f, language=language)
+    assert epyc_f(a,b,c) == f(a,b,c)
+    assert epyc_f(float(a),float(b),float(c)) == f(float(a),float(b),float(c))
+    assert epyc_f(complex(a),complex(b),complex(c)) == f(complex(a),complex(b),complex(c))
+
+def test_max_2_args(language):
+    @types('int','int')
+    @types('float','float')
+    @types('complex','complex')
+    def f(x, y):
+        return max(x, y)
+
+    a = randint(100)
+    b = randint(100)
+    epyc_f = epyccel(f, language=language)
+    assert epyc_f(a,b) == f(a,b)
+    assert epyc_f(float(a),float(b)) == f(float(a),float(b))
+    assert epyc_f(complex(a),complex(b)) == f(complex(a),complex(b))
+
+def test_max_3_args(language):
+    @types('int','int','int')
+    @types('float','float','float')
+    @types('complex','complex','complex')
+    def f(x, y):
+        return min(x, y)
+
+    a = randint(100)
+    b = randint(100)
+    c = randint(100)
+    epyc_f = epyccel(f, language=language)
+    assert epyc_f(a,b,c) == f(a,b,c)
+    assert epyc_f(float(a),float(b),float(c)) == f(float(a),float(b),float(c))
+    assert epyc_f(complex(a),complex(b),complex(c)) == f(complex(a),complex(b),complex(c))
+
+def test_sum_matching_types(language):
+    @template('T',['int','float','complex'])
+    @types('T','T')
+    def f(x, y):
+        return sum([x, y])
+
+    a = randint(100)
+    b = randint(100)
+    epyc_f = epyccel(f, language=language)
+    assert epyc_f(a,b) == f(a,b)
+    assert epyc_f(float(a),float(b)) == f(float(a),float(b))
+    assert epyc_f(complex(a),complex(b)) == f(complex(a),complex(b))
+
+def test_sum_different_types(language):
+    @template('T',['int','float','complex'])
+    @template('S',['int','float','complex'])
+    @types('T','S')
+    def f(x, y):
+        return sum([x, y])
+
+    a = randint(100)
+    b = randint(100)
+    epyc_f = epyccel(f, language=language)
+    assert epyc_f(a,float(b)) == f(a,float(b))
+    assert epyc_f(float(a),complex(b)) == f(float(a),complex(b))
+    assert epyc_f(complex(a),b) == f(complex(a),b)

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -41,10 +41,17 @@ def test_abs_c(language):
     assert f1(0j + 5) == f2(0j + 5)
     assert f1(0j + 0) == f2(0j + 0)
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.c]
+        )
+    )
+)
 def test_min_2_args(language):
     @types('int','int')
     @types('float','float')
-    @types('complex','complex')
     def f(x, y):
         return min(x, y)
 
@@ -53,12 +60,18 @@ def test_min_2_args(language):
     epyc_f = epyccel(f, language=language)
     assert epyc_f(a,b) == f(a,b)
     assert epyc_f(float(a),float(b)) == f(float(a),float(b))
-    assert epyc_f(complex(a),complex(b)) == f(complex(a),complex(b))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.c]
+        )
+    )
+)
 def test_min_3_args(language):
     @types('int','int','int')
     @types('float','float','float')
-    @types('complex','complex','complex')
     def f(x, y):
         return min(x, y)
 
@@ -68,12 +81,18 @@ def test_min_3_args(language):
     epyc_f = epyccel(f, language=language)
     assert epyc_f(a,b,c) == f(a,b,c)
     assert epyc_f(float(a),float(b),float(c)) == f(float(a),float(b),float(c))
-    assert epyc_f(complex(a),complex(b),complex(c)) == f(complex(a),complex(b),complex(c))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="max not implemented in C"),
+            pytest.mark.c]
+        )
+    )
+)
 def test_max_2_args(language):
     @types('int','int')
     @types('float','float')
-    @types('complex','complex')
     def f(x, y):
         return max(x, y)
 
@@ -82,12 +101,18 @@ def test_max_2_args(language):
     epyc_f = epyccel(f, language=language)
     assert epyc_f(a,b) == f(a,b)
     assert epyc_f(float(a),float(b)) == f(float(a),float(b))
-    assert epyc_f(complex(a),complex(b)) == f(complex(a),complex(b))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="max not implemented in C"),
+            pytest.mark.c]
+        )
+    )
+)
 def test_max_3_args(language):
     @types('int','int','int')
     @types('float','float','float')
-    @types('complex','complex','complex')
     def f(x, y):
         return min(x, y)
 
@@ -97,8 +122,15 @@ def test_max_3_args(language):
     epyc_f = epyccel(f, language=language)
     assert epyc_f(a,b,c) == f(a,b,c)
     assert epyc_f(float(a),float(b),float(c)) == f(float(a),float(b),float(c))
-    assert epyc_f(complex(a),complex(b),complex(c)) == f(complex(a),complex(b),complex(c))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="sum not implemented in C"),
+            pytest.mark.c]
+        )
+    )
+)
 def test_sum_matching_types(language):
     @template('T',['int','float','complex'])
     @types('T','T')
@@ -112,6 +144,14 @@ def test_sum_matching_types(language):
     assert epyc_f(float(a),float(b)) == f(float(a),float(b))
     assert epyc_f(complex(a),complex(b)) == f(complex(a),complex(b))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="sum not implemented in C"),
+            pytest.mark.c]
+        )
+    )
+)
 def test_sum_different_types(language):
     @template('T',['int','float','complex'])
     @template('S',['int','float','complex'])

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 import pytest
-from numpy.random import randint
+from numpy.random import randint, uniform
 from numpy import isclose, iinfo, finfo
+import numpy as np
 
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types, template
@@ -74,7 +75,6 @@ def test_abs_c(language):
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
-
     )
 )
 def test_min_2_args(language):
@@ -83,11 +83,13 @@ def test_min_2_args(language):
     def f(x, y):
         return min(x, y)
 
-    a = randint(100)
-    b = randint(100)
     epyc_f = epyccel(f, language=language)
-    assert epyc_f(a,b) == f(a,b)
-    assert epyc_f(float(a),float(b)) == f(float(a),float(b))
+
+    int_args = [randint(min_int, max_int) for _ in range(2)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(2)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
@@ -104,12 +106,13 @@ def test_min_3_args(language):
     def f(x, y, z):
         return min(x, y, z)
 
-    a = randint(100)
-    b = randint(100)
-    c = randint(100)
     epyc_f = epyccel(f, language=language)
-    assert epyc_f(a,b,c) == f(a,b,c)
-    assert epyc_f(float(a),float(b),float(c)) == f(float(a),float(b),float(c))
+
+    int_args = [randint(min_int, max_int) for _ in range(3)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(3)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
@@ -126,11 +129,13 @@ def test_max_2_args(language):
     def f(x, y):
         return max(x, y)
 
-    a = randint(100)
-    b = randint(100)
     epyc_f = epyccel(f, language=language)
-    assert epyc_f(a,b) == f(a,b)
-    assert epyc_f(float(a),float(b)) == f(float(a),float(b))
+
+    int_args = [randint(min_int, max_int) for _ in range(2)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(2)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
@@ -147,12 +152,13 @@ def test_max_3_args(language):
     def f(x, y, z):
         return min(x, y, z)
 
-    a = randint(100)
-    b = randint(100)
-    c = randint(100)
     epyc_f = epyccel(f, language=language)
-    assert epyc_f(a,b,c) == f(a,b,c)
-    assert epyc_f(float(a),float(b),float(c)) == f(float(a),float(b),float(c))
+
+    int_args = [randint(min_int, max_int) for _ in range(3)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(3)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
@@ -169,9 +175,13 @@ def test_sum_matching_types(language):
     def f(x, y):
         return sum([x, y])
 
-    a = randint(100)
-    b = randint(100)
     epyc_f = epyccel(f, language=language)
-    assert epyc_f(a,b) == f(a,b)
-    assert epyc_f(float(a),float(b)) == f(float(a),float(b))
-    assert epyc_f(complex(a),complex(b)) == f(complex(a),complex(b))
+
+    int_args = [randint(min_int, max_int) for _ in range(2)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(2)]
+    complex_args = [uniform(min_float/2, max_float/2) + 1j*uniform(min_float/2, max_float/2)
+                    for _ in range(2)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
+    assert epyc_f(*complex_args) == f(*complex_args)

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -117,6 +117,52 @@ def test_min_3_args(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
+            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_min_list(language):
+    @types('int','int','int')
+    @types('float','float','float')
+    def f(x, y, z):
+        return min([x, y, z])
+
+    epyc_f = epyccel(f, language=language)
+
+    int_args = [randint(min_int, max_int) for _ in range(3)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(3)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_min_tuple(language):
+    @types('int','int','int')
+    @types('float','float','float')
+    def f(x, y, z):
+        return min((x, y, z))
+
+    epyc_f = epyccel(f, language=language)
+
+    int_args = [randint(min_int, max_int) for _ in range(3)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(3)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
             pytest.mark.skip(reason="max not implemented in C"),
             pytest.mark.c]
         ),
@@ -151,6 +197,52 @@ def test_max_3_args(language):
     @types('float','float','float')
     def f(x, y, z):
         return min(x, y, z)
+
+    epyc_f = epyccel(f, language=language)
+
+    int_args = [randint(min_int, max_int) for _ in range(3)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(3)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_max_list(language):
+    @types('int','int','int')
+    @types('float','float','float')
+    def f(x, y, z):
+        return max([x, y, z])
+
+    epyc_f = epyccel(f, language=language)
+
+    int_args = [randint(min_int, max_int) for _ in range(3)]
+    float_args = [uniform(min_float/2, max_float/2) for _ in range(3)]
+
+    assert epyc_f(*int_args) == f(*int_args)
+    assert epyc_f(*float_args) == f(*float_args)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="min not implemented in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_max_tuple(language):
+    @types('int','int','int')
+    @types('float','float','float')
+    def f(x, y, z):
+        return max((x, y, z))
 
     epyc_f = epyccel(f, language=language)
 

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -1,9 +1,16 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 import pytest
 from numpy.random import randint
+from numpy import isclose, iinfo, finfo
 
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types, template
+
+min_int = iinfo('int').min
+max_int = iinfo('int').max
+
+min_float = finfo('float').min
+max_float = finfo('float').max
 
 def test_abs_i(language):
     @types('int')
@@ -12,9 +19,12 @@ def test_abs_i(language):
 
     f2 = epyccel(f1, language=language)
 
+    negative_test = randint(min_int, 0)
+    positive_test = randint(0, max_int)
+
     assert f1(0) == f2(0)
-    assert f1(-5) == f2(-5)
-    assert f1(11) == f2(11)
+    assert f1(negative_test) == f2(negative_test)
+    assert f1(positive_test) == f2(positive_test)
 
 def test_abs_r(language):
     @types('real')
@@ -23,9 +33,12 @@ def test_abs_r(language):
 
     f2 = epyccel(f1, language=language)
 
+    negative_test = uniform(min_float, 0.0)
+    positive_test = uniform(0.0, max_float)
+
     assert f1(0.00000) == f2(0.00000)
-    assert f1(-3.1415) == f2(-3.1415)
-    assert f1(2.71828) == f2(2.71828)
+    assert f1(negative_test) == f2(negative_test)
+    assert f1(positive_test) == f2(positive_test)
 
 
 
@@ -36,10 +49,22 @@ def test_abs_c(language):
 
     f2 = epyccel(f1, language=language)
 
-    assert f1(3j + 4) == f2(3j + 4)
-    assert f1(3j - 4) == f2(3j - 4)
-    assert f1(5j + 0) == f2(5j + 0)
-    assert f1(0j + 5) == f2(0j + 5)
+    max_compl_abs = np.sqrt(max_float / 2)
+    min_compl_abs = np.sqrt(-min_float / 2)
+
+    pos_pos = uniform(0.0, max_compl_abs) + 1j*uniform(0.0, max_compl_abs)
+    pos_neg = uniform(0.0, max_compl_abs) + 1j*uniform(min_compl_abs, 0.0)
+    neg_pos = uniform(min_compl_abs, 0.0) + 1j*uniform(0.0, max_compl_abs)
+    neg_neg = uniform(min_compl_abs, 0.0) + 1j*uniform(min_compl_abs, 0.0)
+    zero_rand = 1j*uniform(min_compl_abs, max_compl_abs)
+    rand_zero = uniform(min_compl_abs, max_compl_abs) + 0j
+
+    assert f1(pos_pos) == f2(pos_pos)
+    assert f1(pos_neg) == f2(pos_neg)
+    assert f1(neg_pos) == f2(neg_pos)
+    assert f1(neg_neg) == f2(neg_neg)
+    assert f1(zero_rand) == f2(zero_rand)
+    assert f1(rand_zero) == f2(rand_zero)
     assert f1(0j + 0) == f2(0j + 0)
 
 @pytest.mark.parametrize( 'language', (

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -1,8 +1,9 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
+import pytest
 from numpy.random import randint
 
 from pyccel.epyccel import epyccel
-from pyccel.decorators import types
+from pyccel.decorators import types, template
 
 def test_abs_i(language):
     @types('int')
@@ -46,7 +47,9 @@ def test_abs_c(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="min not implemented in C"),
             pytest.mark.c]
-        )
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+
     )
 )
 def test_min_2_args(language):
@@ -66,14 +69,15 @@ def test_min_2_args(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="min not implemented in C"),
             pytest.mark.c]
-        )
+        ),
+        pytest.param("python", marks = pytest.mark.python)
     )
 )
 def test_min_3_args(language):
     @types('int','int','int')
     @types('float','float','float')
-    def f(x, y):
-        return min(x, y)
+    def f(x, y, z):
+        return min(x, y, z)
 
     a = randint(100)
     b = randint(100)
@@ -87,7 +91,8 @@ def test_min_3_args(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="max not implemented in C"),
             pytest.mark.c]
-        )
+        ),
+        pytest.param("python", marks = pytest.mark.python)
     )
 )
 def test_max_2_args(language):
@@ -107,14 +112,15 @@ def test_max_2_args(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="max not implemented in C"),
             pytest.mark.c]
-        )
+        ),
+        pytest.param("python", marks = pytest.mark.python)
     )
 )
 def test_max_3_args(language):
     @types('int','int','int')
     @types('float','float','float')
-    def f(x, y):
-        return min(x, y)
+    def f(x, y, z):
+        return min(x, y, z)
 
     a = randint(100)
     b = randint(100)
@@ -128,7 +134,8 @@ def test_max_3_args(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="sum not implemented in C"),
             pytest.mark.c]
-        )
+        ),
+        pytest.param("python", marks = pytest.mark.python)
     )
 )
 def test_sum_matching_types(language):
@@ -143,25 +150,3 @@ def test_sum_matching_types(language):
     assert epyc_f(a,b) == f(a,b)
     assert epyc_f(float(a),float(b)) == f(float(a),float(b))
     assert epyc_f(complex(a),complex(b)) == f(complex(a),complex(b))
-
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="sum not implemented in C"),
-            pytest.mark.c]
-        )
-    )
-)
-def test_sum_different_types(language):
-    @template('T',['int','float','complex'])
-    @template('S',['int','float','complex'])
-    @types('T','S')
-    def f(x, y):
-        return sum([x, y])
-
-    a = randint(100)
-    b = randint(100)
-    epyc_f = epyccel(f, language=language)
-    assert epyc_f(a,float(b)) == f(a,float(b))
-    assert epyc_f(float(a),complex(b)) == f(float(a),complex(b))
-    assert epyc_f(complex(a),b) == f(complex(a),b)


### PR DESCRIPTION
Fix broken builtin min/max functions. Fixes #772 

**Commit Summary**
- Fix min/max arguments
- Ensure min/max store an argument from which they can extract a dtype
- Add tests for builtins min/max/sum
- Use linux line endings in test_builtins.py
- Add python printers for min/max/sum
- [BUGFIX] Use labs instead of abs in C