### PR TITLE
Fix stack arrays in C

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -315,7 +315,7 @@ class CCodePrinter(CodePrinter):
         code_init = ''
         if lhs.is_stack_array:
             declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
-            length = '*'.join(self._print(i) for i in lhs.shape)
+            length = '*'.join(self._print(i) for i in lhs.alloc_shape)
             buffer_array = "({declare_dtype}[{length}]){{}}".format(declare_dtype = declare_dtype, length=length)
             code_init += self._init_stack_array(expr, buffer_array)
         if rhs.fill_value is not None:
@@ -343,15 +343,15 @@ class CCodePrinter(CodePrinter):
         lhs = expr.lhs
         rhs = expr.rhs
         dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
-        shape = ", ".join(self._print(i) for i in lhs.shape)
+        shape = ", ".join(self._print(i) for i in lhs.alloc_shape)
         declare_dtype = self.find_in_dtype_registry('int', 8)
 
         shape_init = "({declare_dtype}[]){{{shape}}}".format(declare_dtype=declare_dtype, shape=shape)
         strides_init = "({declare_dtype}[{length}]){{0}}".format(declare_dtype=declare_dtype, length=len(lhs.shape))
         if isinstance(buffer_array, Variable):
             buffer_array = "{0}.{1}".format(self._print(buffer_array), dtype)
-        cpy_data = '{0} = (t_ndarray){{.{1}={2},\n .shape={3},\n .strides={4},\n '
-        cpy_data += '.nd={5},\n .type={1},\n .is_view={6}}};\n'
+        cpy_data = '{0} = (t_ndarray){{\n.{1}={2},\n .shape={3},\n .strides={4},\n '
+        cpy_data += '.nd={5},\n .type={1},\n .is_view={6}\n}};\n'
         cpy_data = cpy_data.format(self._print(lhs), dtype, buffer_array,
                     shape_init, strides_init, len(lhs.shape), 'false')
         cpy_data += 'stack_array_init(&{});\n'.format(self._print(lhs))

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -413,9 +413,8 @@ def test_pyccel_calling_directory(language):
     compare_pyth_fort_output( pyth_out, fort_out )
 
 #------------------------------------------------------------------------------
-# C does not handle stack arrays of variable size. See #760
-def test_in_specified():
-    pyccel_test("scripts/runtest_degree_in.py")
+def test_in_specified(language):
+    pyccel_test("scripts/runtest_degree_in.py", language=language)
 
 #------------------------------------------------------------------------------
 @pytest.mark.parametrize( "test_file", ["scripts/hope_benchmarks/hope_fib.py",


### PR DESCRIPTION
Fixes #760 :
- Ensure that the shape of the stack array is not a call to its shape property at allocation
- Create a local variable containing the data of the stack array if the size is not a literal