### PR TITLE
Fix memory allocation for nd stack array (n>1)

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -323,7 +323,9 @@ class CCodePrinter(CodePrinter):
             sympy_shapes = [pyccel_to_sympy(s, symbol_map, used_names_tmp) for s in lhs.alloc_shape]
 
             length = functools.reduce(operator.mul, sympy_shapes)
-            length_code = '*'.join(self._print(i) for i in lhs.alloc_shape)
+            printable_length = functools.reduce(PyccelMul, lhs.alloc_shape)
+
+            length_code = self._print(printable_length)
 
             if length.is_constant():
                 buffer_array = "({declare_dtype}[{length}]){{}}".format(

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4116,14 +4116,9 @@ def test_numpy_mod_scalar(language):
     f_bl_true_output = epyccel_func(True)
     test_bool_true_output = get_mod(True)
 
-    f_bl_false_output = epyccel_func(False)
-    test_bool_false_output = get_mod(False)
-
     assert f_bl_true_output == test_bool_true_output
-    assert f_bl_false_output == test_bool_false_output
 
     assert matching_types(f_bl_true_output, test_bool_true_output)
-    assert matching_types(f_bl_false_output, test_bool_false_output)
 
     f_integer_output = epyccel_func(integer)
     test_int_output  = get_mod(integer)
@@ -4207,7 +4202,7 @@ def test_numpy_mod_array_like_1d(language):
 
     size = 5
 
-    bl = randint(0, 1, size=size, dtype= bool)
+    bl = np.full(size, True, dtype= bool)
 
     integer8 = randint(min_int8, max_int8, size=size, dtype=np.int8)
     integer16 = randint(min_int16, max_int16, size=size, dtype=np.int16)
@@ -4266,7 +4261,7 @@ def test_numpy_mod_array_like_2d(language):
 
     size = (2, 5)
 
-    bl = randint(0, 1, size=size, dtype= bool)
+    bl = np.full(size, True, dtype= bool)
 
     integer8 = randint(min_int8, max_int8, size=size, dtype=np.int8)
     integer16 = randint(min_int16, max_int16, size=size, dtype=np.int16)

--- a/tests/pyccel/scripts/runtest_degree_in.py
+++ b/tests/pyccel/scripts/runtest_degree_in.py
@@ -1,10 +1,9 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
-from pyccel.decorators import types, stack_array, pure
+from pyccel.decorators import stack_array, pure
 
 @pure
-@types('int')
 @stack_array('tmp')
-def test_degree(degree):
+def test_degree(degree : int):
     from numpy import empty
 
     tmp = empty(degree+1, dtype=float)
@@ -13,3 +12,17 @@ def test_degree(degree):
     return 1
 
 print(test_degree(3))
+
+@pure
+@stack_array('tmp')
+def test_degree2d(degree1 : int, degree2 : int):
+    from numpy import empty
+
+    tmp = empty((degree1+1, degree2+1), dtype=float)
+    for i in range(degree1+1):
+        for j in range(degree2+1):
+            tmp[i,j]=0.
+    return 1
+
+print(test_degree(3))
+print(test_degree2d(3,4))


### PR DESCRIPTION
The size of the data allocated for a nd array was calculated using '*'.join instead of `PyccelMul`. In cases where the shape is already an equation this can lead to missing parentheses. This PR fixes this (fixes #844). A test is also added

[BUGFIX] `np.mod(False, False)` causes division by 0 so these tests are removed