### PR TITLE
Reorder OpenMP installation in Ubuntu

### DIFF
--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -17,12 +17,12 @@ runs:
       shell: bash
     - name: Install MPI
       run: |
-        sudo apt install libomp5 libopenmpi-dev openmpi-bin
+        sudo apt install libopenmpi-dev openmpi-bin
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash
     - name: Install OpenMP
       run:
-        sudo apt install libomp-dev
+        sudo apt install libomp-dev libomp5
       shell: bash
     - name: Install Valgrind
       run:

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -5,26 +5,26 @@ runs:
   steps:
     - name: update the package list
       run:
-        sudo apt-get update
+        sudo apt update
       shell: bash
     - name: Install fortran
       run:
-        sudo apt-get install gfortran
+        sudo apt install gfortran
       shell: bash
     - name: Install LaPack
       run:
-        sudo apt-get install libblas-dev liblapack-dev
+        sudo apt install libblas-dev liblapack-dev
       shell: bash
     - name: Install MPI
       run: |
-        sudo apt-get install libomp5 libopenmpi-dev openmpi-bin
+        sudo apt install libomp5 libopenmpi-dev openmpi-bin
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash
     - name: Install OpenMP
       run:
-        sudo apt-get install libomp-dev
+        sudo apt install libomp-dev
       shell: bash
     - name: Install Valgrind
       run:
-        sudo apt-get install valgrind
+        sudo apt install valgrind
       shell: bash

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -5,26 +5,26 @@ runs:
   steps:
     - name: update the package list
       run:
-        sudo apt update
+        sudo apt-get update
       shell: bash
     - name: Install fortran
       run:
-        sudo apt install gfortran
+        sudo apt-get install gfortran
       shell: bash
     - name: Install LaPack
       run:
-        sudo apt install libblas-dev liblapack-dev
+        sudo apt-get install libblas-dev liblapack-dev
       shell: bash
     - name: Install MPI
       run: |
-        sudo apt install libopenmpi-dev openmpi-bin
+        sudo apt-get install libopenmpi-dev openmpi-bin
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash
     - name: Install OpenMP
       run:
-        sudo apt install libomp-dev libomp5
+        sudo apt-get install libomp-dev libomp5
       shell: bash
     - name: Install Valgrind
       run:
-        sudo apt install valgrind
+        sudo apt-get install valgrind
       shell: bash

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -39,91 +39,91 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: cobertura.xml
 
-          #Windows:
+  Windows:
 
-          #  runs-on: windows-latest
+    runs-on: windows-latest
 
-          #  steps:
-          #    - uses: actions/checkout@v2
-          #    - name: Setup Python 3.7
-          #      uses: actions/setup-python@v2
-          #      with:
-          #          # The second most recent version is used as
-          #          # setup-python installs the most recent patch
-          #          # which leads to linking problems as there are
-          #          # 2 versions of python3X.a and the wrong one
-          #          # is chosen
-          #          python-version: 3.7
-          #    - name: Install dependencies
-          #      uses: ./.github/actions/windows_install
-          #    - name: Install python dependencies
-          #      uses: ./.github/actions/pip_installation
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v2
+        with:
+            # The second most recent version is used as
+            # setup-python installs the most recent patch
+            # which leads to linking problems as there are
+            # 2 versions of python3X.a and the wrong one
+            # is chosen
+            python-version: 3.7
+      - name: Install dependencies
+        uses: ./.github/actions/windows_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
 
-          #    # This is split into many tests as the test raising an error must be the last line in a multi-line powershell command
-          #    - name: Serial C tests run in parallel
-          #      run: |
-          #        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
-          #      working-directory: ./tests
-          #    - name: Serial C tests run in serial
-          #      run: |
-          #        pyccel-clean
-          #        python -m pytest -rx -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
-          #      working-directory: ./tests
-          #    - name: Serial fortran tests and non-tagged tests run in parallel
-          #      run: |
-          #        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and not (c or python)" --ignore=symbolic --ignore=ndarrays
-          #      working-directory: ./tests
-          #    - name: Serial fortran tests and non-tagged tests run in serial
-          #      run: |
-          #        pyccel-clean
-          #        python -m pytest -rx -m "xdist_incompatible and not parallel and not (c or python)" --ignore=symbolic --ignore=ndarrays
-          #      working-directory: ./tests
-          #    - name: Serial Python tests run in parallel
-          #      run: |
-          #        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
-          #      working-directory: ./tests
-          #    # Remove this action if uncommenting the next action
-          #    - name: Serial Python tests cleanup
-          #      run: |
-          #        pyccel-clean
-          #      working-directory: ./tests
-          #    # Uncomment this test to activate python xdist_incompatible tests (pytest tests raises exit code 5 when it finds no tests)
-          #    #- name: Serial Python tests run in serial
-          #    #- run: |
-          #    #-   pyccel-clean
-          #    #-   python -m pytest -rx -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
-          #    #- working-directory: ./tests
-          #    - name: ND-Array tests
-          #      run: |
-          #        python -m pytest ndarrays/ -rx
-          #      working-directory: ./tests
-          #    - name: ND-Array tests cleanup
-          #      run: |
-          #        pyccel-clean
-          #      working-directory: ./tests/ndarrays
-          #    - name: Parallel tests
-          #      run: |
-          #        mpiexec -n 4 python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rx
-          #        # mpiexec -n 4 python -m pytest epyccel -v -m parallel -rx
-          #      working-directory: ./tests
+      # This is split into many tests as the test raising an error must be the last line in a multi-line powershell command
+      - name: Serial C tests run in parallel
+        run: |
+          python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
+        working-directory: ./tests
+      - name: Serial C tests run in serial
+        run: |
+          pyccel-clean
+          python -m pytest -rx -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
+        working-directory: ./tests
+      - name: Serial fortran tests and non-tagged tests run in parallel
+        run: |
+          python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and not (c or python)" --ignore=symbolic --ignore=ndarrays
+        working-directory: ./tests
+      - name: Serial fortran tests and non-tagged tests run in serial
+        run: |
+          pyccel-clean
+          python -m pytest -rx -m "xdist_incompatible and not parallel and not (c or python)" --ignore=symbolic --ignore=ndarrays
+        working-directory: ./tests
+      - name: Serial Python tests run in parallel
+        run: |
+          python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
+        working-directory: ./tests
+      # Remove this action if uncommenting the next action
+      - name: Serial Python tests cleanup
+        run: |
+          pyccel-clean
+        working-directory: ./tests
+      # Uncomment this test to activate python xdist_incompatible tests (pytest tests raises exit code 5 when it finds no tests)
+      #- name: Serial Python tests run in serial
+      #- run: |
+      #-   pyccel-clean
+      #-   python -m pytest -rx -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
+      #- working-directory: ./tests
+      - name: ND-Array tests
+        run: |
+          python -m pytest ndarrays/ -rx
+        working-directory: ./tests
+      - name: ND-Array tests cleanup
+        run: |
+          pyccel-clean
+        working-directory: ./tests/ndarrays
+      - name: Parallel tests
+        run: |
+          mpiexec -n 4 python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rx
+          # mpiexec -n 4 python -m pytest epyccel -v -m parallel -rx
+        working-directory: ./tests
 
-          #MacOSX:
+  MacOSX:
 
-          #  runs-on: macos-latest
+    runs-on: macos-latest
 
-          #  steps:
-          #    - uses: actions/checkout@v2
-          #    - name: Set up Python 3.9
-          #      uses: actions/setup-python@v2
-          #      with:
-          #        python-version: 3.9
-          #    - name: Install dependencies
-          #      uses: ./.github/actions/macos_install
-          #    - name: Install python dependencies
-          #      uses: ./.github/actions/pip_installation
-          #    - name: Fortran/C tests with pytest
-          #      uses: ./.github/actions/pytest_run
-          #    - name: Python tests with pytest
-          #      uses: ./.github/actions/pytest_run_python
-          #    - name: Parallel tests with pytest
-          #      uses: ./.github/actions/pytest_parallel
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        uses: ./.github/actions/macos_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -39,91 +39,91 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: cobertura.xml
 
-  Windows:
+          #Windows:
 
-    runs-on: windows-latest
+          #  runs-on: windows-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.7
-        uses: actions/setup-python@v2
-        with:
-            # The second most recent version is used as
-            # setup-python installs the most recent patch
-            # which leads to linking problems as there are
-            # 2 versions of python3X.a and the wrong one
-            # is chosen
-            python-version: 3.7
-      - name: Install dependencies
-        uses: ./.github/actions/windows_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
+          #  steps:
+          #    - uses: actions/checkout@v2
+          #    - name: Setup Python 3.7
+          #      uses: actions/setup-python@v2
+          #      with:
+          #          # The second most recent version is used as
+          #          # setup-python installs the most recent patch
+          #          # which leads to linking problems as there are
+          #          # 2 versions of python3X.a and the wrong one
+          #          # is chosen
+          #          python-version: 3.7
+          #    - name: Install dependencies
+          #      uses: ./.github/actions/windows_install
+          #    - name: Install python dependencies
+          #      uses: ./.github/actions/pip_installation
 
-      # This is split into many tests as the test raising an error must be the last line in a multi-line powershell command
-      - name: Serial C tests run in parallel
-        run: |
-          python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
-        working-directory: ./tests
-      - name: Serial C tests run in serial
-        run: |
-          pyccel-clean
-          python -m pytest -rx -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
-        working-directory: ./tests
-      - name: Serial fortran tests and non-tagged tests run in parallel
-        run: |
-          python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and not (c or python)" --ignore=symbolic --ignore=ndarrays
-        working-directory: ./tests
-      - name: Serial fortran tests and non-tagged tests run in serial
-        run: |
-          pyccel-clean
-          python -m pytest -rx -m "xdist_incompatible and not parallel and not (c or python)" --ignore=symbolic --ignore=ndarrays
-        working-directory: ./tests
-      - name: Serial Python tests run in parallel
-        run: |
-          python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
-        working-directory: ./tests
-      # Remove this action if uncommenting the next action
-      - name: Serial Python tests cleanup
-        run: |
-          pyccel-clean
-        working-directory: ./tests
-      # Uncomment this test to activate python xdist_incompatible tests (pytest tests raises exit code 5 when it finds no tests)
-      #- name: Serial Python tests run in serial
-      #- run: |
-      #-   pyccel-clean
-      #-   python -m pytest -rx -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
-      #- working-directory: ./tests
-      - name: ND-Array tests
-        run: |
-          python -m pytest ndarrays/ -rx
-        working-directory: ./tests
-      - name: ND-Array tests cleanup
-        run: |
-          pyccel-clean
-        working-directory: ./tests/ndarrays
-      - name: Parallel tests
-        run: |
-          mpiexec -n 4 python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rx
-          # mpiexec -n 4 python -m pytest epyccel -v -m parallel -rx
-        working-directory: ./tests
+          #    # This is split into many tests as the test raising an error must be the last line in a multi-line powershell command
+          #    - name: Serial C tests run in parallel
+          #      run: |
+          #        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
+          #      working-directory: ./tests
+          #    - name: Serial C tests run in serial
+          #      run: |
+          #        pyccel-clean
+          #        python -m pytest -rx -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
+          #      working-directory: ./tests
+          #    - name: Serial fortran tests and non-tagged tests run in parallel
+          #      run: |
+          #        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and not (c or python)" --ignore=symbolic --ignore=ndarrays
+          #      working-directory: ./tests
+          #    - name: Serial fortran tests and non-tagged tests run in serial
+          #      run: |
+          #        pyccel-clean
+          #        python -m pytest -rx -m "xdist_incompatible and not parallel and not (c or python)" --ignore=symbolic --ignore=ndarrays
+          #      working-directory: ./tests
+          #    - name: Serial Python tests run in parallel
+          #      run: |
+          #        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
+          #      working-directory: ./tests
+          #    # Remove this action if uncommenting the next action
+          #    - name: Serial Python tests cleanup
+          #      run: |
+          #        pyccel-clean
+          #      working-directory: ./tests
+          #    # Uncomment this test to activate python xdist_incompatible tests (pytest tests raises exit code 5 when it finds no tests)
+          #    #- name: Serial Python tests run in serial
+          #    #- run: |
+          #    #-   pyccel-clean
+          #    #-   python -m pytest -rx -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
+          #    #- working-directory: ./tests
+          #    - name: ND-Array tests
+          #      run: |
+          #        python -m pytest ndarrays/ -rx
+          #      working-directory: ./tests
+          #    - name: ND-Array tests cleanup
+          #      run: |
+          #        pyccel-clean
+          #      working-directory: ./tests/ndarrays
+          #    - name: Parallel tests
+          #      run: |
+          #        mpiexec -n 4 python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rx
+          #        # mpiexec -n 4 python -m pytest epyccel -v -m parallel -rx
+          #      working-directory: ./tests
 
-  MacOSX:
+          #MacOSX:
 
-    runs-on: macos-latest
+          #  runs-on: macos-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        uses: ./.github/actions/macos_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+          #  steps:
+          #    - uses: actions/checkout@v2
+          #    - name: Set up Python 3.9
+          #      uses: actions/setup-python@v2
+          #      with:
+          #        python-version: 3.9
+          #    - name: Install dependencies
+          #      uses: ./.github/actions/macos_install
+          #    - name: Install python dependencies
+          #      uses: ./.github/actions/pip_installation
+          #    - name: Fortran/C tests with pytest
+          #      uses: ./.github/actions/pytest_run
+          #    - name: Python tests with pytest
+          #      uses: ./.github/actions/pytest_run_python
+          #    - name: Parallel tests with pytest
+          #      uses: ./.github/actions/pytest_parallel


### PR DESCRIPTION
Place installation of `libomp5` with the other OpenMP commands. Placing this installation after the installation of `libomp-dev` fixes a bug in our continuous integration.