### PR TITLE
Remove obsolete functions `build_types_decorator` and `_construct_header`

### DIFF
--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -35,7 +35,6 @@ from .variable      import (Constant, Variable, ValuedVariable,
 errors = Errors()
 
 __all__ = (
-    'build_types_decorator',
     'builtin_function',
     'builtin_import',
     'builtin_import_registery',
@@ -140,32 +139,6 @@ def get_function_from_ast(ast, func_name):
         print('> could not find {}'.format(func_name))
 
     return node
-
-#==============================================================================
-# TODO: must add a Node Decorator in core
-def build_types_decorator(args, order=None):
-    """
-    builds a types decorator from a list of arguments (of FunctionDef)
-    """
-    types = []
-    for a in args:
-        if isinstance(a, Variable):
-            dtype = a.dtype.name.lower()
-
-        else:
-            raise TypeError('unepected type for {}'.format(a))
-
-        if a.rank > 0:
-            shape = [':' for i in range(0, a.rank)]
-            shape = ','.join(i for i in shape)
-            dtype = '{dtype}[{shape}]'.format(dtype=dtype, shape=shape)
-            if order and a.rank > 1:
-                dtype = "{dtype}(order={ordering})".format(dtype=dtype, ordering=order)
-
-        dtype = LiteralString(dtype)
-        types.append(dtype)
-
-    return types
 
 #==============================================================================
 def split_positional_keyword_arguments(*args):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -22,13 +22,6 @@ from pyccel.errors.messages import PYCCEL_RESTRICTION_TODO
 errors = Errors()
 
 #==============================================================================
-def _construct_header(func_name, args):
-    args = build_types_decorator(args, order='F')
-    args = ','.join("{}".format(i) for i in args)
-    pattern = '#$ header function static {name}({args})'
-    return pattern.format(name=func_name, args=args)
-
-#==============================================================================
 
 # Dictionary mapping imported targets to their aliases used internally by pyccel
 # This prevents a mismatch between printed imports and function calls

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -8,7 +8,6 @@
 
 from pyccel.decorators import __all__ as pyccel_decorators
 
-from pyccel.ast.utilities  import build_types_decorator
 from pyccel.ast.core       import CodeBlock, Import, Assign, FunctionCall, For
 from pyccel.ast.datatypes  import default_precision
 from pyccel.ast.literals   import LiteralTrue, LiteralString


### PR DESCRIPTION
Fixes #888. The following functions are not used in Pyccel and hence they are removed from the library:

-  `build_types_decorator` from `pyccel.ast.utilities`;
- `_construct_header` from `pyccel.codegen.printing.pycode`.