### PR TITLE
Raise specific error for (re)allocating array arguments

### DIFF
--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -140,6 +140,7 @@ INVALID_PYTHON_SYNTAX = 'Python syntax error'
 # ARRAY ERRORS
 ASSIGN_ARRAYS_ONE_ANOTHER = 'Arrays which own their data cannot become views on other arrays'
 ARRAY_ALREADY_IN_USE = 'Attempt to reallocate an array which is being used by another variable'
+ARRAY_IS_ARG = 'Attempt to reallocate an array which is an argument. Array arguments cannot be used as local variables'
 INVALID_POINTER_REASSIGN = 'Attempt to give data ownership to a pointer'
 INVALID_INDICES = 'only integers and slices (`:`) are valid indices'
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1298,7 +1298,7 @@ class SemanticParser(BasicParser):
                     order = getattr(var, 'order', 'None')
                     shape = getattr(var, 'shape', 'None')
 
-                    if var.is_argument:
+                    if rank > 0 and var.is_argument:
                         errors.report(ARRAY_IS_ARG, symbol=var,
                             severity='error', blocker=False,
                             bounding_box=(self._current_fst_node.lineno,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1298,13 +1298,7 @@ class SemanticParser(BasicParser):
                     order = getattr(var, 'order', 'None')
                     shape = getattr(var, 'shape', 'None')
 
-                    if rank > 0 and var.is_argument:
-                        errors.report(ARRAY_IS_ARG, symbol=var,
-                            severity='error', blocker=False,
-                            bounding_box=(self._current_fst_node.lineno,
-                                self._current_fst_node.col_offset))
-
-                    elif (d_var['rank'] != rank) or (rank > 1 and d_var['order'] != order):
+                    if (d_var['rank'] != rank) or (rank > 1 and d_var['order'] != order):
 
                         txt = '|{name}| {dtype}{old} <-> {dtype}{new}'
                         format_shape = lambda s: "" if len(s)==0 else s
@@ -1316,7 +1310,13 @@ class SemanticParser(BasicParser):
 
                     elif d_var['shape'] != shape:
 
-                        if var.is_stack_array:
+                        if var.is_argument:
+                            errors.report(ARRAY_IS_ARG, symbol=var,
+                                severity='error', blocker=False,
+                                bounding_box=(self._current_fst_node.lineno,
+                                    self._current_fst_node.col_offset))
+
+                        elif var.is_stack_array:
                             errors.report(INCOMPATIBLE_REDEFINITION_STACK_ARRAY, symbol=name,
                                 severity='error', blocker=False,
                                 bounding_box=(self._current_fst_node.lineno,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1298,7 +1298,13 @@ class SemanticParser(BasicParser):
                     order = getattr(var, 'order', 'None')
                     shape = getattr(var, 'shape', 'None')
 
-                    if (d_var['rank'] != rank) or (rank > 1 and d_var['order'] != order):
+                    if var.is_argument:
+                        errors.report(ARRAY_IS_ARG, symbol=var,
+                            severity='error', blocker=False,
+                            bounding_box=(self._current_fst_node.lineno,
+                                self._current_fst_node.col_offset))
+
+                    elif (d_var['rank'] != rank) or (rank > 1 and d_var['order'] != order):
 
                         txt = '|{name}| {dtype}{old} <-> {dtype}{new}'
                         format_shape = lambda s: "" if len(s)==0 else s


### PR DESCRIPTION
Raise a specific error if array arguments are (re)allocated. Fixes #930

No test is added as this already raised an error, it is just the error text which has changed