### PR TITLE
Fix complex cast bug

### DIFF
--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -862,7 +862,8 @@ class FCodePrinter(CodePrinter):
 
     def _print_PythonComplex(self, expr):
         if expr.is_cast:
-            code = 'cmplx({0}, kind={1})'.format(expr.internal_var,
+            var = self._print(expr.internal_var)
+            code = 'cmplx({0}, kind={1})'.format(var,
                                 self.print_kind(expr))
         else:
             real = self._print(expr.real)

--- a/tests/epyccel/modules/complex_func.py
+++ b/tests/epyccel/modules/complex_func.py
@@ -38,6 +38,10 @@ def create_complex_literal__complex_complex():
     a = complex(2.8+7j,-1.5-22j)
     return a
 
+def cast_complex_literal():
+    a = complex(2.8+7j)
+    return a
+
 @types('int','int')
 def create_complex_var__int_int(a,b):
     return complex(a,b)

--- a/tests/epyccel/modules/complex_func.py
+++ b/tests/epyccel/modules/complex_func.py
@@ -86,3 +86,6 @@ def cast_complex_1(a):
 def cast_complex_2(a):
     return complex(a)
 
+def cast_float_complex(a : float, b : complex):
+    return complex(a + b * 1j)
+

--- a/tests/epyccel/test_epyccel_complex_func.py
+++ b/tests/epyccel/test_epyccel_complex_func.py
@@ -15,7 +15,8 @@ from pyccel.epyccel import epyccel
                            mod.create_complex_literal__float_complex,
                            mod.create_complex_literal__complex_int,
                            mod.create_complex_literal__complex_float,
-                           mod.create_complex_literal__complex_complex] )
+                           mod.create_complex_literal__complex_complex,
+                           mod.cast_complex_literal] )
 def test_create_complex_literal(f, language):
     f_epyc = epyccel(f, language = language)
     assert f_epyc() == f()

--- a/tests/epyccel/test_epyccel_complex_func.py
+++ b/tests/epyccel/test_epyccel_complex_func.py
@@ -102,3 +102,10 @@ def test_cast_complex_2(language):
     a = np.complex128(complex(randint(100), randint(100)))
     assert f_epyc(a) == f(a)
 
+def test_cast_float_complex(language):
+    f = mod.cast_float_complex
+    f_epyc = epyccel(f, language = language)
+
+    a = rand()*100
+    b = complex(randint(100), randint(100))
+    assert f_epyc(a,b) == f(a,b)


### PR DESCRIPTION
Ensure `_print` call is used in `_print_PythonComplex` to fix #897. Add test