### PR TITLE
Fix variable collision problem

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1244,7 +1244,8 @@ class CCodePrinter(CodePrinter):
     def stored_in_c_pointer(self, a):
         if not isinstance(a, Variable):
             return False
-        return (a.is_pointer and not a.is_ndarray) or a.is_optional or any(a in b for b in self._additional_args)
+        return (a.is_pointer and not a.is_ndarray) or a.is_optional or \
+                any(a is bi for b in self._additional_args for bi in b)
 
     def create_tmp_var(self, match_var):
         tmp_var_name = self._parser.get_new_name('tmp')

--- a/tests/pyccel/scripts/runtest_multiple_results.py
+++ b/tests/pyccel/scripts/runtest_multiple_results.py
@@ -72,3 +72,14 @@ while (k<3):
     print(f4(i,j))
 
 print(i,j)
+
+def print_func(x : int, y : int):
+    print(x,y)
+
+def test_issue910():
+    x = 0
+    y = 1
+    print_func(x,y)
+    return x,y
+
+l,m = test_issue910()

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -597,7 +597,7 @@ def test_multiple_results(language):
             output_dtype = [int,float,complex,bool,int,complex,
                 int,bool,float,float,float,float,float,float,
                 float,float,float,float,float,float
-                ,float,float,float,float], language=language)
+                ,float,float,float,float,int,int], language=language)
 
 #------------------------------------------------------------------------------
 def test_elemental(language):


### PR DESCRIPTION
Use `is` instead of `==` to check if `Variable` is an output in `stored_in_c_pointer` (fixes #910). Add tests