### PR TITLE
Set shape to PyccelArraySize if Variable is a pointer

### DIFF
--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -49,6 +49,9 @@ class Literal(PyccelAstNode):
     def python_value(self):
         """ Get python literal represented by this instance """
 
+    def __repr__(self):
+        return "Literal({})".format(repr(self.python_value))
+
     def __str__(self):
         return str(self.python_value)
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -88,8 +88,10 @@ def broadcast(shape_1, shape_2):
                 and not (sy_e1 - sy_e2).is_constant():
             new_shape.append(e1)
         else:
+            shape1_code = '({})'.format(' '.join([str(s)+',' for s in shape_1]))
+            shape2_code = '({})'.format(' '.join([str(s)+',' for s in shape_2]))
             msg = 'operands could not be broadcast together with shapes {} {}'
-            msg = msg.format(shape_1, shape_2)
+            msg = msg.format(shape1_code, shape2_code)
             raise PyccelSemanticError(msg)
     return tuple(new_shape)
 

--- a/tests/epyccel/modules/pointers.py
+++ b/tests/epyccel/modules/pointers.py
@@ -3,7 +3,8 @@ __all__ = [
         'slice_is_pointer_idx_0',
         'array_copy_is_pointer',
         'pointer_to_pointer_is_pointer',
-        'reassigned_pointer'
+        'reassigned_pointer',
+        'reassigned_pointer_shape'
         ]
 
 def slice_is_pointer_idx_0():
@@ -36,3 +37,12 @@ def reassigned_pointer():
     c[1] = 0
     c = a
     return c[0], c[1], c[2], shape(c)[0]
+
+def reassigned_pointer_shape():
+    from numpy import array, shape
+    a = array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    b = array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    c = a
+    c = a[1:]
+    d = c*b
+    return shape(d)[0], d[0], d[5]


### PR DESCRIPTION
Set shape to PyccelArraySize if Variable is a pointer as it can point to objects of different shapes during its lifetime. Fixes #847

**Commit Summary**
- Add `__repr__` printer for Literal
- Don't print tuple for error message (calls `__repr__`)
- Reorder argument collection in `Variable` so `is_pointer` is known before calculating shape
- Set shape to PyccelArraySize if Variable is a pointer as it can point to objects of different shapes during its lifetime (fixes #847)
- Add test