### PR TITLE
Remove unhelpful warning on mac

### DIFF
--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -81,7 +81,7 @@ jobs:
         uses: ./.github/actions/pip_installation
       - name: Warning test
         run: |
-          python -m pytest -rx -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays -vs tests/epyccel/test_array_as_func_args.py
+          python -m pytest -rx --ignore=symbolic --ignore=ndarrays -vs tests/epyccel/test_array_as_func_args.py
       #- name: Fortran/C tests with pytest
       #  uses: ./.github/actions/pytest_run
       #- name: Python tests with pytest

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,65 +5,65 @@ on:
     branches: [ master ]
 
 jobs:
-  Linux:
+  #Linux:
 
-    runs-on: ubuntu-latest
+  #  runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-      - name: Install dependencies
-        uses: ./.github/actions/linux_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Coverage install
-        uses: ./.github/actions/coverage_install
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
-      - name: Test with valgrind for memory leaks
-        uses: ./.github/actions/valgrind_run
-      - name: Collect coverage information
-        continue-on-error: True
-        uses: ./.github/actions/coverage_collection
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
-        continue-on-error: True
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: cobertura.xml
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Set up Python 3.6
+  #      uses: actions/setup-python@v2
+  #      with:
+  #        python-version: 3.6
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/linux_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Coverage install
+  #      uses: ./.github/actions/coverage_install
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
+  #    - name: Test with valgrind for memory leaks
+  #      uses: ./.github/actions/valgrind_run
+  #    - name: Collect coverage information
+  #      continue-on-error: True
+  #      uses: ./.github/actions/coverage_collection
+  #    - name: Run codacy-coverage-reporter
+  #      uses: codacy/codacy-coverage-reporter-action@master
+  #      continue-on-error: True
+  #      with:
+  #        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  #        coverage-reports: cobertura.xml
 
-  Windows:
+  #Windows:
 
-    runs-on: windows-latest
+  #  runs-on: windows-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.7
-        uses: actions/setup-python@v2
-        with:
-            # The second most recent version is used as
-            # setup-python installs the most recent patch
-            # which leads to linking problems as there are
-            # 2 versions of python3X.a and the wrong one
-            # is chosen
-            python-version: 3.7
-      - name: Install dependencies
-        uses: ./.github/actions/windows_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Setup Python 3.7
+  #      uses: actions/setup-python@v2
+  #      with:
+  #          # The second most recent version is used as
+  #          # setup-python installs the most recent patch
+  #          # which leads to linking problems as there are
+  #          # 2 versions of python3X.a and the wrong one
+  #          # is chosen
+  #          python-version: 3.7
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/windows_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
 
   MacOSX:
 
@@ -79,9 +79,12 @@ jobs:
         uses: ./.github/actions/macos_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+      - name: Warning test
+        run: |
+          python -m pytest -rx -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays -vs tests/epyccel/test_array_as_func_args.py
+      #- name: Fortran/C tests with pytest
+      #  uses: ./.github/actions/pytest_run
+      #- name: Python tests with pytest
+      #  uses: ./.github/actions/pytest_run_python
+      #- name: Parallel tests with pytest
+      #  uses: ./.github/actions/pytest_parallel

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,65 +5,65 @@ on:
     branches: [ master ]
 
 jobs:
-  #Linux:
+  Linux:
 
-  #  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Set up Python 3.6
-  #      uses: actions/setup-python@v2
-  #      with:
-  #        python-version: 3.6
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/linux_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Coverage install
-  #      uses: ./.github/actions/coverage_install
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
-  #    - name: Test with valgrind for memory leaks
-  #      uses: ./.github/actions/valgrind_run
-  #    - name: Collect coverage information
-  #      continue-on-error: True
-  #      uses: ./.github/actions/coverage_collection
-  #    - name: Run codacy-coverage-reporter
-  #      uses: codacy/codacy-coverage-reporter-action@master
-  #      continue-on-error: True
-  #      with:
-  #        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-  #        coverage-reports: cobertura.xml
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        uses: ./.github/actions/linux_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Coverage install
+        uses: ./.github/actions/coverage_install
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
+      - name: Test with valgrind for memory leaks
+        uses: ./.github/actions/valgrind_run
+      - name: Collect coverage information
+        continue-on-error: True
+        uses: ./.github/actions/coverage_collection
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
+        continue-on-error: True
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: cobertura.xml
 
-  #Windows:
+  Windows:
 
-  #  runs-on: windows-latest
+    runs-on: windows-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Setup Python 3.7
-  #      uses: actions/setup-python@v2
-  #      with:
-  #          # The second most recent version is used as
-  #          # setup-python installs the most recent patch
-  #          # which leads to linking problems as there are
-  #          # 2 versions of python3X.a and the wrong one
-  #          # is chosen
-  #          python-version: 3.7
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/windows_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v2
+        with:
+            # The second most recent version is used as
+            # setup-python installs the most recent patch
+            # which leads to linking problems as there are
+            # 2 versions of python3X.a and the wrong one
+            # is chosen
+            python-version: 3.7
+      - name: Install dependencies
+        uses: ./.github/actions/windows_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
 
   MacOSX:
 
@@ -79,12 +79,9 @@ jobs:
         uses: ./.github/actions/macos_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: Warning test
-        run: |
-          python -m pytest -rx --ignore=symbolic --ignore=ndarrays -vs tests/epyccel/test_array_as_func_args.py
-      #- name: Fortran/C tests with pytest
-      #  uses: ./.github/actions/pytest_run
-      #- name: Python tests with pytest
-      #  uses: ./.github/actions/pytest_run_python
-      #- name: Parallel tests with pytest
-      #  uses: ./.github/actions/pytest_parallel
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -62,7 +62,7 @@ def construct_flags(compiler,
     print("mac_target : ",mac_target)
     if mac_target:
         #flags.append("-mmacosx-version-min="+mac_target)
-        os.environ['MACOSX_DEPLOYMENT_TARGET'] = target
+        os.environ['MACOSX_DEPLOYMENT_TARGET'] = mac_target
 
     if compiler == "gfortran":
         if debug:

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 import warnings
 
 __all__ = ['construct_flags', 'compile_files', 'get_gfortran_library_dir']
@@ -56,6 +57,10 @@ def construct_flags(compiler,
         flags = ['-O3']
     else:
         flags = list(fflags)
+
+    mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
+    if mac_target:
+        flags.append("-mmacosx-version-min="+mac_target)
 
     if compiler == "gfortran":
         if debug:

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -59,6 +59,7 @@ def construct_flags(compiler,
         flags = list(fflags)
 
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
+    print("mac_target : ",mac_target)
     if mac_target:
         flags.append("-mmacosx-version-min="+mac_target)
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -59,9 +59,7 @@ def construct_flags(compiler,
         flags = list(fflags)
 
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
-    print("mac_target : ",mac_target)
     if mac_target:
-        #flags.append("-mmacosx-version-min="+mac_target)
         os.environ['MACOSX_DEPLOYMENT_TARGET'] = mac_target
 
     if compiler == "gfortran":

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -61,7 +61,8 @@ def construct_flags(compiler,
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     print("mac_target : ",mac_target)
     if mac_target:
-        flags.append("-mmacosx-version-min="+mac_target)
+        #flags.append("-mmacosx-version-min="+mac_target)
+        os.environ['MACOSX_DEPLOYMENT_TARGET'] = target
 
     if compiler == "gfortran":
         if debug:


### PR DESCRIPTION
When compiling on mac we get many warnings which look like:
```
ld: warning: object file (/Users/runner/work/pyccel/pyccel/tests/__epyccel__/__pyccel__/mod_91a1mdtqizek_91a1mdtqizek.o) was built for newer macOS version (10.15) than being linked (10.14)
```

This happens as python is compatible with an earlier version of mac, but we compile with the current version by default. This is fixed by setting the environment variable `MACOSX_DEPLOYMENT_TARGET`.

The following warning can still be seen (test run with `test_array_as_func_args.py` only):
```
tests/epyccel/test_array_as_func_args.py::test_array_int_1d_scalar_add[fortran]
tests/epyccel/test_array_as_func_args.py::test_array_real_1d_scalar_add[fortran]
tests/epyccel/test_array_as_func_args.py::test_array_complex_1d_scalar_add[fortran]
tests/epyccel/test_array_as_func_args.py::test_array_int_2d_scalar_add[fortran]
tests/epyccel/test_array_as_func_args.py::test_array_real_2d_scalar_add[fortran]
tests/epyccel/test_array_as_func_args.py::test_array_complex_2d_scalar_add[fortran]
  /Users/runner/work/pyccel/pyccel/pyccel/codegen/python_wrapper.py:151: UserWarning: ld: warning: dylib (/usr/local/Cellar/gcc@10/10.3.0/lib/gcc/10/libgfortran.dylib) was built for newer macOS version (10.15) than being linked (10.14)
  
    warnings.warn(UserWarning(err))
```
This cannot be fixed as we do not generate this file, but it is much less problematic as pytest is capable of collecting identical warnings