### PR TITLE
Initialise stack array at declaration without contents

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -338,7 +338,10 @@ class CCodePrinter(CodePrinter):
                 The Assign Node used to get the lhs and rhs
         Returns
         -------
-            Returns a string that contains the initialization of a stack_array
+            buffer_array : str
+                String initialising the stack (C) array which stores the data
+            array_init   : str
+                String containing the rhs of the initialization of a stack_array
         """
 
         var = expr
@@ -356,13 +359,13 @@ class CCodePrinter(CodePrinter):
                 size  = tot_shape)
         shape_init = "({declare_dtype}[]){{{shape}}}".format(declare_dtype=declare_dtype, shape=shape)
         strides_init = "({declare_dtype}[{length}]){{0}}".format(declare_dtype=declare_dtype, length=len(var.shape))
-        cpy_data = ' = (t_ndarray){{\n.{0}={1},\n .shape={2},\n .strides={3},\n '
-        cpy_data += '.nd={4},\n .type={0},\n .is_view={5}\n}};\n'
-        cpy_data = cpy_data.format(np_dtype, dummy_array_name,
+        array_init = ' = (t_ndarray){{\n.{0}={1},\n .shape={2},\n .strides={3},\n '
+        array_init += '.nd={4},\n .type={0},\n .is_view={5}\n}};\n'
+        array_init = array_init.format(np_dtype, dummy_array_name,
                     shape_init, strides_init, len(var.shape), 'false')
-        cpy_data += 'stack_array_init(&{})'.format(self._print(var))
+        array_init += 'stack_array_init(&{})'.format(self._print(var))
         self._additional_imports.add("ndarrays")
-        return buffer_array, cpy_data
+        return buffer_array, array_init
 
     def fill_NumpyArange(self, expr, lhs):
         """ print the assignment of a NumpyArange

--- a/tests/epyccel/test_arrays_multiple_assignments.py
+++ b/tests/epyccel/test_arrays_multiple_assignments.py
@@ -223,7 +223,7 @@ def test_Assign_Between_Allocatables():
 
 #==============================================================================
 
-def test_stack_array_if():
+def test_stack_array_if(language):
 
     @stack_array('x')
     def f(b : bool):
@@ -235,7 +235,7 @@ def test_stack_array_if():
         return x[0]
 
     # Initialize singleton that stores Pyccel errors
-    f2 = epyccel(f)
+    f2 = epyccel(f, language=language)
 
     assert f(True) == f2(True)
     assert f(False) == f2(False)

--- a/tests/epyccel/test_arrays_multiple_assignments.py
+++ b/tests/epyccel/test_arrays_multiple_assignments.py
@@ -222,6 +222,25 @@ def test_Assign_Between_Allocatables():
     assert error_info.message == ASSIGN_ARRAYS_ONE_ANOTHER
 
 #==============================================================================
+
+def test_stack_array_if():
+
+    @stack_array('x')
+    def f(b : bool):
+        import numpy as np
+        if b:
+            x = np.array([1,2,3])
+        else:
+            x = np.array([4,5,6])
+        return x[0]
+
+    # Initialize singleton that stores Pyccel errors
+    f2 = epyccel(f)
+
+    assert f(True) == f2(True)
+    assert f(False) == f2(False)
+
+#==============================================================================
 if __name__ == '__main__':
 
     for l in ['fortran']:


### PR DESCRIPTION
Initialise stack array at declaration without contents. This allows stack arrays to then be treated the same as allocatable arrays and fixes #923 

Previously the following code:
```python
import numpy as np

@stack_array('a')
def f(b : bool):

    if b:
        a = np.array([1,2,3])
    else:
        a = np.array([4,5,6])

    print(a)
```

generated:
```c
#include "tmp.h"
#include <stdlib.h>
#include "ndarrays.h"
#include <stdbool.h>
#include <stdio.h>
#include <stdint.h>

/*........................................*/
void f(bool b)
{
    t_ndarray a;
    int64_t i;
    if (b)
    {
        int64_t array_dummy_0001[] = {1, 2, 3};
        a = (t_ndarray){
            .nd_int64=array_dummy_0001,
            .shape=(int64_t[]){3},
            .strides=(int64_t[1]){0},
            .nd=1,
            .type=nd_int64,
            .is_view=false
        };
        stack_array_init(&a);
    }
    else
    {
        int64_t array_dummy_0002[] = {4, 5, 6};
        a = (t_ndarray){
            .nd_int64=array_dummy_0002,
            .shape=(int64_t[]){3},
            .strides=(int64_t[1]){0},
            .nd=1,
            .type=nd_int64,
            .is_view=false
        };
        stack_array_init(&a);
    }
    printf("%s", "[");
    for (i = 0; i < 2; i += 1)
    {
        printf("%ld ", GET_ELEMENT(a, nd_int64, i));
    }
    printf("%ld]\n", GET_ELEMENT(a, nd_int64, 2));
}
/*........................................*/

```

Now it generates:
```c
#include "tmp.h"
#include "ndarrays.h"
#include <stdint.h>
#include <stdbool.h>
#include <stdlib.h>
#include <stdio.h>

/*........................................*/
void f(bool b)
{
    int64_t array_dummy_0003[3];
    t_ndarray a = (t_ndarray){
        .nd_int64=array_dummy_0003,
        .shape=(int64_t[]){3},
        .strides=(int64_t[1]){0},
        .nd=1,
        .type=nd_int64,
        .is_view=false
    };
    stack_array_init(&a);
    int64_t i;
    if (b)
    {
        int64_t array_dummy_0001[] = {1, 2, 3};
        memcpy(a.nd_int64, array_dummy_0001, a.buffer_size);
    }
    else
    {
        int64_t array_dummy_0002[] = {4, 5, 6};
        memcpy(a.nd_int64, array_dummy_0002, a.buffer_size);
    }
    printf("%s", "[");
    for (i = 0; i < 2; i += 1)
    {
        printf("%ld ", GET_ELEMENT(a, nd_int64, i));
    }
    printf("%ld]\n", GET_ELEMENT(a, nd_int64, 2));
}
/*........................................*/
```