### PR TITLE
Handle IndexedElement in multi-assign

### DIFF
--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -264,10 +264,10 @@ def insert_index(expr, pos, index_var):
     elif isinstance(expr, IndexedElement):
         base = expr.base
         indices = list(expr.indices)
+        while -pos<=expr.base.rank and not isinstance(indices[pos], Slice):
+            pos -= 1
         if -pos>expr.base.rank:
             return expr
-        while not isinstance(indices[pos], Slice):
-            pos -= 1
 
         # Add index at the required position
         if expr.base.shape[pos]==1:

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -264,8 +264,10 @@ def insert_index(expr, pos, index_var):
     elif isinstance(expr, IndexedElement):
         base = expr.base
         indices = list(expr.indices)
-        if -pos>expr.base.rank or not isinstance(indices[pos], Slice):
+        if -pos>expr.base.rank:
             return expr
+        while not isinstance(indices[pos], Slice):
+            pos -= 1
 
         # Add index at the required position
         if expr.base.shape[pos]==1:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1444,7 +1444,9 @@ class SemanticParser(BasicParser):
             Provided to all _visit_ClassName functions
         """
 
-        if isinstance(lhs, PyccelSymbol):
+        if isinstance(lhs, IndexedElement):
+            lhs = self._visit(lhs)
+        elif isinstance(lhs, PyccelSymbol):
 
             name = lhs
             dtype = d_var.pop('datatype')
@@ -1962,7 +1964,7 @@ class SemanticParser(BasicParser):
         elif isinstance(lhs, IndexedElement):
             is_pointer = False
         elif isinstance(lhs, (PythonTuple, PythonList)):
-            is_pointer = any(l.is_pointer for l in lhs)
+            is_pointer = any(l.is_pointer for l in lhs if isinstance(lhs, Variable))
 
         # TODO: does is_pointer refer to any/all or last variable in list (currently last)
         is_pointer = is_pointer and isinstance(rhs, (Variable, Dlist))

--- a/tests/epyccel/modules/tuples.py
+++ b/tests/epyccel/modules/tuples.py
@@ -105,6 +105,12 @@ def tuple_unpacking_2():
     a,b,c = 1,False,3.0
     return a,b,c
 
+def tuple_unpacking_3(x : 'int[:,:]'):
+    x[0,0], x[1,0] = 2, 2
+
+def tuple_unpacking_4(x : 'int[:,:]'):
+    x[:,0], x[0,:] = 2, 3
+
 def tuple_name_clash():
     ai = (1+2j, False, 10.0)
     ai_0 = 44

--- a/tests/epyccel/test_tuples.py
+++ b/tests/epyccel/test_tuples.py
@@ -6,7 +6,15 @@ import numpy as np
 from pyccel.epyccel import epyccel
 from modules import tuples as tuples_module
 
-tuple_funcs = [(f, getattr(tuples_module,f)) for f in tuples_module.__all__ if inspect.isfunction(getattr(tuples_module,f))]
+def is_func_with_0_args(f):
+    """ Test if name 'f' corresponds to an argument in the
+    tuples module with no arguments
+    """
+    func = getattr(tuples_module,f)
+    return inspect.isfunction(func) and len(inspect.signature(func).parameters)==0
+
+tuple_funcs = [(f, getattr(tuples_module,f)) for f in tuples_module.__all__
+                                            if is_func_with_0_args(f)]
 
 failing_tests = {
         'homogenous_tuple_string':'String has no precision',
@@ -51,3 +59,19 @@ def test_tuples(test_func):
     python_out = f1()
     pyccel_out = f2()
     compare_python_pyccel(python_out, pyccel_out)
+
+@pytest.mark.parametrize('test_func',
+        [tuples_module.tuple_unpacking_3,
+         tuples_module.tuple_unpacking_4]
+)
+def test_tuples_with_2d_args(test_func):
+    f1 = test_func
+    f2 = epyccel( f1 )
+
+    python_x = np.random.randint(100, size=(3,4))
+    pyccel_x = python_x.copy()
+
+    f1(python_x)
+    f2(pyccel_x)
+    np.allclose(python_x, pyccel_x)
+

--- a/tests/epyccel/test_tuples.py
+++ b/tests/epyccel/test_tuples.py
@@ -64,9 +64,9 @@ def test_tuples(test_func):
         [tuples_module.tuple_unpacking_3,
          tuples_module.tuple_unpacking_4]
 )
-def test_tuples_with_2d_args(test_func):
+def test_tuples_with_2d_args(test_func, language):
     f1 = test_func
-    f2 = epyccel( f1 )
+    f2 = epyccel( f1, language=language )
 
     python_x = np.random.randint(100, size=(3,4))
     pyccel_x = python_x.copy()


### PR DESCRIPTION
Allow the lhs to contain `IndexedElement`s in expressions such as:
```
a, b[0], c[:,0] = 1, 1, 1
```
Fixes #821 