### PR TITLE
Fix flattening the nd array when dim > 2

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -10,6 +10,7 @@ import operator
 
 from pyccel.ast.builtins  import PythonRange, PythonComplex, PythonEnumerate
 from pyccel.ast.builtins  import PythonZip, PythonMap, PythonLen, PythonPrint
+from pyccel.ast.builtins  import PythonList, PythonTuple
 
 from pyccel.ast.core      import Declare, For, CodeBlock
 from pyccel.ast.core      import FuncAddressDeclare, FunctionCall, FunctionDef
@@ -281,11 +282,11 @@ class CCodePrinter(CodePrinter):
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
         dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
         arg = rhs.arg
-        print(arg)
         if rhs.rank > 1:
             # flattening the args to use them in C initialization.
-            arg = functools.reduce(operator.concat, arg)
-            print(arg.value)
+            flatten_list = lambda irregular_list:[element for item in irregular_list for element in flatten_list(item)] if isinstance(irregular_list, (PythonList, PythonTuple)) else [irregular_list]
+            arg = flatten_list(arg)
+
         if isinstance(arg, Variable):
             arg = self._print(arg)
             if expr.lhs.is_stack_array:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -274,15 +274,18 @@ class CCodePrinter(CodePrinter):
         """
         rhs = expr.rhs
         lhs = expr.lhs
+        print(lhs, rhs)
         if rhs.rank == 0:
             raise NotImplementedError(str(expr))
         dummy_array_name, _ = create_incremented_string(self._parser.used_names, prefix = 'array_dummy')
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
         dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
         arg = rhs.arg
+        print(arg)
         if rhs.rank > 1:
             # flattening the args to use them in C initialization.
             arg = functools.reduce(operator.concat, arg)
+            print(arg.value)
         if isinstance(arg, Variable):
             arg = self._print(arg)
             if expr.lhs.is_stack_array:

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1110,13 +1110,6 @@ def test_array_real_3d_C_array_initialization_1(language):
 
     assert np.array_equal(x1, x2)
 
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="array function doesn't handle 3d lists. See #751"),
-            pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
-    ]
-)
 def test_array_real_3d_C_array_initialization_2(language):
 
     f1 = arrays.array_real_3d_C_array_initialization_2
@@ -1307,13 +1300,6 @@ def test_array_real_3d_F_array_initialization_1(language):
 
     assert np.array_equal(x1, x2)
 
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="array function doesn't handle 3d lists. See #751"),
-            pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
-    ]
-)
 def test_array_real_3d_F_array_initialization_2(language):
 
     f1 = arrays.array_real_3d_F_array_initialization_2


### PR DESCRIPTION
Fixes #751 where the `reduce` function does not flatten the array enough. This is achieved by adding the recursive method `_flatten_list` to the C code printer.