### PR TITLE
Ensure one-line statements in printers end with `\n

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1234,12 +1234,12 @@ class CCodePrinter(CodePrinter):
             variables = last_assign[0].rhs.get_attribute_nodes(Variable, excluded_nodes=(FunctionDef,))
             unneeded_var = not any(b in vars_in_deallocate_nodes for b in variables)
             if unneeded_var:
-                code = '\n'.join(self._print(a) for a in expr.stmt.body if a is not last_assign[0])
+                code = ''.join(self._print(a) for a in expr.stmt.body if a is not last_assign[0])
                 return code + '\nreturn {};\n'.format(self._print(last_assign[0].rhs))
             else:
-                code = '\n'+self._print(expr.stmt)
+                code = ''+self._print(expr.stmt)
                 self._additional_declare.append(last_assign[0].lhs)
-        return code + '\nreturn {0};\n'.format(self._print(args[0]))
+        return code + 'return {0};\n'.format(self._print(args[0]))
 
     def _print_Pass(self, expr):
         return '// pass\n'
@@ -1366,12 +1366,12 @@ class CCodePrinter(CodePrinter):
         if isinstance(test_step, Literal):
             op = '>' if isinstance(expr.iterable.step, PyccelUnarySub) else '<'
             return ('for ({counter} = {start}; {counter} {op} {stop}; {counter} += '
-                        '{step})\n{{\n{body}\n}}\n').format(counter=counter, start=start, op=op,
+                        '{step})\n{{\n{body}}}\n').format(counter=counter, start=start, op=op,
                                                           stop=stop, step=step, body=body)
         else:
             return (
                 'for ({counter} = {start}; ({step} > 0) ? ({counter} < {stop}) : ({counter} > {stop}); {counter} += '
-                '{step})\n{{\n{body}\n}}\n').format(counter=counter, start=start,
+                '{step})\n{{\n{body}}}\n').format(counter=counter, start=start,
                                                   stop=stop, step=step, body=body)
 
     def _print_CodeBlock(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -241,10 +241,10 @@ class CCodePrinter(CodePrinter):
         return self._additional_imports
 
     def _get_statement(self, codestring):
-        return "%s;" % codestring
+        return "%s;\n" % codestring
 
     def _get_comment(self, text):
-        return "// {0}".format(text)
+        return "// {0}\n".format(text)
 
     def _format_code(self, lines):
         return self.indent_code(lines)
@@ -284,16 +284,16 @@ class CCodePrinter(CodePrinter):
             if expr.lhs.is_stack_array:
                 cpy_data = self._init_stack_array(expr, rhs.arg)
             else:
-                cpy_data = "memcpy({0}.{2}, {1}.{2}, {0}.buffer_size);".format(lhs, arg, dtype)
-            return '%s\n' % (cpy_data)
+                cpy_data = "memcpy({0}.{2}, {1}.{2}, {0}.buffer_size);\n".format(lhs, arg, dtype)
+            return '%s' % (cpy_data)
         else :
             arg = ', '.join(self._print(i) for i in arg)
             dummy_array = "%s %s[] = {%s};\n" % (declare_dtype, dummy_array_name, arg)
             if expr.lhs.is_stack_array:
                 cpy_data = self._init_stack_array(expr, dummy_array_name)
             else:
-                cpy_data = "memcpy({0}.{2}, {1}, {0}.buffer_size);".format(self._print(lhs), dummy_array_name, dtype)
-            return  '%s%s\n' % (dummy_array, cpy_data)
+                cpy_data = "memcpy({0}.{2}, {1}, {0}.buffer_size);\n".format(self._print(lhs), dummy_array_name, dtype)
+            return  '%s%s' % (dummy_array, cpy_data)
 
     def arrayFill(self, expr):
         """ print the assignment of a NdArray
@@ -322,7 +322,7 @@ class CCodePrinter(CodePrinter):
                 code_init += 'array_fill(({0}){1}, {2});\n'.format(dtype, self._print(rhs.fill_value), self._print(lhs))
             else:
                 code_init += 'array_fill({0}, {1});\n'.format(self._print(rhs.fill_value), self._print(lhs))
-        return '{}'.format(code_init)
+        return code_init
 
     def _init_stack_array(self, expr, buffer_array):
         """ return a string which handles the assignment of a stack ndarray
@@ -477,57 +477,57 @@ class CCodePrinter(CodePrinter):
     def _print_ModuleHeader(self, expr):
         name = expr.module.name
         # TODO: Add classes and interfaces
-        funcs = '\n\n'.join('{};'.format(self.function_signature(f)) for f in expr.module.funcs)
+        funcs = '\n'.join('{};'.format(self.function_signature(f)) for f in expr.module.funcs)
 
         # Print imports last to be sure that all additional_imports have been collected
         imports = [*expr.module.imports, *map(Import, self._additional_imports)]
-        imports = '\n'.join(self._print(i) for i in imports)
+        imports = ''.join(self._print(i) for i in imports)
 
         return ('#ifndef {name}_H\n'
                 '#define {name}_H\n\n'
-                '{imports}\n\n'
-                #'{classes}\n\n'
-                '{funcs}\n\n'
-                #'{interfaces}\n\n'
+                '{imports}\n'
+                #'{classes}\n'
+                '{funcs}\n'
+                #'{interfaces}\n'
                 '#endif // {name}_H\n').format(
                         name    = name.upper(),
                         imports = imports,
                         funcs   = funcs)
 
     def _print_Module(self, expr):
-        body    = '\n\n'.join(self._print(i) for i in expr.body)
+        body    = ''.join(self._print(i) for i in expr.body)
 
         # Print imports last to be sure that all additional_imports have been collected
         imports = [Import(expr.name), *map(Import, self._additional_imports)]
-        imports = '\n'.join(self._print(i) for i in imports)
-        return ('{imports}\n\n'
+        imports = ''.join(self._print(i) for i in imports)
+        return ('{imports}\n'
                 '{body}\n').format(
                         imports = imports,
                         body    = body)
 
     def _print_Break(self, expr):
-        return 'break;'
+        return 'break;\n'
 
     def _print_Continue(self, expr):
-        return 'continue;'
+        return 'continue;\n'
 
     def _print_While(self, expr):
         body = self._print(expr.body)
         cond = self._print(expr.test)
-        return 'while({condi})\n{{\n{body}\n}}'.format(condi = cond, body = body)
+        return 'while({condi})\n{{\n{body}}}\n'.format(condi = cond, body = body)
 
     def _print_If(self, expr):
         lines = []
         for i, (c, e) in enumerate(expr.blocks):
             var = self._print(e)
             if i == 0:
-                lines.append("if (%s)\n{" % self._print(c))
+                lines.append("if (%s)\n{\n" % self._print(c))
             elif i == len(expr.blocks) - 1 and isinstance(c, LiteralTrue):
-                lines.append("else\n{")
+                lines.append("else\n{\n")
             else:
-                lines.append("else if (%s)\n{" % self._print(c))
-            lines.append("%s\n}" % var)
-        return "\n".join(lines)
+                lines.append("else if (%s)\n{\n" % self._print(c))
+            lines.append("%s}\n" % var)
+        return "".join(lines)
 
     def _print_IfTernaryOperator(self, expr):
         cond = self._print(expr.cond)
@@ -636,9 +636,9 @@ class CCodePrinter(CodePrinter):
         if source is None:
             return ''
         if expr.source in c_library_headers:
-            return '#include <{0}.h>'.format(source)
+            return '#include <{0}.h>\n'.format(source)
         else:
-            return '#include "{0}.h"'.format(source)
+            return '#include "{0}.h"\n'.format(source)
 
     def _print_LiteralString(self, expr):
         format_str = format(expr.arg)
@@ -701,7 +701,7 @@ class CCodePrinter(CodePrinter):
                     args.append(arg)
                 args_format.append('({})'.format(', '.join(tmp_arg_format_list)))
                 assign = Assign(tmp_list, f)
-                self._additional_code += self._print(assign) + '\n'
+                self._additional_code += self._print(assign)
             else:
                 arg_format, arg = self.get_print_format_and_arg(f)
                 args_format.append(arg_format)
@@ -710,7 +710,7 @@ class CCodePrinter(CodePrinter):
         args_format += end
         args_format = self._print(LiteralString(args_format))
         code = ', '.join([args_format, *args])
-        return "printf({});".format(code)
+        return "printf({});\n".format(code)
 
     def find_in_dtype_registry(self, dtype, prec):
         try :
@@ -763,13 +763,13 @@ class CCodePrinter(CodePrinter):
             arg_code = ', '.join('{}'.format(self._print_FuncAddressDeclare(i))
                         if isinstance(i, FunctionAddress) else '{0}{1}'.format(self.get_declare_type(i), i)
                         for i in args)
-        return '{}(*{})({});'.format(ret_type, name, arg_code)
+        return '{}(*{})({});\n'.format(ret_type, name, arg_code)
 
     def _print_Declare(self, expr):
         declaration_type = self.get_declare_type(expr.variable)
         variable = self._print(expr.variable.name)
 
-        return '{0}{1};'.format(declaration_type, variable)
+        return '{0}{1};\n'.format(declaration_type, variable)
 
     def _print_NativeBool(self, expr):
         self._additional_imports.add('stdbool')
@@ -885,6 +885,7 @@ class CCodePrinter(CodePrinter):
             cast=self.find_in_dtype_registry(self._print(dtype), precision)
             return '({}){{}}'.format(cast)
         return '{}'
+
     def _print_DottedVariable(self, expr):
         """convert dotted Variable to their C equivalent"""
         return '{}.{}'.format(self._print(expr.lhs), self._print(expr.name))
@@ -948,7 +949,7 @@ class CCodePrinter(CodePrinter):
         #free the array if its already allocated and checking if its not null if the status is unknown
         if  (expr.status == 'unknown'):
             free_code = 'if (%s.shape != NULL)\n' % self._print(expr.variable.name)
-            free_code += "{{\n{};\n}}\n".format(self._print(Deallocate(expr.variable)))
+            free_code += "{{\n{}}}\n".format(self._print(Deallocate(expr.variable)))
         elif  (expr.status == 'allocated'):
             free_code += self._print(Deallocate(expr.variable))
         self._additional_imports.add('ndarrays')
@@ -957,13 +958,13 @@ class CCodePrinter(CodePrinter):
         dtype = self.find_in_ndarray_type_registry(dtype, expr.variable.precision)
         shape_dtype = self.find_in_dtype_registry('int', 8)
         shape_Assign = "("+ shape_dtype +"[]){" + shape + "}"
-        alloc_code = "{} = array_create({}, {}, {});".format(expr.variable, len(expr.shape), shape_Assign, dtype)
-        return '{}\n{}'.format(free_code, alloc_code)
+        alloc_code = "{} = array_create({}, {}, {});\n".format(expr.variable, len(expr.shape), shape_Assign, dtype)
+        return '{}{}'.format(free_code, alloc_code)
 
     def _print_Deallocate(self, expr):
         if expr.variable.is_pointer:
-            return 'free_pointer({});'.format(self._print(expr.variable))
-        return 'free_array({});'.format(self._print(expr.variable))
+            return 'free_pointer({});\n'.format(self._print(expr.variable))
+        return 'free_array({});\n'.format(self._print(expr.variable))
 
     def _print_Slice(self, expr):
         start = self._print(expr.start)
@@ -1132,7 +1133,7 @@ class CCodePrinter(CodePrinter):
                 elif not isinstance(i, Variable):
                     decs += [FuncAddressDeclare(i)]
         decs += [Declare(i.dtype, i) for i in self._additional_declare]
-        decs  = '\n'.join(self._print(i) for i in decs)
+        decs  = ''.join(self._print(i) for i in decs)
         self._additional_declare.clear()
 
         sep = self._print(SeparatorComment(40))
@@ -1143,14 +1144,14 @@ class CCodePrinter(CodePrinter):
 
         parts = [sep,
                  doc_string,
-                '{signature}\n{{'.format(signature=self.function_signature(expr)),
+                '{signature}\n{{\n'.format(signature=self.function_signature(expr)),
                  imports,
                  decs,
                  body,
-                 '}',
+                 '}\n',
                  sep]
 
-        return '\n'.join(p for p in parts if p)
+        return ''.join(p for p in parts if p)
 
     def stored_in_c_pointer(self, a):
         if not isinstance(a, Variable):
@@ -1183,7 +1184,7 @@ class CCodePrinter(CodePrinter):
         self._temporary_args = []
         args = ', '.join(['{}'.format(self._print(a)) for a in args])
         if not func.results:
-            return '{}({});'.format(func.name, args)
+            return '{}({});\n'.format(func.name, args)
         return '{}({})'.format(func.name, args)
 
     def _print_Constant(self, expr):
@@ -1214,8 +1215,8 @@ class CCodePrinter(CodePrinter):
 
         if len(args) > 1:
             if expr.stmt:
-                return self._print(expr.stmt)+'\n'+'return 0;'
-            return 'return 0;'
+                return self._print(expr.stmt)+'\n'+'return 0;\n'
+            return 'return 0;\n'
 
         if expr.stmt:
             # get Assign nodes from the CodeBlock object expr.stmt.
@@ -1226,7 +1227,7 @@ class CCodePrinter(CodePrinter):
             # Check the Assign objects list in case of
             # the user assigns a variable to an object contains IndexedElement object.
             if not last_assign:
-                return 'return {0};'.format(self._print(args[0]))
+                return 'return {0};\n'.format(self._print(args[0]))
 
             # make sure that stmt contains one assign node.
             assert(len(last_assign)==1)
@@ -1234,14 +1235,14 @@ class CCodePrinter(CodePrinter):
             unneeded_var = not any(b in vars_in_deallocate_nodes for b in variables)
             if unneeded_var:
                 code = '\n'.join(self._print(a) for a in expr.stmt.body if a is not last_assign[0])
-                return code + '\nreturn {};'.format(self._print(last_assign[0].rhs))
+                return code + '\nreturn {};\n'.format(self._print(last_assign[0].rhs))
             else:
                 code = '\n'+self._print(expr.stmt)
                 self._additional_declare.append(last_assign[0].lhs)
-        return code + '\nreturn {0};'.format(self._print(args[0]))
+        return code + '\nreturn {0};\n'.format(self._print(args[0]))
 
     def _print_Pass(self, expr):
-        return '// pass'
+        return '// pass\n'
 
     def _print_Nil(self, expr):
         return 'NULL'
@@ -1314,12 +1315,12 @@ class CCodePrinter(CodePrinter):
         lhs_code = self._print(expr.lhs)
         op = expr.op._symbol
         rhs_code = self._print(expr.rhs)
-        return "{0} {1}= {2};".format(lhs_code, op, rhs_code)
+        return "{0} {1}= {2};\n".format(lhs_code, op, rhs_code)
 
     def _print_Assign(self, expr):
         if isinstance(expr.rhs, FunctionCall) and isinstance(expr.rhs.dtype, NativeTuple):
             self._temporary_args = [VariableAddress(a) for a in expr.lhs]
-            return '{};'.format(self._print(expr.rhs))
+            return '{};\n'.format(self._print(expr.rhs))
         if isinstance(expr.rhs, (NumpyArray)):
             return self.copy_NumpyArray_Data(expr)
         if isinstance(expr.rhs, (NumpyFull)):
@@ -1328,7 +1329,7 @@ class CCodePrinter(CodePrinter):
             return self.fill_NumpyArange(expr.rhs, expr.lhs)
         lhs = self._print(expr.lhs)
         rhs = self._print(expr.rhs)
-        return '{} = {};'.format(lhs, rhs)
+        return '{} = {};\n'.format(lhs, rhs)
 
     def _print_AliasAssign(self, expr):
         lhs = expr.lhs
@@ -1343,9 +1344,9 @@ class CCodePrinter(CodePrinter):
         # setting the pointer's is_view attribute to false so it can be ignored by the free_pointer function.
         if isinstance(expr.lhs, Variable) and expr.lhs.is_ndarray \
                 and isinstance(expr.rhs, Variable) and expr.rhs.is_ndarray and expr.rhs.is_pointer:
-            return 'alias_assign(&{}, {});'.format(lhs, rhs)
+            return 'alias_assign(&{}, {});\n'.format(lhs, rhs)
 
-        return '{} = {};'.format(lhs, rhs)
+        return '{} = {};\n'.format(lhs, rhs)
 
     def _print_For(self, expr):
         counter = self._print(expr.target)
@@ -1365,12 +1366,12 @@ class CCodePrinter(CodePrinter):
         if isinstance(test_step, Literal):
             op = '>' if isinstance(expr.iterable.step, PyccelUnarySub) else '<'
             return ('for ({counter} = {start}; {counter} {op} {stop}; {counter} += '
-                        '{step})\n{{\n{body}\n}}').format(counter=counter, start=start, op=op,
+                        '{step})\n{{\n{body}\n}}\n').format(counter=counter, start=start, op=op,
                                                           stop=stop, step=step, body=body)
         else:
             return (
                 'for ({counter} = {start}; ({step} > 0) ? ({counter} < {stop}) : ({counter} > {stop}); {counter} += '
-                '{step})\n{{\n{body}\n}}').format(counter=counter, start=start,
+                '{step})\n{{\n{body}\n}}\n').format(counter=counter, start=start,
                                                   stop=stop, step=step, body=body)
 
     def _print_CodeBlock(self, expr):
@@ -1385,7 +1386,7 @@ class CCodePrinter(CodePrinter):
             code = self._additional_code + code
             self._additional_code = ''
             body_stmts.append(code)
-        return '\n'.join(self._print(b) for b in body_stmts)
+        return ''.join(self._print(b) for b in body_stmts)
 
     def _print_Idx(self, expr):
         return self._print(expr.label)
@@ -1448,15 +1449,15 @@ class CCodePrinter(CodePrinter):
         if expr.has(Assign):
             for i, (e, c) in enumerate(expr.args):
                 if i == 0:
-                    lines.append("if (%s) {" % self._print(c))
+                    lines.append("if (%s) {\n" % self._print(c))
                 elif i == len(expr.args) - 1 and c is True:
-                    lines.append("else {")
+                    lines.append("else {\n")
                 else:
-                    lines.append("else if (%s) {" % self._print(c))
+                    lines.append("else if (%s) {\n" % self._print(c))
                 code0 = self._print(e)
                 lines.append(code0)
-                lines.append("}")
-            return "\n".join(lines)
+                lines.append("}\n")
+            return "".join(lines)
         else:
             # The piecewise was used in an expression, need to do inline
             # operators. This has the downside that inline operators will
@@ -1482,7 +1483,7 @@ class CCodePrinter(CodePrinter):
     def _print_Comment(self, expr):
         comments = self._print(expr.text)
 
-        return '/*' + comments + '*/'
+        return '/*' + comments + '*/\n'
 
     def _print_PyccelSymbol(self, expr):
         return expr
@@ -1495,17 +1496,15 @@ class CCodePrinter(CodePrinter):
         ln = max(len(i) for i in txts)
         if ln<max(20, header_size+4):
             ln = 20
-        top  = '/*' + '_'*int((ln-header_size)/2) + header + '_'*int((ln-header_size)/2) + '*/'
+        top  = '/*' + '_'*int((ln-header_size)/2) + header + '_'*int((ln-header_size)/2) + '*/\n'
         ln = len(top)-4
-        bottom = '/*' + '_'*ln + '*/'
+        bottom = '/*' + '_'*ln + '*/\n'
 
-        txts = ['/*' + t + ' '*(ln - len(t)) + '*/' for t in txts]
+        txts = ['/*' + t + ' '*(ln - len(t)) + '*/\n' for t in txts]
 
-        body = '\n'.join(i for i in txts)
+        body = ''.join(i for i in txts)
 
-        return ('{0}\n'
-                '{1}\n'
-                '{2}').format(top, body, bottom)
+        return ''.join([top, body, bottom])
 
     def _print_EmptyNode(self, expr):
         return ''
@@ -1519,35 +1518,35 @@ class CCodePrinter(CodePrinter):
         clauses += str(expr.txt)
         if expr.has_nowait:
             clauses = clauses + ' nowait'
-        omp_expr = '#pragma omp {}{}'.format(expr.name, clauses)
+        omp_expr = '#pragma omp {}{}\n'.format(expr.name, clauses)
 
         if expr.is_multiline:
             if expr.combined is None:
-                omp_expr += '\n{'
+                omp_expr += '{\n'
             elif (expr.combined and "for" not in expr.combined):
                 if ("masked taskloop" not in expr.combined) and ("distribute" not in expr.combined):
-                    omp_expr += '\n{'
+                    omp_expr += '{\n'
 
         return omp_expr
 
     def _print_Omp_End_Clause(self, expr):
-        return '}'
+        return '}\n'
     #=====================================
 
     def _print_Program(self, expr):
         body  = self._print(expr.body)
         decs     = [self._print(i) for i in expr.declarations]
         decs    += [self._print(Declare(i.dtype, i)) for i in self._additional_declare]
-        decs    = '\n'.join(self._print(i) for i in decs)
+        decs    = ''.join(self._print(i) for i in decs)
         self._additional_declare.clear()
 
         # PythonPrint imports last to be sure that all additional_imports have been collected
         imports  = [*expr.imports, *map(Import, self._additional_imports)]
-        imports  = '\n'.join(self._print(i) for i in imports)
-        return ('{imports}\n'
+        imports  = ''.join(self._print(i) for i in imports)
+        return ('{imports}'
                 'int main()\n{{\n'
-                '{decs}\n\n'
-                '{body}\n'
+                '{decs}'
+                '{body}'
                 'return 0;\n'
                 '}}').format(imports=imports,
                                     decs=decs,

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -61,7 +61,11 @@ class PythonCodePrinter(CodePrinter):
 
     def _indent_codestring(self, lines):
         tab = " "*self._default_settings['tabwidth']
-        return tab+lines.replace('\n','\n'+tab)
+        if lines == '':
+            return lines
+        else:
+            # lines ends with \n
+            return tab+lines[:-1].replace('\n','\n'+tab)+'\n'
 
     def _format_code(self, lines):
         return lines
@@ -133,13 +137,12 @@ class PythonCodePrinter(CodePrinter):
         doc_string = self._print(expr.doc_string) if expr.doc_string else ''
         doc_string = self._indent_codestring(doc_string)
 
+        body = ''.join([doc_string, imports, body])
+
         code = ('def {name}({args}):\n'
-                '{doc_string}\n'
-                '\n{imports}\n{body}\n').format(
+                '{body}\n').format(
                         name=name,
                         args=args,
-                        doc_string=doc_string,
-                        imports=imports,
                         body=body)
         decorators = expr.decorators
         if decorators:
@@ -310,7 +313,7 @@ class PythonCodePrinter(CodePrinter):
             func_name = expr.funcdef.name
         args = ', '.join(self._print(i) for i in expr.args)
         code = '{func}({args})'.format(func=func_name, args=args)
-        if expr.results:
+        if expr.funcdef.results:
             return code
         else:
             return code+'\n'

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -6,12 +6,6 @@
 # pylint: disable=R0201
 # pylint: disable=missing-function-docstring
 
-from itertools import chain
-
-from sympy.printing.pycode import _known_functions
-from sympy.printing.pycode import _known_functions_math
-from sympy.printing.pycode import _known_constants_math
-
 from pyccel.decorators import __all__ as pyccel_decorators
 
 from pyccel.ast.utilities  import build_types_decorator
@@ -23,7 +17,7 @@ from pyccel.ast.variable   import DottedName
 from pyccel.codegen.printing.codeprinter import CodePrinter
 
 from pyccel.errors.errors import Errors
-from pyccel.errors.messages import *
+from pyccel.errors.messages import PYCCEL_RESTRICTION_TODO
 
 errors = Errors()
 
@@ -181,7 +175,7 @@ class PythonCodePrinter(CodePrinter):
         headers = expr.headers
         if headers:
             headers = self._print(headers)
-            code = '{header}\n{code}'.format(header=header, code=code)
+            code = '{header}\n{code}'.format(header=headers, code=code)
 
         return code
 

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1331,7 +1331,8 @@ def test_array_real_3d_F_array_initialization_2(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="array function doesn't handle list of variables. See #752"),
             pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python)
     ]
 )
 def test_array_real_4d_F_array_initialization(language):
@@ -1351,14 +1352,7 @@ def test_array_real_4d_F_array_initialization(language):
 
     assert np.array_equal(x1, x2)
 
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="array function doesn't handle 4d lists or variables. See #751 and #752"),
-            pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
-    ]
-)
-@pytest.mark.xfail
+@pytest.mark.xfail(reason='Inhomogeneous arguments due to unknown shape')
 def test_array_real_4d_F_array_initialization_mixed_ordering(language):
 
     f1 = arrays.array_real_4d_F_array_initialization_mixed_ordering
@@ -1683,7 +1677,17 @@ def test_array_real_2d_2d_matmul_F_F_F_F(language):
     f2(A2, B2, C2)
     assert np.array_equal(C1, C2)
 
-@pytest.mark.xfail(reason="Should fail as long as mixed order not supported, see #244")
+@pytest.mark.parametrize( 'language', [
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="matmul not implemented in c"),
+            pytest.mark.c]),
+        pytest.param("fortran", marks = [
+            pytest.mark.fortran,
+            pytest.mark.skip(reason="Should fail as long as mixed order not supported, see #244")
+            ]),
+        pytest.param("python", marks = pytest.mark.python)
+    ]
+)
 def test_array_real_2d_2d_matmul_mixorder(language):
     f1 = arrays.array_real_2d_2d_matmul_mixorder
     f2 = epyccel( f1 , language = language)


### PR DESCRIPTION
Currently the behaviour between the C and fortran printer is different. In the C printer the statements are missing the final newline character, so that has to be added when joining lines. Using one-line statements which end with \n prevents unnecessary empty lines being printed. This is what is done in fortran. This PR updates the following printers to use the same syntax:
- CCodePrinter
- PythonPrinter
- CWrapperCodePrinter

This fixes #761. In addition multiple pylint errors are fixed in the python printer (unused import, typo in variable, wildcard import).