### PR TITLE
Add missing copy to macros expecting arguments to occur in results

### DIFF
--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -656,9 +656,7 @@ class MacroFunction(Header):
                     raise ValueError('variable not allowed after an optional argument')
 
             for arg,val in zip(self.arguments[:len(sorted_args)],sorted_args):
-                name = str(arg) if isinstance(arg, PyccelSymbol) \
-                            else arg.name
-                d_arguments[name] = val
+                d_arguments[arg.name] = val
 
             d_unsorted_args = {}
             for arg in self.arguments[len(sorted_args):]:

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -723,25 +723,25 @@ class MacroFunction(Header):
         return newargs
 
     def make_necessary_copies(self, args, results):
-        """ Copy any arguments which are modified in fortran but
-        not in python into the result variable. If the variable
-        is modified in fortran then the argument and result
-        variable should be the same when apply is called
+        """ Copy any arguments provided in python which the macro
+        definition indicates should match the results into the
+        corresponding result.
 
         Parameters
         ----------
         args    : list of Variables
-                   The arguments passed to the macro function
+                   The arguments passed to the macro in the python code
         results : list of Variables
-                  The results collected from the macro function
+                  The results collected from the macro in the python code
 
         Results
         -------
         final_args : list of Variables
                      The arguments which can be passed to the apply function
+                     which match the expectations of the macro definition
         expr       : list of Assigns
-                      Any Assigns necessary before the function is calling
-                      the function returned by the apply function
+                      Any Assigns necessary before the function (result of the 
+                      macro expansion) returned by the apply function is called
         """
         expr = []
         final_args = []

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -658,27 +658,13 @@ class MacroFunction(Header):
             for arg,val in zip(self.arguments[:len(sorted_args)],sorted_args):
                 name = str(arg) if isinstance(arg, PyccelSymbol) \
                             else arg.name
-                if not isinstance(arg, tuple):
-                    d_arguments[name] = val
-                else:
-                    if not isinstance(val, (list, tuple)):
-                        val = [val]
-                    #TODO improve add more checks and generalize
-                    if len(val)>len(arg):
-                        raise ValueError('length mismatch of argument and its value ')
-                    elif len(val)<len(arg):
-                        for val_ in arg[len(val):]:
-                            if isinstance(val_, ValuedVariable):
-                                val +=tuple(val_.value,)
-                            else:
-                                val +=tuple(val_)
-
-                    for arg_,val_ in zip(arg,val):
-                        d_arguments[arg_.name] = val_
+                d_arguments[name] = val
 
             d_unsorted_args = {}
             for arg in self.arguments[len(sorted_args):]:
-                d_unsorted_args[arg.name] = arg.value
+                name = str(arg) if isinstance(arg, PyccelSymbol) \
+                            else arg.name
+                d_unsorted_args[name] = arg.value
 
             for arg in unsorted_args:
                 if arg.name in d_unsorted_args.keys():

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -640,7 +640,9 @@ class MacroFunction(Header):
             n_sorted = len(args)
             for ind, (arg, val) in enumerate(zip(self.arguments, args)):
                 if not isinstance(val, ValuedArgument):
-                    d_arguments[str(arg)] = val
+                    name = str(arg) if isinstance(arg, PyccelSymbol) \
+                            else arg.name
+                    d_arguments[name] = val
                 else:
                     n_sorted=ind
                     break
@@ -661,6 +663,7 @@ class MacroFunction(Header):
                     raise ValueError('Unknown valued argument')
 
             d_arguments.update(d_unsorted_args)
+
             for i, arg in d_arguments.items():
                 if isinstance(arg, Macro):
                     d_arguments[i] = construct_macro(arg.name,

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -656,8 +656,10 @@ class MacroFunction(Header):
                     raise ValueError('variable not allowed after an optional argument')
 
             for arg,val in zip(self.arguments[:len(sorted_args)],sorted_args):
+                name = str(arg) if isinstance(arg, PyccelSymbol) \
+                            else arg.name
                 if not isinstance(arg, tuple):
-                    d_arguments[arg] = val
+                    d_arguments[name] = val
                 else:
                     if not isinstance(val, (list, tuple)):
                         val = [val]

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -656,13 +656,13 @@ class MacroFunction(Header):
                     raise ValueError('variable not allowed after an optional argument')
 
             for arg,val in zip(self.arguments[:len(sorted_args)],sorted_args):
-                d_arguments[arg.name] = val
+                name = str(arg) if isinstance(arg, PyccelSymbol) \
+                            else arg.name
+                d_arguments[name] = val
 
             d_unsorted_args = {}
             for arg in self.arguments[len(sorted_args):]:
-                name = str(arg) if isinstance(arg, PyccelSymbol) \
-                            else arg.name
-                d_unsorted_args[name] = arg.value
+                d_unsorted_args[arg.name] = arg.value
 
             for arg in unsorted_args:
                 if arg.name in d_unsorted_args.keys():

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -740,7 +740,7 @@ class MacroFunction(Header):
                      The arguments which can be passed to the apply function
                      which match the expectations of the macro definition
         expr       : list of Assigns
-                      Any Assigns necessary before the function (result of the 
+                      Any Assigns necessary before the function (result of the
                       macro expansion) returned by the apply function is called
         """
         expr = []

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -638,9 +638,8 @@ class MacroFunction(Header):
 
             unsorted_args = []
             n_sorted = len(args)
-            for ind, (arg, val) in enumerate(self.arguments, args):
-                if not isinstance(i, ValuedArgument):
-                    arg = self.arguments[ind]
+            for ind, (arg, val) in enumerate(zip(self.arguments, args)):
+                if not isinstance(val, ValuedArgument):
                     d_arguments[str(arg)] = val
                 else:
                     n_sorted=ind

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -636,32 +636,23 @@ class MacroFunction(Header):
 
         if len(args) > 0:
 
-            sorted_args   = []
             unsorted_args = []
-            j = -1
-            for ind, i in enumerate(args):
+            n_sorted = len(args)
+            for ind, (arg, val) in enumerate(self.arguments, args):
                 if not isinstance(i, ValuedArgument):
-                    sorted_args.append(i)
+                    arg = self.arguments[ind]
+                    d_arguments[str(arg)] = val
                 else:
-                    j=ind
+                    n_sorted=ind
                     break
-            if j>0:
-                unsorted_args = args[j:]
-                for i in unsorted_args:
-                    if not isinstance(i, ValuedVariable):
-                        raise ValueError('variable not allowed after an optional argument')
 
-            for i in self.arguments[len(sorted_args):]:
+            unsorted_args = args[n_sorted:]
+            for i in unsorted_args:
                 if not isinstance(i, ValuedVariable):
                     raise ValueError('variable not allowed after an optional argument')
 
-            for arg,val in zip(self.arguments[:len(sorted_args)],sorted_args):
-                name = str(arg) if isinstance(arg, PyccelSymbol) \
-                            else arg.name
-                d_arguments[name] = val
-
             d_unsorted_args = {}
-            for arg in self.arguments[len(sorted_args):]:
+            for arg in self.arguments[n_sorted:]:
                 d_unsorted_args[arg.name] = arg.value
 
             for arg in unsorted_args:
@@ -669,6 +660,7 @@ class MacroFunction(Header):
                     d_unsorted_args[arg.name] = arg.value
                 else:
                     raise ValueError('Unknown valued argument')
+
             d_arguments.update(d_unsorted_args)
             for i, arg in d_arguments.items():
                 if isinstance(arg, Macro):

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -202,7 +202,7 @@ class CompileObj:
         """
         Lock the file and its dependencies to prevent race conditions
         """
-        self._lock.acquire()
+        self.acquire_simple_lock()
         for d in self.dependencies:
             d.acquire_simple_lock()
 
@@ -210,13 +210,14 @@ class CompileObj:
         """
         Lock the file to prevent race conditions but not its dependencies
         """
-        self._lock.acquire()
+        if not self.ignore_at_import:
+            self._lock.acquire()
 
     def release_lock(self):
         """
         Unlock the file and its dependencies
         """
-        self._lock.release()
+        self.release_simple_lock()
         for d in self.dependencies:
             d.release_simple_lock()
 
@@ -224,7 +225,8 @@ class CompileObj:
         """
         Unlock the file
         """
-        self._lock.release()
+        if not self.ignore_at_import:
+            self._lock.release()
 
     @property
     def accelerators(self):

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -168,7 +168,7 @@ class CompileObj:
     def extra_modules(self):
         """ Returns the additional objects required to compile the file
         """
-        deps = set(d.target for d in self._dependencies if self.ignore_at_import)
+        deps = set(d.target for d in self._dependencies if not d.ignore_at_import)
         for d in self._dependencies:
             if not self.ignore_at_import:
                 deps.update(d.extra_modules)

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -176,9 +176,10 @@ class CompileObj:
     def extra_modules(self):
         """ Returns the additional objects required to compile the file
         """
-        deps = set(self._dependencies.keys())
+        deps = set()
         for d in self._dependencies.values():
             if d.has_target_file:
+                deps.add(d.module_target)
                 deps.update(d.extra_modules)
         return deps
 

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -98,6 +98,10 @@ class CompileObj:
         """
         Change the folder in which the source file is saved (useful for stdlib)
         """
+        if not self.no_target_file:
+            self._includes.remove(self._folder)
+            self._includes.add(folder)
+
         self._file = os.path.join(folder, os.path.basename(self._file))
         self._folder = folder
 

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -81,7 +81,10 @@ class CompileObj:
         self._lock         = FileLock(self.target+'.lock')
 
         self._flags        = list(flags)
-        self._includes     = set([folder, *includes])
+        if no_target_file:
+            self._includes = includes
+        else:
+            self._includes     = set([folder, *includes])
         self._libs         = list(libs)
         self._libdirs      = set(libdirs)
         self._accelerators = set(accelerators)
@@ -192,7 +195,6 @@ class CompileObj:
             raise TypeError("Dependencies require necessary compile information")
         self._dependencies.update(args)
         for a in args:
-            self._includes.add(a.source_folder)
             self._includes.update(a.includes)
             self._libs.extend(a.libs)
             self._libdirs.update(a.libdirs)

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -176,9 +176,9 @@ class CompileObj:
     def extra_modules(self):
         """ Returns the additional objects required to compile the file
         """
-        deps = set(d.target for d in self._dependencies if d.has_target_file)
-        for d in self._dependencies:
-            if self.has_target_file:
+        deps = set(self._dependencies.keys())
+        for d in self._dependencies.values():
+            if d.has_target_file:
                 deps.update(d.extra_modules)
         return deps
 

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -45,13 +45,13 @@ class CompileObj:
     accelerators  : str
                     Tool used to accelerate the code (e.g. openmp openacc)
 
-    ignore_at_import : bool
+    no_target_file : bool
                     If set to true then this flag indicates that the file has no target.
                     Eg an interface for a library
     """
     __slots__ = ('_file','_folder','_module_name','_module_target','_prog_target',
                  '_target','_lock','_flags','_includes','_libs','_libdirs','_accelerators',
-                 '_dependencies','_is_module','_ignore_at_import')
+                 '_dependencies','_is_module','_no_target_file')
     def __init__(self,
                  file_name,
                  folder,
@@ -62,7 +62,7 @@ class CompileObj:
                  libdirs      = (),
                  dependencies = (),
                  accelerators = (),
-                 ignore_at_import = False):
+                 no_target_file = False):
 
         self._file = os.path.join(folder, file_name)
         self._folder = folder
@@ -89,7 +89,7 @@ class CompileObj:
         if dependencies:
             self.add_dependencies(*dependencies)
         self._is_module    = is_module
-        self._ignore_at_import = ignore_at_import
+        self._no_target_file = no_target_file
 
     def reset_folder(self, folder):
         """
@@ -168,9 +168,9 @@ class CompileObj:
     def extra_modules(self):
         """ Returns the additional objects required to compile the file
         """
-        deps = set(d.target for d in self._dependencies if not d.ignore_at_import)
+        deps = set(d.target for d in self._dependencies if not d.no_target_file)
         for d in self._dependencies:
-            if not self.ignore_at_import:
+            if not self.no_target_file:
                 deps.update(d.extra_modules)
         return deps
 
@@ -210,7 +210,7 @@ class CompileObj:
         """
         Lock the file to prevent race conditions but not its dependencies
         """
-        if not self.ignore_at_import:
+        if not self.no_target_file:
             self._lock.acquire()
 
     def release_lock(self):
@@ -225,7 +225,7 @@ class CompileObj:
         """
         Unlock the file
         """
-        if not self.ignore_at_import:
+        if not self.no_target_file:
             self._lock.release()
 
     @property
@@ -247,9 +247,9 @@ class CompileObj:
         return hash(self.target)
 
     @property
-    def ignore_at_import(self):
+    def no_target_file(self):
         """
         Indicates whether the file has a target.
         Eg an interface for a library may not have a target
         """
-        return self._ignore_at_import
+        return self._no_target_file

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -45,13 +45,13 @@ class CompileObj:
     accelerators  : str
                     Tool used to accelerate the code (e.g. openmp openacc)
 
-    no_target_file : bool
-                    If set to true then this flag indicates that the file has no target.
+    has_target_file : bool
+                    If set to false then this flag indicates that the file has no target.
                     Eg an interface for a library
     """
     __slots__ = ('_file','_folder','_module_name','_module_target','_prog_target',
                  '_target','_lock','_flags','_includes','_libs','_libdirs','_accelerators',
-                 '_dependencies','_is_module','_no_target_file')
+                 '_dependencies','_is_module','_has_target_file')
     def __init__(self,
                  file_name,
                  folder,
@@ -62,7 +62,7 @@ class CompileObj:
                  libdirs      = (),
                  dependencies = (),
                  accelerators = (),
-                 no_target_file = False):
+                 has_target_file = True):
 
         self._file = os.path.join(folder, file_name)
         self._folder = folder
@@ -81,10 +81,10 @@ class CompileObj:
         self._lock         = FileLock(self.target+'.lock')
 
         self._flags        = list(flags)
-        if no_target_file:
-            self._includes = includes
-        else:
+        if has_target_file:
             self._includes     = set([folder, *includes])
+        else:
+            self._includes = set(includes)
         self._libs         = list(libs)
         self._libdirs      = set(libdirs)
         self._accelerators = set(accelerators)
@@ -92,13 +92,13 @@ class CompileObj:
         if dependencies:
             self.add_dependencies(*dependencies)
         self._is_module    = is_module
-        self._no_target_file = no_target_file
+        self._has_target_file = has_target_file
 
     def reset_folder(self, folder):
         """
         Change the folder in which the source file is saved (useful for stdlib)
         """
-        if not self.no_target_file:
+        if self.has_target_file:
             self._includes.remove(self._folder)
             self._includes.add(folder)
 
@@ -175,9 +175,9 @@ class CompileObj:
     def extra_modules(self):
         """ Returns the additional objects required to compile the file
         """
-        deps = set(d.target for d in self._dependencies if not d.no_target_file)
+        deps = set(d.target for d in self._dependencies if d.has_target_file)
         for d in self._dependencies:
-            if not self.no_target_file:
+            if self.has_target_file:
                 deps.update(d.extra_modules)
         return deps
 
@@ -216,7 +216,7 @@ class CompileObj:
         """
         Lock the file to prevent race conditions but not its dependencies
         """
-        if not self.no_target_file:
+        if self.has_target_file:
             self._lock.acquire()
 
     def release_lock(self):
@@ -231,7 +231,7 @@ class CompileObj:
         """
         Unlock the file
         """
-        if not self.no_target_file:
+        if self.has_target_file:
             self._lock.release()
 
     @property
@@ -253,9 +253,9 @@ class CompileObj:
         return hash(self.target)
 
     @property
-    def no_target_file(self):
+    def has_target_file(self):
         """
         Indicates whether the file has a target.
         Eg an interface for a library may not have a target
         """
-        return self._no_target_file
+        return self._has_target_file

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -406,10 +406,12 @@ class Compiler:
         verbose : bool
                   Indicates whether additional output should be shown
         """
+        cmd = [os.path.expandvars(c) for c in cmd]
         if verbose:
             print(' '.join(cmd))
 
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                universal_newlines=True)
         out, err = p.communicate()
 
         if verbose and out:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -349,7 +349,6 @@ def execute_pyccel(fname, *,
 
             # Stop conditions
             if parser.metavars.get('ignore_at_import', False) or \
-
                parser.metavars.get('module_name', None) == 'omp_lib':
                 return
 

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -288,22 +288,6 @@ def execute_pyccel(fname, *,
                 accelerators = accelerators)
         parser.compile_obj = main_obj
 
-        def get_dependencies(main_obj, parser):
-            for p in parser.sons:
-                if p.compile_obj is None:
-                    libs = (p.metavars['libraries'],) if 'libraries' in p.metavars else ()
-                    no_target = p.metavars.get('no_target',False) or \
-                            p.metavars.get('ignore_at_import',False)
-                    s_obj = CompileObj(file_name = p.filename,
-                                folder       = os.path.dirname(p.filename),
-                                libs         = libs,
-                                no_target_file = no_target)
-                    p.compile_obj = s_obj
-                main_obj.add_dependencies(p.compile_obj)
-                get_dependencies(main_obj, p)
-
-        get_dependencies(main_obj, parser)
-
         #------------------------------------------------------
         # TODO: collect dependencies and proceed recursively
         # if recursive:
@@ -355,8 +339,13 @@ def execute_pyccel(fname, *,
             if parser.compile_obj:
                 deps[mod_base] = parser.compile_obj
             elif mod_base not in deps:
+                libs = (parser.metavars['libraries'],) if 'libraries' in parser.metavars else ()
+                no_target = parser.metavars.get('no_target',False) or \
+                        parser.metavars.get('ignore_at_import',False)
                 deps[mod_base] = CompileObj(mod_base,
-                                    folder=mod_folder)
+                                    folder         = mod_folder,
+                                    libs           = libs,
+                                    no_target_file = no_target)
 
             # Proceed recursively
             for son in parser.sons:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -344,9 +344,9 @@ def execute_pyccel(fname, *,
                 no_target = parser.metavars.get('no_target',False) or \
                         parser.metavars.get('ignore_at_import',False)
                 deps[mod_base] = CompileObj(mod_base,
-                                    folder         = mod_folder,
-                                    libs           = compile_libs,
-                                    no_target_file = no_target)
+                                    folder          = mod_folder,
+                                    libs            = compile_libs,
+                                    has_target_file = not no_target)
 
             # Proceed recursively
             for son in parser.sons:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -288,6 +288,20 @@ def execute_pyccel(fname, *,
                 accelerators = accelerators)
         parser.compile_obj = main_obj
 
+        def get_dependencies(main_obj, parser):
+            for p in parser.sons:
+                if p.compile_obj is None:
+                    libs = (p.metavars['libraries'],) if 'libraries' in p.metavars else ()
+                    s_obj = CompileObj(file_name = p.filename,
+                                folder       = os.path.dirname(p.filename),
+                                libs         = libs,
+                                ignore_at_import = p.metavars.get('ignore_at_import',False))
+                    p.compile_obj = s_obj
+                main_obj.add_dependencies(p.compile_obj)
+                get_dependencies(main_obj, p)
+
+        get_dependencies(main_obj, parser)
+
         #------------------------------------------------------
         # TODO: collect dependencies and proceed recursively
         # if recursive:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -292,10 +292,12 @@ def execute_pyccel(fname, *,
             for p in parser.sons:
                 if p.compile_obj is None:
                     libs = (p.metavars['libraries'],) if 'libraries' in p.metavars else ()
+                    no_target = p.metavars.get('no_target_file',False) or \
+                            p.metavars.get('ignore_at_import',False)
                     s_obj = CompileObj(file_name = p.filename,
                                 folder       = os.path.dirname(p.filename),
                                 libs         = libs,
-                                ignore_at_import = p.metavars.get('ignore_at_import',False))
+                                no_target_file = no_target)
                     p.compile_obj = s_obj
                 main_obj.add_dependencies(p.compile_obj)
                 get_dependencies(main_obj, p)
@@ -347,6 +349,7 @@ def execute_pyccel(fname, *,
 
             # Stop conditions
             if parser.metavars.get('ignore_at_import', False) or \
+
                parser.metavars.get('module_name', None) == 'omp_lib':
                 return
 

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -277,6 +277,8 @@ def execute_pyccel(fname, *,
             shutil.copyfile(fname, new_location)
             continue
 
+        compile_libs = [*libs, parser.metavars['libraries']] \
+                        if 'libraries' in parser.metavars else libs
         main_obj = CompileObj(file_name = fname,
                 folder       = pyccel_dirpath,
                 is_module    = codegen.is_module,
@@ -332,19 +334,18 @@ def execute_pyccel(fname, *,
             mod_base = os.path.basename(parser.filename)
 
             # Stop conditions
-            if parser.metavars.get('ignore_at_import', False) or \
-               parser.metavars.get('module_name', None) == 'omp_lib':
+            if parser.metavars.get('module_name', None) == 'omp_lib':
                 return
 
             if parser.compile_obj:
                 deps[mod_base] = parser.compile_obj
             elif mod_base not in deps:
-                libs = (parser.metavars['libraries'],) if 'libraries' in parser.metavars else ()
+                compile_libs = (parser.metavars['libraries'],) if 'libraries' in parser.metavars else ()
                 no_target = parser.metavars.get('no_target',False) or \
                         parser.metavars.get('ignore_at_import',False)
                 deps[mod_base] = CompileObj(mod_base,
                                     folder         = mod_folder,
-                                    libs           = libs,
+                                    libs           = compile_libs,
                                     no_target_file = no_target)
 
             # Proceed recursively

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -284,7 +284,7 @@ def execute_pyccel(fname, *,
                 is_module    = codegen.is_module,
                 flags        = fflags,
                 includes     = includes,
-                libs         = libs,
+                libs         = compile_libs,
                 libdirs      = libdirs,
                 dependencies = modules,
                 accelerators = accelerators)

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -292,7 +292,7 @@ def execute_pyccel(fname, *,
             for p in parser.sons:
                 if p.compile_obj is None:
                     libs = (p.metavars['libraries'],) if 'libraries' in p.metavars else ()
-                    no_target = p.metavars.get('no_target_file',False) or \
+                    no_target = p.metavars.get('no_target',False) or \
                             p.metavars.get('ignore_at_import',False)
                     s_obj = CompileObj(file_name = p.filename,
                                 folder       = os.path.dirname(p.filename),

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -349,7 +349,8 @@ class CCodePrinter(CodePrinter):
         dtype = self.find_in_dtype_registry(dtype_str, var.precision)
         np_dtype = self.find_in_ndarray_type_registry(dtype_str, var.precision)
         shape = ", ".join(self._print(i) for i in var.alloc_shape)
-        tot_shape = self._print(functools.reduce(PyccelMul, var.alloc_shape))
+        tot_shape = self._print(functools.reduce(
+            lambda x,y: PyccelMul(x,y,simplify=True), var.alloc_shape))
         declare_dtype = self.find_in_dtype_registry('int', 8)
 
         dummy_array_name, _ = create_incremented_string(self._parser.used_names, prefix = 'array_dummy')
@@ -1707,7 +1708,8 @@ class CCodePrinter(CodePrinter):
         if var.rank == 0:
             return '1'
         else:
-            return self._print(functools.reduce(PyccelMul, var.shape))
+            return self._print(functools.reduce(
+                lambda x,y: PyccelMul(x,y,simplify=True), var.shape))
 
 
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1680,6 +1680,35 @@ class CCodePrinter(CodePrinter):
                                     decs=decs,
                                     body=body)
 
+    #=================== MACROS ==================
+
+    def _print_MacroShape(self, expr):
+        var = expr.argument
+        if not isinstance(var, (Variable, IndexedElement)):
+            raise TypeError('Expecting a variable, given {}'.format(type(var)))
+        shape = var.shape
+
+        if len(shape) == 1:
+            shape = shape[0]
+
+
+        elif not(expr.index is None):
+            if expr.index < len(shape):
+                shape = shape[expr.index]
+            else:
+                shape = '1'
+
+        return self._print(shape)
+
+    def _print_MacroCount(self, expr):
+
+        var = expr.argument
+
+        if var.rank == 0:
+            return '1'
+        else:
+            return self._print(functools.reduce(PyccelMul, var.shape))
+
 
 
     def indent_code(self, code):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -958,8 +958,7 @@ class FCodePrinter(CodePrinter):
 
         if rank == 0:
             return '1'
-
-        return str(functools.reduce(operator.mul, shape ))
+        return self._print(functools.reduce(PyccelMul, shape))
 
     def _print_Declare(self, expr):
         # ... ignored declarations

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -907,7 +907,8 @@ class FCodePrinter(CodePrinter):
         if var.rank == 0:
             return '1'
         else:
-            return self._print(functools.reduce(PyccelMul, var.shape))
+            return self._print(functools.reduce(
+                lambda x,y: PyccelMul(x,y,simplify=True), var.shape))
 
     def _print_Declare(self, expr):
         # ... ignored declarations

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2067,9 +2067,15 @@ class SemanticParser(BasicParser):
 
                 args = [self._visit(i, **settings) for i in
                             rhs.args]
+                args, expr = macro.make_necessary_copies(args, results)
+                new_expressions += expr
                 args = macro.apply(args, results=results)
                 if isinstance(master, FunctionDef):
-                    return FunctionCall(master, args, self._current_function)
+                    func_call = FunctionCall(master, args, self._current_function)
+                    if new_expressions:
+                        return CodeBlock([*new_expressions, func_call])
+                    else:
+                        return func_call
                 else:
                     # TODO treate interface case
                     errors.report(PYCCEL_RESTRICTION_TODO,

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -165,7 +165,7 @@ class StringStmt(BasicStmt):
         self.arg = kwargs.pop('arg')
     @property
     def expr(self):
-        return LiteralString(repr(str(self.arg)))
+        return LiteralString(str(self.arg))
 
 class UnionTypeStmt(BasicStmt):
     def __init__(self, **kwargs):

--- a/pyccel/stdlib/internal/blas.pyh
+++ b/pyccel/stdlib/internal/blas.pyh
@@ -5,7 +5,7 @@
 #$ header metavar module_version='3.8'
 #$ header metavar ignore_at_import=True
 #$ header metavar save=True
-#$ header metavar libraries='${BLAS_LIBRARIES}'
+#$ header metavar libraries='blas'
 
 # .......................................
 #             LEVEL-1

--- a/pyccel/stdlib/internal/lapack.pyh
+++ b/pyccel/stdlib/internal/lapack.pyh
@@ -2,7 +2,7 @@
 
 #$ header metavar module_version='3.8'
 #$ header metavar ignore_at_import=True
-#$ header metavar libraries='${LAPACK_LIBRARIES}'
+#$ header metavar libraries='lapack'
 #$ header metavar save=True
 
 # .......................................

--- a/pyccel/stdlib/internal/lapack.pyh
+++ b/pyccel/stdlib/internal/lapack.pyh
@@ -11,70 +11,70 @@
 #             
 # .......................................
 
-#$ header function dgetrf(int, int, double [:,:], int, int [:], int)
-#$ header function dgetri(int, double [:,:], int, int [:], double [:], int, int)
+#$ header function dgetrf(int, int, double [:,:](order=F), int, int [:], int)
+#$ header function dgetri(int, double [:,:](order=F), int, int [:], double [:], int, int)
 
-#$ header function dgetrs(str, int, int, double [:,:], int, int [:], double [:,:], int, int)
-#$ header function dgecon(str, int, double [:,:], int, double, double, double [:], int [:], int)
+#$ header function dgetrs(str, int, int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, int)
+#$ header function dgecon(str, int, double [:,:](order=F), int, double, double, double [:], int [:], int)
 
 
 #...............................................................
 
 
-#$ header function sgesv(int, int, float [:,:], int, int [:], float [:,:], int, int)
-#$ header function dgesv(int, int, double [:,:], int, int [:], double [:,:], int, int)
+#$ header function sgesv(int, int, float [:,:](order=F), int, int [:], float [:,:](order=F), int, int)
+#$ header function dgesv(int, int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, int)
 
-#$ header function sgesvx(str, str, str, int, int, float [:,:], int, float, float, int, int, int, float [:], float [:,:], int, float [:,:], int, float [:], int, int [:], int)
-#$ header function dgesvx(str, str, str, int, int, double [:,:], int, double, double, int, int, int, double [:], double [:,:], int, double [:,:], int, double [:], int, int [:], int)
+#$ header function sgesvx(str, str, str, int, int, float [:,:](order=F), int, float, float, int, int, int, float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], int, int [:], int)
+#$ header function dgesvx(str, str, str, int, int, double [:,:](order=F), int, double, double, int, int, int, double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], int, int [:], int)
 
-#$ header function sgbsv(int, int, int, int, float [:,:], int, int [:], float [:,:], int, int)
-#$ header function dgbsv(int, int, int, int, double [:,:], int, int [:], double [:,:], int, int)
+#$ header function sgbsv(int, int, int, int, float [:,:](order=F), int, int [:], float [:,:](order=F), int, int)
+#$ header function dgbsv(int, int, int, int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, int)
 
-#$ header function sgbsvx(str, str, int, int, int, int, float [:,:], int, float [:,:], int, int [:], str, float [:], float [:], float [:,:])
-#$ header function dgbsvx(str, str, int, int, int, int, double [:,:], int, double [:,:], int, int [:], str, double [:], double [:], double [:,:])
+#$ header function sgbsvx(str, str, int, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int [:], str, float [:], float [:], float [:,:](order=F))
+#$ header function dgbsvx(str, str, int, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int [:], str, double [:], double [:], double [:,:](order=F))
 
-#$ header function sgtsv(int, int, float [:], float [:], float [:], float [:,:], int, int)
-#$ header function dgtsv(int, int, double [:], double [:], double [:], double [:,:], int, int)
+#$ header function sgtsv(int, int, float [:], float [:], float [:], float [:,:](order=F), int, int)
+#$ header function dgtsv(int, int, double [:], double [:], double [:], double [:,:](order=F), int, int)
 
-#$ header function sgtsvx(str, str, int, int, float [:], float [:], float [:], float [:], float [:], float [:], float [:], int [:], float [:,:], int, float [:,:], int, float, float [:], float [:], float [:], int [:], int)
-#$ header function dgtsvx(str, str, int, int, double [:], double [:], double [:], double [:], double [:], double [:], double [:], int [:], double [:,:], int, double [:,:], int, double, double [:], double [:], double [:], int [:], int)
+#$ header function sgtsvx(str, str, int, int, float [:], float [:], float [:], float [:], float [:], float [:], float [:], int [:], float [:,:](order=F), int, float [:,:](order=F), int, float, float [:], float [:], float [:], int [:], int)
+#$ header function dgtsvx(str, str, int, int, double [:], double [:], double [:], double [:], double [:], double [:], double [:], int [:], double [:,:](order=F), int, double [:,:](order=F), int, double, double [:], double [:], double [:], int [:], int)
 
 
-#$ header function sposv(str, int, int, float [:,:], int, float [:,:], int, int)
-#$ header function dposv(str, int, int, double [:,:], int, double [:,:], int, int)
+#$ header function sposv(str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int)
+#$ header function dposv(str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int)
 
-#$ header function sposvx(str, str, int, int, float [:,:], int, float [:,:], int, str, float [:], float [:,:], int, float [:,:], int, float, float [:], float [:], float [:], int [:], int)
-#$ header function dposvx(str, str, int, int, double [:,:], int, double [:,:], int, str, double [:], double [:,:], int, double [:,:], int, double, double [:], double [:], double [:], int [:], int)
+#$ header function sposvx(str, str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, str, float [:], float [:,:](order=F), int, float [:,:](order=F), int, float, float [:], float [:], float [:], int [:], int)
+#$ header function dposvx(str, str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, str, double [:], double [:,:](order=F), int, double [:,:](order=F), int, double, double [:], double [:], double [:], int [:], int)
 
-#$ header function sppsv(str, int, int, float [:], float [:,:], int, int)
-#$ header function dppsv(str, int, int, double [:], double [:,:], int, int)
+#$ header function sppsv(str, int, int, float [:], float [:,:](order=F), int, int)
+#$ header function dppsv(str, int, int, double [:], double [:,:](order=F), int, int)
 
-#$ header function sppsvx(str, str, int, int, float [:], float [:], str, float [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dppsvx(str, str, int, int, double [:], double [:], str, double [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function sppsvx(str, str, int, int, float [:], float [:], str, float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dppsvx(str, str, int, int, double [:], double [:], str, double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
-#$ header function spbsv(str, int, int, int, float [:,:], int, float [:,:], int, int)
-#$ header function dpbsv(str, int, int, int, double [:,:], int, double [:,:], int, int)
+#$ header function spbsv(str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int)
+#$ header function dpbsv(str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int)
 
-#$ header function spbsvx(str, str, int, int, int, float [:,:], int, float [:,:], int, str, float [:], float [:,:], int, float [:,:], int, float, float [:], float [:], float [:], int [:], int)
-#$ header function dpbsvx(str, str, int, int, int, double [:,:], int, double [:,:], int, str, double [:], double [:,:], int, double [:,:], int, double, double [:], double [:], double [:], int [:], int)
+#$ header function spbsvx(str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, str, float [:], float [:,:](order=F), int, float [:,:](order=F), int, float, float [:], float [:], float [:], int [:], int)
+#$ header function dpbsvx(str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, str, double [:], double [:,:](order=F), int, double [:,:](order=F), int, double, double [:], double [:], double [:], int [:], int)
 
-#$ header function sptsv(int, int, float [:], float [:], float [:,:], int, int)
-#$ header function dptsv(int, int, double [:], double [:], double [:,:], int, int)
+#$ header function sptsv(int, int, float [:], float [:], float [:,:](order=F), int, int)
+#$ header function dptsv(int, int, double [:], double [:], double [:,:](order=F), int, int)
 
-#$ header function sptsvx(str, int, int, float [:], float [:], float [:], float [:], float [:,:], int, float [:,:], int, float, float [:], float [:], float [:], int)
-#$ header function dptsvx(str, int, int, double [:], double [:], double [:], double [:], double [:,:], int, double [:,:], int, double, double [:], double [:], double [:], int)
+#$ header function sptsvx(str, int, int, float [:], float [:], float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float, float [:], float [:], float [:], int)
+#$ header function dptsvx(str, int, int, double [:], double [:], double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double, double [:], double [:], double [:], int)
 
-#$ header function ssysv(str, int, int, float [:,:], int, int [:], float [:,:], int, float [:], int, int)
-#$ header function dsysv(str, int, int, double [:,:], int, int [:], double [:,:], int, double [:], int, int)
+#$ header function ssysv(str, int, int, float [:,:](order=F), int, int [:], float [:,:](order=F), int, float [:], int, int)
+#$ header function dsysv(str, int, int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, double [:], int, int)
 
-#$ header function ssysvx(str, str, int, int, float [:,:], int, float [:,:], int, int [:], float [:,:], int, float, float [:], float [:], float [:], int, int [:], int)
-#$ header function dsysvx(str, str, int, int, double [:,:], int, double [:,:], int, int [:], double [:,:], int, double, double [:], double [:], double [:], int, int [:], int)
+#$ header function ssysvx(str, str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int [:], float [:,:](order=F), int, float, float [:], float [:], float [:], int, int [:], int)
+#$ header function dsysvx(str, str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, double, double [:], double [:], double [:], int, int [:], int)
 
-#$ header function sspsv(str, int, int, float [:], int [:], float [:,:], int, int)
-#$ header function dspsv(str, int, int, double [:], int [:], double [:,:], int, int)
+#$ header function sspsv(str, int, int, float [:], int [:], float [:,:](order=F), int, int)
+#$ header function dspsv(str, int, int, double [:], int [:], double [:,:](order=F), int, int)
 
-#$ header function sspsvx(str, str, int, int, float [:], float [:], int [:], float [:,:], int, float [:,:], int, float, float [:], float [:], float [:], float [:], int)
-#$ header function dspsvx(str, str, int, int, double [:], double [:], int [:], double [:,:], int, double [:,:], int, double, double [:], double [:], double [:], double [:], int)
+#$ header function sspsvx(str, str, int, int, float [:], float [:], int [:], float [:,:](order=F), int, float [:,:](order=F), int, float, float [:], float [:], float [:], float [:], int)
+#$ header function dspsvx(str, str, int, int, double [:], double [:], int [:], double [:,:](order=F), int, double [:,:](order=F), int, double, double [:], double [:], double [:], double [:], int)
 
 
 
@@ -82,157 +82,157 @@
 
 
 
-#$ header function sgels(str, int, int, int, float [:,:], int, float [:,:], int, float [:], int, int)
-#$ header function dgels(str, int, int, int, double [:,:], int, double [:,:], int, double [:], int, int)
+#$ header function sgels(str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], int, int)
+#$ header function dgels(str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], int, int)
 
-#$ header function sgelsy(int, int, int, float [:,:], int, float [:,:], int, int [:], float, int, float [:], int, int)
-#$ header function dgelsy(int, int, int, double [:,:], int, double [:,:], int, int [:], double, int, double [:], int, int)
+#$ header function sgelsy(int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int [:], float, int, float [:], int, int)
+#$ header function dgelsy(int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int [:], double, int, double [:], int, int)
 
-#$ header function sgelss(int, int, int, float [:,:], int, float [:,:], int, float [:], float, int, float [:], int, int)
-#$ header function dgelss(int, int, int, double [:,:], int, double [:,:], int, double [:], double, int, double [:], int, int)
+#$ header function sgelss(int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float, int, float [:], int, int)
+#$ header function dgelss(int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double, int, double [:], int, int)
 
-#$ header function sgelsd(int, int, float [:,:], int, float [:,:], int, float [:], float, int, float [:], int, int [:], int)
-#$ header function dgelsd(int, int, double [:,:], int, double [:,:], int, double [:], double, int, double [:], int, int [:], int)
+#$ header function sgelsd(int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float, int, float [:], int, int [:], int)
+#$ header function dgelsd(int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double, int, double [:], int, int [:], int)
 
 #...........................................................
 
-#$ header function sgglse(int, int, int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], float [:], int, int)
-#$ header function dgglse(int, int, int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], double [:], int, int)
+#$ header function sgglse(int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], float [:], int, int)
+#$ header function dgglse(int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], double [:], int, int)
 
-#$ header function sggglm(int, int, int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], float [:], int, int)
-#$ header function dggglm(int, int, int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], double [:], int, int)
+#$ header function sggglm(int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], float [:], int, int)
+#$ header function dggglm(int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], double [:], int, int)
 
 #....................................................
 
 
 
-#$ header function ssyev(str, str, int, float [:,:], int, float [:], float [:], int, int)
-#$ header function dsyev(str, str, int, double [:,:], int, double [:], double [:], int, int)
+#$ header function ssyev(str, str, int, float [:,:](order=F), int, float [:], float [:], int, int)
+#$ header function dsyev(str, str, int, double [:,:](order=F), int, double [:], double [:], int, int)
 
-#$ header function ssyevd(str, str, int, float [:,:], int, float [:], float [:], int, float [:], int, int)
-#$ header function dsyevd(str, str, int, double [:,:], int, double [:], double [:], int, double [:], int, int)
-
-
-#$ header function ssyevx(str, str, str, int, float [:,:], int, float, float, int, int, float, int, float [:], float [:,:], int, float [:], int, int [:], int [:], int)
-#$ header function dsyevx(str, str, str, int, double [:,:], int, double, double, int, int, double, int, double [:], double [:,:], int, double [:], int, int [:], int [:], int)
+#$ header function ssyevd(str, str, int, float [:,:](order=F), int, float [:], float [:], int, float [:], int, int)
+#$ header function dsyevd(str, str, int, double [:,:](order=F), int, double [:], double [:], int, double [:], int, int)
 
 
-#$ header function ssyevr(str, str, str, int, float [:,:], int, float, float, int, int, float, int, float [:], float [:,:], int, int [:], float [:], int, int [:], int, int)
-#$ header function dsyevr(str, str, str, int, double [:,:], int, double, double, int, int, double, int, double [:], double [:,:], int, int [:], double [:], int, int [:], int, int)
+#$ header function ssyevx(str, str, str, int, float [:,:](order=F), int, float, float, int, int, float, int, float [:], float [:,:](order=F), int, float [:], int, int [:], int [:], int)
+#$ header function dsyevx(str, str, str, int, double [:,:](order=F), int, double, double, int, int, double, int, double [:], double [:,:](order=F), int, double [:], int, int [:], int [:], int)
 
 
-#$ header function sspev(str, str, int, float [:], float [:], float [:,:], int, float [:], int)
-#$ header function dspev(str, str, int, double [:], double [:], double [:,:], int, double [:], int)
-
-#$ header function sspevd(str, str, int, float [:], float [:], float [:,:], int, float [:], int, int [:], int, int)
-#$ header function dspevd(str, str, int, double [:], double [:], double [:,:], int, double [:], int, int [:], int, int)
-
-#$ header function sspevx(str, str, str, int, float [:], float, float, int, int, float, int, float [:], float [:,:], int, float [:], int [:], int [:], int)
-#$ header function dspevx(str, str, str, int, double [:], double, double, int, int, double, int, double [:], double [:,:], int, double [:], int [:], int [:], int)
+#$ header function ssyevr(str, str, str, int, float [:,:](order=F), int, float, float, int, int, float, int, float [:], float [:,:](order=F), int, int [:], float [:], int, int [:], int, int)
+#$ header function dsyevr(str, str, str, int, double [:,:](order=F), int, double, double, int, int, double, int, double [:], double [:,:](order=F), int, int [:], double [:], int, int [:], int, int)
 
 
-#$ header function ssbev(str, str, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int)
-#$ header function dsbev(str, str, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int)
+#$ header function sspev(str, str, int, float [:], float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dspev(str, str, int, double [:], double [:], double [:,:](order=F), int, double [:], int)
 
-#$ header function ssbevd(str, str, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int [:], int, int)
-#$ header function dsbevd(str, str, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int [:], int, int)
+#$ header function sspevd(str, str, int, float [:], float [:], float [:,:](order=F), int, float [:], int, int [:], int, int)
+#$ header function dspevd(str, str, int, double [:], double [:], double [:,:](order=F), int, double [:], int, int [:], int, int)
 
-
-#$ header function ssbevx(str, str, str, int, int, float [:,:], int, float [:,:], int, float, float, int, int, float, int, float [:], float [:,:], int, float [:], int [:], int [:], int)
-#$ header function dsbevx(str, str, str, int, int, double [:,:], int, double [:,:], int, double, double, int, int, double, int, double [:], double [:,:], int, double [:], int [:], int [:], int)
-
-
-#$ header function sstrev(str, int, float [:], float [:], float [:,:], int, float [:], int)
-#$ header function dstrev(str, int, double [:], double [:], double [:,:], int, double [:], int)
-
-#$ header function sstrevd(str, int, float [:], float [:], float [:,:], int, float [:], int, int [:], int, int)
-#$ header function dstrevd(str, int, double [:], double [:], double [:,:], int, double [:], int, int [:], int, int)
+#$ header function sspevx(str, str, str, int, float [:], float, float, int, int, float, int, float [:], float [:,:](order=F), int, float [:], int [:], int [:], int)
+#$ header function dspevx(str, str, str, int, double [:], double, double, int, int, double, int, double [:], double [:,:](order=F), int, double [:], int [:], int [:], int)
 
 
-#$ header function sstrevx(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:], int, float [:], int [:], int [:], int)
-#$ header function dstrevx(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:], int, double [:], int [:], int [:], int)
+#$ header function ssbev(str, str, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dsbev(str, str, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int)
+
+#$ header function ssbevd(str, str, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int [:], int, int)
+#$ header function dsbevd(str, str, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int [:], int, int)
 
 
-#$ header function sstrevr(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:], int, int [:], float [:], int, int [:], int, int)
-#$ header function dstrevr(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:], int, int [:], double [:], int, int [:], int, int)
-
-# header function sgees(str, str,exter, int, float [:,:], int, int, float [:], float [:], float [:,:], int, float [:], int,bool[:], int)
-# header function dgees(str, str,exter, int, double [:,:], int, int, double [:], double [:], double [:,:], int, double [:], int,bool[:], int)
-
-# header function sgeesx(str, str,exter, str, int, float [:,:], int, int, float [:], float [:], float [:,:], int, float, float, float [:], int, int [:], int,bool[:], int)
-# header function dgeesx(str, str,exter, str, int, double [:,:], int, int, double [:], double [:], double [:,:], int, double, double, double [:], int, int [:], int,bool[:], int)
+#$ header function ssbevx(str, str, str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float, float, int, int, float, int, float [:], float [:,:](order=F), int, float [:], int [:], int [:], int)
+#$ header function dsbevx(str, str, str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double, double, int, int, double, int, double [:], double [:,:](order=F), int, double [:], int [:], int [:], int)
 
 
-#$ header function sgeev(str, str, int, float [:,:], int, float [:], float [:], float [:,:], int, float [:,:], int, float [:], int, int)
-#$ header function dgeev(str, str, int, double [:,:], int, double [:], double [:], double [:,:], int, double [:,:], int, double [:], int, int)
+#$ header function sstrev(str, int, float [:], float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dstrev(str, int, double [:], double [:], double [:,:](order=F), int, double [:], int)
+
+#$ header function sstrevd(str, int, float [:], float [:], float [:,:](order=F), int, float [:], int, int [:], int, int)
+#$ header function dstrevd(str, int, double [:], double [:], double [:,:](order=F), int, double [:], int, int [:], int, int)
 
 
-#$ header function sgeevx(str, str, str, str, int, float [:,:], int, float [:], float [:], float [:,:], int, int, int, float [:], float, float [:], float [:], float [:], int, int [:], int)
-#$ header function dgeevx(str, str, str, str, int, double [:,:], int, double [:], double [:], double [:,:], int, int, int, double [:], double, double [:], double [:], double [:], int, int [:], int)
+#$ header function sstrevx(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:](order=F), int, float [:], int [:], int [:], int)
+#$ header function dstrevx(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:](order=F), int, double [:], int [:], int [:], int)
 
 
-#$ header function sgesvd(str, str, int, int, float [:,:], int, float [:], float [:,:], int, float [:,:], int, float [:], int, int)
-#$ header function dgesvd(str, str, int, int, double [:,:], int, double [:], double [:,:], int, double [:,:], int, double [:], int, int)
+#$ header function sstrevr(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:](order=F), int, int [:], float [:], int, int [:], int, int)
+#$ header function dstrevr(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:](order=F), int, int [:], double [:], int, int [:], int, int)
 
-#$ header function sgesdd(str, int, int, float [:,:], int, float [:], float [:,:], int, float [:,:], int, float [:], int, int [:], int)
-#$ header function dgesdd(str, int, int, double [:,:], int, double [:], double [:,:], int, double [:,:], int, double [:], int, int [:], int)
+# header function sgees(str, str,exter, int, float [:,:](order=F), int, int, float [:], float [:], float [:,:](order=F), int, float [:], int,bool[:], int)
+# header function dgees(str, str,exter, int, double [:,:](order=F), int, int, double [:], double [:], double [:,:](order=F), int, double [:], int,bool[:], int)
 
-#$ header function sstev(str, int, float [:], float [:], float [:,:], int, float [:], int)
-#$ header function dstev(str, int, double [:], double [:], double [:,:], int, double [:], int)
-
-#$ header function sstevd(str, int, float [:], float [:], float [:,:], int, float [:], int, int [:], int, int)
-#$ header function dstevd(str, int, double [:], double [:], double [:,:], int, double [:], int, int [:], int, int)
-
-#$ header function sstevx(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:], int, float [:], int [:], int [:], int)
-#$ header function dstevx(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:], int, double [:], int [:], int [:], int)
+# header function sgeesx(str, str,exter, str, int, float [:,:](order=F), int, int, float [:], float [:], float [:,:](order=F), int, float, float, float [:], int, int [:], int,bool[:], int)
+# header function dgeesx(str, str,exter, str, int, double [:,:](order=F), int, int, double [:], double [:], double [:,:](order=F), int, double, double, double [:], int, int [:], int,bool[:], int)
 
 
-#$ header function sstevr(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:], int, int [:], float [:], int, int [:], int, int)
-#$ header function dstevr(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:], int, int [:], double [:], int, int [:], int, int)
+#$ header function sgeev(str, str, int, float [:,:](order=F), int, float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], int, int)
+#$ header function dgeev(str, str, int, double [:,:](order=F), int, double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], int, int)
 
-#$ header function ssytrd(str, int, float [:,:], int, float [:], float [:], float [:], float [:], int, int)
-#$ header function dsytrd(str, int, double [:,:], int, double [:], double [:], double [:], double [:], int, int)
+
+#$ header function sgeevx(str, str, str, str, int, float [:,:](order=F), int, float [:], float [:], float [:,:](order=F), int, int, int, float [:], float, float [:], float [:], float [:], int, int [:], int)
+#$ header function dgeevx(str, str, str, str, int, double [:,:](order=F), int, double [:], double [:], double [:,:](order=F), int, int, int, double [:], double, double [:], double [:], double [:], int, int [:], int)
+
+
+#$ header function sgesvd(str, str, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], int, int)
+#$ header function dgesvd(str, str, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], int, int)
+
+#$ header function sgesdd(str, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], int, int [:], int)
+#$ header function dgesdd(str, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], int, int [:], int)
+
+#$ header function sstev(str, int, float [:], float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dstev(str, int, double [:], double [:], double [:,:](order=F), int, double [:], int)
+
+#$ header function sstevd(str, int, float [:], float [:], float [:,:](order=F), int, float [:], int, int [:], int, int)
+#$ header function dstevd(str, int, double [:], double [:], double [:,:](order=F), int, double [:], int, int [:], int, int)
+
+#$ header function sstevx(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:](order=F), int, float [:], int [:], int [:], int)
+#$ header function dstevx(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:](order=F), int, double [:], int [:], int [:], int)
+
+
+#$ header function sstevr(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:](order=F), int, int [:], float [:], int, int [:], int, int)
+#$ header function dstevr(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:](order=F), int, int [:], double [:], int, int [:], int, int)
+
+#$ header function ssytrd(str, int, float [:,:](order=F), int, float [:], float [:], float [:], float [:], int, int)
+#$ header function dsytrd(str, int, double [:,:](order=F), int, double [:], double [:], double [:], double [:], int, int)
 
 #$ header function ssptrd(str, int, float [:], float [:], float [:], float [:], int)
 #$ header function dsptrd(str, int, double [:], double [:], double [:], double [:], int)
 
-#$ header function ssbtrd(str, str, int, int, float [:,:], int, float [:], float [:], float [:,:], int, float [:], int)
-#$ header function dsbtrd(str, str, int, int, double [:,:], int, double [:], double [:], double [:,:], int, double [:], int)
+#$ header function ssbtrd(str, str, int, int, float [:,:](order=F), int, float [:], float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dsbtrd(str, str, int, int, double [:,:](order=F), int, double [:], double [:], double [:,:](order=F), int, double [:], int)
 
-#$ header function sorgtr(str, int, float [:,:], int, float [:], float [:], int, int)
-#$ header function dorgtr(str, int, double [:,:], int, double [:], double [:], int, int)
+#$ header function sorgtr(str, int, float [:,:](order=F), int, float [:], float [:], int, int)
+#$ header function dorgtr(str, int, double [:,:](order=F), int, double [:], double [:], int, int)
 
-#$ header function sormtr(str, str, str, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int)
-#$ header function dormtr(str, str, str, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int)
+#$ header function sormtr(str, str, str, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int)
+#$ header function dormtr(str, str, str, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int)
 
-#$ header function sopgtr(str, int, float [:], float [:], float [:,:], int, float [:], int)
-#$ header function dopgtr(str, int, double [:], double [:], double [:,:], int, double [:], int)
+#$ header function sopgtr(str, int, float [:], float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dopgtr(str, int, double [:], double [:], double [:,:](order=F), int, double [:], int)
 
-#$ header function sopmtr(str, str, str, int, int, float [:], float [:], float [:,:], int, float [:], int)
-#$ header function dopmtr(str, str, str, int, int, double [:], double [:], double [:,:], int, double [:], int)
+#$ header function sopmtr(str, str, str, int, int, float [:], float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dopmtr(str, str, str, int, int, double [:], double [:], double [:,:](order=F), int, double [:], int)
 
-#$ header function ssteqr(str, int, float [:], float [:], float [:,:], int, float [:], int)
-#$ header function dsteqr(str, int, double [:], double [:], double [:,:], int, double [:], int)
+#$ header function ssteqr(str, int, float [:], float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dsteqr(str, int, double [:], double [:], double [:,:](order=F), int, double [:], int)
 
 #$ header function ssterf(int, float [:], float [:], int)
 #$ header function dsterf(int, double [:], double [:], int)
 
-#$ header function sstedc(str, int, float [:], float [:], float [:,:], int, float [:], int, int [:], int, int)
-#$ header function dstedc(str, int, double [:], double [:], double [:,:], int, double [:], int, int [:], int, int)
+#$ header function sstedc(str, int, float [:], float [:], float [:,:](order=F), int, float [:], int, int [:], int, int)
+#$ header function dstedc(str, int, double [:], double [:], double [:,:](order=F), int, double [:], int, int [:], int, int)
 
 
-#$ header function sstegr(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:], int, int [:], float [:], int, int [:], int, int)
-#$ header function dstegr(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:], int, int [:], double [:], int, int [:], int, int)
+#$ header function sstegr(str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:](order=F), int, int [:], float [:], int, int [:], int, int)
+#$ header function dstegr(str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:](order=F), int, int [:], double [:], int, int [:], int, int)
 
 
 #$ header function sstebz(str, str, int, float, float, int, int, float, float [:], float [:], int, int, float [:], int [:], int [:], float [:], int [:], int)
 #$ header function dstebz(str, str, int, double, double, int, int, double, double [:], double [:], int, int, double [:], int [:], int [:], double [:], int [:], int)
 
-#$ header function sstein(int, float [:], float [:], int, float [:], float [:], float [:], float [:,:], int, float [:], int [:], int [:], int)
-#$ header function dstein(int, double [:], double [:], int, double [:], double [:], double [:], double [:,:], int, double [:], int [:], int [:], int)
+#$ header function sstein(int, float [:], float [:], int, float [:], float [:], float [:], float [:,:](order=F), int, float [:], int [:], int [:], int)
+#$ header function dstein(int, double [:], double [:], int, double [:], double [:], double [:], double [:,:](order=F), int, double [:], int [:], int [:], int)
 
-#$ header function spteqr(str, int, float [:], float [:], float [:,:], int, float [:], int)
-#$ header function dpteqr(str, int, double [:], double [:], double [:,:], int, double [:], int)
+#$ header function spteqr(str, int, float [:], float [:], float [:,:](order=F), int, float [:], int)
+#$ header function dpteqr(str, int, double [:], double [:], double [:,:](order=F), int, double [:], int)
 
 
 
@@ -242,134 +242,134 @@
 
 
 
-#$ header function dsygv(int, str, str, int, double [:,:], int, double [:,:], int, double [:], double [:], int, int)
-#$ header function ssygv(int, str, str, int, float [:,:], int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dsygv(int, str, str, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function ssygv(int, str, str, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], int, int)
 
-#$ header function dsygvd(int, str, str, int, double [:,:], int, double [:,:], int, double [:], double [:], int, int [:], int, int)
-#$ header function ssygvd(int, str, str, int, float [:,:], int, float [:,:], int, float [:], float [:], int, int [:], int, int)
+#$ header function dsygvd(int, str, str, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], int, int [:], int, int)
+#$ header function ssygvd(int, str, str, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], int, int [:], int, int)
 
-#$ header function dsygvx(int, str, str, str, int, double [:,:], int, double [:,:], int, double, double, int, int, double, int, double [:], double [:,:], int, double [:], int, int [:], int [:], int)
-#$ header function ssygvx(int, str, str, str, int, float [:,:], int, float [:,:], int, float, float, int, int, float, int, float [:], float [:,:], int, float [:], int, int [:], int [:], int)
+#$ header function dsygvx(int, str, str, str, int, double [:,:](order=F), int, double [:,:](order=F), int, double, double, int, int, double, int, double [:], double [:,:](order=F), int, double [:], int, int [:], int [:], int)
+#$ header function ssygvx(int, str, str, str, int, float [:,:](order=F), int, float [:,:](order=F), int, float, float, int, int, float, int, float [:], float [:,:](order=F), int, float [:], int, int [:], int [:], int)
 
-#$ header function dspgv(int, str, str, int, double [:], double [:], double [:], double [:,:], int, double [:], int)
-#$ header function sspgv(int, str, str, int, float [:], float [:], float [:], float [:,:], int, float [:], int)
+#$ header function dspgv(int, str, str, int, double [:], double [:], double [:], double [:,:](order=F), int, double [:], int)
+#$ header function sspgv(int, str, str, int, float [:], float [:], float [:], float [:,:](order=F), int, float [:], int)
 
-#$ header function dspgvd(int, str, str, int, double [:], double [:], double [:], double [:,:], int, double [:], int, int [:], int, int)
-#$ header function sspgvd(int, str, str, int, float [:], float [:], float [:], float [:,:], int, float [:], int, int [:], int, int)
+#$ header function dspgvd(int, str, str, int, double [:], double [:], double [:], double [:,:](order=F), int, double [:], int, int [:], int, int)
+#$ header function sspgvd(int, str, str, int, float [:], float [:], float [:], float [:,:](order=F), int, float [:], int, int [:], int, int)
 
-#$ header function dspgvx(int, str, str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:], int, double [:], int [:], int [:], int)
-#$ header function sspgvx(int, str, str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:], int, float [:], int [:], int [:], int)
+#$ header function dspgvx(int, str, str, str, int, double [:], double [:], double, double, int, int, double, int, double [:], double [:,:](order=F), int, double [:], int [:], int [:], int)
+#$ header function sspgvx(int, str, str, str, int, float [:], float [:], float, float, int, int, float, int, float [:], float [:,:](order=F), int, float [:], int [:], int [:], int)
 
-#$ header function dsbgv(str, str, int, int, int, double [:,:], int, double [:,:], int, double [:], double [:,:], int, double [:], int)
-#$ header function ssbgv(str, str, int, int, int, float [:,:], int, float [:,:], int, float [:], float [:,:], int, float [:], int)
+#$ header function dsbgv(str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int)
+#$ header function ssbgv(str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int)
 
-#$ header function dsbgvd(str, str, int, int, int, double [:,:], int, double [:,:], int, double [:], double [:,:], int, double [:], int, int [:], int, int)
-#$ header function ssbgvd(str, str, int, int, int, float [:,:], int, float [:,:], int, float [:], float [:,:], int, float [:], int, int [:], int, int)
+#$ header function dsbgvd(str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int [:], int, int)
+#$ header function ssbgvd(str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int [:], int, int)
 
-#$ header function dsbgvx(str, str, str, int, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double, double, int, int, double, int, double [:], double [:,:], int, double [:], int [:], int [:], int)
-#$ header function ssbgvx(str, str, str, int, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float, float, int, int, float, int, float [:], float [:,:], int, float [:], int [:], int [:], int)
+#$ header function dsbgvx(str, str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double, double, int, int, double, int, double [:], double [:,:](order=F), int, double [:], int [:], int [:], int)
+#$ header function ssbgvx(str, str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float, float, int, int, float, int, float [:], float [:,:](order=F), int, float [:], int [:], int [:], int)
 
-# header function dgges(str, str, str,exter, int, double [:,:], int, double [:,:], int, int, double [:], double [:], double [:], double [:,:], int, double [:,:], int, double [:], int,bool[:], int)
-# header function sgges(str, str, str,exter, int, float [:,:], int, float [:,:], int, int, float [:], float [:], float [:], float [:,:], int, float [:,:], int, float [:], int,bool[:], int)
+# header function dgges(str, str, str,exter, int, double [:,:](order=F), int, double [:,:](order=F), int, int, double [:], double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], int,bool[:], int)
+# header function sgges(str, str, str,exter, int, float [:,:](order=F), int, float [:,:](order=F), int, int, float [:], float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], int,bool[:], int)
 
-# header function dggesx(str, str, str,exter, str, int, double [:,:], int, double [:,:], int, int, double [:], double [:], double [:], double [:,:], int, double [:,:], int, double [2], double [2], double [:], int, int [:], int,bool[:], int)
-# header function sggesx(str, str, str,exter, str, int, float [:,:], int, float [:,:], int, int, float [:], float [:], float [:], float [:,:], int, float [:,:], int, float [2], float [2], float [:], int, int [:], int,bool[:], int)
-
-
-#$ header function dggev(str, str, int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], double [:,:], int, double [:,:], int, double [:], int, int)
-#$ header function sggev(str, str, int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], float [:,:], int, float [:,:], int, float [:], int, int)
+# header function dggesx(str, str, str,exter, str, int, double [:,:](order=F), int, double [:,:](order=F), int, int, double [:], double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [2], double [2], double [:], int, int [:], int,bool[:], int)
+# header function sggesx(str, str, str,exter, str, int, float [:,:](order=F), int, float [:,:](order=F), int, int, float [:], float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [2], float [2], float [:], int, int [:], int,bool[:], int)
 
 
-#$ header function dggevx(str, str, str, str, int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], double [:,:], int, double [:,:], int, int, int, double [:], double [:], double, double, double [:], double [:], double [:], int, int [:],bool[:], int)
-#$ header function sggevx(str, str, str, str, int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], float [:,:], int, float [:,:], int, int, int, float [:], float [:], float, float, float [:], float [:], float [:], int, int [:],bool[:], int)
+#$ header function dggev(str, str, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], int, int)
+#$ header function sggev(str, str, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], int, int)
 
 
-#$ header function dggsvd(str, str, str, int, int, int, int, int, double [:,:], int, double [:,:], int, double [:], double [:], double [:,:], int, double [:,:], int, double [:,:], int, double [:], int [:], int)
-#$ header function sggsvd(str, str, str, int, int, int, int, int, float [:,:], int, float [:,:], int, float [:], float [:], float [:,:], int, float [:,:], int, float [:,:], int, float [:], int [:], int)
+#$ header function dggevx(str, str, str, str, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, int, int, double [:], double [:], double, double, double [:], double [:], double [:], int, int [:],bool[:], int)
+#$ header function sggevx(str, str, str, str, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, int, int, float [:], float [:], float, float, float [:], float [:], float [:], int, int [:],bool[:], int)
+
+
+#$ header function dggsvd(str, str, str, int, int, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], int [:], int)
+#$ header function sggsvd(str, str, str, int, int, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], int [:], int)
 
 
 
 #............................................................
 #Lineaire equation
 #............................................................
-#$ header function sgetrf(int, int, float [:,:], int, float [:], int)
-#$ header function dgetrf(int, int, double [:,:], int, double [:], int)
+#$ header function sgetrf(int, int, float [:,:](order=F), int, float [:], int)
+#$ header function dgetrf(int, int, double [:,:](order=F), int, double [:], int)
 
-#$ header function sgetrs(str, int, int, float [:,:], int, float [:], float [:,:], int, int)
-#$ header function dgetrs(str, int, int, double [:,:], int, double [:], double [:,:], int, int)
-
-
-#$ header function sgecon(str, int, float [:,:], int, float, float, float [:], int [:], int)
-#$ header function dgecon(str, int, double [:,:], int, double, double, double [:], int [:], int)
-
-#$ header function sgerfs(str, int, int, float [:,:], int, float [:,:], int, int [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dgerfs(str, int, int, double [:,:], int, double [:,:], int, int [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function sgetrs(str, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, int)
+#$ header function dgetrs(str, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, int)
 
 
-#$ header function sgetri(int, float [:,:], int, int [:], float [:], int, int)
-#$ header function dgetri(int, double [:,:], int, int [:], double [:], int, int)
+#$ header function sgecon(str, int, float [:,:](order=F), int, float, float, float [:], int [:], int)
+#$ header function dgecon(str, int, double [:,:](order=F), int, double, double, double [:], int [:], int)
+
+#$ header function sgerfs(str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dgerfs(str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
 
-#$ header function sgeequ(int, int, float [:,:], int, float [:], float [:], float, float, float, int)
-#$ header function dgeequ(int, int, double [:,:], int, double [:], double [:], double, double, double, int)
+#$ header function sgetri(int, float [:,:](order=F), int, int [:], float [:], int, int)
+#$ header function dgetri(int, double [:,:](order=F), int, int [:], double [:], int, int)
 
 
-#$ header function sgbtrf(int, int, int, int, float [:,:], int, int [:], int)
-#$ header function dgbtrf(int, int, int, int, double [:,:], int, int [:], int)
+#$ header function sgeequ(int, int, float [:,:](order=F), int, float [:], float [:], float, float, float, int)
+#$ header function dgeequ(int, int, double [:,:](order=F), int, double [:], double [:], double, double, double, int)
 
 
-#$ header function sgbtrs(str, int, int, int, int, float [:,:], int, int [:], float [:,:], int, int)
-#$ header function dgbtrs(str, int, int, int, int, double [:,:], int, int [:], double [:,:], int, int)
+#$ header function sgbtrf(int, int, int, int, float [:,:](order=F), int, int [:], int)
+#$ header function dgbtrf(int, int, int, int, double [:,:](order=F), int, int [:], int)
 
-#$ header function sgbcon(str, int, int, int, float [:,:], int, int [:], float, float, float [:], int [:], int)
-#$ header function dgbcon(str, int, int, int, double [:,:], int, int [:], double, double, double [:], int [:], int)
 
-#$ header function sgbrfs(str, int, int, int, int, float [:,:], int, float [:,:], int, int [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dgbrfs(str, int, int, int, int, double [:,:], int, double [:,:], int, int [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function sgbtrs(str, int, int, int, int, float [:,:](order=F), int, int [:], float [:,:](order=F), int, int)
+#$ header function dgbtrs(str, int, int, int, int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, int)
 
-#$ header function sgbequ(int, int, int, int, float [:,:], int, float [:], float [:], float, float, float, int)
-#$ header function dgbequ(int, int, int, int, double [:,:], int, double [:], double [:], double, double, double, int)
+#$ header function sgbcon(str, int, int, int, float [:,:](order=F), int, int [:], float, float, float [:], int [:], int)
+#$ header function dgbcon(str, int, int, int, double [:,:](order=F), int, int [:], double, double, double [:], int [:], int)
+
+#$ header function sgbrfs(str, int, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dgbrfs(str, int, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
+
+#$ header function sgbequ(int, int, int, int, float [:,:](order=F), int, float [:], float [:], float, float, float, int)
+#$ header function dgbequ(int, int, int, int, double [:,:](order=F), int, double [:], double [:], double, double, double, int)
 
 
 #$ header function sgttrf(int, float [:], float [:], float [:], float [:], int [:], int)
 #$ header function dgttrf(int, double [:], double [:], double [:], double [:], int [:], int)
 
-#$ header function sgttrs(str, int, int, float [:], float [:], float [:], float [:], int [:], float [:,:], int, int)
-#$ header function dgttrs(str, int, int, double [:], double [:], double [:], double [:], int [:], double [:,:], int, int)
+#$ header function sgttrs(str, int, int, float [:], float [:], float [:], float [:], int [:], float [:,:](order=F), int, int)
+#$ header function dgttrs(str, int, int, double [:], double [:], double [:], double [:], int [:], double [:,:](order=F), int, int)
 
 
 #$ header function sgtcon(str, float [:], float [:], float [:], float [:], int [:], float, float, float [:], int [:], int)
 #$ header function dgtcon(str, double [:], double [:], double [:], double [:], int [:], double, double, double [:], int [:], int)
 
 
-#$ header function sgtrfs(str, int, int, float [:], float [:], float [:], float [:], float [:], float [:], float [:], int [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dgtrfs(str, int, int, double [:], double [:], double [:], double [:], double [:], double [:], double [:], int [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function sgtrfs(str, int, int, float [:], float [:], float [:], float [:], float [:], float [:], float [:], int [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dgtrfs(str, int, int, double [:], double [:], double [:], double [:], double [:], double [:], double [:], int [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
 
 
 
 
 
-#$ header function spotrf(str, int, float [:,:], int, int)
-#$ header function dpotrf(str, int, double [:,:], int, int)
+#$ header function spotrf(str, int, float [:,:](order=F), int, int)
+#$ header function dpotrf(str, int, double [:,:](order=F), int, int)
 
-#$ header function spotrs(str, int, int, float [:,:], int, float [:,:], int, int)
-#$ header function dpotrs(str, int, int, double [:,:], int, double [:,:], int, int)
-
-
-#$ header function spocon(str, int, float [:,:], int, float, float, float [:], int [:], int)
-#$ header function dpocon(str, int, double [:,:], int, double, double, double [:], int [:], int)
+#$ header function spotrs(str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int)
+#$ header function dpotrs(str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int)
 
 
-#$ header function sporfs(str, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dporfs(str, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
-
-#$ header function spotri(str, int, float [:,:], int, int)
-#$ header function dpotri(str, int, double [:,:], int, int)
+#$ header function spocon(str, int, float [:,:](order=F), int, float, float, float [:], int [:], int)
+#$ header function dpocon(str, int, double [:,:](order=F), int, double, double, double [:], int [:], int)
 
 
-#$ header function spoequ(int, float [:,:], int, float [:], float, float, int)
-#$ header function dpoequ(int, double [:,:], int, double [:], double, double, int)
+#$ header function sporfs(str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dporfs(str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
+
+#$ header function spotri(str, int, float [:,:](order=F), int, int)
+#$ header function dpotri(str, int, double [:,:](order=F), int, int)
+
+
+#$ header function spoequ(int, float [:,:](order=F), int, float [:], float, float, int)
+#$ header function dpoequ(int, double [:,:](order=F), int, double [:], double, double, int)
 
 
 
@@ -377,16 +377,16 @@
 #$ header function dpptrf(str, int, double [:], int)
 
 
-#$ header function spptrs(str, int, int, float [:], float [:,:], int, int)
-#$ header function dpptrs(str, int, int, double [:], double [:,:], int, int)
+#$ header function spptrs(str, int, int, float [:], float [:,:](order=F), int, int)
+#$ header function dpptrs(str, int, int, double [:], double [:,:](order=F), int, int)
 
 #$ header function sppcon(str, int, float [:], float, float, float [:], int [:], int)
 #$ header function dppcon(str, int, double [:], double, double, double [:], int [:], int)
 
 
 
-#$ header function spprfs(str, int, int, float [:], float [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dpprfs(str, int, int, double [:], double [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function spprfs(str, int, int, float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dpprfs(str, int, int, double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
 
 #$ header function spptri(str, int, float [:], int)
@@ -397,256 +397,256 @@
 #$ header function dppequ(str, int, double [:], double [:], double, double, int)
 
 
-#$ header function spbtrf(str, int, int, float [:,:], int, int)
-#$ header function dpbtrf(str, int, int, double [:,:], int, int)
+#$ header function spbtrf(str, int, int, float [:,:](order=F), int, int)
+#$ header function dpbtrf(str, int, int, double [:,:](order=F), int, int)
 
 
-#$ header function spbtrs(str, int, int, int, float [:,:], int, float [:,:], int, int)
-#$ header function dpbtrs(str, int, int, int, double [:,:], int, double [:,:], int, int)
+#$ header function spbtrs(str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int)
+#$ header function dpbtrs(str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int)
 
-#$ header function spbcon(str, int, int, float [:,:], int, float, float, float [:], int [:], int)
-#$ header function dpbcon(str, int, int, double [:,:], int, double, double, double [:], int [:], int)
+#$ header function spbcon(str, int, int, float [:,:](order=F), int, float, float, float [:], int [:], int)
+#$ header function dpbcon(str, int, int, double [:,:](order=F), int, double, double, double [:], int [:], int)
 
-#$ header function spbrfs(str, int, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dpbrfs(str, int, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function spbrfs(str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dpbrfs(str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
-#$ header function spbequ(str, int, int, float [:,:], int, float [:], float, float, int)
-#$ header function dpbequ(str, int, int, double [:,:], int, double [:], double, double, int)
+#$ header function spbequ(str, int, int, float [:,:](order=F), int, float [:], float, float, int)
+#$ header function dpbequ(str, int, int, double [:,:](order=F), int, double [:], double, double, int)
 
 
 #$ header function spttrf(int, float [:], float [:], int)
 #$ header function dpttrf(int, double [:], double [:], int)
 
-#$ header function spttrs(int, int, float [:], float [:], float [:,:], int, int)
-#$ header function dpttrs(int, int, double [:], double [:], double [:,:], int, int)
+#$ header function spttrs(int, int, float [:], float [:], float [:,:](order=F), int, int)
+#$ header function dpttrs(int, int, double [:], double [:], double [:,:](order=F), int, int)
 
 #$ header function sptcon(int, float [:], float [:], float, float, float [:], int)
 #$ header function dptcon(int, double [:], double [:], double, double, double [:], int)
 
 
-#$ header function sptrfs(int, int, float [:], float [:], float [:], float [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int)
-#$ header function dptrfs(int, int, double [:], double [:], double [:], double [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int)
+#$ header function sptrfs(int, int, float [:], float [:], float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int)
+#$ header function dptrfs(int, int, double [:], double [:], double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int)
 
-#$ header function ssytrf(str, int, float [:,:], int, int [:], float [:], int, int)
-#$ header function dsytrf(str, int, double [:,:], int, int [:], double [:], int, int)
+#$ header function ssytrf(str, int, float [:,:](order=F), int, int [:], float [:], int, int)
+#$ header function dsytrf(str, int, double [:,:](order=F), int, int [:], double [:], int, int)
 
-#$ header function ssytrs(str, int, int, float [:,:], int, int [:], float [:,:], int, int)
-#$ header function dsytrs(str, int, int, double [:,:], int, int [:], double [:,:], int, int)
+#$ header function ssytrs(str, int, int, float [:,:](order=F), int, int [:], float [:,:](order=F), int, int)
+#$ header function dsytrs(str, int, int, double [:,:](order=F), int, int [:], double [:,:](order=F), int, int)
 
 
-#$ header function ssycon(str, int, float [:,:], int, int [:], float, float, float [:], int [:], int)
-#$ header function dsycon(str, int, double [:,:], int, int [:], double, double, double [:], int [:], int)
+#$ header function ssycon(str, int, float [:,:](order=F), int, int [:], float, float, float [:], int [:], int)
+#$ header function dsycon(str, int, double [:,:](order=F), int, int [:], double, double, double [:], int [:], int)
 
-#$ header function ssyrfs(str, int, int, float [:,:], int, float [:,:], int, float [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dsyrfs(str, int, int, double [:,:], int, double [:,:], int, double [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function ssyrfs(str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dsyrfs(str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
-#$ header function ssytri(str, int, float [:,:], int, int [:], float [:], int)
-#$ header function dsytri(str, int, double [:,:], int, int [:], double [:], int)
+#$ header function ssytri(str, int, float [:,:](order=F), int, int [:], float [:], int)
+#$ header function dsytri(str, int, double [:,:](order=F), int, int [:], double [:], int)
 
 
 #$ header function ssptrf(str, int, float [:], int [:], int)
 #$ header function dsptrf(str, int, double [:], int [:], int)
 
 
-#$ header function ssptrs(str, int, int, float [:], int [:], float [:,:], int, int)
-#$ header function dsptrs(str, int, int, double [:], int [:], double [:,:], int, int)
+#$ header function ssptrs(str, int, int, float [:], int [:], float [:,:](order=F), int, int)
+#$ header function dsptrs(str, int, int, double [:], int [:], double [:,:](order=F), int, int)
 
 
 #$ header function sspcon(str, int, float [:], int [:], float, float, float [:], int [:], int)
 #$ header function dspcon(str, int, double [:], int [:], double, double, double [:], int [:], int)
 
-#$ header function ssprfs(str, int, int, float [:], float [:], int [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dsprfs(str, int, int, double [:], double [:], int [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function ssprfs(str, int, int, float [:], float [:], int [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dsprfs(str, int, int, double [:], double [:], int [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
 
 #$ header function ssptri(str, int, float [:], int [:], float [:], int)
 #$ header function dsptri(str, int, double [:], int [:], double [:], int)
 
-#$ header function strtrs(str, str, str, int, int, float [:,:], int, float [:,:], int, int)
-#$ header function dtrtrs(str, str, str, int, int, double [:,:], int, double [:,:], int, int)
+#$ header function strtrs(str, str, str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, int)
+#$ header function dtrtrs(str, str, str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, int)
 
-#$ header function strcon(str, str, str, int, float [:,:], int, float, float [:], int [:], int)
-#$ header function dtrcon(str, str, str, int, double [:,:], int, double, double [:], int [:], int)
+#$ header function strcon(str, str, str, int, float [:,:](order=F), int, float, float [:], int [:], int)
+#$ header function dtrcon(str, str, str, int, double [:,:](order=F), int, double, double [:], int [:], int)
 
-#$ header function strrfs(str, str, str, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dtrrfs(str, str, str, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function strrfs(str, str, str, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dtrrfs(str, str, str, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
-#$ header function strtri(str, str, int, float [:,:], int, int)
-#$ header function dtrtri(str, str, int, double [:,:], int, int)
+#$ header function strtri(str, str, int, float [:,:](order=F), int, int)
+#$ header function dtrtri(str, str, int, double [:,:](order=F), int, int)
 
-#$ header function stptrs(str, str, str, int, int, float [:], float [:,:], int, int)
-#$ header function dtptrs(str, str, str, int, int, double [:], double [:,:], int, int)
+#$ header function stptrs(str, str, str, int, int, float [:], float [:,:](order=F), int, int)
+#$ header function dtptrs(str, str, str, int, int, double [:], double [:,:](order=F), int, int)
 
 #$ header function stpcon(str, str, str, int, float [:], float, float [:], int [:], int)
 #$ header function dtpcon(str, str, str, int, double [:], double, double [:], int [:], int)
 
 
-#$ header function stprfs(str, str, str, int, int, float [:], float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dtprfs(str, str, str, int, int, double [:], double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function stprfs(str, str, str, int, int, float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dtprfs(str, str, str, int, int, double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
 #$ header function stptri(str, str, int, float [:], int)
 #$ header function dtptri(str, str, int, double [:], int)
 
-#$ header function stbtrs(str, str, str, int, int, int, float [:,:], int, float [:,:], int)
-#$ header function dtbtrs(str, str, str, int, int, int, double [:,:], int, double [:,:], int)
+#$ header function stbtrs(str, str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int)
+#$ header function dtbtrs(str, str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int)
 
-#$ header function stbcon(str, str, str, int, int, float [:,:], int, float, float [:], int [:], int)
-#$ header function dtbcon(str, str, str, int, int, double [:,:], int, double, double [:], int [:], int)
+#$ header function stbcon(str, str, str, int, int, float [:,:](order=F), int, float, float [:], int [:], int)
+#$ header function dtbcon(str, str, str, int, int, double [:,:](order=F), int, double, double [:], int [:], int)
 
-#$ header function stbrfs(str, str, str, int, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], int [:], int)
-#$ header function dtbrfs(str, str, str, int, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], int [:], int)
+#$ header function stbrfs(str, str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], int [:], int)
+#$ header function dtbrfs(str, str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], int [:], int)
 
 
 #..............................................
 #Orthogonal Factorizations and Linear Least Squares Problems
 
-#$ header function dgebrd(int, int, double [:,:], int, double [:], double [:], double [:], double [:], double [:], int, int)
-#$ header function sgebrd(int, int, float [:,:], int, float [:], float [:], float [:], float [:], float [:], int, int)
+#$ header function dgebrd(int, int, double [:,:](order=F), int, double [:], double [:], double [:], double [:], double [:], int, int)
+#$ header function sgebrd(int, int, float [:,:](order=F), int, float [:], float [:], float [:], float [:], float [:], int, int)
 
 
-#$ header function dgeqp3(int, int, double [:,:], int, int [:], double [:], double [:], int, int)
-#$ header function sgeqp3(int, int, float [:,:], int, int [:], float [:], float [:], int, int)
+#$ header function dgeqp3(int, int, double [:,:](order=F), int, int [:], double [:], double [:], int, int)
+#$ header function sgeqp3(int, int, float [:,:](order=F), int, int [:], float [:], float [:], int, int)
 
 
-#$ header function dgeqrf(int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sgeqrf(int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dgeqrf(int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sgeqrf(int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
 
-#$ header function dgelqf(int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sgelqf(int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dgelqf(int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sgelqf(int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
 
-#$ header function dgeqlf(int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sgeqlf(int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dgeqlf(int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sgeqlf(int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
-#$ header function dgerqf(int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sgerqf(int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dgerqf(int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sgerqf(int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
-#$ header function dorgbr(str, int, int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sorgbr(str, int, int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dorgbr(str, int, int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sorgbr(str, int, int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
-#$ header function dormbr(str, str, str, int, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int)
-#$ header function sormbr(str, str, str, int, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int)
+#$ header function dormbr(str, str, str, int, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int)
+#$ header function sormbr(str, str, str, int, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int)
 
-#$ header function dorgqr(int, int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sorgqr(int, int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dorgqr(int, int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sorgqr(int, int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
-#$ header function dormqr(str, str, int, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int)
-#$ header function sormqr(str, str, int, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int)
+#$ header function dormqr(str, str, int, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int)
+#$ header function sormqr(str, str, int, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int)
 
-#$ header function dormlq(str, str, int, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int)
-#$ header function sormlq(str, str, int, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int)
+#$ header function dormlq(str, str, int, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int)
+#$ header function sormlq(str, str, int, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int)
 
-#$ header function dorgql(int, int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sorgql(int, int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dorgql(int, int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sorgql(int, int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
-#$ header function dormql(str, str, int, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int)
-#$ header function sormql(str, str, int, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int)
+#$ header function dormql(str, str, int, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int)
+#$ header function sormql(str, str, int, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int)
 
-#$ header function dormrq(str, str, int, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int)
-#$ header function sormrq(str, str, int, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int)
+#$ header function dormrq(str, str, int, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int)
+#$ header function sormrq(str, str, int, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int)
 
-#$ header function dormrz(str, str, int, int, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int)
-#$ header function sormrz(str, str, int, int, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int)
+#$ header function dormrz(str, str, int, int, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int)
+#$ header function sormrz(str, str, int, int, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int)
 
-#$ header function dorgrq(int, int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sorgrq(int, int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dorgrq(int, int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sorgrq(int, int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
-#$ header function dorglq(int, int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sorglq(int, int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dorglq(int, int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sorglq(int, int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
-#$ header function dbdsqr(str, int, int, int, int, double [:], double [:], double [:,:], int, double [:,:], int, double [:,:], int, double [:], int)
-#$ header function sbdsqr(str, int, int, int, int, float [:], float [:], float [:,:], int, float [:,:], int, float [:,:], int, float [:], int)
+#$ header function dbdsqr(str, int, int, int, int, double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], int)
+#$ header function sbdsqr(str, int, int, int, int, float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], int)
 
-#$ header function dbdsdc(str, str, int, double [:], double [:], double [:,:], int, double [:,:], int, double [:], int [:], double [:], int [:], int)
-#$ header function sbdsdc(str, str, int, float [:], float [:], float [:,:], int, float [:,:], int, float [:], int [:], float [:], int [:], int)
+#$ header function dbdsdc(str, str, int, double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], int [:], double [:], int [:], int)
+#$ header function sbdsdc(str, str, int, float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], int [:], float [:], int [:], int)
 
-#$ header function dgbbrd(str, int, int, int, int, int, double [:,:], int, double [:], double [:], double [:,:], int, double [:,:], int, double [:,:], int, double [:], int)
-#$ header function sgbbrd(str, int, int, int, int, int, float [:,:], int, float [:], float [:], float [:,:], int, float [:,:], int, float [:,:], int, float [:], int)
+#$ header function dgbbrd(str, int, int, int, int, int, double [:,:](order=F), int, double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], int)
+#$ header function sgbbrd(str, int, int, int, int, int, float [:,:](order=F), int, float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], int)
 
-#$ header function dtzrzf(int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function stzrzf(int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dtzrzf(int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function stzrzf(int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
 
 #...................................................................
 
 #Invariant Subspaces and Condition Numbers
 
-#$ header function dgehrd(int, int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sgehrd(int, int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dgehrd(int, int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sgehrd(int, int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
 
 
 
-#$ header function dgebal(str, int, double [:,:], int, int, int, double [:], int)
-#$ header function sgebal(str, int, float [:,:], int, int, int, float [:], int)
+#$ header function dgebal(str, int, double [:,:](order=F), int, int, int, double [:], int)
+#$ header function sgebal(str, int, float [:,:](order=F), int, int, int, float [:], int)
 
 
 
 
-#$ header function dgebak(str, str, int, int, int, double [:], int, double [:,:], int, int)
-#$ header function sgebak(str, str, int, int, int, float [:], int, float [:,:], int, int)
+#$ header function dgebak(str, str, int, int, int, double [:], int, double [:,:](order=F), int, int)
+#$ header function sgebak(str, str, int, int, int, float [:], int, float [:,:](order=F), int, int)
 
 
 
 
-#$ header function dorghr(int, int, int, double [:,:], int, double [:], double [:], int, int)
-#$ header function sorghr(int, int, int, float [:,:], int, float [:], float [:], int, int)
+#$ header function dorghr(int, int, int, double [:,:](order=F), int, double [:], double [:], int, int)
+#$ header function sorghr(int, int, int, float [:,:](order=F), int, float [:], float [:], int, int)
 
 
 
 
-#$ header function dormhr(str, str, int, int, int, int, double [:,:], int, double [:], double [:,:], int, double [:], int, int)
-#$ header function sormhr(str, str, int, int, int, int, float [:,:], int, float [:], float [:,:], int, float [:], int, int)
+#$ header function dormhr(str, str, int, int, int, int, double [:,:](order=F), int, double [:], double [:,:](order=F), int, double [:], int, int)
+#$ header function sormhr(str, str, int, int, int, int, float [:,:](order=F), int, float [:], float [:,:](order=F), int, float [:], int, int)
 
 
 
 
-#$ header function dhseqr(str, str, int, int, int, double [:,:], int, double [:], double [:], double [:,:], int, double [:], int, int)
-#$ header function shseqr(str, str, int, int, int, float [:,:], int, float [:], float [:], float [:,:], int, float [:], int, int)
+#$ header function dhseqr(str, str, int, int, int, double [:,:](order=F), int, double [:], double [:], double [:,:](order=F), int, double [:], int, int)
+#$ header function shseqr(str, str, int, int, int, float [:,:](order=F), int, float [:], float [:], float [:,:](order=F), int, float [:], int, int)
 
 
 
 
-#$ header function dhsein(str, str, str,bool[:], int, double [:,:], int, double [:], double [:], double [:,:], int, double [:,:], int, int, int, double [:], int [:], int [:], int)
-#$ header function shsein(str, str, str,bool[:], int, float [:,:], int, float [:], float [:], float [:,:], int, float [:,:], int, int, int, float [:], int [:], int [:], int)
+#$ header function dhsein(str, str, str,bool[:], int, double [:,:](order=F), int, double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, int, int, double [:], int [:], int [:], int)
+#$ header function shsein(str, str, str,bool[:], int, float [:,:](order=F), int, float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, int, int, float [:], int [:], int [:], int)
 
 
 
 
-#$ header function dtrevc(str, str,bool[:], int, double [:,:], int, double [:,:], int, double [:,:], int, int, int, double [:], int)
-#$ header function strevc(str, str,bool[:], int, float [:,:], int, float [:,:], int, float [:,:], int, int, int, float [:], int)
+#$ header function dtrevc(str, str,bool[:], int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, int, int, double [:], int)
+#$ header function strevc(str, str,bool[:], int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, int, int, float [:], int)
 
 
 
 
-#$ header function dtrexc(str, int, double [:,:], int, double [:,:], int, int, int, double [:], int)
-#$ header function strexc(str, int, float [:,:], int, float [:,:], int, int, int, float [:], int)
+#$ header function dtrexc(str, int, double [:,:](order=F), int, double [:,:](order=F), int, int, int, double [:], int)
+#$ header function strexc(str, int, float [:,:](order=F), int, float [:,:](order=F), int, int, int, float [:], int)
 
 
 
 
-#$ header function dtrsyl(str, str, int, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double, int)
-#$ header function strsyl(str, str, int, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float, int)
+#$ header function dtrsyl(str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double, int)
+#$ header function strsyl(str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float, int)
 
 
 
 
-#$ header function dtrsna(str, str,bool[:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:], double [:], int, int, double [:,:], int, int [:], int)
-#$ header function strsna(str, str,bool[:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:], float [:], int, int, float [:,:], int, int [:], int)
+#$ header function dtrsna(str, str,bool[:], int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], int, int, double [:,:](order=F), int, int [:], int)
+#$ header function strsna(str, str,bool[:], int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], int, int, float [:,:](order=F), int, int [:], int)
 
 
 
 
-#$ header function dtrsen(str, str,bool[:], int, double [:,:], int, double [:,:], int, double [:], double [:], int, double, double, double [:], int, int [:], int, int)
-#$ header function strsen(str, str,bool[:], int, float [:,:], int, float [:,:], int, float [:], float [:], int, float, float, float [:], int, int [:], int, int)
+#$ header function dtrsen(str, str,bool[:], int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], int, double, double, double [:], int, int [:], int, int)
+#$ header function strsen(str, str,bool[:], int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], int, float, float, float [:], int, int [:], int, int)
 
 #.................................
 #Generalized Eigenvalue and Singular Value Problems
 
 
-#$ header function ssygst(int, str, int, float [:,:], int, float [:,:], int, int)
-#$ header function dsygst(int, str, int, double [:,:], int, double [:,:], int, int)
+#$ header function ssygst(int, str, int, float [:,:](order=F), int, float [:,:](order=F), int, int)
+#$ header function dsygst(int, str, int, double [:,:](order=F), int, double [:,:](order=F), int, int)
 
 
 
@@ -657,65 +657,65 @@
 
 
 
-#$ header function spbstf(str, int, int, float [:,:], int, int)
-#$ header function dpbstf(str, int, int, double [:,:], int, int)
+#$ header function spbstf(str, int, int, float [:,:](order=F), int, int)
+#$ header function dpbstf(str, int, int, double [:,:](order=F), int, int)
 
 
 
 
-#$ header function ssbgst(str, str, int, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float [:], int)
-#$ header function dsbgst(str, str, int, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double [:], int)
+#$ header function ssbgst(str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], int)
+#$ header function dsbgst(str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], int)
 
 
 
 
-#$ header function sgghrd(str, str, int, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, int)
-#$ header function dgghrd(str, str, int, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, int)
+#$ header function sgghrd(str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, int)
+#$ header function dgghrd(str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, int)
 
 
 
 
-#$ header function sggbal(str, int, float [:,:], int, float [:,:], int, int, int, float [:], float [:], float [:], int)
-#$ header function dggbal(str, int, double [:,:], int, double [:,:], int, int, int, double [:], double [:], double [:], int)
+#$ header function sggbal(str, int, float [:,:](order=F), int, float [:,:](order=F), int, int, int, float [:], float [:], float [:], int)
+#$ header function dggbal(str, int, double [:,:](order=F), int, double [:,:](order=F), int, int, int, double [:], double [:], double [:], int)
 
 
 
 
-#$ header function sggbak(str, str, int, int, int, float [:], float [:], int, float [:,:], int, int)
-#$ header function dggbak(str, str, int, int, int, double [:], double [:], int, double [:,:], int, int)
+#$ header function sggbak(str, str, int, int, int, float [:], float [:], int, float [:,:](order=F), int, int)
+#$ header function dggbak(str, str, int, int, int, double [:], double [:], int, double [:,:](order=F), int, int)
 
 
 
 
-#$ header function shgeqz(str, str, str, int, int, int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], float [:,:], int, float [:,:], int, float [:], int, int)
-#$ header function dhgeqz(str, str, str, int, int, int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], double [:,:], int, double [:,:], int, double [:], int, int)
+#$ header function shgeqz(str, str, str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, float [:], int, int)
+#$ header function dhgeqz(str, str, str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, double [:], int, int)
 
 
 
 
-#$ header function stgevc(str, str,bool[:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, int, int, float [:], int)
-#$ header function dtgevc(str, str,bool[:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, int, int, double [:], int)
+#$ header function stgevc(str, str,bool[:], int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, int, int, float [:], int)
+#$ header function dtgevc(str, str,bool[:], int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, int, int, double [:], int)
 
 
 
 
-#$ header function stgexc(bool,bool, int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, int, int, float [:], int, int)
-#$ header function dtgexc(bool,bool, int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, int, int, double [:], int, int)
+#$ header function stgexc(bool,bool, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, int, int, float [:], int, int)
+#$ header function dtgexc(bool,bool, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, int, int, double [:], int, int)
 
 
 
 
-#$ header function stgsyl(str, int, int, int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, float, float, float [:], int, int [:], int)
-#$ header function dtgsyl(str, int, int, int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, double, double, double [:], int, int [:], int)
+#$ header function stgsyl(str, int, int, int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float, float, float [:], int, int [:], int)
+#$ header function dtgsyl(str, int, int, int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double, double, double [:], int, int [:], int)
 
 
 
 
-#$ header function stgsna(str, str,bool[:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:], float [:], int, int, float [:], int, float [:], int)
-#$ header function dtgsna(str, str,bool[:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:], double [:], int, int, double [:], int, double [:], int)
+#$ header function stgsna(str, str,bool[:], int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], int, int, float [:], int, float [:], int)
+#$ header function dtgsna(str, str,bool[:], int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], int, int, double [:], int, double [:], int)
 
 
 
 
-#$ header function stgsen(int,bool,bool,bool[:], int, float [:,:], int, float [:,:], int, float [:,:], int, float [:], float [:], float [:], float [:,:], int, float [:,:], int, int, float, float, float [:], float [:], int, int [:], int, int)
-#$ header function dtgsen(int,bool,bool,bool[:], int, double [:,:], int, double [:,:], int, double [:,:], int, double [:], double [:], double [:], double [:,:], int, double [:,:], int, int, double, double, double [:], double [:], int, int [:], int, int)
+#$ header function stgsen(int,bool,bool,bool[:], int, float [:,:](order=F), int, float [:,:](order=F), int, float [:,:](order=F), int, float [:], float [:], float [:], float [:,:](order=F), int, float [:,:](order=F), int, int, float, float, float [:], float [:], int, int [:], int, int)
+#$ header function dtgsen(int,bool,bool,bool[:], int, double [:,:](order=F), int, double [:,:](order=F), int, double [:,:](order=F), int, double [:], double [:], double [:], double [:,:](order=F), int, double [:,:](order=F), int, int, double, double, double [:], double [:], int, int [:], int, int)

--- a/pyccel/stdlib/internal/lapack.pyh
+++ b/pyccel/stdlib/internal/lapack.pyh
@@ -17,8 +17,6 @@
 #$ header function dgetrs(str, int, int, double [:,:], int, int [:], double [:,:], int, int)
 #$ header function dgecon(str, int, double [:,:], int, double, double, double [:], int [:], int)
 
-#$ header function dgesv(int, int, double [:,:], int, int [:], double [:,:], int, int)
-
 
 #...............................................................
 

--- a/pyccel/stdlib/internal/openmp.pyh
+++ b/pyccel/stdlib/internal/openmp.pyh
@@ -6,6 +6,7 @@
 #$ header metavar module_version = '4.5'
 #$ header metavar import_all = True
 #$ header metavar save=True
+#$ header metavar no_target=True
 
 # ............................................................
 #            Runtime Library Routines for Fortran

--- a/tests/external/scripts/lapack/ex1.py
+++ b/tests/external/scripts/lapack/ex1.py
@@ -16,7 +16,7 @@ from scipy.linalg.lapack import dgecon
 
 from scipy.linalg.lapack import dgetri
 
-from numpy import zeros
+from numpy import zeros, empty
 
 def test_1():
     n   = 25
@@ -128,10 +128,12 @@ def test_4():
     a[2,1] = 8.0
     a[2,2] = 0.0
 
+    lu = empty((lda,n))
+
     info = -1
     ipiv = zeros(n, 'int')
 
-    a, ipiv, info = dgetrf(a)
+    lu, ipiv, info = dgetrf(a)
 #    assert(info == 0)
 
     # Compute the inverse matrix.
@@ -140,8 +142,10 @@ def test_4():
     b[1] = 32.0
     b[2] = 23.0
 
+    x = empty((1,n))
+
     # Solve the linear system.
-    b, info = dgetrs(a, ipiv, b, 'n')
+    x, info = dgetrs(a, ipiv, b, 'n')
 #    assert(info == 0)
 
 test_1()

--- a/tests/external/scripts/lapack/ex1.py
+++ b/tests/external/scripts/lapack/ex1.py
@@ -1,4 +1,6 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring/
+# pylint: disable=missing-function-docstring, missing-module-docstring
+# pylint: disable=unused-variable
+# TODO: Remove disable unused variable when #927 is fixed
 # > Usage:
 #
 #   pyccel test.py -t
@@ -12,9 +14,9 @@ from scipy.linalg.lapack import dgbtrs
 
 from scipy.linalg.lapack import dgetrf
 from scipy.linalg.lapack import dgetrs
-from scipy.linalg.lapack import dgecon
+#from scipy.linalg.lapack import dgecon
 
-from scipy.linalg.lapack import dgetri
+#from scipy.linalg.lapack import dgetri
 
 from numpy import zeros, empty
 
@@ -69,13 +71,13 @@ def test_2():
     a, ipiv, info = dgetrf(a)
 #    assert(info == 0)
 
-    iwork = zeros(n, 'int')
-    lwork = 4 * n
-    work  = zeros(lwork)
+    #iwork = zeros(n, 'int')
+    #lwork = 4 * n
+    #work  = zeros(lwork)
 
-    # Get the condition number.
-    anorm = 1.0
-    rcond = -1.0
+    ## Get the condition number.
+    #anorm = 1.0
+    #rcond = -1.0
     # [TODO] dgecon('I', n, a, lda, anorm, rcond, work, iwork, info)
 #    assert(info == 0)
 
@@ -103,8 +105,8 @@ def test_3():
     a, ipiv, info = dgetrf(a)
 #    assert(info == 0)
 
-    lwork = 4 * n
-    work  = zeros(lwork)
+    #lwork = 4 * n
+    #work  = zeros(lwork)
 
     # Compute the inverse matrix.
     # [TODO] dgetri(n, a, lda, ipiv, work, lwork, info)

--- a/tests/external/scripts/lapack/ex1.py
+++ b/tests/external/scripts/lapack/ex1.py
@@ -1,0 +1,150 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+# > Usage:
+#
+#   pyccel test.py -t
+#   gfortran test.f90 -lblas -llapack
+#   ./a.out
+
+# TODO: - assert
+
+from scipy.linalg.lapack import dgbtrf
+from scipy.linalg.lapack import dgbtrs
+
+from scipy.linalg.lapack import dgetrf
+from scipy.linalg.lapack import dgetrs
+from scipy.linalg.lapack import dgecon
+
+from scipy.linalg.lapack import dgetri
+
+from numpy import zeros
+
+def test_1():
+    n   = 25
+    ml  = 1
+    mu  = 1
+    lda = 2 * ml + mu + 1
+
+    a = zeros((lda,n))
+    b = zeros((1,n))
+
+    b[0]   = 1.0
+    b[n-1] = 1.0
+
+    # Superdiagonal, Diagonal, Subdiagonal
+    m = ml + mu
+    a[m-1,1:n] = -1.0
+    a[  m,0:n] =  2.0
+    a[m+1,0:n-1] = -1.0
+
+    info = -1
+    ipiv = zeros(n, 'int')
+
+    a, ipiv, info = dgbtrf(a, ml, mu)
+#    assert(info == 0)
+
+    b, info = dgbtrs(a, ml, mu, b, ipiv)
+#    assert(info == 0)
+
+def test_2():
+    n = 3
+    lda = n
+
+    a = zeros((lda,n))
+
+    a[0,0] = 0.0
+    a[0,1] = 1.0
+    a[0,2] = 2.0
+
+    a[1,0] = 4.0
+    a[1,1] = 5.0
+    a[1,2] = 6.0
+
+    a[2,0] = 7.0
+    a[2,1] = 8.0
+    a[2,2] = 0.0
+
+    info = -1
+    ipiv = zeros(n, 'int')
+
+    a, ipiv, info = dgetrf(a)
+#    assert(info == 0)
+
+    iwork = zeros(n, 'int')
+    lwork = 4 * n
+    work  = zeros(lwork)
+
+    # Get the condition number.
+    anorm = 1.0
+    rcond = -1.0
+    # [TODO] dgecon('I', n, a, lda, anorm, rcond, work, iwork, info)
+#    assert(info == 0)
+
+def test_3():
+    n = 3
+    lda = n
+
+    a = zeros((lda,n))
+
+    a[0,0] = 0.0
+    a[0,1] = 1.0
+    a[0,2] = 2.0
+
+    a[1,0] = 4.0
+    a[1,1] = 5.0
+    a[1,2] = 6.0
+
+    a[2,0] = 7.0
+    a[2,1] = 8.0
+    a[2,2] = 0.0
+
+    info = -1
+    ipiv = zeros(n, 'int')
+
+    a, ipiv, info = dgetrf(a)
+#    assert(info == 0)
+
+    lwork = 4 * n
+    work  = zeros(lwork)
+
+    # Compute the inverse matrix.
+    # [TODO] dgetri(n, a, lda, ipiv, work, lwork, info)
+#    assert(info == 0)
+
+def test_4():
+    n = 3
+    lda = n
+
+    a = zeros((lda,n))
+
+    a[0,0] = 0.0
+    a[0,1] = 1.0
+    a[0,2] = 2.0
+
+    a[1,0] = 4.0
+    a[1,1] = 5.0
+    a[1,2] = 6.0
+
+    a[2,0] = 7.0
+    a[2,1] = 8.0
+    a[2,2] = 0.0
+
+    info = -1
+    ipiv = zeros(n, 'int')
+
+    a, ipiv, info = dgetrf(a)
+#    assert(info == 0)
+
+    # Compute the inverse matrix.
+    b = zeros((1,n))
+    b[0] = 14.0
+    b[1] = 32.0
+    b[2] = 23.0
+
+    # Solve the linear system.
+    b, info = dgetrs(a, ipiv, b, 'n')
+#    assert(info == 0)
+
+test_1()
+test_2()
+test_3()
+test_4()

--- a/tests/external/test_external.py
+++ b/tests/external/test_external.py
@@ -25,6 +25,13 @@ def test_mpi4py(f):
 
     print('\n')
 
+@pytest.mark.parametrize("f", get_files_from_folder('lapack'))
+def test_lapack(f):
+
+    execute_pyccel(f)
+
+    print('\n')
+
 
 ######################
 if __name__ == '__main__':


### PR DESCRIPTION
**Commit Summary**
- Add function `make_necessary_copies` to `MacroFunction` to ensure that any results which should match arguments are initialised from the argument (fixes #926)
- Add `ignore_at_import` to compile information to allow libraries to be linked to a `.pyh` file which does not need to be compiled
- Ensure any environment variables in compile command are expanded before executing
- Loop over parser sons to collect all useful dependencies to ensure libraries are linked
- Collect libraries from macro metavars
- [BUGFIX] Correctly collect strings from macros
- [BUGFIX] Use `PyccelMul` instead of `*` when printing `MacroShape`
- Remove duplicate lapack function declaration
- Link to `lapack` library using `-llapack` (instead of requiring the environment variable `LAPACK_LIBRARIES` to be declared and defined as `lapack`)
- Link to `blas` library using `-lblas` (instead of requiring the environment variable `BLAS_LIBRARIES` to be declared and defined as `blas`)
- Add basic test for lapack
- Add macro printing to C
- Simplify Fortran macro printing

Tests which check the output are not implemented as this would be blocked by issue #936 