### PR TITLE
Add c standard specification to flags

### DIFF
--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -61,7 +61,7 @@ def construct_flags(compiler,
         if debug:
             flags.append("-fcheck=bounds")
 
-    if compiler in ["gcc", "icc"]:
+    if compiler == "icc":
         flags.append("-std=c99")
 
     if compiler == "mpif90":

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -61,6 +61,9 @@ def construct_flags(compiler,
         if debug:
             flags.append("-fcheck=bounds")
 
+    if compiler in ["gcc", "icc"]:
+        flags.append("-std=c99")
+
     if compiler == "mpif90":
         if debug:
             flags.append("-fcheck=bounds")


### PR DESCRIPTION
Add c standard specification to intel flags (without this `ndarrays.c` does not compile with `icc`)