### PR TITLE
Add homogeneous tuples in C

### DIFF
--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -282,6 +282,10 @@ class Basic:
         self._user_nodes.append(user_nodes)
 
     def clear_user_nodes(self):
+        """ Delete all information about user nodes. This is useful
+        if the same node is used for the syntactic and semantic
+        stages, and it should only have 1 user.
+        """
         self._user_nodes = []
 
     def remove_user_node(self, user_node):

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -193,8 +193,6 @@ class Basic:
         def prepare_sub(found_node):
             idx = original.index(found_node)
             rep = replacement[idx]
-            if not self.ignore(found_node):
-                found_node.remove_user_node(self)
             if iterable(rep):
                 for r in rep:
                     if not self.ignore(r):
@@ -202,6 +200,8 @@ class Basic:
             else:
                 if not self.ignore(rep):
                     rep.set_current_user_node(self)
+            if not self.ignore(found_node):
+                found_node.remove_user_node(self)
             return rep
 
         for n in self._my_attribute_nodes:
@@ -280,6 +280,9 @@ class Basic:
         """ Inform the class about the most recent user of the node
         """
         self._user_nodes.append(user_nodes)
+
+    def clear_user_nodes(self):
+        self._user_nodes = []
 
     def remove_user_node(self, user_node):
         """ Indicate that the current node is no longer used

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -521,10 +521,16 @@ class PyccelAdd(PyccelArithmeticOperator):
         if simplify:
             if isinstance(arg2, PyccelUnarySub):
                 return PyccelMinus(arg1, arg2.args[0], simplify = True)
-            elif isinstance(arg1, Literal) and isinstance(arg2, Literal):
-                dtype, precision = cls._calculate_dtype(arg1, arg2)
+            dtype, precision = cls._calculate_dtype(arg1, arg2)
+            if isinstance(arg1, Literal) and isinstance(arg2, Literal):
                 return convert_to_literal(arg1.python_value + arg2.python_value,
                                           dtype, precision)
+            if dtype == arg2.dtype and precision == arg2.precision and \
+                    isinstance(arg1, Literal) and arg1.python_value == 0:
+                return arg2
+            if dtype == arg1.dtype and precision == arg1.precision and \
+                    isinstance(arg2, Literal) and arg2.python_value == 0:
+                return arg1
 
         if isinstance(arg1, (LiteralInteger, LiteralFloat)) and \
             isinstance(arg2, LiteralComplex) and \

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -486,7 +486,7 @@ def collect_loops(block, indices, new_index_name, tmp_vars, language_has_vectors
                 if len(tmp_indices)>len(indices)-1:
                     indices.extend(tmp_indices[len(indices)-1:])
 
-                result.append(LoopCollection([block[-1]],  rhs.val.shape[0], set([lhs])))
+                result.append(LoopCollection([block[-1]], rhs.length, set([lhs])))
 
             else:
                 assigns = [Assign(lhs[Slice(PyccelMul(rhs.val.shape[0], LiteralInteger(idx), simplify=True),

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -502,7 +502,7 @@ def collect_loops(block, indices, new_index_name, tmp_vars, language_has_vectors
                 if len(tmp_indices)>len(indices)-1:
                     indices.extend(tmp_indices[len(indices)-1:])
 
-                result.append(LoopCollection([block[-1]], rhs.length, set([lhs])))
+                result.append(LoopCollection(block, rhs.length, set([lhs])))
 
             else:
                 assigns = [Assign(lhs[Slice(PyccelMul(rhs.val.shape[0], LiteralInteger(idx), simplify=True),

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -542,8 +542,7 @@ def insert_fors(blocks, indices, level = 0):
     if all(not isinstance(b, LoopCollection) for b in blocks.body):
         body = blocks.body
     else:
-        body = [insert_fors(b, indices, level+1) if isinstance(b, LoopCollection) \
-                else [b] \
+        body = [insert_fors(b, indices, level+1) if isinstance(b, LoopCollection) else [b] \
                 for b in blocks.body]
         body = [bi for b in body for bi in b]
     if blocks.length == 1:
@@ -641,8 +640,7 @@ def expand_to_loops(block, new_index_name, language_has_vectors = False):
     tmp_vars = []
     res = collect_loops(block.body, indices, new_index_name, tmp_vars, language_has_vectors)
 
-    body = [insert_fors(b, indices) if isinstance(b, tuple) \
-            else [b] for b in res]
+    body = [insert_fors(b, indices) if isinstance(b, tuple) else [b] for b in res]
     body = [bi for b in body for bi in b]
 
     return body, indices+tmp_vars

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -536,7 +536,7 @@ def insert_fors(blocks, indices, level = 0):
         return [For(indices[level], PythonRange(0,blocks.length), body)]
 
 #==============================================================================
-def expand_tuple_creation(block):
+def expand_tuple_creation(block, language_has_vectors = False):
     """
     Ensure that tuple expressions which will be unravelled contain allocation statements
 
@@ -559,6 +559,9 @@ def expand_tuple_creation(block):
     >>> expand_tuple_assignments(CodeBlock(expr))
     [Assign(a, LiteralInteger(0)), Assign(b, LiteralInteger(1)), Assign(c, LiteralInteger(2))]
     """
+    if language_has_vectors:
+        return
+
     allocs_to_unravel = [a for a in block.get_attribute_nodes(Assign) \
                 if isinstance(a.lhs, HomogeneousTupleVariable) \
                 and isinstance(a.rhs, (Duplicate, Concatenate))]
@@ -570,7 +573,40 @@ def expand_tuple_creation(block):
     block.substitute(allocs_to_unravel, new_allocs)
 
 #==============================================================================
-def expand_tuple_assignments(block):
+def expand_inhomog_tuple_assignments(block):
+    """
+    Simplify expressions in a CodeBlock by unravelling tuple assignments into multiple lines
+
+    Parameters
+    ==========
+    block      : CodeBlock
+                The expression to be modified
+
+    Examples
+    --------
+    >>> from pyccel.ast.builtins  import PythonTuple
+    >>> from pyccel.ast.core      import Assign, CodeBlock
+    >>> from pyccel.ast.literals  import LiteralInteger
+    >>> from pyccel.ast.utilities import expand_to_loops
+    >>> from pyccel.ast.variable  import Variable
+    >>> a = Variable('int', 'a', shape=(,), rank=0)
+    >>> b = Variable('int', 'b', shape=(,), rank=0)
+    >>> c = Variable('int', 'c', shape=(,), rank=0)
+    >>> expr = [Assign(PythonTuple(a,b,c),PythonTuple(LiteralInteger(0),LiteralInteger(1),LiteralInteger(2))]
+    >>> expand_inhomog_tuple_assignments(CodeBlock(expr))
+    [Assign(a, LiteralInteger(0)), Assign(b, LiteralInteger(1)), Assign(c, LiteralInteger(2))]
+    """
+
+    assigns = [a for a in block.get_attribute_nodes(Assign) \
+                if isinstance(a.lhs, InhomogeneousTupleVariable) \
+                and isinstance(a.rhs, (PythonTuple, InhomogeneousTupleVariable))]
+    if len(assigns) != 0:
+        new_assigns = [[Assign(l,r) for l,r in zip(a.lhs, a.rhs)] for a in assigns]
+        block.substitute(assigns, new_assigns)
+        expand_inhomog_tuple_assignments(block)
+
+#==============================================================================
+def expand_tuple_slice_assignments(block, language_has_vectors = False):
     """
     Simplify expressions in a CodeBlock by unravelling tuple assignments into multiple lines
 
@@ -595,12 +631,14 @@ def expand_tuple_assignments(block):
     """
 
     assigns = [a for a in block.get_attribute_nodes(Assign) \
-                if isinstance(a.lhs, InhomogeneousTupleVariable) \
-                and isinstance(a.rhs, (PythonTuple, InhomogeneousTupleVariable))]
-    if len(assigns) != 0:
-        new_assigns = [[Assign(l,r) for l,r in zip(a.lhs, a.rhs)] for a in assigns]
+                if isinstance(a.lhs, IndexedElement) \
+                and isinstance(a.rhs, PythonTuple)]
+    if not (len(assigns) == 0 or language_has_vectors):
+        new_assigns = [[Assign(insert_index(a.lhs,-1,LiteralInteger(j)),rj) for j, rj in enumerate(a.rhs)] for a in assigns]
         block.substitute(assigns, new_assigns)
-        expand_tuple_assignments(block)
+        return expand_tuple_slice_assignments(block, language_has_vectors)
+    else:
+        return block
 
 #==============================================================================
 def expand_to_loops(block, new_index_name, language_has_vectors = False):
@@ -637,16 +675,14 @@ def expand_to_loops(block, new_index_name, language_has_vectors = False):
     >>> expand_to_loops(expr, language_has_vectors = False)
     [For(i_0, PythonRange(0, LiteralInteger(4), LiteralInteger(1)), CodeBlock([IndexedElement(c, i_0) := PyccelAdd(IndexedElement(a, i_0), IndexedElement(b, i_0))]), [])]
     """
-    if not language_has_vectors:
-        expand_tuple_creation(block)
-
-    expand_tuple_assignments(block)
+    expand_tuple_creation(block, language_has_vectors)
+    expand_inhomog_tuple_assignments(block)
 
     indices = []
     tmp_vars = []
     res = collect_loops(block.body, indices, new_index_name, tmp_vars, language_has_vectors)
 
     body = [insert_fors(b, indices) if isinstance(b, tuple) else [b] for b in res]
-    body = [bi for b in body for bi in b]
+    body = [expand_tuple_slice_assignments(bi, language_has_vectors) for b in body for bi in b]
 
     return body, indices+tmp_vars

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -28,7 +28,7 @@ from .mathext       import math_functions, math_constants
 from .literals      import LiteralString, LiteralInteger, Literal, Nil
 
 from .numpyext      import (NumpyEmpty, numpy_functions, numpy_linalg_functions,
-                            numpy_random_functions, numpy_constants)
+                            numpy_random_functions, numpy_constants, NumpyArray)
 from .operators     import PyccelAdd, PyccelMul, PyccelIs
 from .variable      import (Constant, Variable, ValuedVariable,
                             IndexedElement, InhomogeneousTupleVariable, VariableAddress,
@@ -458,10 +458,12 @@ def collect_loops(block, indices, new_index_name, tmp_vars, language_has_vectors
             current_level = new_level
 
         elif isinstance(line, Assign) and isinstance(line.lhs, IndexedElement) \
-                and isinstance(line.rhs, PythonTuple) and not language_has_vectors:
+                and isinstance(line.rhs, (PythonTuple, NumpyArray)) and not language_has_vectors:
 
             lhs = line.lhs
             rhs = line.rhs
+            if isinstance(rhs, NumpyArray):
+                rhs = rhs.arg
 
             lhs_rank = lhs.rank
 

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -458,7 +458,7 @@ def collect_loops(block, indices, new_index_name, tmp_vars, language_has_vectors
             current_level = new_level
 
         elif isinstance(line, Assign) and isinstance(line.lhs, IndexedElement) \
-                and isinstance(line.rhs, PythonTuple):
+                and isinstance(line.rhs, PythonTuple) and not language_has_vectors:
 
             lhs = line.lhs
             rhs = line.rhs

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -617,6 +617,10 @@ class HomogeneousTupleVariable(TupleVariable):
     def __len__(self):
         return self.shape[0]
 
+    def __iter__(self):
+        assert isinstance(self.shape[0], LiteralInteger)
+        return (self[i] for i in range(self.shape[0]))
+
 class InhomogeneousTupleVariable(TupleVariable):
 
     """Represents a tuple variable in the code.
@@ -871,8 +875,8 @@ class VariableAddress(PyccelAstNode):
     _attribute_nodes = ('_variable',)
 
     def __init__(self, variable):
-        if not isinstance(variable, Variable):
-            raise TypeError('variable must be a variable')
+        if not isinstance(variable, (Variable, IndexedElement)):
+            raise TypeError('variable must be a variable or indexed element')
         self._variable = variable
 
         self._shape     = variable.shape

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -915,7 +915,7 @@ class CCodePrinter(CodePrinter):
         base = expr.base
         inds = list(expr.indices)
         base_shape = base.shape
-        allow_negative_indexes = base.allows_negative_indexes
+        allow_negative_indexes = True if isinstance(base, PythonTuple) else base.allows_negative_indexes
         for i, ind in enumerate(inds):
             if isinstance(ind, PyccelUnarySub) and isinstance(ind.args[0], LiteralInteger):
                 inds[i] = PyccelMinus(base_shape[i], ind.args[0], simplify = True)
@@ -930,7 +930,7 @@ class CCodePrinter(CodePrinter):
         #set dtype to the C struct types
         dtype = self._print(expr.dtype)
         dtype = self.find_in_ndarray_type_registry(dtype, expr.precision)
-        base_name = self._print(base.name)
+        base_name = self._print(base)
         if base.is_ndarray:
             if expr.rank > 0:
                 #managing the Slice input

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -38,7 +38,7 @@ from pyccel.ast.numpyext import NumpyReal, NumpyImag, NumpyFloat
 
 from pyccel.ast.utilities import expand_to_loops
 
-from pyccel.ast.variable import ValuedVariable
+from pyccel.ast.variable import ValuedVariable, IndexedElement
 from pyccel.ast.variable import PyccelArraySize, Variable, VariableAddress
 from pyccel.ast.variable import DottedName
 from pyccel.ast.variable import InhomogeneousTupleVariable
@@ -1597,7 +1597,9 @@ class CCodePrinter(CodePrinter):
             return expr.name
 
     def _print_VariableAddress(self, expr):
-        if self.stored_in_c_pointer(expr.variable) or expr.variable.rank > 0:
+        if isinstance(expr.variable, IndexedElement):
+            return '&{}'.format(self._print(expr.variable))
+        elif self.stored_in_c_pointer(expr.variable) or expr.variable.rank > 0:
             return '{}'.format(expr.variable.name)
         else:
             return '&{}'.format(expr.variable.name)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -273,7 +273,7 @@ class CCodePrinter(CodePrinter):
 
     #========================== Numpy Elements ===============================#
     def copy_NumpyArray_Data(self, expr):
-        """ print the assignment of a NdArray
+        """ print the assignment of a NdArray or a homogeneous tuple
 
         parameters
         ----------
@@ -293,7 +293,7 @@ class CCodePrinter(CodePrinter):
         dummy_array_name, _ = create_incremented_string(self._parser.used_names, prefix = 'array_dummy')
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
         dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
-        arg = rhs.arg
+        arg = rhs.arg if isinstance(rhs, NumpyArray) else rhs
         if rhs.rank > 1:
             # flattening the args to use them in C initialization.
             arg = self._flatten_list(arg)
@@ -1430,7 +1430,8 @@ class CCodePrinter(CodePrinter):
         if isinstance(rhs, FunctionCall) and isinstance(rhs.dtype, NativeTuple):
             self._temporary_args = [VariableAddress(a) for a in lhs]
             return prefix_code+'{};\n'.format(self._print(rhs))
-        if isinstance(rhs, (NumpyArray)):
+        # Inhomogenous tuples are unravelled and therefore do not exist in the c printer
+        if isinstance(rhs, (NumpyArray, PythonTuple)):
             return prefix_code+self.copy_NumpyArray_Data(expr)
         if isinstance(rhs, (NumpyFull)):
             return prefix_code+self.arrayFill(expr)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -146,8 +146,9 @@ class PythonCodePrinter(CodePrinter):
         body    = self._indent_codestring(body)
         args    = ', '.join(self._print(i) for i in expr.arguments)
 
-        imports   = self._indent_codestring(imports)
-        functions = self._indent_codestring(functions)
+        imports    = self._indent_codestring(imports)
+        functions  = self._indent_codestring(functions)
+        interfaces = self._indent_codestring(interfaces)
 
         doc_string = self._print(expr.doc_string) if expr.doc_string else ''
         doc_string = self._indent_codestring(doc_string)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -5,7 +5,6 @@
 #------------------------------------------------------------------------------------------#
 # pylint: disable=R0201
 # pylint: disable=missing-function-docstring
-from itertools import chain
 
 from pyccel.decorators import __all__ as pyccel_decorators
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1461,8 +1461,8 @@ class SemanticParser(BasicParser):
         expr.clear_user_nodes()
         return expr
     def _visit_Comment(self, expr, **settings):
-        return expr
         expr.clear_user_nodes()
+        return expr
     def _visit_CommentBlock(self, expr, **settings):
         expr.clear_user_nodes()
         return expr

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1108,7 +1108,7 @@ class SemanticParser(BasicParser):
 
             d_lhs['is_pointer'] = any(v.is_pointer for v in elem_vars)
             d_lhs['is_stack_array'] = d_lhs.get('is_stack_array', False) and not d_lhs['is_pointer']
-            if is_homogeneous:
+            if is_homogeneous and not (d_lhs['is_pointer'] and isinstance(rhs, PythonTuple)):
                 lhs = HomogeneousTupleVariable(dtype, name, **d_lhs, is_temp=is_temp)
             else:
                 lhs = InhomogeneousTupleVariable(elem_vars, dtype, name, **d_lhs, is_temp=is_temp)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1451,21 +1451,27 @@ class SemanticParser(BasicParser):
     def _visit_Nil(self, expr, **settings):
         expr.clear_user_nodes()
         return expr
+
     def _visit_EmptyNode(self, expr, **settings):
         expr.clear_user_nodes()
         return expr
+
     def _visit_Break(self, expr, **settings):
         expr.clear_user_nodes()
         return expr
+    
     def _visit_Continue(self, expr, **settings):
         expr.clear_user_nodes()
         return expr
+
     def _visit_Comment(self, expr, **settings):
         expr.clear_user_nodes()
         return expr
+
     def _visit_CommentBlock(self, expr, **settings):
         expr.clear_user_nodes()
         return expr
+
     def _visit_AnnotatedComment(self, expr, **settings):
         expr.clear_user_nodes()
         return expr

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1459,7 +1459,7 @@ class SemanticParser(BasicParser):
     def _visit_Break(self, expr, **settings):
         expr.clear_user_nodes()
         return expr
-    
+
     def _visit_Continue(self, expr, **settings):
         expr.clear_user_nodes()
         return expr

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1471,7 +1471,6 @@ class SemanticParser(BasicParser):
         return expr
 
     def _visit_OmpAnnotatedComment(self, expr, **settings):
-        expr.clear_user_nodes()
         code = expr._user_nodes
         code = code[-1]
         index = code.body.index(expr)
@@ -1506,6 +1505,7 @@ class SemanticParser(BasicParser):
                 errors.report(msg, symbol=type(code.body[index]).__name__,
                     severity='fatal', blocker=self.blocking)
 
+        expr.clear_user_nodes()
         return expr
 
     def _visit_Literal(self, expr, **settings):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1449,21 +1449,29 @@ class SemanticParser(BasicParser):
         return CodeBlock(ls)
 
     def _visit_Nil(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
     def _visit_EmptyNode(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
     def _visit_Break(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
     def _visit_Continue(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
     def _visit_Comment(self, expr, **settings):
         return expr
+        expr.clear_user_nodes()
     def _visit_CommentBlock(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
     def _visit_AnnotatedComment(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
 
     def _visit_OmpAnnotatedComment(self, expr, **settings):
+        expr.clear_user_nodes()
         code = expr._user_nodes
         code = code[-1]
         index = code.body.index(expr)
@@ -1501,10 +1509,13 @@ class SemanticParser(BasicParser):
         return expr
 
     def _visit_Literal(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
     def _visit_PythonComplex(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
     def _visit_Pass(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
 
     def _visit_Variable(self, expr, **settings):
@@ -2593,15 +2604,18 @@ class SemanticParser(BasicParser):
 
     def _visit_FunctionHeader(self, expr, **settings):
         # TODO should we return it and keep it in the AST?
+        expr.clear_user_nodes()
         self.insert_header(expr)
         return expr
 
     def _visit_Template(self, expr, **settings):
+        expr.clear_user_nodes()
         self.insert_template(expr)
         return expr
 
     def _visit_ClassHeader(self, expr, **settings):
         # TODO should we return it and keep it in the AST?
+        expr.clear_user_nodes()
         self.insert_header(expr)
         return expr
 
@@ -3313,6 +3327,7 @@ class SemanticParser(BasicParser):
         return macro
 
     def _visit_MacroShape(self, expr, **settings):
+        expr.clear_user_nodes()
         return expr
 
     def _visit_MacroVariable(self, expr, **settings):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1114,7 +1114,9 @@ class SemanticParser(BasicParser):
                 lhs = InhomogeneousTupleVariable(elem_vars, dtype, name, **d_lhs, is_temp=is_temp)
 
         else:
-            new_type = HomogeneousTupleVariable if isinstance(rhs, HomogeneousTupleVariable) else Variable
+            new_type = HomogeneousTupleVariable \
+                    if isinstance(rhs, (HomogeneousTupleVariable, Concatenate, Duplicate)) \
+                    else Variable
             lhs = new_type(dtype, name, **d_lhs, is_temp=is_temp)
 
         return lhs

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -741,6 +741,7 @@ class SemanticParser(BasicParser):
             d_var['rank'          ] = expr.rank
             d_var['is_pointer'    ] = False
             d_var['allocatable'   ] = any(getattr(a, 'allocatable', False) for a in expr.args)
+            d_var['is_stack_array'] = not d_var['allocatable'   ]
             d_var['cls_base'      ] = TupleClass
             return d_var
 

--- a/tests/epyccel/modules/tuples.py
+++ b/tests/epyccel/modules/tuples.py
@@ -88,7 +88,9 @@ def inhomogenous_tuple_3():
     return ai[0], ai[1], ai[2]
 
 def inhomogenous_tuple_2_levels_1():
-    ai = ((1,2), (4,False), (3.0, 'boo'))
+    # TODO [EB 15.06.21] Put back original test when strings are supported
+    #ai = ((1,2), (4,False), (3.0, 'boo'))
+    ai = ((1,2), (4,False), (3.0, True))
     return ai[0][0], ai[0][1], ai[1][0], ai[1][1], ai[2][0]
 
 def inhomogenous_tuple_2_levels_2():

--- a/tests/epyccel/modules/tuples.py
+++ b/tests/epyccel/modules/tuples.py
@@ -88,7 +88,7 @@ def inhomogenous_tuple_3():
     return ai[0], ai[1], ai[2]
 
 def inhomogenous_tuple_2_levels_1():
-    # TODO [EB 15.06.21] Put back original test when strings are supported
+    # TODO [EB 15.06.21] Put back original test when strings are supported in C
     #ai = ((1,2), (4,False), (3.0, 'boo'))
     ai = ((1,2), (4,False), (3.0, True))
     return ai[0][0], ai[0][1], ai[1][0], ai[1][1], ai[2][0]

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -1921,6 +1921,15 @@ def test_array(language):
     assert(f2_val()   == create_array_tuple_val())
     assert matching_types(f2_val(), create_array_tuple_val())
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="rand not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_rand_basic(language):
     def create_val():
         from numpy.random import rand # pylint: disable=reimported
@@ -1933,6 +1942,15 @@ def test_rand_basic(language):
     assert(all([isinstance(yi,float) for yi in y]))
     assert(len(set(y))>1)
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="rand not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_rand_args(language):
     @types('int')
     def create_array_size_1d(n):
@@ -1991,6 +2009,15 @@ def test_rand_args(language):
     assert(all([isinstance(yi,float) for yi in y]))
     assert(len(set(y))>1)
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="rand not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_rand_expr(language):
     def create_val():
         from numpy.random import rand # pylint: disable=reimported
@@ -2099,6 +2126,15 @@ def test_randint_expr(language):
     assert(all([isinstance(yi,int) for yi in y]))
     assert(len(set(y))>1)
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="sum not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_sum_int(language):
     @types('int[:]')
     def sum_call(x):
@@ -2109,6 +2145,15 @@ def test_sum_int(language):
     x = randint(99,size=10)
     assert(f1(x) == sum_call(x))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="sum not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_sum_real(language):
     @types('real[:]')
     def sum_call(x):
@@ -2119,6 +2164,15 @@ def test_sum_real(language):
     x = rand(10)
     assert(isclose(f1(x), sum_call(x), rtol=RTOL, atol=ATOL))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="sum not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_sum_phrase(language):
     @types('real[:]','real[:]')
     def sum_phrase(x,y):
@@ -2131,6 +2185,15 @@ def test_sum_phrase(language):
     y = rand(15)
     assert(isclose(f2(x,y), sum_phrase(x,y), rtol=RTOL, atol=ATOL))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="sum not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_sum_property(language):
     @types('int[:]')
     def sum_call(x):
@@ -2140,6 +2203,15 @@ def test_sum_property(language):
     x = randint(99,size=10)
     assert(f1(x) == sum_call(x))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="amin not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_min_int(language):
     @types('int[:]')
     def min_call(x):
@@ -2150,6 +2222,15 @@ def test_min_int(language):
     x = randint(99,size=10)
     assert(f1(x) == min_call(x))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="amin not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_min_real(language):
     @types('real[:]')
     def min_call(x):
@@ -2160,6 +2241,15 @@ def test_min_real(language):
     x = rand(10)
     assert(isclose(f1(x), min_call(x), rtol=RTOL, atol=ATOL))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="amin not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_min_phrase(language):
     @types('real[:]','real[:]')
     def min_phrase(x,y):
@@ -2172,6 +2262,15 @@ def test_min_phrase(language):
     y = rand(15)
     assert(isclose(f2(x,y), min_phrase(x,y), rtol=RTOL, atol=ATOL))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="amin not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_min_property(language):
     @types('int[:]')
     def min_call(x):
@@ -2181,6 +2280,15 @@ def test_min_property(language):
     x = randint(99,size=10)
     assert(f1(x) == min_call(x))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="amax not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_max_int(language):
     @types('int[:]')
     def max_call(x):
@@ -2191,6 +2299,15 @@ def test_max_int(language):
     x = randint(99,size=10)
     assert(f1(x) == max_call(x))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="amax not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_max_real(language):
     @types('real[:]')
     def max_call(x):
@@ -2201,6 +2318,15 @@ def test_max_real(language):
     x = rand(10)
     assert(isclose(f1(x), max_call(x), rtol=RTOL, atol=ATOL))
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="amax not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_max_phrase(language):
     @types('real[:]','real[:]')
     def max_phrase(x,y):
@@ -2214,6 +2340,15 @@ def test_max_phrase(language):
     assert(isclose(f2(x,y), max_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="amax not implemented"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_max_property(language):
     @types('int[:]')
     def max_call(x):

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -1002,15 +1002,6 @@ def test_floor_phrase(language):
     assert(isclose(f2(-x,y), floor_phrase(-x,y), rtol=RTOL, atol=ATOL))
     assert(isclose(f2(x,-y), floor_phrase(x,-y), rtol=RTOL, atol=ATOL))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_shape_indexed(language):
     @types('int[:]')
     def test_shape_1d(f):
@@ -1034,15 +1025,6 @@ def test_shape_indexed(language):
     assert(f1(x1) == test_shape_1d(x1))
     assert(f2(x2) == test_shape_2d(x2))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_shape_property(language):
     @types('int[:]')
     def test_shape_1d(f):
@@ -1064,15 +1046,6 @@ def test_shape_property(language):
     assert(f1(x1) == test_shape_1d(x1))
     assert(all(isclose(f2(x2), test_shape_2d(x2))))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_shape_tuple_output(language):
     @types('int[:]')
     def test_shape_1d(f):
@@ -1105,15 +1078,6 @@ def test_shape_tuple_output(language):
     f2 = epyccel(test_shape_2d, language = language)
     assert(f2(x2)   == test_shape_2d(x2))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_shape_real(language):
     @types('real[:]')
     def test_shape_1d(f):
@@ -1138,15 +1102,6 @@ def test_shape_real(language):
     assert(f1(x1) == test_shape_1d(x1))
     assert(f2(x2) == test_shape_2d(x2))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_shape_int(language):
     @types('int[:]')
     def test_shape_1d(f):
@@ -1172,15 +1127,6 @@ def test_shape_int(language):
     assert(f1(x1) == test_shape_1d(x1))
     assert(f2(x2) == test_shape_2d(x2))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_shape_bool(language):
     @types('bool[:]')
     def test_shape_1d(f):
@@ -1205,15 +1151,6 @@ def test_shape_bool(language):
     assert(f1(x1) == test_shape_1d(x1))
     assert(f2(x2) == test_shape_2d(x2))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_full_basic_int(language):
     @types('int')
     def create_full_shape_1d(n):
@@ -1254,15 +1191,6 @@ def test_full_basic_int(language):
     assert(f_arg_names(size) == create_full_arg_names(size))
     assert matching_types(f_arg_names(size)[0], create_full_arg_names(size)[0])
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_full_basic_real(language):
     @types('int')
     def create_full_shape_1d(n):
@@ -1304,15 +1232,6 @@ def test_full_basic_real(language):
     assert(f_arg_names(val)     == create_full_arg_names(val))
     assert matching_types(f_arg_names(val)[0], create_full_arg_names(val)[0])
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_full_basic_bool(language):
     @types('int')
     def create_full_shape_1d(n):
@@ -1354,15 +1273,6 @@ def test_full_basic_bool(language):
     assert(f_arg_names(val)     == create_full_arg_names(val))
     assert matching_types(f_arg_names(val)[0], create_full_arg_names(val)[0])
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_full_order(language):
     @types('int','int')
     def create_full_shape_C(n,m):
@@ -1471,15 +1381,6 @@ def test_full_dtype(language):
     assert(isclose(     f_real_complex128(val_float)       ,      create_full_val_real_complex128(val_float), rtol=RTOL, atol=ATOL))
     assert matching_types(f_real_complex128(val_float), create_full_val_real_complex128(val_float))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_full_combined_args(language):
     def create_full_1_shape():
         from numpy import full, shape
@@ -1527,15 +1428,6 @@ def test_full_combined_args(language):
     assert(isclose(     f3_val()  ,      create_full_3_val()        , rtol=RTOL, atol=ATOL))
     assert matching_types(f3_val(), create_full_3_val())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_empty_basic(language):
     @types('int')
     def create_empty_shape_1d(n):
@@ -1558,15 +1450,6 @@ def test_empty_basic(language):
     f_shape_2d  = epyccel(create_empty_shape_2d, language = language)
     assert(     f_shape_2d(size)      ==      create_empty_shape_2d(size))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_empty_order(language):
     @types('int','int')
     def create_empty_shape_C(n,m):
@@ -1648,15 +1531,6 @@ def test_empty_dtype(language):
     f_real_complex128   = epyccel(create_empty_val_complex128, language = language)
     assert matching_types(f_real_complex128(), create_empty_val_complex128())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_empty_combined_args(language):
     def create_empty_1_shape():
         from numpy import empty, shape
@@ -1701,15 +1575,6 @@ def test_empty_combined_args(language):
     assert(all(isclose(     f3_shape(),      create_empty_3_shape()      )))
     assert matching_types(f3_val(), create_empty_3_val())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_ones_basic(language):
     @types('int')
     def create_ones_shape_1d(n):
@@ -1732,15 +1597,6 @@ def test_ones_basic(language):
     f_shape_2d  = epyccel(create_ones_shape_2d, language = language)
     assert(     f_shape_2d(size)      ==      create_ones_shape_2d(size))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_ones_order(language):
     @types('int','int')
     def create_ones_shape_C(n,m):
@@ -1830,15 +1686,6 @@ def test_ones_dtype(language):
     assert(isclose(     f_real_complex128() ,      create_ones_val_complex128(), rtol=RTOL, atol=ATOL))
     assert matching_types(f_real_complex128(), create_ones_val_complex128())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_ones_combined_args(language):
     def create_ones_1_shape():
         from numpy import ones, shape
@@ -1886,15 +1733,6 @@ def test_ones_combined_args(language):
     assert(isclose(     f3_val()  ,      create_ones_3_val()        , rtol=RTOL, atol=ATOL))
     assert matching_types(f3_val(), create_ones_3_val())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_zeros_basic(language):
     @types('int')
     def create_zeros_shape_1d(n):
@@ -1917,15 +1755,6 @@ def test_zeros_basic(language):
     f_shape_2d  = epyccel(create_zeros_shape_2d, language = language)
     assert(     f_shape_2d(size)      ==      create_zeros_shape_2d(size))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_zeros_order(language):
     @types('int','int')
     def create_zeros_shape_C(n,m):
@@ -2015,15 +1844,6 @@ def test_zeros_dtype(language):
     assert(isclose(     f_real_complex128() ,      create_zeros_val_complex128(), rtol=RTOL, atol=ATOL))
     assert matching_types(f_real_complex128(), create_zeros_val_complex128())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_zeros_combined_args(language):
     def create_zeros_1_shape():
         from numpy import zeros, shape
@@ -2071,15 +1891,6 @@ def test_zeros_combined_args(language):
     assert(isclose(     f3_val()  ,      create_zeros_3_val()        , rtol=RTOL, atol=ATOL))
     assert matching_types(f3_val(), create_zeros_3_val())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_array(language):
     def create_array_list_val():
         from numpy import array
@@ -2110,15 +1921,6 @@ def test_array(language):
     assert(f2_val()   == create_array_tuple_val())
     assert matching_types(f2_val(), create_array_tuple_val())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_rand_basic(language):
     def create_val():
         from numpy.random import rand # pylint: disable=reimported
@@ -2131,15 +1933,6 @@ def test_rand_basic(language):
     assert(all([isinstance(yi,float) for yi in y]))
     assert(len(set(y))>1)
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_rand_args(language):
     @types('int')
     def create_array_size_1d(n):
@@ -2198,15 +1991,6 @@ def test_rand_args(language):
     assert(all([isinstance(yi,float) for yi in y]))
     assert(len(set(y))>1)
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_rand_expr(language):
     def create_val():
         from numpy.random import rand # pylint: disable=reimported
@@ -2315,15 +2099,6 @@ def test_randint_expr(language):
     assert(all([isinstance(yi,int) for yi in y]))
     assert(len(set(y))>1)
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_sum_int(language):
     @types('int[:]')
     def sum_call(x):
@@ -2334,15 +2109,6 @@ def test_sum_int(language):
     x = randint(99,size=10)
     assert(f1(x) == sum_call(x))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_sum_real(language):
     @types('real[:]')
     def sum_call(x):
@@ -2353,15 +2119,6 @@ def test_sum_real(language):
     x = rand(10)
     assert(isclose(f1(x), sum_call(x), rtol=RTOL, atol=ATOL))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_sum_phrase(language):
     @types('real[:]','real[:]')
     def sum_phrase(x,y):
@@ -2374,15 +2131,6 @@ def test_sum_phrase(language):
     y = rand(15)
     assert(isclose(f2(x,y), sum_phrase(x,y), rtol=RTOL, atol=ATOL))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_sum_property(language):
     @types('int[:]')
     def sum_call(x):
@@ -2392,15 +2140,6 @@ def test_sum_property(language):
     x = randint(99,size=10)
     assert(f1(x) == sum_call(x))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_min_int(language):
     @types('int[:]')
     def min_call(x):
@@ -2411,15 +2150,6 @@ def test_min_int(language):
     x = randint(99,size=10)
     assert(f1(x) == min_call(x))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_min_real(language):
     @types('real[:]')
     def min_call(x):
@@ -2430,15 +2160,6 @@ def test_min_real(language):
     x = rand(10)
     assert(isclose(f1(x), min_call(x), rtol=RTOL, atol=ATOL))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_min_phrase(language):
     @types('real[:]','real[:]')
     def min_phrase(x,y):
@@ -2451,15 +2172,6 @@ def test_min_phrase(language):
     y = rand(15)
     assert(isclose(f2(x,y), min_phrase(x,y), rtol=RTOL, atol=ATOL))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_min_property(language):
     @types('int[:]')
     def min_call(x):
@@ -2469,15 +2181,6 @@ def test_min_property(language):
     x = randint(99,size=10)
     assert(f1(x) == min_call(x))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_max_int(language):
     @types('int[:]')
     def max_call(x):
@@ -2488,15 +2191,6 @@ def test_max_int(language):
     x = randint(99,size=10)
     assert(f1(x) == max_call(x))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_max_real(language):
     @types('real[:]')
     def max_call(x):
@@ -2507,15 +2201,6 @@ def test_max_real(language):
     x = rand(10)
     assert(isclose(f1(x), max_call(x), rtol=RTOL, atol=ATOL))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_max_phrase(language):
     @types('real[:]','real[:]')
     def max_phrase(x,y):
@@ -2529,15 +2214,6 @@ def test_max_phrase(language):
     assert(isclose(f2(x,y), max_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_max_property(language):
     @types('int[:]')
     def max_call(x):
@@ -2547,15 +2223,6 @@ def test_max_property(language):
     x = randint(99,size=10)
     assert(f1(x) == max_call(x))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 
 def test_full_like_basic_int(language):
     @types('int')
@@ -2601,15 +2268,6 @@ def test_full_like_basic_int(language):
     assert(f_arg_names(size) == create_full_like_arg_names(size))
     assert matching_types(f_arg_names(size)[0], create_full_like_arg_names(size)[0])
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_full_like_basic_real(language):
     @types('real')
     def create_full_like_shape_1d(n):
@@ -2709,15 +2367,6 @@ def test_full_like_basic_bool(language):
     assert(f_arg_names(val)     == create_full_like_arg_names(val))
     assert matching_types(f_arg_names(val)[0], create_full_like_arg_names(val)[0])
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_full_like_order(language):
     @types('int')
     def create_full_like_shape_C(n):
@@ -2835,15 +2484,6 @@ def test_full_like_dtype(language):
     assert(isclose(     f_real_complex128(val_float)       ,      create_full_like_val_real_complex128(val_float), rtol=RTOL, atol=ATOL))
     assert matching_types(f_real_complex128(val_float), create_full_like_val_real_complex128(val_float))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_full_like_combined_args(language):
     def create_full_like_1_shape():
         from numpy import full_like, shape, array
@@ -2898,15 +2538,6 @@ def test_full_like_combined_args(language):
     assert(isclose(     f3_val()  ,      create_full_like_3_val()        , rtol=RTOL, atol=ATOL))
     assert matching_types(f3_val(), create_full_like_3_val())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_empty_like_basic(language):
     @types('int')
     def create_empty_like_shape_1d(n):
@@ -2931,15 +2562,6 @@ def test_empty_like_basic(language):
     f_shape_2d  = epyccel(create_empty_like_shape_2d, language = language)
     assert(     f_shape_2d(size)      ==      create_empty_like_shape_2d(size))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_empty_like_order(language):
     @types('int','int')
     def create_empty_like_shape_C(n,m):
@@ -3040,15 +2662,6 @@ def test_empty_like_dtype(language):
     f_real_complex128   = epyccel(create_empty_like_val_complex128, language = language)
     assert matching_types(f_real_complex128(), create_empty_like_val_complex128())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_empty_like_combined_args(language):
 
     def create_empty_like_1_shape():
@@ -3105,15 +2718,6 @@ def test_empty_like_combined_args(language):
     assert(all(isclose(     f3_shape(),      create_empty_like_3_shape()      )))
     assert matching_types(f3_val(), create_empty_like_3_val())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_ones_like_basic(language):
     @types('int')
     def create_ones_like_shape_1d(n):
@@ -3138,15 +2742,6 @@ def test_ones_like_basic(language):
     f_shape_2d  = epyccel(create_ones_like_shape_2d, language = language)
     assert(     f_shape_2d(size)      ==      create_ones_like_shape_2d(size))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_ones_like_order(language):
     @types('int','int')
     def create_ones_like_shape_C(n,m):
@@ -3255,15 +2850,6 @@ def test_ones_like_dtype(language):
     assert(isclose(     f_real_complex128() ,      create_ones_like_val_complex128(), rtol=RTOL, atol=ATOL))
     assert matching_types(f_real_complex128(), create_ones_like_val_complex128())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_ones_like_combined_args(language):
 
     def create_ones_like_1_shape():
@@ -3323,15 +2909,6 @@ def test_ones_like_combined_args(language):
     assert(isclose(     f3_val()  ,      create_ones_like_3_val()        , rtol=RTOL, atol=ATOL))
     assert matching_types(f3_val(), create_ones_like_3_val())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_zeros_like_basic(language):
     @types('int')
     def create_zeros_like_shape_1d(n):
@@ -3356,15 +2933,6 @@ def test_zeros_like_basic(language):
     f_shape_2d  = epyccel(create_zeros_like_shape_2d, language = language)
     assert(     f_shape_2d(size)      ==      create_zeros_like_shape_2d(size))
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_zeros_like_order(language):
     @types('int','int')
     def create_zeros_like_shape_C(n,m):
@@ -3472,15 +3040,6 @@ def test_zeros_like_dtype(language):
     assert(isclose(     f_real_complex128() ,      create_zeros_like_val_complex128(), rtol=RTOL, atol=ATOL))
     assert matching_types(f_real_complex128(), create_zeros_like_val_complex128())
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_zeros_like_combined_args(language):
 
     def create_zeros_like_1_shape():
@@ -3691,10 +3250,8 @@ def test_numpy_real_array_like_1d(language):
     def get_real(arr):
         from numpy import real, shape
         a = real(arr)
-        return shape(a)[0], a[0]
-        # Tuples not implemented yet, once be implemented we can use:
-        # s = shape(a)
-        # return len(s), s[0], a[0]
+        s = shape(a)
+        return len(s), s[0], a[0]
 
     size = 5
 
@@ -3763,10 +3320,8 @@ def test_numpy_real_array_like_2d(language):
     def get_real(arr):
         from numpy import real, shape
         a = real(arr)
-        return shape(a)[0], shape(a)[1], a[0,1], a[1,0]
-        # Tuples not implemented yet, once be implemented we can use:
-        # s = shape(a)
-        # return len(s), s[0], s[1], a[0,1], a[1,0]
+        s = shape(a)
+        return len(s), s[0], s[1], a[0,1], a[1,0]
 
     size = (2, 5)
 
@@ -3929,10 +3484,7 @@ def test_numpy_imag_scalar(language):
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
+        pytest.param("c", marks = pytest.mark.c),
         pytest.param("python", marks = [
             pytest.mark.skip(reason=("imag handles types in __new__ so it "
                 "cannot be used in a translated interface in python")),
@@ -3957,10 +3509,8 @@ def test_numpy_imag_array_like_1d(language):
     def get_imag(arr):
         from numpy import imag, shape
         a = imag(arr)
-        return shape(a)[0], a[0]
-        # Tuples not implemented yet, once be implemented we can use:
-        # s = shape(a)
-        # return len(s), s[0], a[0]
+        s = shape(a)
+        return len(s), s[0], a[0]
 
     size = 5
 
@@ -4001,10 +3551,7 @@ def test_numpy_imag_array_like_1d(language):
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="Tuples not implemented yet"),
-            pytest.mark.c]
-        ),
+        pytest.param("c", marks = pytest.mark.c),
         pytest.param("python", marks = [
             pytest.mark.skip(reason=("imag handles types in __new__ so it "
                 "cannot be used in a translated interface in python")),
@@ -4029,10 +3576,8 @@ def test_numpy_imag_array_like_2d(language):
     def get_imag(arr):
         from numpy import imag, shape
         a = imag(arr)
-        return shape(a)[0], shape(a)[1], a[0,1], a[1,0]
-        # Tuples not implemented yet, once be implemented we can use:
-        # s = shape(a)
-        # return len(s), s[0], s[1], a[0,1], a[1,0]
+        s = shape(a)
+        return len(s), s[0], s[1], a[0,1], a[1,0]
 
     size = (2, 5)
 
@@ -4173,10 +3718,8 @@ def test_numpy_mod_array_like_1d(language):
     def get_mod(arr):
         from numpy import mod, shape
         a = mod(arr, arr)
-        return shape(a)[0], a[0], a[1]
-        # Tuples not implemented yet, once be implemented we can use:
-        # s = shape(a)
-        # return len(s), s[0], a[0]
+        s = shape(a)
+        return len(s), s[0], a[0]
 
     size = 5
 
@@ -4232,10 +3775,8 @@ def test_numpy_mod_array_like_2d(language):
     def get_mod(arr):
         from numpy import mod, shape
         a = mod(arr, arr)
-        return shape(a)[0], shape(a)[1], a[0,1], a[1,0]
-        # Tuples not implemented yet, once be implemented we can use:
-        # s = shape(a)
-        # return len(s), s[0], s[1], a[0,1], a[1,0]
+        s = shape(a)
+        return len(s), s[0], s[1], a[0,1], a[1,0]
 
     size = (2, 5)
 

--- a/tests/epyccel/test_tuples.py
+++ b/tests/epyccel/test_tuples.py
@@ -13,12 +13,8 @@ def is_func_with_0_args(f):
     func = getattr(tuples_module,f)
     return inspect.isfunction(func) and len(inspect.signature(func).parameters)==0
 
-inhomog_homog = ['inhomogenous_tuple_2_levels_1', 'inhomogenous_tuple_2_levels_2']
-
 tuple_funcs = [(f, getattr(tuples_module,f)) for f in tuples_module.__all__
                                             if is_func_with_0_args(f)]
-inhomogeneous_funcs = [(n,f) for n,f in tuple_funcs if 'inhomog' in n and n not in inhomog_homog]
-homogeneous_funcs = [(n,f) for n,f in tuple_funcs if ((n,f) not in inhomogeneous_funcs)]
 
 failing_tests = {
         'homogenous_tuple_string':'String has no precision',
@@ -28,6 +24,12 @@ failing_tests = {
         'tuple_inhomogeneous_return':"Can't return a tuple",
         'tuple_visitation_inhomogeneous':"Can't iterate over an inhomogeneous tuple",
         }
+
+failing_c_tests = {
+    'tuple_arg_unpacking':'Functions in functions not implemented in c',
+    'tuples_func':'Functions in functions not implemented in c',
+}
+
 
 def compare_python_pyccel( p_output, f_output ):
     if p_output is None:
@@ -52,11 +54,11 @@ def compare_python_pyccel( p_output, f_output ):
         else:
             assert(np.isclose(pth,pycc))
 
-homog_marks = [f[1] if f[0] not in failing_tests else
-        pytest.param(f[1], marks = pytest.mark.xfail(reason=failing_tests[f[0]])) for f in homogeneous_funcs]
-
-@pytest.mark.parametrize('test_func',homog_marks)
-def test_homogeneous_tuples(test_func, language):
+marks = [f[1] if f[0] not in failing_tests else
+        pytest.param(f[1], marks = pytest.mark.xfail(reason=failing_tests[f[0]])) \
+                for f in tuple_funcs if f[0] not in failing_c_tests]
+@pytest.mark.parametrize('test_func', marks)
+def test_tuples(test_func, language):
     f1 = test_func
     f2 = epyccel( f1, language=language )
 
@@ -64,11 +66,19 @@ def test_homogeneous_tuples(test_func, language):
     pyccel_out = f2()
     compare_python_pyccel(python_out, pyccel_out)
 
-inhomog_marks = [f[1] if f[0] not in failing_tests else
-        pytest.param(f[1], marks = pytest.mark.xfail(reason=failing_tests[f[0]])) for f in inhomogeneous_funcs]
-
-@pytest.mark.parametrize('test_func',inhomog_marks)
-def test_inhomogeneous_tuples(test_func, language):
+c_marks = [f[1] for f in failing_c_tests]
+@pytest.mark.parametrize('test_func', c_marks)
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="function in function is not implemented yet\
+                in C language"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_tuples_c_fail(test_func, language):
     f1 = test_func
     f2 = epyccel( f1, language=language )
 

--- a/tests/epyccel/test_tuples.py
+++ b/tests/epyccel/test_tuples.py
@@ -66,7 +66,7 @@ def test_tuples(test_func, language):
     pyccel_out = f2()
     compare_python_pyccel(python_out, pyccel_out)
 
-c_marks = [f[1] for f in failing_c_tests]
+c_marks = [f[1] for f in tuple_funcs if f[0] in failing_c_tests]
 @pytest.mark.parametrize('test_func', c_marks)
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),

--- a/tests/epyccel/test_tuples.py
+++ b/tests/epyccel/test_tuples.py
@@ -56,9 +56,9 @@ homog_marks = [f[1] if f[0] not in failing_tests else
         pytest.param(f[1], marks = pytest.mark.xfail(reason=failing_tests[f[0]])) for f in homogeneous_funcs]
 
 @pytest.mark.parametrize('test_func',homog_marks)
-def test_homogeneous_tuples(test_func):
+def test_homogeneous_tuples(test_func, language):
     f1 = test_func
-    f2 = epyccel( f1 )
+    f2 = epyccel( f1, language=language )
 
     python_out = f1()
     pyccel_out = f2()


### PR DESCRIPTION
Add homogeneous tuples in C. Fixes #850 . Fix bugs in unravelling. Improve python printer

**Commit Summary**
- When substituting add new user node before removing old user node to avoid unnecessary node invalidation
- Add `clear_user_nodes` function to prevent objects holding their syntactic and semantic users when they are valid for both stages (e.g. Literals)
- Add simplification step to `PyccelAdd` avoid printing `a+0`
- Unravel expressions such as `a[1:3] = (4,5)` or `a[:] = np.array([3,4])` these expressions don't require memory allocation and have known size
- Correct `Duplicate` loop creation (fixed wrong size, collect multiple expressions to handle tuple assignment unravelling)
- Update `expand_inhomog_tuple_assignments` doc
- Ensure `Duplicate`, `Concatenate`, and `HomogeneousTupleVariable` assignments have memory allocation before unravelling (accessing elements)
- Add `__iter__` to `HomogeneousTupleVariable` (default `__iter__` calls `__getitem__` until `IndexError` is raised, but we don't always know the size)
- Allow `VariableAddress` to contain `IndexedElement`
- Allow `copy_NumpyArray_Data` to also handle homogenous `PythonTuple`s
- Make tuples of arrays inhomogeneous (neither our C framework, nor fortran can handle arrays of pointers)
- Activate tuple tests
- Add functions in functions to python printer
- Add `_print_Duplicate` and `_print_Concatenate` to python printer
- Correct tuple indexing in python printer to print `a[i][j]` instead of `a[i,j]` when indexing `((1,2),(3,4))`
- Avoid printing `from pyccel.decorators import types` multiple times
- Add `_print_Interface` (to be improved, see #885) to python printer