### PR TITLE
Add FunctionalFor, Enumerate, Zip, and Map to C printer

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -394,6 +394,9 @@ class Assign(Basic):
     def __str__(self):
         return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
 
+    def __repr__(self):
+        return '({0} := {1})'.format(repr(self.lhs), repr(self.rhs))
+
     @property
     def lhs(self):
         return self._lhs

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -121,6 +121,9 @@ class DataType(metaclass=Singleton):
     def __str__(self):
         return str(self.name).lower()
 
+    def __repr__(self):
+        return str(self.__class__.__name__)+'()'
+
 class NativeBool(DataType):
     __slots__ = ()
     _name = 'Bool'

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -376,6 +376,9 @@ class Variable(PyccelAstNode):
     def __str__(self):
         return str(self.name)
 
+    def __repr__(self):
+        return 'Variable({}, dtype={})'.format(repr(self.name), repr(self.dtype))
+
     def __eq__(self, other):
         if type(self) is type(other):
             return self._name == other.name
@@ -798,6 +801,9 @@ class IndexedElement(PyccelAstNode):
 
     def __str__(self):
         return '{}[{}]'.format(self.base, ','.join(str(i) for i in self.indices))
+
+    def __repr__(self):
+        return '{}[{}]'.format(repr(self.base), ','.join(repr(i) for i in self.indices))
 
 class VariableAddress(PyccelAstNode):
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1383,7 +1383,7 @@ class CCodePrinter(CodePrinter):
                                                   stop=stop, step=step, body=body)
 
     def _print_FunctionalFor(self, expr):
-        loops = '\n'.join(self._print(i) for i in expr.loops)
+        loops = ''.join(self._print(i) for i in expr.loops)
         return loops
 
     def _print_CodeBlock(self, expr):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -379,7 +379,7 @@ class PythonCodePrinter(CodePrinter):
             for_loops.append('for {} in {}'.format(self._print(idx), self._print(iters)))
         for_loops = ' '.join(for_loops)
         lhs = self._print(expr.lhs)
-        return '{} = [{} {}]'.format(lhs, body, for_loops)
+        return '{} = [{} {}]\n'.format(lhs, body, for_loops)
 
     def _print_While(self, expr):
         cond = self._print(expr.test)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -15,7 +15,7 @@ from sympy.printing.pycode import _known_constants_math
 from pyccel.decorators import __all__ as pyccel_decorators
 
 from pyccel.ast.utilities  import build_types_decorator
-from pyccel.ast.core       import CodeBlock, Import, Assign, FunctionCall
+from pyccel.ast.core       import CodeBlock, Import, Assign, FunctionCall, For
 from pyccel.ast.datatypes  import default_precision
 from pyccel.ast.literals   import LiteralTrue, LiteralString
 from pyccel.ast.variable   import DottedName
@@ -355,6 +355,30 @@ class PythonCodePrinter(CodePrinter):
                 '{2}\n').format(target,iterable,body)
 
         return code
+
+    def _print_FunctionalFor(self, expr):
+        dummy_var = expr.index
+        iterators = []
+        body = expr.loops[1]
+        while not isinstance(body, Assign):
+            if isinstance(body, CodeBlock):
+                body = body.body
+                if len(body) > 1:
+                    if any(not(isinstance(b, Assign) and b.lhs is dummy_var) for b in body[1:]):
+                        raise NotImplementedError("Pyccel has introduced unnecessary statements which it cannot yet disambiguate in the python printer")
+                body = body[0]
+            elif isinstance(body, For):
+                iterators.append(body.iterable)
+                body = body.body
+            else:
+                raise NotImplementedError("Type {} not handled in a FunctionalFor".format(type(body)))
+        body = self._print(body.rhs)
+        for_loops = []
+        for idx, iters in zip(expr.indices, iterators):
+            for_loops.append('for {} in {}'.format(self._print(idx), self._print(iters)))
+        for_loops = ' '.join(for_loops)
+        lhs = self._print(expr.lhs)
+        return '{} = [{} {}]'.format(lhs, body, for_loops)
 
     def _print_While(self, expr):
         cond = self._print(expr.test)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -374,10 +374,8 @@ class PythonCodePrinter(CodePrinter):
             else:
                 raise NotImplementedError("Type {} not handled in a FunctionalFor".format(type(body)))
         body = self._print(body.rhs)
-        for_loops = []
-        for idx, iters in zip(expr.indices, iterators):
-            for_loops.append('for {} in {}'.format(self._print(idx), self._print(iters)))
-        for_loops = ' '.join(for_loops)
+        for_loops = ' '.join(['for {} in {}'.format(self._print(idx), self._print(iters))
+                        for idx, iters in zip(expr.indices, iterators)])
         lhs = self._print(expr.lhs)
         return '{} = [{} {}]\n'.format(lhs, body, for_loops)
 

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -8,9 +8,8 @@ from modules import base
 
 class epyccel_test:
     """
-    Class to pyccelize module then compare different results
-    This avoids the need to pyccelize the file multiple times
-    or write the arguments multiple times
+    Class to pyccelize module or function then compare different results
+    This avoids the need to pyccelize the object multiple times
     """
     def __init__(self, f, lang='fortran'):
         self._f  = f

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -2,7 +2,7 @@
 import pytest
 
 from modules import base
-from .utilities import epyccel_test
+from utilities import epyccel_test
 
 
 def test_is_false(language):

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -1,24 +1,9 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 import pytest
-import numpy as np
 
-from pyccel.epyccel import epyccel
 from modules import base
+from .utilities import epyccel_test
 
-
-class epyccel_test:
-    """
-    Class to pyccelize module or function then compare different results
-    This avoids the need to pyccelize the object multiple times
-    """
-    def __init__(self, f, lang='fortran'):
-        self._f  = f
-        self._f2 = epyccel(f, language=lang)
-
-    def compare_epyccel(self, *args):
-        out1 = self._f(*args)
-        out2 = self._f2(*args)
-        assert np.equal(out1, out2 )
 
 def test_is_false(language):
     test = epyccel_test(base.is_false, lang=language)

--- a/tests/epyccel/test_compare_expressions.py
+++ b/tests/epyccel/test_compare_expressions.py
@@ -6,9 +6,8 @@ from pyccel.decorators import types
 #==============================================================================
 class epyccel_test:
     """
-    Class to pyccelize module then compare different results
-    This avoids the need to pyccelize the file multiple times
-    or write the arguments multiple times
+    Class to pyccelize module or function then compare different results
+    This avoids the need to pyccelize the object multiple times
     """
     def __init__(self, f, lang='fortran'):
         self._f  = f

--- a/tests/epyccel/test_compare_expressions.py
+++ b/tests/epyccel/test_compare_expressions.py
@@ -1,22 +1,6 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
-import numpy as np
-from pyccel.epyccel import epyccel
 from pyccel.decorators import types
-
-#==============================================================================
-class epyccel_test:
-    """
-    Class to pyccelize module or function then compare different results
-    This avoids the need to pyccelize the object multiple times
-    """
-    def __init__(self, f, lang='fortran'):
-        self._f  = f
-        self._f2 = epyccel(f, language=lang)
-
-    def compare_epyccel(self, *args):
-        out1 = self._f(*args)
-        out2 = self._f2(*args)
-        assert np.equal(out1, out2 )
+from .utilities import epyccel_test
 
 #==============================================================================
 @types('int, int, int')

--- a/tests/epyccel/test_compare_expressions.py
+++ b/tests/epyccel/test_compare_expressions.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 from pyccel.decorators import types
-from .utilities import epyccel_test
+from utilities import epyccel_test
 
 #==============================================================================
 @types('int, int, int')

--- a/tests/epyccel/test_compare_expressions.py
+++ b/tests/epyccel/test_compare_expressions.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
-from pyccel.decorators import types
 from utilities import epyccel_test
+from pyccel.decorators import types
 
 #==============================================================================
 @types('int, int, int')

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -6,16 +6,6 @@ from numpy import equal
 from pyccel.epyccel import epyccel
 from modules import functionals
 
-@pytest.fixture(params=[
-    pytest.param('fortran', marks = pytest.mark.fortran),
-    pytest.param('c', marks = pytest.mark.c),
-    pytest.param('python'      , marks = [pytest.mark.python,
-        pytest.mark.skip(message='Functional object not retrievable in python')])
-    ]
-)
-def language(request):
-    return request.param
-
 #==============================================================================
 class epyccel_test:
     """
@@ -38,6 +28,15 @@ def test_functional_for_1d_range(language):
     test = epyccel_test(functionals.functional_for_1d_range, lang=language)
     test.compare_epyccel()
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("python", marks = [
+            pytest.mark.python,
+            pytest.mark.skip(reason = "Too many expressions introduced for 'for xi in x'")
+        ])
+    )
+)
 def test_functional_for_1d_var(language):
     y = randint(99,size = 4)
     test = epyccel_test(functionals.functional_for_1d_var, lang=language)
@@ -47,11 +46,29 @@ def test_functional_for_2d_range(language):
     test = epyccel_test(functionals.functional_for_2d_range, lang=language)
     test.compare_epyccel()
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("python", marks = [
+            pytest.mark.python,
+            pytest.mark.skip(reason = "Too many expressions introduced for 'for xi in x'")
+        ])
+    )
+)
 def test_functional_for_2d_var_range(language):
     y = randint(99, size = 3)
     test = epyccel_test(functionals.functional_for_2d_var_range, lang=language)
     test.compare_epyccel(y)
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("python", marks = [
+            pytest.mark.python,
+            pytest.mark.skip(reason = "Too many expressions introduced for 'for xi in x'")
+        ])
+    )
+)
 def test_functional_for_2d_var_var(language):
     y = randint(99, size = 3)
     z = randint(99, size = 2)

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -1,99 +1,43 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
-import pytest
 from numpy.random import randint
 from numpy import equal
 
 from pyccel.epyccel import epyccel
 from modules import functionals
 
-#==============================================================================
-class epyccel_test:
-    """
-    Class to pyccelize module then compare different results
-    This avoids the need to pyccelize the file multiple times
-    or write the arguments multiple times
-    """
-    def __init__(self, f, lang='fortran'):
-        self._f  = f
-        self._f2 = epyccel(f, language=lang)
+def compare_epyccel(f, *args):
+    f2 = epyccel(f)
+    out1 = f(*args)
+    out2 = f2(*args)
+    assert equal(out1, out2).all()
 
-    def compare_epyccel(self, *args):
-        out1 = self._f(*args)
-        out2 = self._f2(*args)
-        assert equal(out1, out2 ).all()
+def test_functional_for_1d_range():
+    compare_epyccel(functionals.functional_for_1d_range)
 
-#==============================================================================
-
-def test_functional_for_1d_range(language):
-    test = epyccel_test(functionals.functional_for_1d_range, lang=language)
-    test.compare_epyccel()
-
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.c),
-        pytest.param("python", marks = [
-            pytest.mark.python,
-            pytest.mark.skip(reason = "Too many expressions introduced for 'for xi in x'")
-        ])
-    )
-)
-def test_functional_for_1d_var(language):
+def test_functional_for_1d_var():
     y = randint(99,size = 4)
-    test = epyccel_test(functionals.functional_for_1d_var, lang=language)
-    test.compare_epyccel(y)
+    compare_epyccel(functionals.functional_for_1d_var, y)
 
-def test_functional_for_2d_range(language):
-    test = epyccel_test(functionals.functional_for_2d_range, lang=language)
-    test.compare_epyccel()
+def test_functional_for_2d_range():
+    compare_epyccel(functionals.functional_for_2d_range)
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.c),
-        pytest.param("python", marks = [
-            pytest.mark.python,
-            pytest.mark.skip(reason = "Too many expressions introduced for 'for xi in x'")
-        ])
-    )
-)
-def test_functional_for_2d_var_range(language):
+def test_functional_for_2d_var_range():
     y = randint(99, size = 3)
-    test = epyccel_test(functionals.functional_for_2d_var_range, lang=language)
-    test.compare_epyccel(y)
+    compare_epyccel(functionals.functional_for_2d_var_range, y)
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.c),
-        pytest.param("python", marks = [
-            pytest.mark.python,
-            pytest.mark.skip(reason = "Too many expressions introduced for 'for xi in x'")
-        ])
-    )
-)
-def test_functional_for_2d_var_var(language):
+def test_functional_for_2d_var_var():
     y = randint(99, size = 3)
     z = randint(99, size = 2)
-    test = epyccel_test(functionals.functional_for_2d_var_var, lang=language)
-    test.compare_epyccel(y, z)
+    compare_epyccel(functionals.functional_for_2d_var_var, y, z)
 
-def test_functional_for_2d_dependant_range(language):
-    test = epyccel_test(functionals.functional_for_2d_dependant_range_1, lang=language)
-    test.compare_epyccel()
-    test.compare_epyccel()
-    test.compare_epyccel()
+def test_functional_for_2d_dependant_range():
+    compare_epyccel(functionals.functional_for_2d_dependant_range_1)
+    compare_epyccel(functionals.functional_for_2d_dependant_range_2)
+    compare_epyccel(functionals.functional_for_2d_dependant_range_3)
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="Tuples not implemented in C"),
-            pytest.mark.c]
-        )
-    )
-)
-def test_functional_for_2d_array_range(language):
+def test_functional_for_2d_array_range():
     idx = randint(28)
-    test = epyccel_test(functionals.functional_for_2d_array_range, lang=language)
-    test.compare_epyccel(idx)
+    compare_epyccel(functionals.functional_for_2d_array_range,idx)
 
-def test_functional_for_3d_range(language):
-    test = epyccel_test(functionals.functional_for_3d_range, lang=language)
-    test.compare_epyccel()
+def test_functional_for_3d_range():
+    compare_epyccel(functionals.functional_for_3d_range)

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -121,8 +121,7 @@ def test_product_loop_on_2d_array_F(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="python Map iterable is not implemented\
-                yet in C language"),
+            pytest.mark.xfail(reason="Function in function not implemented in C"),
             pytest.mark.c]
         )
     )
@@ -136,15 +135,6 @@ def test_map_on_1d_array(language):
 
     assert np.array_equal( f1(z), f2(z) )
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="Enumerate iterable is not implemented yet\
-                in C language"),
-            pytest.mark.c]
-        )
-    )
-)
 def test_enumerate_on_1d_array(language):
 
     f1 = loops.enumerate_on_1d_array
@@ -154,14 +144,6 @@ def test_enumerate_on_1d_array(language):
 
     assert np.array_equal( f1(z), f2(z) )
 
-@pytest.mark.parametrize( 'lang', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="zip and functional for not implemented"),
-            pytest.mark.c]
-        )
-    )
-)
 def test_zip_prod(lang):
 
     f1 = loops.zip_prod

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -82,7 +82,11 @@ def test_double_loop_on_2d_array_F(language):
             pytest.mark.xfail(reason="product iterable is not implemented yet\
                 in C language"),
             pytest.mark.c]
-        )
+        ),
+        pytest.param("python", marks = [
+            pytest.mark.python,
+            pytest.mark.skip(reason="Cannot handle partially unpacked iterables. See #736")
+        ])
     )
 )
 def test_product_loop_on_2d_array_C(language):
@@ -103,7 +107,11 @@ def test_product_loop_on_2d_array_C(language):
             pytest.mark.xfail(reason="product iterable is not implemented yet\
                 in C language"),
             pytest.mark.c]
-        )
+        ),
+        pytest.param("python", marks = [
+            pytest.mark.python,
+            pytest.mark.skip(reason="Cannot handle partially unpacked iterables. See #736")
+        ])
     )
 )
 def test_product_loop_on_2d_array_F(language):
@@ -123,7 +131,11 @@ def test_product_loop_on_2d_array_F(language):
         pytest.param("c", marks = [
             pytest.mark.xfail(reason="Function in function not implemented in C"),
             pytest.mark.c]
-        )
+        ),
+        pytest.param("python", marks = [
+            pytest.mark.python,
+            pytest.mark.skip(reason="Cannot handle partially unpacked iterables. See #736")
+        ])
     )
 )
 def test_map_on_1d_array(language):
@@ -135,6 +147,15 @@ def test_map_on_1d_array(language):
 
     assert np.array_equal( f1(z), f2(z) )
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("python", marks = [
+            pytest.mark.python,
+            pytest.mark.skip(reason="Cannot handle partially unpacked iterables. See #736")
+        ])
+    )
+)
 def test_enumerate_on_1d_array(language):
 
     f1 = loops.enumerate_on_1d_array
@@ -144,6 +165,15 @@ def test_enumerate_on_1d_array(language):
 
     assert np.array_equal( f1(z), f2(z) )
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("python", marks = [
+            pytest.mark.python,
+            pytest.mark.skip(reason="Cannot handle partially unpacked iterables. See #736")
+        ])
+    )
+)
 def test_zip_prod(language):
 
     f1 = loops.zip_prod

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -144,10 +144,10 @@ def test_enumerate_on_1d_array(language):
 
     assert np.array_equal( f1(z), f2(z) )
 
-def test_zip_prod(lang):
+def test_zip_prod(language):
 
     f1 = loops.zip_prod
-    f2 = epyccel( f1, language = lang )
+    f2 = epyccel( f1, language = language )
 
     assert np.array_equal( f1(10), f2(10) )
 

--- a/tests/epyccel/utilities.py
+++ b/tests/epyccel/utilities.py
@@ -1,0 +1,21 @@
+from pyccel.epyccel import epyccel
+import numpy as np
+
+
+#==============================================================================
+class epyccel_test:
+    """
+    Class which stores a pyccelized function
+
+    This avoids the need to pyccelize the object multiple times
+    while still providing a clean interface for the tests
+    through the compare_epyccel function
+    """
+    def __init__(self, f, lang='fortran'):
+        self._f  = f
+        self._f2 = epyccel(f, language=lang)
+
+    def compare_epyccel(self, *args):
+        out1 = self._f(*args)
+        out2 = self._f2(*args)
+        assert np.equal(out1, out2 )

--- a/tests/epyccel/utilities.py
+++ b/tests/epyccel/utilities.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
-from pyccel.epyccel import epyccel
 import numpy as np
+from pyccel.epyccel import epyccel
 
 
 #==============================================================================

--- a/tests/epyccel/utilities.py
+++ b/tests/epyccel/utilities.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
 from pyccel.epyccel import epyccel
 import numpy as np
 


### PR DESCRIPTION
Add FunctionalFor, Enumerate, Zip, and Map to C printer and activate tests. FunctionalFor is also added to the python printer but the iterators cannot be added easily due to issue #736 