### PR TITLE
Remove unnecessary NativeOp class

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -36,7 +36,6 @@ errors = Errors()
 
 # TODO [YG, 12.03.2020]: Move non-Python constructs to other modules
 # TODO [YG, 12.03.2020]: Rename classes to avoid name clashes in pyccel/ast
-# NOTE: commented-out symbols are never used in Pyccel
 __all__ = (
     'AliasAssign',
     'Allocate',
@@ -811,8 +810,7 @@ class AugAssign(Assign):
         super().__init__(lhs, rhs, status, like)
 
     def __str__(self):
-        return '{0} {1}= {2}'.format(str(self.lhs), self.op,
-                str(self.rhs))
+        return '{0} {1}= {2}'.format(str(self.lhs), self.op, str(self.rhs))
 
     @property
     def op(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -27,7 +27,7 @@ from .literals       import LiteralInteger, Nil, convert_to_literal
 from .itertoolsext   import Product
 from .functionalexpr import FunctionalFor
 
-from .operators import PyccelMul, Relational
+from .operators import PyccelAdd, PyccelMinus, PyccelMul, PyccelDiv, PyccelMod, Relational
 
 from .variable import DottedName, DottedVariable, IndexedElement
 from .variable import ValuedVariable, Variable
@@ -38,7 +38,6 @@ errors = Errors()
 # TODO [YG, 12.03.2020]: Rename classes to avoid name clashes in pyccel/ast
 # NOTE: commented-out symbols are never used in Pyccel
 __all__ = (
-    'AddOp',
     'AliasAssign',
     'Allocate',
     'AnnotatedComment',
@@ -57,7 +56,6 @@ __all__ = (
     'Continue',
     'Declare',
     'Del',
-    'DivOp',
     'Dlist',
     'DoConcurrent',
     'EmptyNode',
@@ -69,11 +67,8 @@ __all__ = (
     'If',
     'Import',
     'Interface',
-    'ModOp',
     'Module',
     'ModuleHeader',
-    'MulOp',
-    'NativeOp',
     'ParserResult',
     'Pass',
     'Program',
@@ -81,7 +76,6 @@ __all__ = (
     'Return',
     'SeparatorComment',
     'StarredArguments',
-    'SubOp',
     'SymbolicAssign',
     'SymbolicPrint',
     'SympyFunction',
@@ -93,8 +87,6 @@ __all__ = (
     'get_initial_value',
     'get_iterable_ranges',
     'inline',
-#    'operator',
-#    'op_registry',
     'process_shape',
     'subs'
 )
@@ -754,60 +746,6 @@ class SymbolicAssign(Basic):
         return self._rhs
 
 
-# The following were defined to be sympy approved nodes. If there is something
-# smaller that could be used, that would be preferable. We only use them as
-# tokens.
-
-class NativeOp(metaclass=Singleton):
-
-    """Base type for native operands."""
-    __slots__ = ()
-
-    pass
-
-
-class AddOp(NativeOp):
-    __slots__ = ()
-    _symbol = '+'
-
-
-class SubOp(NativeOp):
-    __slots__ = ()
-    _symbol = '-'
-
-
-class MulOp(NativeOp):
-    __slots__ = ()
-    _symbol = '*'
-
-
-class DivOp(NativeOp):
-    __slots__ = ()
-    _symbol = '/'
-
-
-class ModOp(NativeOp):
-    __slots__ = ()
-    _symbol = '%'
-
-
-op_registry = {
-    '+': AddOp(),
-    '-': SubOp(),
-    '*': MulOp(),
-    '/': DivOp(),
-    '%': ModOp(),
-    }
-
-
-def operator(op):
-    """Returns the operator singleton for the given operator"""
-
-    if op.lower() not in op_registry:
-        raise ValueError('Unrecognized operator ' + op)
-    return op_registry[op]
-
-
 class AugAssign(Assign):
     r"""
     Represents augmented variable assignment for code generation.
@@ -849,6 +787,12 @@ class AugAssign(Assign):
     s += 1 + 2*t
     """
     __slots__ = ('_op',)
+    _accepted_operators = {
+            '+' : PyccelAdd,
+            '-' : PyccelMinus,
+            '*' : PyccelMul,
+            '/' : PyccelDiv,
+            '%' : PyccelMod}
 
     def __init__(
         self,
@@ -859,9 +803,7 @@ class AugAssign(Assign):
         like=None,
         ):
 
-        if isinstance(op, str):
-            op = operator(op)
-        elif op not in list(op_registry.values()):
+        if op not in self._accepted_operators.keys():
             raise TypeError('Unrecognized Operator')
 
         self._op = op
@@ -869,12 +811,18 @@ class AugAssign(Assign):
         super().__init__(lhs, rhs, status, like)
 
     def __str__(self):
-        return '{0} {1}= {2}'.format(str(self.lhs), self.op._symbol,
+        return '{0} {1}= {2}'.format(str(self.lhs), self.op,
                 str(self.rhs))
 
     @property
     def op(self):
         return self._op
+
+    def to_basic_assign(self):
+        return Assign(self.lhs,
+                self._accepted_operators[self._op](self.lhs, self.rhs),
+                status = self.status
+                like   = self.like)
 
 
 class While(Basic):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -821,7 +821,7 @@ class AugAssign(Assign):
     def to_basic_assign(self):
         return Assign(self.lhs,
                 self._accepted_operators[self._op](self.lhs, self.rhs),
-                status = self.status
+                status = self.status,
                 like   = self.like)
 
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -819,6 +819,13 @@ class AugAssign(Assign):
         return self._op
 
     def to_basic_assign(self):
+        """
+        Convert the AugAssign to an Assign
+        E.g. convert:
+        a += b
+        to:
+        a = a + b
+        """
         return Assign(self.lhs,
                 self._accepted_operators[self._op](self.lhs, self.rhs),
                 status = self.status,

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1312,7 +1312,7 @@ class CCodePrinter(CodePrinter):
 
     def _print_AugAssign(self, expr):
         lhs_code = self._print(expr.lhs)
-        op = expr.op._symbol
+        op = expr.op
         rhs_code = self._print(expr.rhs)
         return "{0} {1}= {2};".format(lhs_code, op, rhs_code)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -21,7 +21,6 @@ from sympy.core.numbers import NegativeInfinity as NINF
 from sympy.core.numbers import Infinity as INF
 
 from pyccel.ast.core import get_iterable_ranges
-from pyccel.ast.core import AddOp, MulOp, SubOp, DivOp
 from pyccel.ast.core import SeparatorComment, Comment
 from pyccel.ast.core import ConstructorCall
 from pyccel.ast.core import ErrorExit, FunctionAddress

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1741,26 +1741,8 @@ class FCodePrinter(CodePrinter):
         return 'cycle\n'
 
     def _print_AugAssign(self, expr):
-        lhs    = expr.lhs
-        op     = expr.op
-        rhs    = expr.rhs
-        status = expr.status
-        like   = expr.like
-
-        if isinstance(op, AddOp):
-            rhs = PyccelAdd(lhs, rhs)
-        elif isinstance(op, MulOp):
-            rhs = PyccelMul(lhs, rhs)
-        elif isinstance(op, SubOp):
-            rhs = PyccelMinus(lhs, rhs)
-        # TODO fix bug with division of integers
-        elif isinstance(op, DivOp):
-            rhs = PyccelDiv(lhs, rhs)
-        else:
-            raise ValueError('Unrecognized operation', op)
-
-        stmt = Assign(lhs, rhs, status=status, like=like)
-        return self._print_Assign(stmt)
+        new_expr = expr.to_basic_assign()
+        return self._print(new_expr)
 
     def _print_PythonRange(self, expr):
         start = self._print(expr.start)

--- a/pyccel/codegen/printing/luacode.py
+++ b/pyccel/codegen/printing/luacode.py
@@ -465,7 +465,7 @@ class LuaCodePrinter(CodePrinter):
 
     def _print_AugAssign(self, expr):
         lhs_code = self._print(expr.lhs)
-        op = expr.op._symbol
+        op = expr.op
         rhs_code = self._print(expr.rhs)
         return "{0} {1}= {2}".format(lhs_code, op, rhs_code)
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -382,7 +382,7 @@ class PythonCodePrinter(CodePrinter):
     def _print_AugAssign(self, expr):
         lhs = self._print(expr.lhs)
         rhs = self._print(expr.rhs)
-        op  = self._print(expr.op._symbol)
+        op  = self._print(expr.op)
         return'{0} {1}= {2}'.format(lhs,op,rhs)
 
     def _print_PythonRange(self, expr):


### PR DESCRIPTION
The code contains the following message:
> The following were defined to be sympy approved nodes. If there is something
> smaller that could be used, that would be preferable. We only use them as
> tokens.

Now that sympy has been removed this is no longer necessary and a simple string can be used.