### PR TITLE
Add printer for NumpyMod

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -20,7 +20,7 @@ from pyccel.ast.core      import SeparatorComment
 from pyccel.ast.core      import create_incremented_string
 
 from pyccel.ast.operators import PyccelAdd, PyccelMul, PyccelMinus, PyccelLt, PyccelGt
-from pyccel.ast.operators import PyccelAssociativeParenthesis
+from pyccel.ast.operators import PyccelAssociativeParenthesis, PyccelMod
 from pyccel.ast.operators import PyccelUnarySub, IfTernaryOperator
 
 from pyccel.ast.datatypes import NativeInteger, NativeBool, NativeComplex
@@ -1176,6 +1176,9 @@ class CCodePrinter(CodePrinter):
 
     def _print_NumpyRandint(self, expr):
         raise NotImplementedError("Randint not implemented")
+
+    def _print_NumpyMod(self, expr):
+        return self._print(PyccelMod(*expr.args))
 
     def _print_Interface(self, expr):
         return ""

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2465,7 +2465,7 @@ class FCodePrinter(CodePrinter):
         try:
             func_name = numpy_ufunc_to_fortran[type_name]
         except KeyError:
-            errors.report(PYCCEL_RESTRICTION_TODO, severity='fatal')
+            self._print_not_supported(expr)
         args = [self._print(NumpyFloat(a) if a.dtype is NativeInteger() else a)\
 				for a in expr.args]
         code_args = ', '.join(args)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1236,12 +1236,6 @@ class FCodePrinter(CodePrinter):
         if isinstance(rhs, NumpyEmpty):
             return ''
 
-        if isinstance(rhs, NumpyMod):
-            lhs = self._print(expr.lhs)
-            args = ','.join(self._print(i) for i in rhs.args)
-            rhs  = 'modulo({})'.format(args)
-            return '{0} = {1}\n'.format(lhs, rhs)
-
         if isinstance(rhs, ConstructorCall):
             func = rhs.func
             name = str(func.name)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -35,6 +35,7 @@ from pyccel.ast.variable  import (Variable, TupleVariable,
                              DottedName, PyccelArraySize)
 
 from pyccel.ast.operators      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus, PyccelNot
+from pyccel.ast.operators      import PyccelMod
 
 from pyccel.ast.operators      import PyccelUnarySub, PyccelLt, PyccelGt, IfTernaryOperator
 
@@ -759,6 +760,9 @@ class FCodePrinter(CodePrinter):
                            shape  = self._print(shape))
 
         return code
+
+    def _print_NumpyMod(self, expr):
+        return self._print(PyccelMod(*expr.args))
 
     # ======================================================================= #
     def _print_PyccelArraySize(self, expr):

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4200,8 +4200,10 @@ def test_numpy_mod_array_like_1d(language):
     def get_mod(arr):
         from numpy import mod, shape
         a = mod(arr, arr)
-        s = shape(a)
-        return len(s), s[0], a[0]
+        return shape(a)[0], a[0], a[1]
+        # Tuples not implemented yet, once be implemented we can use:
+        # s = shape(a)
+        # return len(s), s[0], a[0]
 
     size = 5
 
@@ -4258,7 +4260,10 @@ def test_numpy_mod_array_like_2d(language):
         from numpy import mod, shape
         a = mod(arr, arr)
         s = shape(a)
-        return len(s), s[0], s[1], a[0,1], a[1,0]
+        return shape(a)[0], shape(a)[1], a[0,1], a[1,0]
+        # Tuples not implemented yet, once be implemented we can use:
+        # s = shape(a)
+        # return len(s), s[0], s[1], a[0,1], a[1,0]
 
     size = (2, 5)
 

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4259,7 +4259,6 @@ def test_numpy_mod_array_like_2d(language):
     def get_mod(arr):
         from numpy import mod, shape
         a = mod(arr, arr)
-        s = shape(a)
         return shape(a)[0], shape(a)[1], a[0,1], a[1,0]
         # Tuples not implemented yet, once be implemented we can use:
         # s = shape(a)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4071,13 +4071,10 @@ def test_numpy_imag_array_like_2d(language):
     assert epyccel_func(cmplx128) == get_imag(cmplx128)
 
 @pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [pytest.mark.fortran]),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Needs a C printer see https://github.com/pyccel/pyccel/issues/791"),
-            pytest.mark.c]
-        ),
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
         pytest.param("python", marks = [
-            pytest.mark.skip(reason=("mod handles types in __new__ so it "
+            pytest.mark.skip(reason=("mod has special treatment for bool so it "
                 "cannot be used in a translated interface in python")),
             pytest.mark.python]
         )
@@ -4180,12 +4177,9 @@ def test_numpy_mod_scalar(language):
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = [pytest.mark.fortran]),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Needs a C printer see https://github.com/pyccel/pyccel/issues/791"),
-            pytest.mark.c]
-        ),
+        pytest.param("c", marks = pytest.mark.c),
         pytest.param("python", marks = [
-            pytest.mark.skip(reason=("mod handles types in __new__ so it "
+            pytest.mark.skip(reason=("mod has special treatment for bool so it "
                 "cannot be used in a translated interface in python")),
             pytest.mark.python]
         )
@@ -4240,12 +4234,9 @@ def test_numpy_mod_array_like_1d(language):
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = [pytest.mark.fortran]),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Needs a C printer see https://github.com/pyccel/pyccel/issues/791"),
-            pytest.mark.c]
-        ),
+        pytest.param("c", marks = pytest.mark.c),
         pytest.param("python", marks = [
-            pytest.mark.skip(reason=("mod handles types in __new__ so it "
+            pytest.mark.skip(reason=("mod has special treatment for bool so it "
                 "cannot be used in a translated interface in python")),
             pytest.mark.python]
         )


### PR DESCRIPTION
Fixes #786 

**Commit Summary**
- Use print_not_supported to get extra information when a `NumpyUfuncBase` is not implemented
- Use `PyccelMod` to print `NumpyMod` (elementwise modulo operator)
- Remove `NumpyMod` treatment in `_print_Assign` in fortran printer which does not work for `NumpyMod` in an expression
- Activate tests (tuple usage commented for now)