### PR TITLE
Fix empty returns

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1790,6 +1790,9 @@ class Return(Basic):
         args = (self.expr, self.stmt)
         return args
 
+    def __repr__(self):
+        return "Return({})".format(','.join([repr(e) for e in self.expr]))
+
 class FunctionDef(Basic):
 
     """Represents a function definition.

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1296,6 +1296,9 @@ class CCodePrinter(CodePrinter):
         code = ''
         args = [VariableAddress(a) if self.stored_in_c_pointer(a) else a for a in expr.expr]
 
+        if len(args) == 0:
+            return 'return;\n'
+
         if len(args) > 1:
             if expr.stmt:
                 return self._print(expr.stmt)+'\n'+'return 0;\n'

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -267,7 +267,6 @@ class PythonCodePrinter(CodePrinter):
 
     def _print_PythonRange(self, expr):
         return 'range({start}, {stop}, {step})'.format(
-                name  = expr.name,
                 start = self._print(expr.start),
                 stop  = self._print(expr.stop ),
                 step  = self._print(expr.step ))

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -273,6 +273,12 @@ class PythonCodePrinter(CodePrinter):
                 stop  = self._print(expr.stop ),
                 step  = self._print(expr.step ))
 
+    def _print_PythonEnumerate(self, expr):
+        name = self._aliases.get(type(expr), expr.name)
+        return '{name}({elem})'.format(
+                name = name,
+                elem = self._print(expr.element))
+
     def _print_PythonReal(self, expr):
         return '({}).real'.format(self._print(expr.internal_var))
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -266,17 +266,14 @@ class PythonCodePrinter(CodePrinter):
             return '{}({}+{}*1j)'.format(name, self._print(expr.real), self._print(expr.imag))
 
     def _print_PythonRange(self, expr):
-        name = self._aliases.get(type(expr), expr.name)
-        return '{name}({start}, {stop}, {step})'.format(
-                name  = name,
+        return 'range({start}, {stop}, {step})'.format(
+                name  = expr.name,
                 start = self._print(expr.start),
                 stop  = self._print(expr.stop ),
                 step  = self._print(expr.step ))
 
     def _print_PythonEnumerate(self, expr):
-        name = self._aliases.get(type(expr), expr.name)
-        return '{name}({elem})'.format(
-                name = name,
+        return 'enumerate({elem})'.format(
                 elem = self._print(expr.element))
 
     def _print_PythonReal(self, expr):

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -589,11 +589,13 @@ class SyntaxParser(BasicParser):
                       severity='fatal')
 
     def _visit_Return(self, stmt):
-        results = self._visit(stmt.value)
-        if not isinstance(results, (list, PythonTuple, PythonList)):
-            results = [results]
-        expr = Return(results)
-        return expr
+        if stmt.value is None:
+            return Return([])
+        else:
+            results = self._visit(stmt.value)
+            if not isinstance(results, (list, PythonTuple, PythonList)):
+                results = [results]
+            return Return(results)
 
     def _visit_Pass(self, stmt):
         return Pass()

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -589,13 +589,12 @@ class SyntaxParser(BasicParser):
                       severity='fatal')
 
     def _visit_Return(self, stmt):
-        if stmt.value is None:
-            return Return([])
-        else:
-            results = self._visit(stmt.value)
-            if not isinstance(results, (list, PythonTuple, PythonList)):
-                results = [results]
-            return Return(results)
+        results = self._visit(stmt.value)
+        if results is Nil():
+            results = []
+        elif not isinstance(results, (list, PythonTuple, PythonList)):
+            results = [results]
+        return Return(results)
 
     def _visit_Pass(self, stmt):
         return Pass()

--- a/tests/epyccel/test_return.py
+++ b/tests/epyccel/test_return.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring, disable=unused-variable, missing-module-docstring/
+import numpy as np
 from pyccel.decorators import types
 from pyccel.epyccel import epyccel
 
@@ -134,3 +135,23 @@ def test_multi_allocs(language):
         return ((4 + 5)/(d[0] + e[2]) * c[0])%(b[2] + a[1]) - 4
     epyc_multi_allocs = epyccel(multi_allocs, language=language, fflags="-Werror -Wunused-variable")
     assert (epyc_multi_allocs(7) == multi_allocs(7))
+
+def test_return_nothing(language):
+    def divide_by(a : 'float[:]', b : 'float'):
+        if abs(b)<0.1:
+            return
+        for i,ai in enumerate(a):
+            a[i] = ai/b
+
+    epyc_divide_by = epyccel(divide_by, language=language, fflags="-Werror -Wunused-variable")
+    x = np.ones(5)
+    x_copy = x.copy()
+    b = 0.01
+    divide_by(x,b)
+    divide_by(x_copy,b)
+    assert np.allclose(x, x_copy, rtol=1e-13, atol=1e-14)
+    b = 4
+    divide_by(x,b)
+    divide_by(x_copy,b)
+    assert np.allclose(x, x_copy, rtol=1e-13, atol=1e-14)
+

--- a/tests/epyccel/test_return.py
+++ b/tests/epyccel/test_return.py
@@ -158,7 +158,7 @@ def test_return_nothing(language):
 def test_return_None(language):
     def divide_by(a : 'float[:]', b : 'float'):
         if abs(b)<0.1:
-            return None
+            return None # pylint: disable=inconsistent-return-statements
         for i,ai in enumerate(a):
             a[i] = ai/b
 

--- a/tests/epyccel/test_return.py
+++ b/tests/epyccel/test_return.py
@@ -143,7 +143,7 @@ def test_return_nothing(language):
         for i,ai in enumerate(a):
             a[i] = ai/b
 
-    epyc_divide_by = epyccel(divide_by, language=language, fflags="-Werror -Wunused-variable")
+    epyc_divide_by = epyccel(divide_by, language=language)
     x = np.ones(5)
     x_copy = x.copy()
     b = 0.01

--- a/tests/epyccel/test_return.py
+++ b/tests/epyccel/test_return.py
@@ -155,3 +155,22 @@ def test_return_nothing(language):
     divide_by(x_copy,b)
     assert np.allclose(x, x_copy, rtol=1e-13, atol=1e-14)
 
+def test_return_None(language):
+    def divide_by(a : 'float[:]', b : 'float'):
+        if abs(b)<0.1:
+            return None
+        for i,ai in enumerate(a):
+            a[i] = ai/b
+
+    epyc_divide_by = epyccel(divide_by, language=language)
+    x = np.ones(5)
+    x_copy = x.copy()
+    b = 0.01
+    divide_by(x,b)
+    divide_by(x_copy,b)
+    assert np.allclose(x, x_copy, rtol=1e-13, atol=1e-14)
+    b = 4
+    divide_by(x,b)
+    divide_by(x_copy,b)
+    assert np.allclose(x, x_copy, rtol=1e-13, atol=1e-14)
+

--- a/tests/epyccel/test_return.py
+++ b/tests/epyccel/test_return.py
@@ -156,9 +156,9 @@ def test_return_nothing(language):
     assert np.allclose(x, x_copy, rtol=1e-13, atol=1e-14)
 
 def test_return_None(language):
-    def divide_by(a : 'float[:]', b : 'float'):
+    def divide_by(a : 'float[:]', b : 'float'): # pylint: disable=inconsistent-return-statements
         if abs(b)<0.1:
-            return None # pylint: disable=inconsistent-return-statements
+            return None
         for i,ai in enumerate(a):
             a[i] = ai/b
 


### PR DESCRIPTION
**Commit Summary**
- Add `Return.__repr__`
- Add failing test
- Ensure 'return' or 'return None' is saved as 'return' (fixes #900 for fortran and python)
- Add enumerate in pycode
- Handle empty return in C (fixes #900 for C)