### PR TITLE
Improve indenting of Fortran code

### DIFF
--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -165,6 +165,18 @@ python_builtin_datatypes = {
     'complex' : PythonComplex
 }
 
+inc_keyword = (r'do\b', r'if\b',
+               r'else\b', r'type\b',
+               r'(recursive )?(pure )?(elemental )?subroutine\b',
+               r'(recursive )?(pure )?(elemental )?function\b',
+               r'interface\b',r'module\b')
+inc_regex = re.compile('^\\s*({})'.format('|'.join('({})'.format(i) for i in inc_keyword)))
+
+end_keyword = ('do', 'if', 'type', 'function',
+               'subroutine', 'interface','module')
+end_regex_str = 'end ?({})'.format('|'.join('({})'.format(k) for k in end_keyword))
+dec_regex = re.compile('^\\s*(({})|(else))'.format(end_regex_str))
+
 errors = Errors()
 
 class FCodePrinter(CodePrinter):
@@ -2862,20 +2874,6 @@ class FCodePrinter(CodePrinter):
             return ''.join(code_lines)
 
         code = [line.lstrip(' \t') for line in code]
-
-        inc_keyword = (r'do\b', r'if\b',
-                       r'else\b', r'type\b',
-                       r'(recursive )?(pure )?(elemental )?subroutine\b',
-                       r'(recursive )?(pure )?(elemental )?function\b',
-                       r'interface\b',r'module\b')
-        inc_regex = '^\\s*({})'.format('|'.join('({})'.format(i) for i in inc_keyword))
-        inc_regex = re.compile(inc_regex)
-
-        end_keyword = ('do', 'if', 'type', 'function',
-                       'subroutine', 'interface','module')
-        end_regex = 'end ?({})'.format('|'.join('({})'.format(k) for k in end_keyword))
-        dec_regex = '^\\s*(({})|(else))'.format(end_regex)
-        dec_regex = re.compile(dec_regex)
 
         increase = [int(inc_regex.match(line) is not None)
                      for line in code]

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -170,12 +170,12 @@ inc_keyword = (r'do\b', r'if\b',
                r'(recursive )?(pure )?(elemental )?subroutine\b',
                r'(recursive )?(pure )?(elemental )?function\b',
                r'interface\b',r'module\b')
-inc_regex = re.compile('^\\s*({})'.format('|'.join('({})'.format(i) for i in inc_keyword)))
+inc_regex = re.compile('\\s*({})'.format('|'.join('({})'.format(i) for i in inc_keyword)))
 
 end_keyword = ('do', 'if', 'type', 'function',
                'subroutine', 'interface','module')
 end_regex_str = 'end ?({})'.format('|'.join('({})'.format(k) for k in end_keyword))
-dec_regex = re.compile('^\\s*(({})|(else))'.format(end_regex_str))
+dec_regex = re.compile('\\s*(({})|(else))'.format(end_regex_str))
 
 errors = Errors()
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -167,13 +167,13 @@ python_builtin_datatypes = {
 }
 
 inc_keyword = (r'do\b', r'if\b',
-               r'else\b', r'type\b',
+               r'else\b', r'type\b\s*[^\(]',
                r'(recursive )?(pure )?(elemental )?((subroutine)|(function))\b',
-               r'interface\b',r'module\b')
+               r'interface\b',r'module\b',r'program\b')
 inc_regex = re.compile('|'.join('({})'.format(i) for i in inc_keyword))
 
 end_keyword = ('do', 'if', 'type', 'function',
-               'subroutine', 'interface','module')
+               'subroutine', 'interface','module','program')
 end_regex_str = '(end ?({}))|(else)'.format('|'.join('({})'.format(k) for k in end_keyword))
 dec_regex = re.compile(end_regex_str)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -168,15 +168,14 @@ python_builtin_datatypes = {
 
 inc_keyword = (r'do\b', r'if\b',
                r'else\b', r'type\b',
-               r'(recursive )?(pure )?(elemental )?subroutine\b',
-               r'(recursive )?(pure )?(elemental )?function\b',
+               r'(recursive )?(pure )?(elemental )?((subroutine)|(function))\b',
                r'interface\b',r'module\b')
-inc_regex = re.compile('\\s*({})'.format('|'.join('({})'.format(i) for i in inc_keyword)))
+inc_regex = re.compile('|'.join('({})'.format(i) for i in inc_keyword))
 
 end_keyword = ('do', 'if', 'type', 'function',
                'subroutine', 'interface','module')
-end_regex_str = 'end ?({})'.format('|'.join('({})'.format(k) for k in end_keyword))
-dec_regex = re.compile('\\s*(({})|(else))'.format(end_regex_str))
+end_regex_str = '(end ?({}))|(else)'.format('|'.join('({})'.format(k) for k in end_keyword))
+dec_regex = re.compile(end_regex_str)
 
 errors = Errors()
 


### PR DESCRIPTION
Use regexes to avoid repetition in indenting checks. Correct indenting of elemental/recursive/pure functions (fixes #870). Indent module body too

**Commit summary**
- Use regex to recognise start and end of indentation
- Add module and program to indentation triggers
- Remove extra space after 'recursive' keyword
- Correctly indent elemental/recursive/pure functions (fixes #870)
- Only indent type if it is not followed by `(` to avoid indenting declarations