### PR TITLE
Add Matmul operator

### DIFF
--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -474,11 +474,14 @@ class NumpyMatmul(PyccelInternalFunction):
     __slots__ = ('_dtype','_precision','_shape','_rank','_order')
 
     def __init__(self, a ,b):
+        super().__init__(a, b)
+        if PyccelAstNode.stage == 'syntactic':
+            return
+
         if not isinstance(a, PyccelAstNode):
             raise TypeError('Unknown type of  %s.' % type(a))
         if not isinstance(b, PyccelAstNode):
             raise TypeError('Unknown type of  %s.' % type(a))
-        super().__init__(a, b)
 
         args      = (a, b)
         integers  = [e for e in args if e.dtype is NativeInteger()]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3307,6 +3307,7 @@ class SemanticParser(BasicParser):
         return StarredArguments([var[i] for i in range(size)])
 
     def _visit_NumpyMatmul(self, expr, **settings):
+        self.insert_import('numpy', 'matmul')
         a = self._visit(expr.a)
         b = self._visit(expr.b)
         return NumpyMatmul(a, b)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -81,7 +81,7 @@ from pyccel.ast.builtins import python_builtin_datatype
 from pyccel.ast.builtins import (PythonRange, PythonZip, PythonEnumerate,
                                  PythonMap, PythonTuple, Lambda)
 
-from pyccel.ast.numpyext import NumpyZeros
+from pyccel.ast.numpyext import NumpyZeros, NumpyMatmul
 from pyccel.ast.numpyext import NumpyBool
 from pyccel.ast.numpyext import NumpyInt, NumpyInt8, NumpyInt16, NumpyInt32, NumpyInt64
 from pyccel.ast.numpyext import NumpyFloat, NumpyFloat32, NumpyFloat64
@@ -3305,6 +3305,11 @@ class SemanticParser(BasicParser):
         assert(var.rank==1)
         size = var.shape[0]
         return StarredArguments([var[i] for i in range(size)])
+
+    def _visit_NumpyMatmul(self, expr, **settings):
+        a = self._visit(expr.a)
+        b = self._visit(expr.b)
+        return NumpyMatmul(a, b)
 
 #==============================================================================
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -52,6 +52,7 @@ from pyccel.ast.operators import PyccelAnd, PyccelOr,  PyccelNot, PyccelMinus
 from pyccel.ast.operators import PyccelUnary, PyccelUnarySub
 from pyccel.ast.operators import PyccelIs, PyccelIsNot
 from pyccel.ast.operators import IfTernaryOperator
+from pyccel.ast.numpyext  import NumpyMatmul
 
 from pyccel.ast.builtins import PythonTuple, PythonList
 from pyccel.ast.builtins import PythonPrint, Lambda
@@ -533,6 +534,9 @@ class SyntaxParser(BasicParser):
 
         elif isinstance(stmt.op, ast.BitAnd):
             return PyccelBitAnd(first, second)
+
+        elif isinstance(stmt.op, ast.MatMult):
+            return NumpyMatmul(first, second)
 
         else:
             errors.report(PYCCEL_RESTRICTION_UNSUPPORTED_SYNTAX,

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -641,6 +641,10 @@ def array_real_2d_2d_matmul_mixorder(A, B, out):
     from numpy import matmul
     out[:,:] = matmul(A, B)
 
+@types('real[:,:], real[:,:], real[:,:]')
+def array_real_2d_2d_matmul_operator(A, B, out):
+    out[:,:] = A @ B
+
 @types('real[:], real[:], real[:]')
 def array_real_loopdiff(x, y, out):
     dxy = x - y

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1565,7 +1565,8 @@ def test_multiple_2d_stack_array_2(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="prod not implemented in c"),
             pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python)
     ]
 )
 def test_array_real_1d_1d_prod(language):
@@ -1583,7 +1584,8 @@ def test_array_real_1d_1d_prod(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="matmul not implemented in c"),
             pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python)
     ]
 )
 def test_array_real_2d_1d_matmul(language):
@@ -1604,7 +1606,8 @@ def test_array_real_2d_1d_matmul(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="matmul not implemented in c"),
             pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python)
     ]
 )
 def test_array_real_2d_1d_matmul_order_F_F(language):
@@ -1625,7 +1628,8 @@ def test_array_real_2d_1d_matmul_order_F_F(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="matmul not implemented in c"),
             pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python)
     ]
 )
 def test_array_real_2d_2d_matmul(language):
@@ -1646,7 +1650,8 @@ def test_array_real_2d_2d_matmul(language):
         pytest.param("c", marks = [
             pytest.mark.skip(reason="matmul not implemented in c"),
             pytest.mark.c]),
-        pytest.param("fortran", marks = pytest.mark.fortran)
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python)
     ]
 )
 def test_array_real_2d_2d_matmul_F_F_F_F(language):
@@ -1681,6 +1686,28 @@ def test_array_real_2d_2d_matmul_mixorder(language):
     A1[1, 0] = 2
     A2 = np.copy(A1)
     B1 = np.ones([2, 3], order = 'F')
+    B2 = np.copy(B1)
+    C1 = np.empty([3,3])
+    C2 = np.empty([3,3])
+    f1(A1, B1, C1)
+    f2(A2, B2, C2)
+    assert np.array_equal(C1, C2)
+
+@pytest.mark.parametrize( 'language', [
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="matmul not implemented in c"),
+            pytest.mark.c]),
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python)
+    ]
+)
+def test_array_real_2d_2d_matmul_operator(language):
+    f1 = arrays.array_real_2d_2d_matmul_operator
+    f2 = epyccel( f1 , language = language)
+    A1 = np.ones([3, 2])
+    A1[1, 0] = 2
+    A2 = np.copy(A1)
+    B1 = np.ones([2, 3])
     B2 = np.copy(B1)
     C1 = np.empty([3,3])
     C2 = np.empty([3,3])


### PR DESCRIPTION
Add the matmul operator `@` to pyccel. Fixes #839 

**Commit Summary**
- Do not calculate shape etc in syntactic stage of `NumpyMatmul`
- Add matmul operator to syntactic stage
- Add matmul operator to semantic stage
- Add matmul operator test
- Activate python matmul tests
- Add matmul to imports if matmul operator used