### PR TITLE
Remove useless statements and raise a warning

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -53,6 +53,7 @@ __all__ = (
     'CommentBlock',
     'ConstructorCall',
     'Continue',
+    'Deallocate',
     'Declare',
     'Del',
     'Dlist',

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1324,7 +1324,7 @@ class SemanticParser(BasicParser):
         if len(visited_body) != len(useful_body):
             removed = [v for v in visited_body if v not in useful_body]
             for r in removed:
-                errors.report("Expression with no effect has been removed {}".format(type(r)),
+                errors.report("Expression with no effect has been removed",
                         symbol=r, severity='warning')
         ls = [line for l in useful_body for line in (l.body if isinstance(l, CodeBlock) else [l])]
         return CodeBlock(ls)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -87,13 +87,13 @@ from pyccel.ast.numpyext import NumpyFloat, NumpyFloat32, NumpyFloat64
 from pyccel.ast.numpyext import NumpyComplex, NumpyComplex64, NumpyComplex128
 from pyccel.ast.numpyext import NumpyArrayClass, NumpyNewArray
 
-from pyccel.ast.internals import Slice, PyccelSymbol
+from pyccel.ast.internals import Slice, PyccelSymbol, PyccelInternalFunction
 
 from pyccel.ast.sympy_helper import sympy_to_pyccel, pyccel_to_sympy
 
 from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Construct,
                             OMP_TaskLoop_Construct, OMP_Sections_Construct, Omp_End_Clause,
-                            OMP_Single_Construct)
+                            OMP_Single_Construct, OmpAnnotatedComment)
 
 from pyccel.errors.errors import Errors
 from pyccel.errors.errors import PyccelSemanticError

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -67,7 +67,7 @@ from pyccel.ast.literals import LiteralInteger, LiteralFloat
 from pyccel.ast.literals import Nil
 
 from pyccel.ast.headers import FunctionHeader, ClassHeader, MethodHeader
-from pyccel.ast.headers import MacroFunction, MacroVariable
+from pyccel.ast.headers import MacroFunction, MacroVariable, Header
 
 from pyccel.ast.utilities import builtin_function as pyccel_builtin_function
 from pyccel.ast.utilities import builtin_import as pyccel_builtin_import
@@ -1314,10 +1314,11 @@ class SemanticParser(BasicParser):
 
     def _visit_CodeBlock(self, expr, **settings):
         expr_types = (CodeBlock, Assign, AliasAssign, SymbolicAssign,
-                      FunctionCall , For,
+                      FunctionCall , For, PyccelInternalFunction,
                       While, If, Return, Comment, Pass, Continue,
                       Break, Allocate, Deallocate, CommentBlock,
-                      AnnotatedComment, Del, With, EmptyNode)
+                      AnnotatedComment, OmpAnnotatedComment, Del,
+                      With, EmptyNode, Header)
         visited_body = [self._visit(i, **settings) for i in expr.body]
         useful_body  = [l for l in visited_body if isinstance(l, expr_types)]
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -87,7 +87,7 @@ from pyccel.ast.numpyext import NumpyFloat, NumpyFloat32, NumpyFloat64
 from pyccel.ast.numpyext import NumpyComplex, NumpyComplex64, NumpyComplex128
 from pyccel.ast.numpyext import NumpyArrayClass, NumpyNewArray
 
-from pyccel.ast.internals import Slice, PyccelSymbol, PyccelInternalFunction
+from pyccel.ast.internals import Slice, PyccelSymbol
 
 from pyccel.ast.sympy_helper import sympy_to_pyccel, pyccel_to_sympy
 
@@ -1314,11 +1314,11 @@ class SemanticParser(BasicParser):
 
     def _visit_CodeBlock(self, expr, **settings):
         expr_types = (CodeBlock, Assign, AliasAssign, SymbolicAssign,
-                      FunctionCall , For, PyccelInternalFunction,
+                      FunctionCall , For, Lambda,
                       While, If, Return, Comment, Pass, Continue,
                       Break, Allocate, Deallocate, CommentBlock,
                       AnnotatedComment, OmpAnnotatedComment, Del,
-                      With, EmptyNode, Header)
+                      With, EmptyNode, Header, PythonPrint)
         visited_body = [self._visit(i, **settings) for i in expr.body]
         useful_body  = [l for l in visited_body if isinstance(l, expr_types)]
 

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4108,9 +4108,7 @@ def test_numpy_mod_scalar(language):
     assert matching_types(f_bl_true_output, test_bool_true_output)
 
     def test_int(min_int, max_int, dtype):
-        integer = randint(min_int, max_int, dtype=dtype)
-        if 0 == integer:
-            integer += 1
+        integer = randint(min_int, max_int, dtype=dtype) or 1
 
         f_integer_output = epyccel_func(integer)
         test_int_output  = get_mod(integer)
@@ -4188,8 +4186,7 @@ def test_numpy_mod_array_like_1d(language):
 
     def test_int(min_int, max_int, dtype):
         integer = randint(min_int, max_int-1, size=size, dtype=dtype)
-        if 0 in integer:
-            integer += 1
+        integer = np.where(integer==0, integer, 1)
         assert epyccel_func(integer) == get_mod(integer)
 
     test_int(min_int8 , max_int8 , np.int8)
@@ -4248,8 +4245,7 @@ def test_numpy_mod_array_like_2d(language):
 
     def test_int(min_int, max_int, dtype):
         integer = randint(min_int, max_int-1, size=size, dtype=dtype)
-        if 0 in integer:
-            integer += 1
+        integer = np.where(integer==0, integer, 1)
         assert epyccel_func(integer) == get_mod(integer)
 
     test_int(min_int8 , max_int8 , np.int8)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4202,29 +4202,30 @@ def test_numpy_mod_array_like_1d(language):
 
     size = 5
 
-    bl = np.full(size, True, dtype= bool)
+    epyccel_func = epyccel(get_mod, language=language)
 
-    integer8 = randint(min_int8, max_int8, size=size, dtype=np.int8)
-    integer16 = randint(min_int16, max_int16, size=size, dtype=np.int16)
-    integer = randint(min_int, max_int, size=size, dtype=int)
-    integer32 = randint(min_int32, max_int32, size=size, dtype=np.int32)
-    integer64 = randint(min_int64, max_int64, size=size, dtype=np.int64)
+    bl = np.full(size, True, dtype= bool)
+    assert epyccel_func(bl) == get_mod(bl)
+
+    def test_int(min_int, max_int, dtype):
+        integer = randint(min_int, max_int-1, size=size, dtype=dtype)
+        if 0 in integer:
+            integer += 1
+        assert epyccel_func(integer) == get_mod(integer)
+
+    test_int(min_int8 , max_int8 , np.int8)
+    test_int(min_int16, max_int16, np.int16)
+    test_int(min_int  , max_int  , int)
+    test_int(min_int32, max_int32, np.int32)
+    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
+    if sys.platform != 'win32':
+        test_int(min_int64, max_int64, np.int64)
 
     fl = uniform(min_float / 2, max_float / 2, size = size)
     fl32 = uniform(min_float32 / 2, max_float32 / 2, size = size)
     fl32 = np.float32(fl32)
     fl64 = uniform(min_float64 / 2, max_float64 / 2, size = size)
 
-    epyccel_func = epyccel(get_mod, language=language)
-
-    assert epyccel_func(bl) == get_mod(bl)
-    assert epyccel_func(integer8) == get_mod(integer8)
-    assert epyccel_func(integer16) == get_mod(integer16)
-    assert epyccel_func(integer) == get_mod(integer)
-    assert epyccel_func(integer32) == get_mod(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_mod(integer64)
     assert epyccel_func(fl) == get_mod(fl)
     assert epyccel_func(fl32) == get_mod(fl32)
     assert epyccel_func(fl64) == get_mod(fl64)
@@ -4261,29 +4262,30 @@ def test_numpy_mod_array_like_2d(language):
 
     size = (2, 5)
 
-    bl = np.full(size, True, dtype= bool)
+    epyccel_func = epyccel(get_mod, language=language)
 
-    integer8 = randint(min_int8, max_int8, size=size, dtype=np.int8)
-    integer16 = randint(min_int16, max_int16, size=size, dtype=np.int16)
-    integer = randint(min_int, max_int, size=size, dtype=int)
-    integer32 = randint(min_int32, max_int32, size=size, dtype=np.int32)
-    integer64 = randint(min_int64, max_int64, size=size, dtype=np.int64)
+    bl = np.full(size, True, dtype= bool)
+    assert epyccel_func(bl) == get_mod(bl)
+
+    def test_int(min_int, max_int, dtype):
+        integer = randint(min_int, max_int-1, size=size, dtype=dtype)
+        if 0 in integer:
+            integer += 1
+        assert epyccel_func(integer) == get_mod(integer)
+
+    test_int(min_int8 , max_int8 , np.int8)
+    test_int(min_int16, max_int16, np.int16)
+    test_int(min_int  , max_int  , int)
+    test_int(min_int32, max_int32, np.int32)
+    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
+    if sys.platform != 'win32':
+        test_int(min_int64, max_int64, np.int64)
 
     fl = uniform(min_float / 2, max_float / 2, size = size)
     fl32 = uniform(min_float32 / 2, max_float32 / 2, size = size)
     fl32 = np.float32(fl32)
     fl64 = uniform(min_float64 / 2, max_float64 / 2, size = size)
 
-    epyccel_func = epyccel(get_mod, language=language)
-
-    assert epyccel_func(bl) == get_mod(bl)
-    assert epyccel_func(integer8) == get_mod(integer8)
-    assert epyccel_func(integer16) == get_mod(integer16)
-    assert epyccel_func(integer) == get_mod(integer)
-    assert epyccel_func(integer32) == get_mod(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_mod(integer64)
     assert epyccel_func(fl) == get_mod(fl)
     assert epyccel_func(fl32) == get_mod(fl32)
     assert epyccel_func(fl64) == get_mod(fl64)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4186,7 +4186,7 @@ def test_numpy_mod_array_like_1d(language):
 
     def test_int(min_int, max_int, dtype):
         integer = randint(min_int, max_int-1, size=size, dtype=dtype)
-        integer = np.where(integer==0, integer, 1)
+        integer = np.where(integer==0, 1, integer)
         assert epyccel_func(integer) == get_mod(integer)
 
     test_int(min_int8 , max_int8 , np.int8)
@@ -4245,7 +4245,7 @@ def test_numpy_mod_array_like_2d(language):
 
     def test_int(min_int, max_int, dtype):
         integer = randint(min_int, max_int-1, size=size, dtype=dtype)
-        integer = np.where(integer==0, integer, 1)
+        integer = np.where(integer==0, 1, integer)
         assert epyccel_func(integer) == get_mod(integer)
 
     test_int(min_int8 , max_int8 , np.int8)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4109,7 +4109,7 @@ def test_numpy_mod_scalar(language):
 
     def test_int(min_int, max_int, dtype):
         integer = randint(min_int, max_int, dtype=dtype)
-        if 0 in integer:
+        if 0 == integer:
             integer += 1
 
         f_integer_output = epyccel_func(integer)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4108,7 +4108,7 @@ def test_numpy_mod_scalar(language):
     assert matching_types(f_bl_true_output, test_bool_true_output)
 
     def test_int(min_int, max_int, dtype):
-        integer = randint(min_int, max_int-1, size=size, dtype=dtype)
+        integer = randint(min_int, max_int, dtype=dtype)
         if 0 in integer:
             integer += 1
 

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -4099,58 +4099,37 @@ def test_numpy_mod_scalar(language):
         b = mod(a, a)
         return b
 
-    integer8 = randint(min_int8, max_int8, dtype=np.int8)
-    integer16 = randint(min_int16, max_int16, dtype=np.int16)
-    integer = randint(min_int, max_int, dtype=int)
-    integer32 = randint(min_int32, max_int32, dtype=np.int32)
-    integer64 = randint(min_int64, max_int64, dtype=np.int64)
-
-    fl = uniform(min_float / 2, max_float / 2)
-    fl32 = uniform(min_float32 / 2, max_float32 / 2)
-    fl32 = np.float32(fl32)
-    fl64 = uniform(min_float64 / 2, max_float64 / 2)
-
-
     epyccel_func = epyccel(get_mod, language=language)
 
     f_bl_true_output = epyccel_func(True)
     test_bool_true_output = get_mod(True)
 
     assert f_bl_true_output == test_bool_true_output
-
     assert matching_types(f_bl_true_output, test_bool_true_output)
 
-    f_integer_output = epyccel_func(integer)
-    test_int_output  = get_mod(integer)
+    def test_int(min_int, max_int, dtype):
+        integer = randint(min_int, max_int-1, size=size, dtype=dtype)
+        if 0 in integer:
+            integer += 1
 
-    assert f_integer_output == test_int_output
-    assert matching_types(f_integer_output, test_int_output)
+        f_integer_output = epyccel_func(integer)
+        test_int_output  = get_mod(integer)
 
-    f_integer8_output = epyccel_func(integer8)
-    test_int8_output = get_mod(integer8)
+        assert f_integer_output == test_int_output
+        assert matching_types(f_integer_output, test_int_output)
 
-    assert f_integer8_output == test_int8_output
-    assert matching_types(f_integer8_output, test_int8_output)
-
-    f_integer16_output = epyccel_func(integer16)
-    test_int16_output = get_mod(integer16)
-
-    assert f_integer16_output == test_int16_output
-    assert matching_types(f_integer16_output, test_int16_output)
-
-    f_integer32_output = epyccel_func(integer32)
-    test_int32_output = get_mod(integer32)
-
-    assert f_integer32_output == test_int32_output
-    assert matching_types(f_integer32_output, test_int32_output)
-
+    test_int(min_int8 , max_int8 , np.int8)
+    test_int(min_int16, max_int16, np.int16)
+    test_int(min_int  , max_int  , int)
+    test_int(min_int32, max_int32, np.int32)
     # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
     if sys.platform != 'win32':
-        f_integer64_output = epyccel_func(integer64)
-        test_int64_output = get_mod(integer64)
+        test_int(min_int64, max_int64, np.int64)
 
-        assert f_integer64_output == test_int64_output
-        assert matching_types(f_integer64_output, test_int64_output)
+    fl = uniform(min_float / 2, max_float / 2)
+    fl32 = uniform(min_float32 / 2, max_float32 / 2)
+    fl32 = np.float32(fl32)
+    fl64 = uniform(min_float64 / 2, max_float64 / 2)
 
     f_fl_output = epyccel_func(fl)
     test_float_output = get_mod(fl)

--- a/tests/warnings/semantic/USELESS_EXPRESSION.py
+++ b/tests/warnings/semantic/USELESS_EXPRESSION.py
@@ -1,0 +1,3 @@
+@types('int', 'int')
+def sum_two_numbers(x, y):
+    x + y

--- a/tests/warnings/semantic/USELESS_EXPRESSION.py
+++ b/tests/warnings/semantic/USELESS_EXPRESSION.py
@@ -1,3 +1,3 @@
-@types('int', 'int')
-def sum_two_numbers(x, y):
+# pylint: disable=missing-function-docstring, missing-module-docstring, pointless-statement
+def sum_two_numbers(x : 'int', y : 'int'):
     x + y


### PR DESCRIPTION
Remove any statements which have no effect (e.g. standalone arithmetic) and raise a warning to warn the user. Fixes #425

Ensure modulo tests do not test 0 (causes floating point exception)