### PR TITLE
Raise error when function call has wrong number of arguments

### DIFF
--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -244,12 +244,17 @@ class Basic:
         if not isinstance(fst, ast.AST):
             raise TypeError("Fst must be an AST object, not {}".format(type(fst)))
 
-        if not hasattr(fst, 'lineno'):
-            # Handle module object
-            fst.lineno     = 1
-            fst.col_offset = 1
+        if self._fst:
+            if hasattr(fst, 'lineno'):
+                if self.fst.lineno != fst.lineno or self.fst.col_offset != fst.col_offset:
+                    self._fst.append(fst)
+        else:
+            if not hasattr(fst, 'lineno'):
+                # Handle module object
+                fst.lineno     = 1
+                fst.col_offset = 1
 
-        self._fst.append(fst)
+            self._fst.append(fst)
 
     @property
     def fst(self):

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -244,7 +244,7 @@ class Basic:
         if not isinstance(fst, ast.AST):
             raise TypeError("Fst must be an AST object, not {}".format(type(fst)))
 
-        if self._fst:
+        if self.fst:
             if hasattr(fst, 'lineno'):
                 if self.fst.lineno != fst.lineno or self.fst.col_offset != fst.col_offset:
                     self._fst.append(fst)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -905,16 +905,20 @@ class SemanticParser(BasicParser):
     def _handle_function(self, expr, func, args, **settings):
         """
         Create a FunctionCall or an instance of a PyccelInternalFunction
-        from the function informations and arguments
+        from the function information and arguments
 
         Parameters
         ==========
         expr : PyccelAstNode
                The expression where this call is found (used for error output)
-        func : FunctionDef, Interface or PyccelInternalFunction type
+        func : FunctionDef instance, Interface instance or PyccelInternalFunction type
                The function being called
         args : tuple
                The arguments passed to the function
+
+        Returns
+        =======
+        new_expr : FunctionCall or PyccelInternalFunction
         """
         if not isinstance(func, (FunctionDef, Interface)):
             args, kwargs = split_positional_keyword_arguments(*args)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -903,6 +903,19 @@ class SemanticParser(BasicParser):
         return args
 
     def _handle_function(self, expr, func, args, **settings):
+        """
+        Create a FunctionCall or an instance of a PyccelInternalFunction
+        from the function informations and arguments
+
+        Parameters
+        ==========
+        expr : PyccelAstNode
+               The expression where this call is found (used for error output)
+        func : FunctionDef, Interface or PyccelInternalFunction type
+               The function being called
+        args : tuple
+               The arguments passed to the function
+        """
         if not isinstance(func, (FunctionDef, Interface)):
             args, kwargs = split_positional_keyword_arguments(*args)
             for a in args:
@@ -911,9 +924,9 @@ class SemanticParser(BasicParser):
             for a in kwargs.values():
                 if getattr(a,'dtype',None) == 'tuple':
                     self._infere_type(a, **settings)
-            expr = func(*args, **kwargs)
+            new_expr = func(*args, **kwargs)
 
-            return expr
+            return new_expr
         else:
             if isinstance(func, FunctionDef) and len(args) > len(func.arguments):
                 errors.report("Too many arguments passed in function call",

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -915,7 +915,7 @@ class SemanticParser(BasicParser):
 
             return expr
         else:
-            if len(args) > len(func.arguments):
+            if isinstance(func, FunctionDef) and len(args) > len(func.arguments):
                 errors.report("Too many arguments passed in function call",
                         symbol = expr,
                         severity='fatal')
@@ -923,7 +923,7 @@ class SemanticParser(BasicParser):
             if None in new_expr.args:
                 errors.report("Too few arguments passed in function call",
                         symbol = expr,
-                        severity='fatal')
+                        severity='error')
             return new_expr
 
     def _create_variable(self, name, dtype, rhs, d_lhs):

--- a/tests/errors/semantic/blocking/TOO_MANY_ARGS.py
+++ b/tests/errors/semantic/blocking/TOO_MANY_ARGS.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+
 def f(b:'int'):
     print(b)
 

--- a/tests/errors/semantic/blocking/TOO_MANY_ARGS.py
+++ b/tests/errors/semantic/blocking/TOO_MANY_ARGS.py
@@ -1,0 +1,4 @@
+def f(b:'int'):
+    print(b)
+
+f(1, 2)

--- a/tests/errors/semantic/non_blocking/TOO_FEW_ARGS.py
+++ b/tests/errors/semantic/non_blocking/TOO_FEW_ARGS.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring, no-value-for-parameter
+
 def f(b:'int'):
     print(b)
 

--- a/tests/errors/semantic/non_blocking/TOO_FEW_ARGS.py
+++ b/tests/errors/semantic/non_blocking/TOO_FEW_ARGS.py
@@ -1,0 +1,4 @@
+def f(b:'int'):
+    print(b)
+
+f()


### PR DESCRIPTION
Pyccel is not guaranteed to work when the underlying python code will not run, however the error raised when too few arguments are passed to the function is particularly unclear:
```
ERROR at code generation stage
pyccel:
 |fatal [codegen]: tmp.py| _print_NoneType is not yet implemented for language : Fortran
Pyccel has encountered syntax that has not been implemented yet. Please create an issue at https://github.com/pyccel/pyccel/issues and provide a small example of your problem. Do not forget to specify your target language
```
The `NoneType` appears as pyccel uses `None` internally as a placeholder for arguments which have no default value. It is trivial to test that the number of arguments is correct and to raise a more human readable error with an identifiable line of code

**Commit Summary**
- Stop obfuscation of fst when one pyccel object is represented by multiple python.ast nodes (e.g. `pyccel.ast.Assign` is represented by `ast.assign` and `ast.Expr`)
- Raise an error if too many arguments are passed to a function
- Raise an error if too few arguments are passed to a function