### PR TITLE
Fix AliasAssign of array in C

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1333,17 +1333,18 @@ class CCodePrinter(CodePrinter):
     def _print_AliasAssign(self, expr):
         lhs = expr.lhs
         rhs = expr.rhs
+
+        # the below condition handles the case of reassinging a pointer to an array view.
+        # setting the pointer's is_view attribute to false so it can be ignored by the free_pointer function.
+        if isinstance(lhs, Variable) and lhs.is_ndarray \
+                and isinstance(rhs, Variable) and rhs.is_ndarray:
+            return 'alias_assign(&{}, {});'.format(lhs, rhs)
+
         if isinstance(rhs, Variable):
             rhs = VariableAddress(rhs)
 
         lhs = self._print(lhs.name)
         rhs = self._print(rhs)
-
-        # the below condition handles the case of reassinging a pointer to an array view.
-        # setting the pointer's is_view attribute to false so it can be ignored by the free_pointer function.
-        if isinstance(expr.lhs, Variable) and expr.lhs.is_ndarray \
-                and isinstance(expr.rhs, Variable) and expr.rhs.is_ndarray and expr.rhs.is_pointer:
-            return 'alias_assign(&{}, {});'.format(lhs, rhs)
 
         return '{} = {};'.format(lhs, rhs)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1335,19 +1335,19 @@ class CCodePrinter(CodePrinter):
         lhs = expr.lhs
         rhs = expr.rhs
 
+        if isinstance(rhs, Variable):
+            rhs = VariableAddress(rhs)
+
+        lhs_code = self._print(lhs.name)
+        rhs_code = self._print(rhs)
+
         # the below condition handles the case of reassinging a pointer to an array view.
         # setting the pointer's is_view attribute to false so it can be ignored by the free_pointer function.
         if isinstance(lhs, Variable) and lhs.is_ndarray \
                 and isinstance(rhs, Variable) and rhs.is_ndarray:
-            return 'alias_assign(&{}, {});\n'.format(lhs, rhs)
+            return 'alias_assign(&{}, {});\n'.format(lhs_code, rhs_code)
 
-        if isinstance(rhs, Variable):
-            rhs = VariableAddress(rhs)
-
-        lhs = self._print(lhs.name)
-        rhs = self._print(rhs)
-
-        return '{} = {};\n'.format(lhs, rhs)
+        return '{} = {};\n'.format(lhs_code, rhs_code)
 
     def _print_For(self, expr):
         counter = self._print(expr.target)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1338,7 +1338,7 @@ class CCodePrinter(CodePrinter):
         if isinstance(rhs, Variable):
             rhs = VariableAddress(rhs)
 
-        lhs_code = self._print(lhs.name)
+        lhs_code = self._print(VariableAddress(lhs))
         rhs_code = self._print(rhs)
 
         # the below condition handles the case of reassinging a pointer to an array view.

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1332,22 +1332,22 @@ class CCodePrinter(CodePrinter):
         return '{} = {};\n'.format(lhs, rhs)
 
     def _print_AliasAssign(self, expr):
-        lhs = expr.lhs
-        rhs = expr.rhs
+        lhs_var = expr.lhs
+        rhs_var = expr.rhs
 
-        if isinstance(rhs, Variable):
-            rhs = VariableAddress(rhs)
+        lhs = VariableAddress(lhs_var)
+        rhs = VariableAddress(rhs_var) if isinstance(rhs_var, Variable) else rhs_var
 
-        lhs_code = self._print(VariableAddress(lhs))
-        rhs_code = self._print(rhs)
+        lhs = self._print(lhs)
+        rhs = self._print(rhs)
 
         # the below condition handles the case of reassinging a pointer to an array view.
         # setting the pointer's is_view attribute to false so it can be ignored by the free_pointer function.
-        if isinstance(lhs, Variable) and lhs.is_ndarray \
-                and isinstance(rhs, Variable) and rhs.is_ndarray:
-            return 'alias_assign(&{}, {});\n'.format(lhs_code, rhs_code)
+        if isinstance(lhs_var, Variable) and lhs_var.is_ndarray \
+                and isinstance(rhs_var, Variable) and rhs_var.is_ndarray:
+            return 'alias_assign(&{}, {});\n'.format(lhs, rhs)
 
-        return '{} = {};\n'.format(lhs_code, rhs_code)
+        return '{} = {};\n'.format(lhs, rhs)
 
     def _print_For(self, expr):
         counter = self._print(expr.target)


### PR DESCRIPTION
Fixes #794 

No tests have been added as this is a memory problem not a functional problem. There is already a test for this case [here](https://github.com/pyccel/pyccel/blob/master/tests/epyccel/modules/pointers.py#L17-L22) but it doesn't show the memory problem (no double free as shape is set to NULL, no access to freed objects as no argument)