### PR TITLE
Treat extra spaces in flag options

### DIFF
--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -220,7 +220,7 @@ def execute_pyccel(fname, *,
                                  accelerator=accelerator,
                                  includes=())
     elif fflags is not None:
-        fflags = fflags.strip().split(' ')
+        fflags = [f for f in fflags.strip().split(' ') if f]
     else:
         fflags = [] # Used for python
 

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -220,7 +220,7 @@ def execute_pyccel(fname, *,
                                  accelerator=accelerator,
                                  includes=())
     elif fflags is not None:
-        fflags = [f for f in fflags.strip().split(' ') if f]
+        fflags = fflags.split()
     else:
         fflags = [] # Used for python
 

--- a/tests/epyccel/test_return.py
+++ b/tests/epyccel/test_return.py
@@ -15,7 +15,7 @@ def test_assign_vars_return(language):
         c = a+b
         d = a-b
         return c+d
-    epyc_assign_vars_return = epyccel(assign_vars_return, language=language, fflags="-Werror -Wunused-variable")
+    epyc_assign_vars_return = epyccel(assign_vars_return, language=language, fflags="-Werror  -Wunused-variable")
     assert (epyc_assign_vars_return(3, 4) == assign_vars_return(3, 4))
 
 


### PR DESCRIPTION
Handle extra spaces in the `fflags` argument passed to `execute_pyccel`. Fixes #881. Add an unnecessary space to a function using `fflags` to act as a test.