### PR TITLE
Add shortcuts to Fortran literals

### DIFF
--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -69,7 +69,7 @@ iso_c_binding = {
         2  : 'C_INT16_T',
         4  : 'C_INT32_T',
         8  : 'C_INT64_T',
-        16 : 'C_INT128'}, #no supported yet
+        16 : 'C_INT128_T'}, #no supported yet
     "real"    : {
         4  : 'C_FLOAT',
         8  : 'C_DOUBLE',
@@ -86,6 +86,7 @@ iso_c_binding_shortcut_mapping = {
     'C_INT16_T'             : 'i16',
     'C_INT32_T'             : 'i32',
     'C_INT64_T'             : 'i64',
+    'C_INT128_T'            : 'i128',
     'C_FLOAT'               : 'f32',
     'C_DOUBLE'              : 'f64',
     'C_LONG_DOUBLE'         : 'f128',

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -81,7 +81,37 @@ iso_c_binding = {
     "logical" : {
         4  : "C_BOOL"}
 }
-
+iso_c_binding_shortcut = {
+    "integer" : {
+        1  : 'i8',
+        2  : 'i16',
+        4  : 'i32',
+        8  : 'i64',
+        16 : 'i128'}, #no supported yet
+    "real"    : {
+        4  : 'f32',
+        8  : 'f64',
+        16 : 'f128'},
+    "logical" : {
+        4  : "b4"}
+}
+iso_c_bindings = ['C_INT8_T', 'C_INT16_T', 'C_INT32_T', 'C_INT64_T', 'C_INT128',
+                  'C_FLOAT', 'C_DOUBLE', 'C_LONG_DOUBLE', "C_BOOL"]
+iso_c_binding_shortcuts = ['i8', 'i16', 'i32', 'i64', 'i128', 'f32', 'f64', 'f128', "b4"]
+iso_c_binding_check_index = {
+    "integer" : {
+        1  : 0,
+        2  : 1,
+        4  : 2,
+        8  : 3,
+        16 : 4}, #no supported yet
+    "real"    : {
+        4  : 5,
+        8  : 6,
+        16 : 7},
+    "logical" : {
+        4  : 8}
+}
 default_precision = {'real': 8,
                     'int': numpy.dtype(int).alignment,
                     'integer': numpy.dtype(int).alignment,

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -81,36 +81,18 @@ iso_c_binding = {
     "logical" : {
         4  : "C_BOOL"}
 }
-iso_c_binding_shortcut = {
-    "integer" : {
-        1  : 'i8',
-        2  : 'i16',
-        4  : 'i32',
-        8  : 'i64',
-        16 : 'i128'}, #no supported yet
-    "real"    : {
-        4  : 'f32',
-        8  : 'f64',
-        16 : 'f128'},
-    "logical" : {
-        4  : "b4"}
-}
-iso_c_bindings = ['C_INT8_T', 'C_INT16_T', 'C_INT32_T', 'C_INT64_T', 'C_INT128',
-                  'C_FLOAT', 'C_DOUBLE', 'C_LONG_DOUBLE', "C_BOOL"]
-iso_c_binding_shortcuts = ['i8', 'i16', 'i32', 'i64', 'i128', 'f32', 'f64', 'f128', "b4"]
-iso_c_binding_check_index = {
-    "integer" : {
-        1  : 0,
-        2  : 1,
-        4  : 2,
-        8  : 3,
-        16 : 4}, #no supported yet
-    "real"    : {
-        4  : 5,
-        8  : 6,
-        16 : 7},
-    "logical" : {
-        4  : 8}
+iso_c_binding_shortcut_mapping = {
+    'C_INT8_T'              : 'i8',
+    'C_INT16_T'             : 'i16',
+    'C_INT32_T'             : 'i32',
+    'C_INT64_T'             : 'i64',
+    'C_FLOAT'               : 'f32',
+    'C_DOUBLE'              : 'f64',
+    'C_LONG_DOUBLE'         : 'f128',
+    'C_FLOAT_COMPLEX'       : 'C_FLOAT_COMPLEX',
+    'C_DOUBLE_COMPLEX'      : 'C_DOUBLE_COMPLEX',
+    'C_LONG_DOUBLE_COMPLEX' : 'C_LONG_DOUBLE_COMPLEX',
+    'C_BOOL'                : 'b4'
 }
 default_precision = {'real': 8,
                     'int': numpy.dtype(int).alignment,

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -90,9 +90,9 @@ iso_c_binding_shortcut_mapping = {
     'C_FLOAT'               : 'f32',
     'C_DOUBLE'              : 'f64',
     'C_LONG_DOUBLE'         : 'f128',
-    'C_FLOAT_COMPLEX'       : 'C_FLOAT_COMPLEX',
-    'C_DOUBLE_COMPLEX'      : 'C_DOUBLE_COMPLEX',
-    'C_LONG_DOUBLE_COMPLEX' : 'C_LONG_DOUBLE_COMPLEX',
+    'C_FLOAT_COMPLEX'       : 'c32',
+    'C_DOUBLE_COMPLEX'      : 'c64',
+    'C_LONG_DOUBLE_COMPLEX' : 'c128',
     'C_BOOL'                : 'b4'
 }
 default_precision = {'real': 8,

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -214,8 +214,6 @@ class FCodePrinter(CodePrinter):
 
     def check_restrictions(self):
         """Checks if the namespace contains any of the shortcuts"""
-            def check_restrictions(self):
-        """Checks if the namespace contains any of the shortcuts"""
         valid = [True] * len(iso_c_binding_shortcuts)
         for variableName in self._namespace.variables:
             for idx in range(len(iso_c_binding_shortcuts)):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -216,20 +216,20 @@ class FCodePrinter(CodePrinter):
         """Checks if the namespace contains any of the shortcuts"""
         valid = [True] * len(iso_c_binding_shortcuts)
         for variableName in self._namespace.variables:
-            for idx in range(len(iso_c_binding_shortcuts)):
-                if variableName == iso_c_binding_shortcuts[idx]:
+            for idx, alias in enumerate(iso_c_binding_shortcuts):
+                if variableName == alias:
                     valid[idx] = False
         for functionName in self._namespace.functions:
-            for idx in range(len(iso_c_binding_shortcuts)):
-                if functionName == iso_c_binding_shortcuts[idx]:
+            for idx, alias in enumerate(iso_c_binding_shortcuts):
+                if functionName == alias:
                     valid[idx] = False
         for variableName in self._namespace.imports['variables']:
-            for idx in range(len(iso_c_binding_shortcuts)):
-                if variableName == iso_c_binding_shortcuts[idx]:
+            for idx, alias in enumerate(iso_c_binding_shortcuts):
+                if variableName == alias:
                     valid[idx] = False
         for functionName in self._namespace.imports['functions']:
-            for idx in range(len(iso_c_binding_shortcuts)):
-                if functionName == iso_c_binding_shortcuts[idx]:
+            for idx, alias in enumerate(iso_c_binding_shortcuts):
+                if functionName == alias:
                     valid[idx] = False
         return valid
 
@@ -237,7 +237,7 @@ class FCodePrinter(CodePrinter):
         """Prints the use line that indicates the macros used"""
         macro = "use ISO_C_BINDING, only: "
         rename = []
-        for idx in range(len(self._macros)):
+        for idx, mc in enumerate(self._macros):
             if self._macros[idx]:
                 rename.append(iso_c_binding_shortcuts[idx] + ' => ' + iso_c_bindings[idx])
         macro += " , ".join(rename)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -211,12 +211,7 @@ class FCodePrinter(CodePrinter):
     def print_constant_imports(self):
         """Prints the use line for the constant imports used"""
         macro = "use, intrinsic :: ISO_C_Binding, only : "
-        rename = []
-        for constant in self._constantImports:
-            if isinstance(constant, str):
-                rename.append(constant)
-            else:
-                rename.append(constant[0] + ' => ' + constant[1])
+        rename = [c if isinstance(c, str) else c[0] + ' => ' + c[1] for c in self._constantImports]
         if len(rename) == 0:
             return ''
         macro += " , ".join(rename)
@@ -299,7 +294,7 @@ class FCodePrinter(CodePrinter):
 
     def print_kind(self, expr):
         """
-        Prints the kind(precision) of a literal value
+        Prints the kind(precision) of a literal value or its shortcut if possible
         """
         constant_name = iso_c_binding[self._print(expr.dtype)][expr.precision]
         constant_shortcut = iso_c_binding_shortcut_mapping[constant_name]

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -237,8 +237,8 @@ class FCodePrinter(CodePrinter):
         """Prints the use line that indicates the macros used"""
         macro = "use ISO_C_BINDING, only: "
         rename = []
-        for idx, mc in enumerate(self._macros):
-            if self._macros[idx]:
+        for idx, used in enumerate(self._macros):
+            if used:
                 rename.append(iso_c_binding_shortcuts[idx] + ' => ' + iso_c_bindings[idx])
         macro += " , ".join(rename)
         return macro

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -210,7 +210,7 @@ class FCodePrinter(CodePrinter):
 
     def print_constant_imports(self):
         """Prints the use line for the constant imports used"""
-        macro = "use ISO_C_BINDING, only: "
+        macro = "use, intrinsic :: ISO_C_Binding, only : "
         rename = []
         for constant in self._constantImports:
             if isinstance(constant, str):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -214,14 +214,29 @@ class FCodePrinter(CodePrinter):
 
     def check_restrictions(self):
         """Checks if the namespace contains any of the shortcuts"""
+            def check_restrictions(self):
+        """Checks if the namespace contains any of the shortcuts"""
         valid = [True] * len(iso_c_binding_shortcuts)
-        for variable in self._namespace.variables:
+        for variableName in self._namespace.variables:
             for idx in range(len(iso_c_binding_shortcuts)):
-                if variable == iso_c_binding_shortcuts[idx]:
+                if variableName == iso_c_binding_shortcuts[idx]:
+                    valid[idx] = False
+        for functionName in self._namespace.functions:
+            for idx in range(len(iso_c_binding_shortcuts)):
+                if functionName == iso_c_binding_shortcuts[idx]:
+                    valid[idx] = False
+        for variableName in self._namespace.imports['variables']:
+            for idx in range(len(iso_c_binding_shortcuts)):
+                if variableName == iso_c_binding_shortcuts[idx]:
+                    valid[idx] = False
+        for functionName in self._namespace.imports['functions']:
+            for idx in range(len(iso_c_binding_shortcuts)):
+                if functionName == iso_c_binding_shortcuts[idx]:
                     valid[idx] = False
         return valid
 
     def print_macros(self):
+        """Prints the use line that indicates the macros used"""
         macro = "use ISO_C_BINDING, only: "
         rename = []
         for idx in range(len(self._macros)):
@@ -309,8 +324,10 @@ class FCodePrinter(CodePrinter):
         """
         Prints the kind(precision) of a literal value
         """
+        if self._print(expr.dtype) == 'complex':
+            return iso_c_binding[self._print(expr.dtype)][expr.precision]
         index = iso_c_binding_check_index[self._print(expr.dtype)][expr.precision]
-        if expr.dtype == 'complex' or not self._namespace_restrictions[index]:
+        if not self._namespace_restrictions[index]:
             return iso_c_binding[self._print(expr.dtype)][expr.precision]
         self._macros[index] = True
         return iso_c_binding_shortcut[self._print(expr.dtype)][expr.precision]
@@ -1376,7 +1393,7 @@ class FCodePrinter(CodePrinter):
             for f in expr.functions:
                 parts = self.function_signature(f, f.name)
                 parts = ["{}({}) {}\n".format(parts['sig'], parts['arg_code'], parts['func_end']),
-                        'use, intrinsic :: ISO_C_BINDING\n',
+                        'use, intrinsic :: ISO_C_BINDING\n'+self.print_macros()+'\n',
                         parts['arg_decs'],
                         'end {} {}\n'.format(parts['func_type'], f.name)]
                 funcs_sigs.append(''.join(a for a in parts))

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1,14 +1,13 @@
 # coding: utf-8
-#------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------#
 # This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
 # go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
-#------------------------------------------------------------------------------------------#
+# ------------------------------------------------------------------------------------------#
 # pylint: disable=R0201
 # pylint: disable=missing-function-docstring
 
 """Print to F90 standard. Trying to follow the information provided at
 www.fortran90.org as much as possible."""
-
 
 import string
 import re
@@ -23,43 +22,47 @@ from pyccel.ast.core import get_iterable_ranges
 from pyccel.ast.core import SeparatorComment, Comment
 from pyccel.ast.core import ConstructorCall
 from pyccel.ast.core import ErrorExit, FunctionAddress
-from pyccel.ast.internals    import PyccelInternalFunction
+from pyccel.ast.internals import PyccelInternalFunction
 from pyccel.ast.itertoolsext import Product
 from pyccel.ast.core import (Assign, AliasAssign, Declare,
                              CodeBlock, AsName,
                              If, IfSection, FunctionDef)
 
-from pyccel.ast.variable  import (Variable, TupleVariable,
-                             IndexedElement, HomogeneousTupleVariable,
-                             InhomogeneousTupleVariable,
-                             DottedName, PyccelArraySize, Constant)
+from pyccel.ast.variable import (Variable, TupleVariable,
+                                 IndexedElement, HomogeneousTupleVariable,
+                                 InhomogeneousTupleVariable,
+                                 DottedName, PyccelArraySize, Constant)
 
-from pyccel.ast.operators      import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus, PyccelNot
-from pyccel.ast.operators      import PyccelMod
+from pyccel.ast.operators import PyccelAdd, PyccelMul, PyccelDiv, PyccelMinus, PyccelNot
+from pyccel.ast.operators import PyccelMod
 
-from pyccel.ast.operators      import PyccelUnarySub, PyccelLt, PyccelGt, IfTernaryOperator
+from pyccel.ast.operators import PyccelUnarySub, PyccelLt, PyccelGt, IfTernaryOperator
 
-from pyccel.ast.core      import FunctionCall, DottedFunctionCall
+from pyccel.ast.core import FunctionCall, DottedFunctionCall
 
-from pyccel.ast.builtins  import (PythonInt,
-                                  PythonPrint, PythonRange,
-                                  PythonFloat, PythonTuple)
-from pyccel.ast.builtins  import PythonComplex, PythonBool, PythonAbs
+from pyccel.ast.builtins import (PythonInt,
+                                 PythonPrint, PythonRange,
+                                 PythonFloat, PythonTuple)
+from pyccel.ast.builtins import PythonComplex, PythonBool, PythonAbs
 from pyccel.ast.datatypes import is_pyccel_datatype
 from pyccel.ast.datatypes import is_iterable_datatype, is_with_construct_datatype
 from pyccel.ast.datatypes import NativeSymbol, NativeString, str_dtype
 from pyccel.ast.datatypes import NativeInteger, NativeBool, NativeReal, NativeComplex
 from pyccel.ast.datatypes import iso_c_binding
+from pyccel.ast.datatypes import iso_c_binding_shortcut
+from pyccel.ast.datatypes import iso_c_bindings
+from pyccel.ast.datatypes import iso_c_binding_shortcuts
+from pyccel.ast.datatypes import iso_c_binding_check_index
 from pyccel.ast.datatypes import NativeRange, NativeTuple
 from pyccel.ast.datatypes import CustomDataType
 
 from pyccel.ast.internals import Slice
 
-from pyccel.ast.literals  import LiteralInteger, LiteralFloat, Literal
-from pyccel.ast.literals  import LiteralTrue
-from pyccel.ast.literals  import Nil
+from pyccel.ast.literals import LiteralInteger, LiteralFloat, Literal
+from pyccel.ast.literals import LiteralTrue
+from pyccel.ast.literals import Nil
 
-from pyccel.ast.mathext  import math_constants
+from pyccel.ast.mathext import math_constants
 
 from pyccel.ast.numpyext import NumpyEmpty
 from pyccel.ast.numpyext import NumpyMod, NumpyFloat
@@ -74,111 +77,111 @@ from pyccel.errors.errors import Errors
 from pyccel.errors.messages import *
 from pyccel.codegen.printing.codeprinter import CodePrinter
 
-
 # TODO: add examples
 # TODO: use _get_statement when returning a string
 
 __all__ = ["FCodePrinter", "fcode"]
 
 numpy_ufunc_to_fortran = {
-    'NumpyAbs'  : 'abs',
-    'NumpyFabs'  : 'abs',
-    'NumpyMin'  : 'minval',
-    'NumpyAmin'  : 'minval',
-    'NumpyAmax'  : 'maxval',
+    'NumpyAbs': 'abs',
+    'NumpyFabs': 'abs',
+    'NumpyMin': 'minval',
+    'NumpyAmin': 'minval',
+    'NumpyAmax': 'maxval',
     'NumpyFloor': 'floor',  # TODO: might require special treatment with casting
     # ---
-    'NumpyExp' : 'exp',
-    'NumpyLog' : 'Log',
+    'NumpyExp': 'exp',
+    'NumpyLog': 'Log',
     # 'NumpySqrt': 'Sqrt',  # sqrt is printed using _Print_NumpySqrt
     # ---
-    'NumpySin'    : 'sin',
-    'NumpyCos'    : 'cos',
-    'NumpyTan'    : 'tan',
-    'NumpyArcsin' : 'asin',
-    'NumpyArccos' : 'acos',
-    'NumpyArctan' : 'atan',
+    'NumpySin': 'sin',
+    'NumpyCos': 'cos',
+    'NumpyTan': 'tan',
+    'NumpyArcsin': 'asin',
+    'NumpyArccos': 'acos',
+    'NumpyArctan': 'atan',
     'NumpyArctan2': 'atan2',
-    'NumpySinh'   : 'sinh',
-    'NumpyCosh'   : 'cosh',
-    'NumpyTanh'   : 'tanh',
+    'NumpySinh': 'sinh',
+    'NumpyCosh': 'cosh',
+    'NumpyTanh': 'tanh',
     'NumpyArcsinh': 'asinh',
     'NumpyArccosh': 'acosh',
     'NumpyArctanh': 'atanh',
 }
 
 math_function_to_fortran = {
-    'MathAcos'   : 'acos',
-    'MathAcosh'  : 'acosh',
-    'MathAsin'   : 'asin',
-    'MathAsinh'  : 'asinh',
-    'MathAtan'   : 'atan',
-    'MathAtan2'  : 'atan2',
-    'MathAtanh'  : 'atanh',
+    'MathAcos': 'acos',
+    'MathAcosh': 'acosh',
+    'MathAsin': 'asin',
+    'MathAsinh': 'asinh',
+    'MathAtan': 'atan',
+    'MathAtan2': 'atan2',
+    'MathAtanh': 'atanh',
     'MathCopysign': 'sign',
-    'MathCos'    : 'cos',
-    'MathCosh'   : 'cosh',
-    'MathErf'    : 'erf',
-    'MathErfc'   : 'erfc',
-    'MathExp'    : 'exp',
+    'MathCos': 'cos',
+    'MathCosh': 'cosh',
+    'MathErf': 'erf',
+    'MathErfc': 'erfc',
+    'MathExp': 'exp',
     # 'MathExpm1'  : '???', # TODO
-    'MathFabs'   : 'abs',
+    'MathFabs': 'abs',
     # 'MathFmod'   : '???',  # TODO
     # 'MathFsum'   : '???',  # TODO
-    'MathGamma'  : 'gamma',
-    'MathHypot'  : 'hypot',
+    'MathGamma': 'gamma',
+    'MathHypot': 'hypot',
     # 'MathLdexp'  : '???',  # TODO
-    'MathLgamma' : 'log_gamma',
-    'MathLog'    : 'log',
-    'MathLog10'  : 'log10',
+    'MathLgamma': 'log_gamma',
+    'MathLog': 'log',
+    'MathLog10': 'log10',
     # 'MathLog1p'  : '???', # TODO
     # 'MathLog2'   : '???', # TODO
     # 'MathPow'    : '???', # TODO
-    'MathSin'    : 'sin',
-    'MathSinh'   : 'sinh',
-    'MathSqrt'   : 'sqrt',
-    'MathTan'    : 'tan',
-    'MathTanh'   : 'tanh',
+    'MathSin': 'sin',
+    'MathSinh': 'sinh',
+    'MathSqrt': 'sqrt',
+    'MathTan': 'tan',
+    'MathTanh': 'tanh',
     # ---
-    'MathFloor'    : 'floor',
+    'MathFloor': 'floor',
     # ---
     # 'MathIsclose' : '???', # TODO
     # 'MathIsfinite': '???', # TODO
     # 'MathIsinf'   : '???', # TODO
     # --------------------------- internal functions --------------------------
-    'MathFactorial' : 'pyc_factorial',
-    'MathGcd'       : 'pyc_gcd',
-    'MathDegrees'   : 'pyc_degrees',
-    'MathRadians'   : 'pyc_radians',
-    'MathLcm'       : 'pyc_lcm',
+    'MathFactorial': 'pyc_factorial',
+    'MathGcd': 'pyc_gcd',
+    'MathDegrees': 'pyc_degrees',
+    'MathRadians': 'pyc_radians',
+    'MathLcm': 'pyc_lcm',
 }
 
 INF = math_constants['inf']
 
 _default_methods = {
     '__init__': 'create',
-    '__del__' : 'free',
+    '__del__': 'free',
 }
 
 python_builtin_datatypes = {
-    'integer' : PythonInt,
-    'real'    : PythonFloat,
-    'bool'    : PythonBool,
-    'complex' : PythonComplex
+    'integer': PythonInt,
+    'real': PythonFloat,
+    'bool': PythonBool,
+    'complex': PythonComplex
 }
 
 inc_keyword = (r'do\b', r'if\b',
                r'else\b', r'type\b\s*[^\(]',
                r'(recursive )?(pure )?(elemental )?((subroutine)|(function))\b',
-               r'interface\b',r'module\b',r'program\b')
+               r'interface\b', r'module\b', r'program\b')
 inc_regex = re.compile('|'.join('({})'.format(i) for i in inc_keyword))
 
 end_keyword = ('do', 'if', 'type', 'function',
-               'subroutine', 'interface','module','program')
+               'subroutine', 'interface', 'module', 'program')
 end_regex_str = '(end ?({}))|(else)'.format('|'.join('({})'.format(k) for k in end_keyword))
 dec_regex = re.compile(end_regex_str)
 
 errors = Errors()
+
 
 class FCodePrinter(CodePrinter):
     """A printer to convert sympy expressions to strings of Fortran code"""
@@ -189,8 +192,7 @@ class FCodePrinter(CodePrinter):
         'tabwidth': 2,
     }
 
-
-    def __init__(self, parser, prefix_module = None):
+    def __init__(self, parser, prefix_module=None):
 
         if parser.filename:
             errors.set_target(parser.filename, 'file')
@@ -198,13 +200,33 @@ class FCodePrinter(CodePrinter):
         super().__init__()
         self.parser = parser
         self._namespace = self.parser.namespace
+        self._namespace_restrictions = self.check_restrictions()
+        self._macros = [False] * len(iso_c_binding_shortcuts)
         self._current_function = None
-        self._current_class    = None
+        self._current_class = None
 
         self._additional_code = None
         self._additional_imports = set([])
 
         self.prefix_module = prefix_module
+
+    def check_restrictions(self):
+        """Checks if the namespace contains any of the shortcuts"""
+        valid = [True] * len(iso_c_binding_shortcuts)
+        for variable in self._namespace.variables:
+            for idx in range(len(iso_c_binding_shortcuts)):
+                if variable == iso_c_binding_shortcuts[idx]:
+                    valid[idx] = False
+        return valid
+
+    def print_macros(self):
+        macro = "use ISO_C_BINDING, only: "
+        rename = []
+        for idx in range(len(self._macros)):
+            if self._macros[idx]:
+                rename.append(iso_c_binding_shortcuts[idx] + ' => ' + iso_c_bindings[idx])
+        macro += " , ".join(rename)
+        return macro
 
     def get_additional_imports(self):
         """return the additional imports collected in printing stage"""
@@ -242,16 +264,16 @@ class FCodePrinter(CodePrinter):
                 if method_name in methods:
                     return methods[method_name]
                 else:
-                    interface_funcs = {f.name:f for i in cls.interfaces for f in i.functions}
+                    interface_funcs = {f.name: f for i in cls.interfaces for f in i.functions}
                     if method_name in interface_funcs:
                         return interface_funcs[method_name]
                     errors.report(UNDEFINED_METHOD, symbol=method_name,
-                        severity='fatal')
+                                  severity='fatal')
             container = container.parent_scope
         if isinstance(method_name, DottedName):
             return self.get_function(DottedName(method_name.name[1:]))
         errors.report(UNDEFINED_FUNCTION, symbol=method_name,
-            severity='fatal')
+                      severity='fatal')
 
     def get_function(self, name):
         container = self._namespace
@@ -262,7 +284,7 @@ class FCodePrinter(CodePrinter):
         if isinstance(name, DottedName):
             return self.get_function(name.name[-1])
         errors.report(UNDEFINED_FUNCTION, symbol=name,
-            severity='fatal')
+                      severity='fatal')
 
     def add_vars_to_namespace(self, *new_vars):
         if self._current_function:
@@ -285,7 +307,11 @@ class FCodePrinter(CodePrinter):
         """
         Prints the kind(precision) of a literal value
         """
-        return iso_c_binding[self._print(expr.dtype)][expr.precision]
+        index = iso_c_binding_check_index[self._print(expr.dtype)][expr.precision]
+        if expr.dtype == 'complex' or not self._namespace_restrictions[index]:
+            return iso_c_binding[self._print(expr.dtype)][expr.precision]
+        self._macros[index] = True
+        return iso_c_binding_shortcut[self._print(expr.dtype)][expr.precision]
 
     # ============ Elements ============ #
     def _print_PyccelSymbol(self, expr):
@@ -301,8 +327,8 @@ class FCodePrinter(CodePrinter):
         imports = ''.join(self._print(i) for i in expr.imports)
         imports += 'use, intrinsic :: ISO_C_BINDING\n'
 
-        decs    = ''.join(self._print(i) for i in expr.declarations)
-        body    = ''
+        decs = ''.join(self._print(i) for i in expr.declarations)
+        body = ''
 
         # ... TODO add other elements
         private_funcs = [f.name for f in expr.funcs if f.is_private]
@@ -347,10 +373,10 @@ class FCodePrinter(CodePrinter):
         return '\n'.join([a for a in parts if a])
 
     def _print_Program(self, expr):
-        name    = 'prog_{0}'.format(self._print(expr.name)).replace('.', '_')
+        name = 'prog_{0}'.format(self._print(expr.name)).replace('.', '_')
         imports = ''.join(self._print(i) for i in expr.imports)
         imports += 'use, intrinsic :: ISO_C_BINDING\n'
-        body    = self._print(expr.body)
+        body = self._print(expr.body)
 
         # Print the declarations of all variables in the namespace, which include:
         #  - user-defined variables (available in Program.variables)
@@ -365,21 +391,22 @@ class FCodePrinter(CodePrinter):
         # Additional code and variable declarations for MPI usage
         # TODO: check if we should really add them like this
         if mpi:
-            body = 'call mpi_init(ierr)\n'+\
-                   '\nallocate(status(0:-1 + mpi_status_size)) '+\
-                   '\nstatus = 0\n'+\
-                   body +\
+            body = 'call mpi_init(ierr)\n' + \
+                   '\nallocate(status(0:-1 + mpi_status_size)) ' + \
+                   '\nstatus = 0\n' + \
+                   body + \
                    '\ncall mpi_finalize(ierr)'
 
-            decs += '\ninteger :: ierr = -1' +\
+            decs += '\ninteger :: ierr = -1' + \
                     '\ninteger, allocatable :: status (:)'
         imports += "\n".join('use ' + lib for lib in self._additional_imports)
+        imports += "\n" + self.print_macros()
         parts = ['program {}\n'.format(name),
                  imports,
-                'implicit none\n',
+                 'implicit none\n',
                  decs,
                  body,
-                'end program {}\n'.format(name)]
+                 'end program {}\n'.format(name)]
 
         return '\n'.join(a for a in parts if a)
 
@@ -398,7 +425,7 @@ class FCodePrinter(CodePrinter):
         if source in pyccel_builtin_import_registery:
             return ''
 
-        if 'mpi4py' == str(getattr(expr.source,'name',expr.source)):
+        if 'mpi4py' == str(getattr(expr.source, 'name', expr.source)):
             return 'use mpi\n' + 'use mpiext\n'
 
         if len(expr.target) == 0:
@@ -462,18 +489,18 @@ class FCodePrinter(CodePrinter):
         return '!' + comments + '\n'
 
     def _print_CommentBlock(self, expr):
-        txts   = expr.comments
+        txts = expr.comments
         header = expr.header
         header_size = len(expr.header)
 
         ln = max(len(i) for i in txts)
-        if ln<max(20, header_size+2):
+        if ln < max(20, header_size + 2):
             ln = 20
-        top  = '!' + '_'*int((ln-header_size)/2) + header + '_'*int((ln-header_size)/2) + '!'
+        top = '!' + '_' * int((ln - header_size) / 2) + header + '_' * int((ln - header_size) / 2) + '!'
         ln = len(top) - 2
-        bottom = '!' + '_'*ln + '!'
+        bottom = '!' + '_' * ln + '!'
 
-        txts = ['!' + txt + ' '*(ln - len(txt)) + '!' for txt in txts]
+        txts = ['!' + txt + ' ' * (ln - len(txt)) + '!' for txt in txts]
 
         body = '\n'.join(i for i in txts)
 
@@ -486,12 +513,12 @@ class FCodePrinter(CodePrinter):
 
     def _print_AnnotatedComment(self, expr):
         accel = self._print(expr.accel)
-        txt   = str(expr.txt)
-        if len(txt)>72:
+        txt = str(expr.txt)
+        if len(txt) > 72:
             txts = []
-            while len(txt)>72:
+            while len(txt) > 72:
                 txts.append(txt[:72])
-                txt  = txt[72:]
+                txt = txt[72:]
             if txt:
                 txts.append(txt)
 
@@ -500,7 +527,7 @@ class FCodePrinter(CodePrinter):
         return '!${0} {1}\n'.format(accel, txt)
 
     def _print_tuple(self, expr):
-        if expr[0].rank>0:
+        if expr[0].rank > 0:
             raise NotImplementedError(' tuple with elements of rank > 0 is not implemented')
         fs = ', '.join(self._print(f) for f in expr)
         return '[{0}]'.format(fs)
@@ -513,10 +540,10 @@ class FCodePrinter(CodePrinter):
 
     def _print_PythonTuple(self, expr):
         shape = tuple(reversed(expr.shape))
-        if len(shape)>1:
+        if len(shape) > 1:
             elements = ', '.join(self._print(i) for i in expr)
-            shape    = ', '.join(self._print(i) for i in shape)
-            return 'reshape(['+ elements + '], '+ '[' + shape + ']' + ')'
+            shape = ', '.join(self._print(i) for i in shape)
+            return 'reshape([' + elements + '], ' + '[' + shape + ']' + ')'
         fs = ', '.join(self._print(f) for f in expr)
         return '[{0}]'.format(fs)
 
@@ -550,10 +577,10 @@ class FCodePrinter(CodePrinter):
 
             self.add_vars_to_namespace(var)
 
-            self._additional_code = self._additional_code + self._print(Assign(var,expr.lhs)) + '\n'
-            return self._print(var) + '%' +self._print(expr.name)
+            self._additional_code = self._additional_code + self._print(Assign(var, expr.lhs)) + '\n'
+            return self._print(var) + '%' + self._print(expr.name)
         else:
-            return self._print(expr.lhs) + '%' +self._print(expr.name)
+            return self._print(expr.lhs) + '%' + self._print(expr.name)
 
     def _print_DottedName(self, expr):
         return ' % '.join(self._print(n) for n in expr.name)
@@ -581,13 +608,12 @@ class FCodePrinter(CodePrinter):
     def _print_PythonReal(self, expr):
         value = self._print(expr.internal_var)
         return 'real({0})'.format(value)
+
     def _print_PythonImag(self, expr):
         value = self._print(expr.internal_var)
         return 'aimag({0})'.format(value)
 
-
-
-    #========================== Numpy Elements ===============================#
+    # ========================== Numpy Elements ===============================#
 
     def _print_NumpySum(self, expr):
         """Fortran print."""
@@ -646,11 +672,11 @@ class FCodePrinter(CodePrinter):
         template = '[({start} + {index}*{step},{index} = {zero},{end})]'
 
         init_value = template.format(
-            start = self._print(expr.start),
-            step  = self._print(expr.step ),
-            index = self._print(expr.index),
-            zero  = self._print(LiteralInteger(0)),
-            end   = self._print(PyccelMinus(expr.size, LiteralInteger(1), simplify = True)),
+            start=self._print(expr.start),
+            step=self._print(expr.step),
+            index=self._print(expr.index),
+            zero=self._print(LiteralInteger(0)),
+            end=self._print(PyccelMinus(expr.size, LiteralInteger(1), simplify=True)),
         )
         code = init_value
 
@@ -658,10 +684,10 @@ class FCodePrinter(CodePrinter):
 
     def _print_NumpyWhere(self, expr):
 
-        ind   = self._print(expr.index)
-        mask  = self._print(expr.mask)
+        ind = self._print(expr.index)
+        mask = self._print(expr.mask)
 
-        stmt  = 'pack([({ind},{ind}=0,size({mask})-1)],{mask})'.format(ind=ind,mask=mask)
+        stmt = 'pack([({ind},{ind}=0,size({mask})-1)],{mask})'.format(ind=ind, mask=mask)
 
         return stmt
 
@@ -675,36 +701,36 @@ class FCodePrinter(CodePrinter):
                 rhs_code = self._print(expr.arg)
                 rhs_code = 'transpose({})'.format(rhs_code)
             elif expr.rank > 2:
-                args     = [self._print(a) for a in expr.arg]
+                args = [self._print(a) for a in expr.arg]
                 new_args = []
                 for ac, a in zip(args, expr.arg):
                     if a.order == 'C':
-                        shape    = ', '.join(self._print(i) for i in a.shape)
-                        order    = ', '.join(self._print(LiteralInteger(i)) for i in range(a.rank, 0, -1))
-                        ac       = 'reshape({}, [{}], order=[{}])'.format(ac, shape, order)
+                        shape = ', '.join(self._print(i) for i in a.shape)
+                        order = ', '.join(self._print(LiteralInteger(i)) for i in range(a.rank, 0, -1))
+                        ac = 'reshape({}, [{}], order=[{}])'.format(ac, shape, order)
                     new_args.append(ac)
 
-                args     = new_args
+                args = new_args
                 rhs_code = '[' + ' ,'.join(args) + ']'
-                shape    = ', '.join(self._print(i) for i in expr.shape)
-                order    = [LiteralInteger(i) for i in range(1, expr.rank+1)]
-                order    = order[1:]+ order[:1]
-                order    = ', '.join(self._print(i) for i in order)
+                shape = ', '.join(self._print(i) for i in expr.shape)
+                order = [LiteralInteger(i) for i in range(1, expr.rank + 1)]
+                order = order[1:] + order[:1]
+                order = ', '.join(self._print(i) for i in order)
                 rhs_code = 'reshape({}, [{}], order=[{}])'.format(rhs_code, shape, order)
         elif expr.order == 'C':
             if expr.rank > 2:
-                args     = [self._print(a) for a in expr.arg]
+                args = [self._print(a) for a in expr.arg]
                 new_args = []
                 for ac, a in zip(args, expr.arg):
                     if a.order == 'F':
-                        shape    = ', '.join(self._print(i) for i in a.shape[::-1])
-                        order    = ', '.join(self._print(LiteralInteger(i)) for i in range(a.rank, 0, -1))
-                        ac       = 'reshape({}, [{}], order=[{}])'.format(ac, shape, order)
+                        shape = ', '.join(self._print(i) for i in a.shape[::-1])
+                        order = ', '.join(self._print(LiteralInteger(i)) for i in range(a.rank, 0, -1))
+                        ac = 'reshape({}, [{}], order=[{}])'.format(ac, shape, order)
                     new_args.append(ac)
 
-                args     = new_args
+                args = new_args
                 rhs_code = '[' + ' ,'.join(args) + ']'
-                shape    = ', '.join(self._print(i) for i in expr.shape[::-1])
+                shape = ', '.join(self._print(i) for i in expr.shape[::-1])
                 rhs_code = 'reshape({}, [{}])'.format(rhs_code, shape)
             else:
                 rhs_code = self._print(expr.arg)
@@ -715,20 +741,20 @@ class FCodePrinter(CodePrinter):
         return 'real({}, {})'.format(result_code, self.print_kind(expr))
 
     def _print_NumpyArange(self, expr):
-        start  = self._print(expr.start)
-        step   = self._print(expr.step)
-        shape  = PyccelMinus(expr.shape[0], LiteralInteger(1), simplify = True)
-        index  = Variable(NativeInteger(), name =  self.parser.get_new_name('i'))
+        start = self._print(expr.start)
+        step = self._print(expr.step)
+        shape = PyccelMinus(expr.shape[0], LiteralInteger(1), simplify=True)
+        index = Variable(NativeInteger(), name=self.parser.get_new_name('i'))
 
         self.add_vars_to_namespace(index)
 
         code = '[({start} + {step} * {index}, {index} = {0}, {shape}, {1})]'
         code = code.format(self._print(LiteralInteger(0)),
                            self._print(LiteralInteger(1)),
-                           start  = start,
-                           step   = step,
-                           index  = self._print(index),
-                           shape  = self._print(shape))
+                           start=start,
+                           step=step,
+                           index=self._print(index),
+                           shape=self._print(shape))
 
         return code
 
@@ -741,10 +767,10 @@ class FCodePrinter(CodePrinter):
         prec = self.print_kind(expr)
 
         if expr.arg.order == 'C':
-            index = PyccelMinus(LiteralInteger(expr.arg.rank), expr.index, simplify = True)
+            index = PyccelMinus(LiteralInteger(expr.arg.rank), expr.index, simplify=True)
             index = self._print(index)
         else:
-            index = PyccelAdd(expr.index, LiteralInteger(1), simplify = True)
+            index = PyccelAdd(expr.index, LiteralInteger(1), simplify=True)
             index = self._print(index)
 
         if expr.arg.rank == 1:
@@ -755,17 +781,17 @@ class FCodePrinter(CodePrinter):
     def _print_PythonInt(self, expr):
         value = self._print(expr.arg)
         if (expr.arg.dtype is NativeBool()):
-            code = 'MERGE(1_{0}, 0_{1}, {2})'.format(self.print_kind(expr), self.print_kind(expr),value)
+            code = 'MERGE(1_{0}, 0_{1}, {2})'.format(self.print_kind(expr), self.print_kind(expr), value)
         else:
-            code  = 'Int({0}, {1})'.format(value, self.print_kind(expr))
+            code = 'Int({0}, {1})'.format(value, self.print_kind(expr))
         return code
 
     def _print_PythonFloat(self, expr):
         value = self._print(expr.arg)
         if (expr.arg.dtype is NativeBool()):
-            code = 'MERGE(1.0_{0}, 0.0_{1}, {2})'.format(self.print_kind(expr), self.print_kind(expr),value)
+            code = 'MERGE(1.0_{0}, 0.0_{1}, {2})'.format(self.print_kind(expr), self.print_kind(expr), value)
         else:
-            code  = 'Real({0}, {1})'.format(value, self.print_kind(expr))
+            code = 'Real({0}, {1})'.format(value, self.print_kind(expr))
         return code
 
     def _print_MathFloor(self, expr):
@@ -785,17 +811,17 @@ class FCodePrinter(CodePrinter):
         if expr.is_cast:
             var = self._print(expr.internal_var)
             code = 'cmplx({0}, kind={1})'.format(var,
-                                self.print_kind(expr))
+                                                 self.print_kind(expr))
         else:
             real = self._print(expr.real)
             imag = self._print(expr.imag)
             code = 'cmplx({0}, {1}, {2})'.format(real, imag,
-                                self.print_kind(expr))
+                                                 self.print_kind(expr))
         return code
 
     def _print_PythonBool(self, expr):
         if isinstance(expr.arg.dtype, NativeBool):
-            return 'logical({}, kind = {prec})'.format(self._print(expr.arg), prec = self.print_kind(expr))
+            return 'logical({}, kind = {prec})'.format(self._print(expr.arg), prec=self.print_kind(expr))
         else:
             return '{} /= 0'.format(self._print(expr.arg))
 
@@ -807,13 +833,13 @@ class FCodePrinter(CodePrinter):
         if (not self._additional_code):
             self._additional_code = ''
         var_name = self.parser.get_new_name()
-        var = Variable(expr.dtype, var_name, is_stack_array = all([s.is_constant for s in expr.shape]),
-                shape = expr.shape, precision = expr.precision,
-                order = expr.order, rank = expr.rank)
+        var = Variable(expr.dtype, var_name, is_stack_array=all([s.is_constant for s in expr.shape]),
+                       shape=expr.shape, precision=expr.precision,
+                       order=expr.order, rank=expr.rank)
 
         self.add_vars_to_namespace(var)
 
-        self._additional_code = self._additional_code + self._print(Assign(var,expr)) + '\n'
+        self._additional_code = self._additional_code + self._print(Assign(var, expr)) + '\n'
         return self._print(var)
 
     def _print_NumpyRandint(self, expr):
@@ -821,9 +847,11 @@ class FCodePrinter(CodePrinter):
             errors.report(FORTRAN_ALLOCATABLE_IN_EXPRESSION,
                           symbol=expr, severity='fatal')
         if expr.low is None:
-            randreal = self._print(PyccelMul(expr.high, NumpyRand(), simplify = True))
+            randreal = self._print(PyccelMul(expr.high, NumpyRand(), simplify=True))
         else:
-            randreal = self._print(PyccelAdd(PyccelMul(PyccelMinus(expr.high, expr.low, simplify = True), NumpyRand(), simplify=True), expr.low, simplify = True))
+            randreal = self._print(
+                PyccelAdd(PyccelMul(PyccelMinus(expr.high, expr.low, simplify=True), NumpyRand(), simplify=True),
+                          expr.low, simplify=True))
 
         prec_code = self.print_kind(expr)
         return 'floor({}, kind={})'.format(randreal, prec_code)
@@ -841,7 +869,7 @@ class FCodePrinter(CodePrinter):
             code = 'minval({0})'.format(self._print(arg))
         else:
             code = ','.join(self._print(arg) for arg in args)
-            code = 'min('+code+')'
+            code = 'min(' + code + ')'
         return self._get_statement(code)
 
     def _print_PythonMax(self, expr):
@@ -851,7 +879,7 @@ class FCodePrinter(CodePrinter):
             code = 'maxval({0})'.format(self._print(arg))
         else:
             code = ','.join(self._print(arg) for arg in args)
-            code = 'max('+code+')'
+            code = 'max(' + code + ')'
         return self._get_statement(code)
 
     # ... MACROS
@@ -868,9 +896,9 @@ class FCodePrinter(CodePrinter):
             shape = []
             for i in range(0, rank):
                 l = 'lbound({var},{i})'.format(var=self._print(var),
-                                               i=self._print(i+1))
+                                               i=self._print(i + 1))
                 u = 'ubound({var},{i})'.format(var=self._print(var),
-                                               i=self._print(i+1))
+                                               i=self._print(i + 1))
                 s = '{u}-{l}+1'.format(u=u, l=l)
                 shape.append(s)
 
@@ -878,7 +906,7 @@ class FCodePrinter(CodePrinter):
             shape = shape[0]
 
 
-        elif not(expr.index is None):
+        elif not (expr.index is None):
             if expr.index < len(shape):
                 shape = shape[expr.index]
             else:
@@ -887,44 +915,45 @@ class FCodePrinter(CodePrinter):
         code = '{}'.format(self._print(shape))
 
         return self._get_statement(code)
+
     # ...
     def _print_MacroType(self, expr):
         dtype = self._print(expr.argument.dtype)
-        prec  = expr.argument.precision
+        prec = expr.argument.precision
 
         if dtype == 'integer':
-            if prec==4:
+            if prec == 4:
                 return 'MPI_INTEGER'
-            elif prec==8:
+            elif prec == 8:
                 return 'MPI_INTEGER8'
             else:
                 errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
-                    severity='fatal')
+                              severity='fatal')
 
         elif dtype == 'real':
-            if prec==8:
+            if prec == 8:
                 return 'MPI_DOUBLE'
-            if prec==4:
+            if prec == 4:
                 return 'MPI_FLOAT'
             else:
                 errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
-                    severity='fatal')
+                              severity='fatal')
 
         else:
             errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
-                severity='fatal')
+                          severity='fatal')
 
     def _print_MacroCount(self, expr):
 
         var = expr.argument
-        #TODO calculate size when type is pointer
+        # TODO calculate size when type is pointer
         # it must work according to fortran documentation
         # but it raises somehow an error when it's a pointer
         # and shape is None
 
         if isinstance(var, Variable):
             shape = var.shape
-            if not isinstance(shape,(tuple,list)):
+            if not isinstance(shape, (tuple, list)):
                 shape = [shape]
             rank = len(shape)
             if shape is None:
@@ -942,24 +971,27 @@ class FCodePrinter(CodePrinter):
                     if i.start is None and i.stop is None:
                         shape.append(s)
                     elif i.start is None:
-                        if (isinstance(i.stop, (int, LiteralInteger)) and i.stop>0) or not(isinstance(i.stop, (int, LiteralInteger))):
+                        if (isinstance(i.stop, (int, LiteralInteger)) and i.stop > 0) or not (
+                        isinstance(i.stop, (int, LiteralInteger))):
                             shape.append(i.stop)
                     elif i.stop is None:
-                        if (isinstance(i.start, (int, LiteralInteger)) and i.start<s-1) or not(isinstance(i.start, (int, LiteralInteger))):
-                            shape.append(PyccelMinus(s, i.start, simplify = True))
+                        if (isinstance(i.start, (int, LiteralInteger)) and i.start < s - 1) or not (
+                        isinstance(i.start, (int, LiteralInteger))):
+                            shape.append(PyccelMinus(s, i.start, simplify=True))
                     else:
-                        shape.append(PyccelMinus(i.stop, PyccelAdd(i.start, LiteralInteger(1), simplify = True), simplify = True))
+                        shape.append(
+                            PyccelMinus(i.stop, PyccelAdd(i.start, LiteralInteger(1), simplify=True), simplify=True))
 
             rank = len(shape)
 
         else:
             errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
-                severity='fatal')
+                          severity='fatal')
 
         if rank == 0:
             return '1'
 
-        return str(functools.reduce(operator.mul, shape ))
+        return str(functools.reduce(operator.mul, shape))
 
     def _print_Declare(self, expr):
         # ... ignored declarations
@@ -978,19 +1010,20 @@ class FCodePrinter(CodePrinter):
 
         # meta-variables
         if (isinstance(expr.variable, Variable) and
-            expr.variable.name.startswith('__')):
+                expr.variable.name.startswith('__')):
             return ''
         # ...
 
         if isinstance(expr.variable, InhomogeneousTupleVariable):
-            return ''.join(self._print_Declare(Declare(v.dtype,v,intent=expr.intent, static=expr.static)) for v in expr.variable)
+            return ''.join(
+                self._print_Declare(Declare(v.dtype, v, intent=expr.intent, static=expr.static)) for v in expr.variable)
 
         # ... TODO improve
         # Group the variables by intent
         var = expr.variable
-        rank        = var.rank
+        rank = var.rank
         allocatable = var.allocatable
-        shape       = var.alloc_shape
+        shape = var.alloc_shape
         is_pointer = var.is_pointer
         is_target = var.is_target
         is_const = var.is_const
@@ -999,7 +1032,7 @@ class FCodePrinter(CodePrinter):
         is_static = expr.static
         intent = expr.intent
 
-        if isinstance(shape, (tuple,PythonTuple)) and len(shape) ==1:
+        if isinstance(shape, (tuple, PythonTuple)) and len(shape) == 1:
             shape = shape[0]
         # ...
 
@@ -1007,9 +1040,9 @@ class FCodePrinter(CodePrinter):
         if isinstance(expr.dtype, CustomDataType):
             dtype = expr.dtype
 
-            name   = dtype.__class__.__name__
+            name = dtype.__class__.__name__
             prefix = dtype.prefix
-            alias  = dtype.alias
+            alias = dtype.alias
 
             if dtype.is_polymorphic or expr.passed_from_dotted:
                 sig = 'class'
@@ -1025,12 +1058,12 @@ class FCodePrinter(CodePrinter):
             expr_dtype = expr.dtype
             dtype = self._print(expr_dtype)
 
-        # ...
+            # ...
             if isinstance(expr_dtype, NativeString):
 
                 if expr.intent:
-                    dtype = dtype[:9] +'(len =*)'
-                    #TODO improve ,this is the case of character as argument
+                    dtype = dtype[:9] + '(len =*)'
+                    # TODO improve ,this is the case of character as argument
             else:
                 dtype += '({0})'.format(self.print_kind(expr.variable))
 
@@ -1042,14 +1075,14 @@ class FCodePrinter(CodePrinter):
 
         # arrays are 0-based in pyccel, to avoid ambiguity with range
         s = '0'
-        if not(is_static) and (allocatable or (var.shape is None)):
+        if not (is_static) and (allocatable or (var.shape is None)):
             s = ''
 
         # Default empty strings
-        intentstr      = ''
+        intentstr = ''
         allocatablestr = ''
-        optionalstr    = ''
-        rankstr        = ''
+        optionalstr = ''
+        rankstr = ''
 
         # Compute intent string
         if intent:
@@ -1079,33 +1112,36 @@ class FCodePrinter(CodePrinter):
         # Compute rank string
         # TODO: improve
         if ((rank == 1) and (isinstance(shape, (int, PyccelAstNode))) and
-            (not(allocatable or is_pointer) or is_static or is_stack_array)):
-            rankstr = '({0}:{1})'.format(self._print(s), self._print(PyccelMinus(shape, LiteralInteger(1), simplify = True)))
+                (not (allocatable or is_pointer) or is_static or is_stack_array)):
+            rankstr = '({0}:{1})'.format(self._print(s),
+                                         self._print(PyccelMinus(shape, LiteralInteger(1), simplify=True)))
 
         elif ((rank > 0) and (isinstance(shape, (PythonTuple, tuple))) and
-            (not(allocatable or is_pointer) or is_static or is_stack_array)):
-            #TODO fix bug when we include shape of type list
+              (not (allocatable or is_pointer) or is_static or is_stack_array)):
+            # TODO fix bug when we include shape of type list
 
             if var.order == 'C':
                 rankstr = ','.join('{0}:{1}'.format(self._print(s),
-                                                      self._print(PyccelMinus(i, LiteralInteger(1), simplify = True))) for i in shape[::-1])
+                                                    self._print(PyccelMinus(i, LiteralInteger(1), simplify=True))) for i
+                                   in shape[::-1])
             else:
-                rankstr =  ','.join('{0}:{1}'.format(self._print(s),
-                                                     self._print(PyccelMinus(i, LiteralInteger(1), simplify = True))) for i in shape)
+                rankstr = ','.join('{0}:{1}'.format(self._print(s),
+                                                    self._print(PyccelMinus(i, LiteralInteger(1), simplify=True))) for i
+                                   in shape)
             rankstr = '({rank})'.format(rank=rankstr)
 
         elif (rank > 0) and allocatable and intent:
             rankstr = '({})'.format(','.join(['0:'] * rank))
 
         elif (rank > 0) and (allocatable or is_pointer):
-            rankstr = '({})'.format(','.join( [':'] * rank))
+            rankstr = '({})'.format(','.join([':'] * rank))
 
-#        else:
-#            errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
-#                severity='fatal')
+        #        else:
+        #            errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
+        #                severity='fatal')
 
         # Construct declaration
-        left  = dtype + intentstr + allocatablestr + optionalstr
+        left = dtype + intentstr + allocatablestr + optionalstr
         right = vstr + rankstr + code_value
         return '{} :: {}\n'.format(left, right)
 
@@ -1115,30 +1151,30 @@ class FCodePrinter(CodePrinter):
         rhs = expr.rhs
 
         if isinstance(lhs, InhomogeneousTupleVariable):
-            return self._print(CodeBlock([AliasAssign(l, r) for l,r in zip(lhs,rhs)]))
+            return self._print(CodeBlock([AliasAssign(l, r) for l, r in zip(lhs, rhs)]))
 
         # TODO improve
         op = '=>'
         shape_code = ''
         if lhs.rank > 0:
             shape_code = ', '.join('0:' for i in range(lhs.rank))
-            shape_code = '({s_c})'.format(s_c = shape_code)
+            shape_code = '({s_c})'.format(s_c=shape_code)
 
         code += '{lhs}{s_c} {op} {rhs}'.format(lhs=self._print(expr.lhs),
-                                          s_c = shape_code,
-                                          op=op,
-                                          rhs=self._print(expr.rhs))
+                                               s_c=shape_code,
+                                               op=op,
+                                               rhs=self._print(expr.rhs))
 
         return self._get_statement(code) + '\n'
 
     def _print_CodeBlock(self, expr):
         if not expr.unravelled:
-            body_exprs, new_vars = expand_to_loops(expr, self.parser.get_new_variable, language_has_vectors = True)
+            body_exprs, new_vars = expand_to_loops(expr, self.parser.get_new_variable, language_has_vectors=True)
             self.add_vars_to_namespace(*new_vars)
         else:
             body_exprs = expr.body
         body_stmts = []
-        for b in body_exprs :
+        for b in body_exprs:
             line = self._print(b)
             if (self._additional_code):
                 body_stmts.append(self._additional_code)
@@ -1188,13 +1224,13 @@ class FCodePrinter(CodePrinter):
 
             # TODO uncomment later
 
-#            # we don't print the constructor call if iterable object
-#            if this.dtype.is_iterable:
-#                return ''
-#
-#            # we don't print the constructor call if with construct object
-#            if this.dtype.is_with_construct:
-#                return ''
+            #            # we don't print the constructor call if iterable object
+            #            if this.dtype.is_iterable:
+            #                return ''
+            #
+            #            # we don't print the constructor call if with construct object
+            #            if this.dtype.is_with_construct:
+            #                return ''
 
             if name == "__init__":
                 name = "create"
@@ -1210,13 +1246,12 @@ class FCodePrinter(CodePrinter):
             # we should append them to the procedure arguments
             if isinstance(expr.lhs, (tuple, list, PythonTuple, InhomogeneousTupleVariable)) \
                     or (isinstance(expr.lhs, HomogeneousTupleVariable) and expr.lhs.is_stack_array):
-
                 rhs_code = rhs.funcdef.name
                 args = rhs.args
                 code_args = [self._print(i) for i in args]
                 func = rhs.funcdef
                 output_names = func.results
-                lhs_code = [self._print(name) + ' = ' + self._print(i) for (name,i) in zip(output_names,expr.lhs)]
+                lhs_code = [self._print(name) + ' = ' + self._print(i) for (name, i) in zip(output_names, expr.lhs)]
 
                 call_args = ', '.join(code_args + lhs_code)
 
@@ -1224,7 +1259,7 @@ class FCodePrinter(CodePrinter):
                 return self._get_statement(code)
 
         if (isinstance(expr.lhs, Variable) and
-              expr.lhs.dtype == NativeSymbol()):
+                expr.lhs.dtype == NativeSymbol()):
             return ''
 
         # Right-hand side code
@@ -1236,37 +1271,37 @@ class FCodePrinter(CodePrinter):
         #     code += self._print(stmt)
         #     code += '\n'
         code += '{0} = {1}'.format(lhs_code, rhs_code)
-#        else:
-#            code_args = ''
-#            func = expr.rhs
-#            # func here is of instance FunctionCall
-#            cls_name = func.func.cls_name
-#            keys = func.func.arguments
+        #        else:
+        #            code_args = ''
+        #            func = expr.rhs
+        #            # func here is of instance FunctionCall
+        #            cls_name = func.func.cls_name
+        #            keys = func.func.arguments
 
-#            # for MPI statements, we need to add the lhs as the last argument
-#            # TODO improve
-#            if isinstance(func.func, MPI):
-#                if not func.arguments:
-#                    code_args = lhs_code
-#                else:
-#                    code_args = ', '.join(self._print(i) for i in func.arguments)
-#                    code_args = '{0}, {1}'.format(code_args, lhs_code)
-#            else:
-#                _ij_print = lambda i, j: '{0}={1}'.format(self._print(i), \
-#                                                         self._print(j))
-#
-#                code_args = ', '.join(_ij_print(i, j) \
-#                                      for i, j in zip(keys, func.arguments))
-#            if (not func.arguments is None) and (len(func.arguments) > 0):
-#                if (not cls_name):
-#                    code_args = ', '.join(self._print(i) for i in func.arguments)
-#                    code_args = '{0}, {1}'.format(code_args, lhs_code)
-#                else:
-#            print('code_args > {0}'.format(code_args))
-#            code = 'call {0}({1})'.format(rhs_code, code_args)
+        #            # for MPI statements, we need to add the lhs as the last argument
+        #            # TODO improve
+        #            if isinstance(func.func, MPI):
+        #                if not func.arguments:
+        #                    code_args = lhs_code
+        #                else:
+        #                    code_args = ', '.join(self._print(i) for i in func.arguments)
+        #                    code_args = '{0}, {1}'.format(code_args, lhs_code)
+        #            else:
+        #                _ij_print = lambda i, j: '{0}={1}'.format(self._print(i), \
+        #                                                         self._print(j))
+        #
+        #                code_args = ', '.join(_ij_print(i, j) \
+        #                                      for i, j in zip(keys, func.arguments))
+        #            if (not func.arguments is None) and (len(func.arguments) > 0):
+        #                if (not cls_name):
+        #                    code_args = ', '.join(self._print(i) for i in func.arguments)
+        #                    code_args = '{0}, {1}'.format(code_args, lhs_code)
+        #                else:
+        #            print('code_args > {0}'.format(code_args))
+        #            code = 'call {0}({1})'.format(rhs_code, code_args)
         return self._get_statement(code) + '\n'
 
-#------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
     def _print_Allocate(self, expr):
 
         # Transpose indices because of Fortran column-major ordering
@@ -1274,7 +1309,7 @@ class FCodePrinter(CodePrinter):
 
         var_code = self._print(expr.variable)
         size_code = ', '.join(self._print(i) for i in shape)
-        shape_code = ', '.join('0:' + self._print(PyccelMinus(i, LiteralInteger(1), simplify = True)) for i in shape)
+        shape_code = ', '.join('0:' + self._print(PyccelMinus(i, LiteralInteger(1), simplify=True)) for i in shape)
         code = ''
 
         if expr.status == 'unallocated':
@@ -1283,7 +1318,7 @@ class FCodePrinter(CodePrinter):
         elif expr.status == 'unknown':
             code += 'if (allocated({})) then\n'.format(var_code)
             code += '  if (any(size({}) /= [{}])) then\n'.format(var_code, size_code)
-            code += '    deallocate({})\n'     .format(var_code)
+            code += '    deallocate({})\n'.format(var_code)
             code += '    allocate({0}({1}))\n'.format(var_code, shape_code)
             code += '  end if\n'
             code += 'else\n'
@@ -1292,16 +1327,17 @@ class FCodePrinter(CodePrinter):
 
         elif expr.status == 'allocated':
             code += 'if (any(size({}) /= [{}])) then\n'.format(var_code, size_code)
-            code += '  deallocate({})\n'     .format(var_code)
+            code += '  deallocate({})\n'.format(var_code)
             code += '  allocate({0}({1}))\n'.format(var_code, shape_code)
             code += 'end if\n'
 
         return code
 
-#-----------------------------------------------------------------------------
+    # -----------------------------------------------------------------------------
     def _print_Deallocate(self, expr):
         return ''
-#------------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------------
 
     def _print_NativeBool(self, expr):
         return 'logical'
@@ -1317,7 +1353,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_NativeString(self, expr):
         return 'character(len=280)'
-        #TODO fix improve later
+        # TODO fix improve later
 
     def _print_DataType(self, expr):
         return self._print(expr.name)
@@ -1346,9 +1382,9 @@ class FCodePrinter(CodePrinter):
             for f in expr.functions:
                 parts = self.function_signature(f, f.name)
                 parts = ["{}({}) {}\n".format(parts['sig'], parts['arg_code'], parts['func_end']),
-                        'use, intrinsic :: ISO_C_BINDING\n',
-                        parts['arg_decs'],
-                        'end {} {}\n'.format(parts['func_type'], f.name)]
+                         'use, intrinsic :: ISO_C_BINDING\n',
+                         parts['arg_decs'],
+                         'end {} {}\n'.format(parts['func_type'], f.name)]
                 funcs_sigs.append(''.join(a for a in parts))
             interface = 'interface\n' + '\n'.join(a for a in funcs_sigs) + 'end interface\n'
             return interface
@@ -1364,49 +1400,46 @@ class FCodePrinter(CodePrinter):
                 # because we may have a class Point with init: Point___init__
                 if i in name:
                     name = name.replace(i, _default_methods[i])
-        interface = 'interface ' + name +'\n'
+        interface = 'interface ' + name + '\n'
         for f in expr.functions:
-            interface += 'module procedure ' + str(f.name)+'\n'
+            interface += 'module procedure ' + str(f.name) + '\n'
         interface += 'end interface\n'
         return interface
 
-
-
-   # def _print_With(self, expr):
-   #     test = 'call '+self._print(expr.test) + '%__enter__()'
-   #     body = self._print(expr.body)
-   #     end = 'call '+self._print(expr.test) + '%__exit__()'
-   #     code = ('{test}\n'
-   #            '{body}\n'
-   #            '{end}').format(test=test, body=body, end=end)
-        #TODO return code later
-  #      expr.block
-  #      return ''
+    # def _print_With(self, expr):
+    #     test = 'call '+self._print(expr.test) + '%__enter__()'
+    #     body = self._print(expr.body)
+    #     end = 'call '+self._print(expr.test) + '%__exit__()'
+    #     code = ('{test}\n'
+    #            '{body}\n'
+    #            '{end}').format(test=test, body=body, end=end)
+    # TODO return code later
+    #      expr.block
+    #      return ''
 
     def _print_Block(self, expr):
 
-        decs=[]
+        decs = []
         for i in expr.variables:
             dec = Declare(i.dtype, i)
             decs += [dec]
         body = expr.body
 
         body_code = self._print(body)
-        prelude   = ''.join(self._print(i) for i in decs)
+        prelude = ''.join(self._print(i) for i in decs)
 
-
-        #case of no local variables
+        # case of no local variables
         if len(decs) == 0:
             return body_code
 
         return ('{name} : Block\n'
                 '{prelude}\n'
-                 '{body}\n'
+                '{body}\n'
                 'end Block {name}\n').format(name=expr.name, prelude=prelude, body=body_code)
 
     def _print_BindCFunctionDef(self, expr):
         name = self._print(expr.name)
-        results   = list(expr.results)
+        results = list(expr.results)
         arguments = list(expr.arguments)
         if any([isinstance(a, FunctionAddress) for a in arguments]):
             # Functions with function addresses as arguments cannot be
@@ -1414,13 +1447,13 @@ class FCodePrinter(CodePrinter):
             return ''
         arguments_inout = expr.arguments_inout
         args_decs = OrderedDict()
-        for i,arg in enumerate(arguments):
+        for i, arg in enumerate(arguments):
             if arguments_inout[i]:
-                intent='inout'
+                intent = 'inout'
             else:
-                intent='in'
+                intent = 'in'
 
-            dec = Declare(arg.dtype, arg, intent=intent , static=True)
+            dec = Declare(arg.dtype, arg, intent=intent, static=True)
             args_decs[arg] = dec
 
         for result in results:
@@ -1429,7 +1462,7 @@ class FCodePrinter(CodePrinter):
 
         if len(results) != 1:
             func_type = 'subroutine'
-            func_end  = ''
+            func_end = ''
         else:
             func_type = 'function'
             result = results.pop()
@@ -1439,16 +1472,16 @@ class FCodePrinter(CodePrinter):
         # ...
 
         interfaces = '\n'.join(self._print(i) for i in expr.interfaces)
-        arg_code  = ', '.join(self._print(i) for i in chain( arguments, results ))
-        imports   = ''.join(self._print(i) for i in expr.imports)
-        prelude   = ''.join(self._print(i) for i in args_decs.values())
+        arg_code = ', '.join(self._print(i) for i in chain(arguments, results))
+        imports = ''.join(self._print(i) for i in expr.imports)
+        prelude = ''.join(self._print(i) for i in args_decs.values())
         body_code = self._print(expr.body)
         doc_string = self._print(expr.doc_string) if expr.doc_string else ''
 
         parts = [doc_string,
-                '{0} {1}({2}) bind(c) {3}\n'.format(func_type, name, arg_code, func_end),
+                 '{0} {1}({2}) bind(c) {3}\n'.format(func_type, name, arg_code, func_end),
                  imports,
-                'implicit none\n',
+                 'implicit none\n',
                  prelude,
                  interfaces,
                  body_code,
@@ -1459,12 +1492,12 @@ class FCodePrinter(CodePrinter):
         return expr.name
 
     def function_signature(self, expr, name):
-        is_pure      = expr.is_pure
+        is_pure = expr.is_pure
         is_elemental = expr.is_elemental
         out_args = []
         args_decs = OrderedDict()
 
-        func_end  = ''
+        func_end = ''
         rec = 'recursive ' if expr.is_recursive else ''
         if len(expr.results) != 1:
             func_type = 'subroutine'
@@ -1479,7 +1512,7 @@ class FCodePrinter(CodePrinter):
             functions = expr.functions
 
         else:
-           #todo: if return is a function
+            # todo: if return is a function
             func_type = 'function'
             result = expr.results[0]
             functions = expr.functions
@@ -1490,17 +1523,17 @@ class FCodePrinter(CodePrinter):
             args_decs[result] = dec
         # ...
 
-        for i,arg in enumerate(expr.arguments):
+        for i, arg in enumerate(expr.arguments):
             if isinstance(arg, Variable):
                 if i == 0 and expr.cls_name:
-                    dec = Declare(arg.dtype, arg, intent='inout', passed_from_dotted = True)
+                    dec = Declare(arg.dtype, arg, intent='inout', passed_from_dotted=True)
                 elif expr.arguments_inout[i]:
                     dec = Declare(arg.dtype, arg, intent='inout')
                 else:
                     dec = Declare(arg.dtype, arg, intent='in')
                 args_decs[arg] = dec
 
-        #remove parametres intent(inout) from out_args to prevent repetition
+        # remove parametres intent(inout) from out_args to prevent repetition
         for i in expr.arguments:
             if i in out_args:
                 out_args.remove(i)
@@ -1514,16 +1547,16 @@ class FCodePrinter(CodePrinter):
         if is_elemental:
             sig = 'elemental {}'.format(sig)
 
-        arg_code  = ', '.join(self._print(i) for i in chain( expr.arguments, out_args ))
+        arg_code = ', '.join(self._print(i) for i in chain(expr.arguments, out_args))
 
         arg_decs = ''.join(self._print(i) for i in args_decs.values())
 
         parts = {
-                'sig' : sig,
-                'arg_code' : arg_code,
-                'func_end' : func_end,
-                'arg_decs' : arg_decs,
-                'func_type' : func_type
+            'sig': sig,
+            'arg_code': arg_code,
+            'func_end': func_end,
+            'arg_decs': arg_decs,
+            'func_type': func_type
         }
         return parts
 
@@ -1560,24 +1593,24 @@ class FCodePrinter(CodePrinter):
         vars_to_print = self.parser.get_variables(self._namespace)
         for v in vars_to_print:
             if (v not in expr.local_vars) and (v not in expr.results) and (v not in expr.arguments):
-                decs[v] = Declare(v.dtype,v)
+                decs[v] = Declare(v.dtype, v)
         prelude += ''.join(self._print(i) for i in decs.values())
-        if len(functions)>0:
-            functions_code = '\n'.join(self._print(i) for  i in functions)
-            body_code = body_code +'\ncontains\n' + functions_code
+        if len(functions) > 0:
+            functions_code = '\n'.join(self._print(i) for i in functions)
+            body_code = body_code + '\ncontains\n' + functions_code
 
         imports = ''.join(self._print(i) for i in expr.imports)
 
         self.set_current_function(None)
 
         parts = [doc_string,
-                "{}({}) {}\n".format(sig_parts['sig'], sig_parts['arg_code'], sig_parts['func_end']),
-                imports,
-                'implicit none\n',
-                prelude,
-                func_interfaces,
-                body_code,
-                'end {} {}\n'.format(sig_parts['func_type'], name)]
+                 "{}({}) {}\n".format(sig_parts['sig'], sig_parts['arg_code'], sig_parts['func_end']),
+                 imports,
+                 'implicit none\n',
+                 prelude,
+                 func_interfaces,
+                 body_code,
+                 'end {} {}\n'.format(sig_parts['func_type'], name)]
 
         return '\n'.join(a for a in parts if a)
 
@@ -1591,7 +1624,7 @@ class FCodePrinter(CodePrinter):
         code = ''
         if expr.stmt:
             code += self._print(expr.stmt)
-        code +='return\n'
+        code += 'return\n'
         return code
 
     def _print_Del(self, expr):
@@ -1606,7 +1639,7 @@ class FCodePrinter(CodePrinter):
                     code = 'deallocate({0}){1}'.format(self._print(var), code)
             else:
                 errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
-                    severity='fatal')
+                              severity='fatal')
         return code + '\n'
 
     def _print_ClassDef(self, expr):
@@ -1617,15 +1650,15 @@ class FCodePrinter(CodePrinter):
 
         name = self._print(expr.name)
         self.set_current_class(name)
-        base = None # TODO: add base in ClassDef
+        base = None  # TODO: add base in ClassDef
 
         decs = ''.join(self._print(Declare(i.dtype, i)) for i in expr.attributes)
 
         aliases = []
-        names   = []
+        names = []
         ls = [self._print(i.name) for i in expr.methods]
         for i in ls:
-            j = _default_methods.get(i,i)
+            j = _default_methods.get(i, i)
             aliases.append(j)
             names.append('{0}_{1}'.format(name, self._print(j)))
         methods = ''.join('procedure :: {0} => {1}\n'.format(i, j) for i, j in zip(aliases, names))
@@ -1634,12 +1667,10 @@ class FCodePrinter(CodePrinter):
             methods += 'generic, public :: {0} => {1}\n'.format(self._print(i.name), names)
             methods += 'procedure :: {0}\n'.format(names)
 
-
-
         options = ', '.join(i for i in expr.options)
 
         sig = 'type, {0}'.format(options)
-        if not(base is None):
+        if not (base is None):
             sig = '{0}, extends({1})'.format(sig, base)
 
         code = ('{0} :: {1}').format(sig, name)
@@ -1657,14 +1688,14 @@ class FCodePrinter(CodePrinter):
         # we rename all methods because of the aliasing
         cls_methods = [i.clone('{0}'.format(i.name)) for i in expr.methods]
         for i in expr.interfaces:
-            cls_methods +=  [j.clone('{0}'.format(j.name)) for j in i.functions]
+            cls_methods += [j.clone('{0}'.format(j.name)) for j in i.functions]
 
         methods = ''
         for i in cls_methods:
             methods = ('{methods}\n'
-                     '{sep}\n'
-                     '{f}\n'
-                     '{sep}\n').format(methods=methods, sep=sep, f=self._print(i))
+                       '{sep}\n'
+                       '{f}\n'
+                       '{sep}\n').format(methods=methods, sep=sep, f=self._print(i))
 
         self.set_current_class(None)
 
@@ -1682,7 +1713,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_PythonRange(self, expr):
         start = self._print(expr.start)
-        step  = self._print(expr.step)
+        step = self._print(expr.step)
 
         test_step = expr.step
         if isinstance(test_step, PyccelUnarySub):
@@ -1691,13 +1722,13 @@ class FCodePrinter(CodePrinter):
         # testing if the step is a value or an expression
         if isinstance(test_step, Literal):
             if isinstance(expr.step, PyccelUnarySub):
-                stop = PyccelAdd(expr.stop, LiteralInteger(1), simplify = True)
+                stop = PyccelAdd(expr.stop, LiteralInteger(1), simplify=True)
             else:
-                stop = PyccelMinus(expr.stop, LiteralInteger(1), simplify = True)
+                stop = PyccelMinus(expr.stop, LiteralInteger(1), simplify=True)
         else:
             stop = IfTernaryOperator(PyccelGt(expr.step, LiteralInteger(0)),
-                                     PyccelMinus(expr.stop, LiteralInteger(1), simplify = True),
-                                     PyccelAdd(expr.stop, LiteralInteger(1), simplify = True))
+                                     PyccelMinus(expr.stop, LiteralInteger(1), simplify=True),
+                                     PyccelAdd(expr.stop, LiteralInteger(1), simplify=True))
 
         stop = self._print(stop)
         return '{0}, {1}, {2}'.format(start, stop, step)
@@ -1713,15 +1744,15 @@ class FCodePrinter(CodePrinter):
         if expr.iterable.num_loop_counters_required:
             self.add_vars_to_namespace(index)
 
-        target   = index
+        target = index
         my_range = expr.iterable.get_range()
 
         if not isinstance(my_range, PythonRange):
             # Only iterable currently supported is PythonRange
             errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
-                severity='fatal')
+                          severity='fatal')
 
-        tar        = self._print(target)
+        tar = self._print(target)
         range_code = self._print(my_range)
 
         prolog = 'do {0} = {1}\n'.format(tar, range_code)
@@ -1766,8 +1797,8 @@ class FCodePrinter(CodePrinter):
 
     # .....................................................
     def _print_OMP_Parallel(self, expr):
-        clauses = ' '.join(self._print(i)  for i in expr.clauses)
-        body    = ''.join(self._print(i) for i in expr.body)
+        clauses = ' '.join(self._print(i) for i in expr.clauses)
+        body = ''.join(self._print(i) for i in expr.body)
 
         # ... TODO adapt get_statement to have continuation with OpenMP
         prolog = '!$omp parallel {clauses}\n'.format(clauses=clauses)
@@ -1784,11 +1815,11 @@ class FCodePrinter(CodePrinter):
 
     def _print_OMP_For(self, expr):
         # ...
-        loop    = self._print(expr.loop)
-        clauses = ' '.join(self._print(i)  for i in expr.clauses)
+        loop = self._print(expr.loop)
+        clauses = ' '.join(self._print(i) for i in expr.clauses)
 
-        nowait  = ''
-        if not(expr.nowait is None):
+        nowait = ''
+        if not (expr.nowait is None):
             nowait = 'nowait'
         # ...
         # ... TODO adapt get_statement to have continuation with OpenMP
@@ -1845,7 +1876,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_OMP_Reduction(self, expr):
         args = ', '.join('{0}'.format(self._print(i)) for i in expr.variables)
-        op   = self._print(expr.operation)
+        op = self._print(expr.operation)
         return "reduction({0}: {1})".format(op, args)
 
     def _print_OMP_Schedule(self, expr):
@@ -1870,20 +1901,21 @@ class FCodePrinter(CodePrinter):
         return 'collapse({0})'.format(n_loops)
 
     def _print_OMP_Linear(self, expr):
-        variables= ', '.join('{0}'.format(self._print(i)) for i in expr.variables)
+        variables = ', '.join('{0}'.format(self._print(i)) for i in expr.variables)
         step = self._print(expr.step)
         return "linear({0}: {1})".format(variables, step)
 
     def _print_OMP_If(self, expr):
         return 'if({})'.format(self._print(expr.test))
+
     # .....................................................
 
     # .....................................................
     #                   OpenACC statements
     # .....................................................
     def _print_ACC_Parallel(self, expr):
-        clauses = ' '.join(self._print(i)  for i in expr.clauses)
-        body    = ''.join(self._print(i) for i in expr.body)
+        clauses = ' '.join(self._print(i) for i in expr.clauses)
+        body = ''.join(self._print(i) for i in expr.body)
 
         # ... TODO adapt get_statement to have continuation with OpenACC
         prolog = '!$acc parallel {clauses}\n'.format(clauses=clauses)
@@ -1900,8 +1932,8 @@ class FCodePrinter(CodePrinter):
 
     def _print_ACC_For(self, expr):
         # ...
-        loop    = self._print(expr.loop)
-        clauses = ' '.join(self._print(i)  for i in expr.clauses)
+        loop = self._print(expr.loop)
+        clauses = ' '.join(self._print(i) for i in expr.clauses)
         # ...
 
         # ... TODO adapt get_statement to have continuation with OpenACC
@@ -2020,7 +2052,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_ACC_Reduction(self, expr):
         args = ', '.join('{0}'.format(self._print(i)) for i in expr.variables)
-        op   = self._print(expr.operation)
+        op = self._print(expr.operation)
         return "reduction({0}: {1})".format(op, args)
 
     def _print_ACC_Self(self, expr):
@@ -2053,6 +2085,7 @@ class FCodePrinter(CodePrinter):
     def _print_ACC_Worker(self, expr):
         args = ', '.join('{0}'.format(self._print(i)) for i in expr.variables)
         return 'worker({})'.format(args)
+
     # .....................................................
 
     def _print_ForIterator(self, expr):
@@ -2063,13 +2096,14 @@ class FCodePrinter(CodePrinter):
 
         # ...
         def _do_range(target, iterable, prolog, epilog):
-            tar        = self._print(target)
+            tar = self._print(target)
             range_code = self._print(iterable)
 
             prolog += 'do {0} = {1}\n'.format(tar, range_code)
             epilog = 'end do\n' + epilog
 
             return prolog, epilog
+
         # ...
 
         # ...
@@ -2086,7 +2120,7 @@ class FCodePrinter(CodePrinter):
         # ...
 
         # ...
-        for i,a in zip(targets, iters):
+        for i, a in zip(targets, iters):
             prolog, epilog = _do_range(i, a, \
                                        prolog, epilog)
 
@@ -2097,13 +2131,12 @@ class FCodePrinter(CodePrinter):
                 '{body}'
                 '{epilog}').format(prolog=prolog, body=body, epilog=epilog)
 
-
-    #def _print_Block(self, expr):
+    # def _print_Block(self, expr):
     #    body    = '\n'.join(self._print(i) for i in expr.body)
     #    prelude = '\n'.join(self._print(i) for i in expr.declarations)
     #    return prelude, body
 
-    def _print_While(self,expr):
+    def _print_While(self, expr):
         body = self._print(expr.body)
         return ('do while ({test})\n'
                 '{body}'
@@ -2187,8 +2220,8 @@ class FCodePrinter(CodePrinter):
         value_true = expr.value_true
         value_false = expr.value_false
 
-        if value_true.dtype != value_false.dtype :
-            try :
+        if value_true.dtype != value_false.dtype:
+            try:
                 cast_func = python_builtin_datatypes[str_dtype(expr.dtype)]
             except KeyError:
                 errors.report(PYCCEL_RESTRICTION_TODO, severity='fatal')
@@ -2197,19 +2230,19 @@ class FCodePrinter(CodePrinter):
         cond = self._print(cond)
         value_true = self._print(value_true)
         value_false = self._print(value_false)
-        return 'merge({true}, {false}, {cond})'.format(cond = cond, true = value_true, false = value_false)
+        return 'merge({true}, {false}, {cond})'.format(cond=cond, true=value_true, false=value_false)
 
     def _print_PyccelPow(self, expr):
         base = expr.args[0]
-        e    = expr.args[1]
+        e = expr.args[1]
 
         base_c = self._print(base)
-        e_c    = self._print(e)
+        e_c = self._print(e)
         return '{} ** {}'.format(base_c, e_c)
 
     def _print_PyccelAdd(self, expr):
         if expr.dtype is NativeString():
-            return '//'.join('trim('+self._print(a)+')' for a in expr.args)
+            return '//'.join('trim(' + self._print(a) + ')' for a in expr.args)
         else:
             return ' + '.join(self._print(a) for a in expr.args)
 
@@ -2230,7 +2263,7 @@ class FCodePrinter(CodePrinter):
         return ' / '.join(self._print(a) for a in args)
 
     def _print_PyccelMod(self, expr):
-        is_real  = expr.dtype is NativeReal()
+        is_real = expr.dtype is NativeReal()
 
         def correct_type_arg(a):
             if is_real and a.dtype is NativeInteger():
@@ -2247,11 +2280,11 @@ class FCodePrinter(CodePrinter):
 
     def _print_PyccelFloorDiv(self, expr):
 
-        code   = self._print(expr.args[0])
+        code = self._print(expr.args[0])
         adtype = expr.args[0].dtype
-        is_real  = expr.dtype is NativeReal()
+        is_real = expr.dtype is NativeReal()
         for b in expr.args[1:]:
-            bdtype    = b.dtype
+            bdtype = b.dtype
             if adtype is NativeInteger() and bdtype is NativeInteger():
                 b = NumpyFloat(b)
             c = self._print(b)
@@ -2370,8 +2403,8 @@ class FCodePrinter(CodePrinter):
             func_name = numpy_ufunc_to_fortran[type_name]
         except KeyError:
             self._print_not_supported(expr)
-        args = [self._print(NumpyFloat(a) if a.dtype is NativeInteger() else a)\
-				for a in expr.args]
+        args = [self._print(NumpyFloat(a) if a.dtype is NativeInteger() else a) \
+                for a in expr.args]
         code_args = ', '.join(args)
         code = '{0}({1})'.format(func_name, code_args)
         return self._get_statement(code)
@@ -2448,10 +2481,10 @@ class FCodePrinter(CodePrinter):
 
     def _print_MathPow(self, expr):
         base = expr.args[0]
-        e    = expr.args[1]
+        e = expr.args[1]
 
         base_c = self._print(base)
-        e_c    = self._print(e)
+        e_c = self._print(e)
         return '{} ** {}'.format(base_c, e_c)
 
     def _print_NumpySqrt(self, expr):
@@ -2494,16 +2527,16 @@ class FCodePrinter(CodePrinter):
                 if (not self._additional_code):
                     self._additional_code = ''
                 var_name = self.parser.get_new_name()
-                var = Variable(base.dtype, var_name, is_stack_array = True,
-                        shape=base.shape,precision=base.precision,
-                        order=base.order,rank=base.rank)
+                var = Variable(base.dtype, var_name, is_stack_array=True,
+                               shape=base.shape, precision=base.precision,
+                               order=base.order, rank=base.rank)
 
                 self.add_vars_to_namespace(var)
 
-                self._additional_code = self._additional_code + self._print(Assign(var,base)) + '\n'
+                self._additional_code = self._additional_code + self._print(Assign(var, base)) + '\n'
                 return self._print(var[expr.indices])
         elif isinstance(base, InhomogeneousTupleVariable):
-            if len(expr.indices)==1:
+            if len(expr.indices) == 1:
                 return self._print(base[expr.indices[0]])
             else:
                 var = base[expr.indices[0]]
@@ -2522,14 +2555,14 @@ class FCodePrinter(CodePrinter):
             if isinstance(ind, Slice):
                 inds[i] = self._new_slice_with_processed_arguments(ind, _shape, allow_negative_indexes)
             elif isinstance(ind, PyccelUnarySub) and isinstance(ind.args[0], LiteralInteger):
-                inds[i] = PyccelMinus(_shape, ind.args[0], simplify = True)
+                inds[i] = PyccelMinus(_shape, ind.args[0], simplify=True)
             else:
-                #indices of indexedElement of len==1 shouldn't be a tuple
+                # indices of indexedElement of len==1 shouldn't be a tuple
                 if isinstance(ind, tuple) and len(ind) == 1:
                     inds[i] = ind[0]
                 if allow_negative_indexes and not isinstance(ind, LiteralInteger):
                     inds[i] = IfTernaryOperator(PyccelLt(ind, LiteralInteger(0)),
-                            PyccelAdd(base_shape[i], ind, simplify = True), ind)
+                                                PyccelAdd(base_shape[i], ind, simplify=True), ind)
 
         inds = [self._print(i) for i in inds]
 
@@ -2557,42 +2590,42 @@ class FCodePrinter(CodePrinter):
 
         # negative start and end in slice
         if isinstance(start, PyccelUnarySub) and isinstance(start.args[0], LiteralInteger):
-            start = PyccelMinus(array_size, start.args[0], simplify = True)
-        elif start is not None and allow_negative_index and not isinstance(start,LiteralInteger):
+            start = PyccelMinus(array_size, start.args[0], simplify=True)
+        elif start is not None and allow_negative_index and not isinstance(start, LiteralInteger):
             start = IfTernaryOperator(PyccelLt(start, LiteralInteger(0)),
-                        PyccelAdd(array_size, start, simplify = True), start)
+                                      PyccelAdd(array_size, start, simplify=True), start)
 
         if isinstance(stop, PyccelUnarySub) and isinstance(stop.args[0], LiteralInteger):
-            stop = PyccelMinus(array_size, stop.args[0], simplify = True)
+            stop = PyccelMinus(array_size, stop.args[0], simplify=True)
         elif stop is not None and allow_negative_index and not isinstance(stop, LiteralInteger):
             stop = IfTernaryOperator(PyccelLt(stop, LiteralInteger(0)),
-                        PyccelAdd(array_size, stop, simplify = True), stop)
+                                     PyccelAdd(array_size, stop, simplify=True), stop)
 
         # negative step in slice
         if isinstance(step, PyccelUnarySub) and isinstance(step.args[0], LiteralInteger):
-            stop = PyccelAdd(stop, LiteralInteger(1), simplify = True) if stop is not None else LiteralInteger(0)
-            start = start if start is not None else PyccelMinus(array_size, LiteralInteger(1), simplify = True)
+            stop = PyccelAdd(stop, LiteralInteger(1), simplify=True) if stop is not None else LiteralInteger(0)
+            start = start if start is not None else PyccelMinus(array_size, LiteralInteger(1), simplify=True)
 
         # variable step in slice
         elif step and allow_negative_index and not isinstance(step, LiteralInteger):
-            if start is None :
+            if start is None:
                 start = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)),
-                    LiteralInteger(0), PyccelMinus(array_size , LiteralInteger(1), simplify = True))
+                                          LiteralInteger(0), PyccelMinus(array_size, LiteralInteger(1), simplify=True))
 
-            if stop is None :
+            if stop is None:
                 stop = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)),
-                    PyccelMinus(array_size, LiteralInteger(1), simplify = True), LiteralInteger(0))
-            else :
+                                         PyccelMinus(array_size, LiteralInteger(1), simplify=True), LiteralInteger(0))
+            else:
                 stop = IfTernaryOperator(PyccelGt(step, LiteralInteger(0)),
-                    stop, PyccelAdd(stop, LiteralInteger(1), simplify = True))
+                                         stop, PyccelAdd(stop, LiteralInteger(1), simplify=True))
 
         elif stop is not None:
-            stop = PyccelMinus(stop, LiteralInteger(1), simplify = True)
+            stop = PyccelMinus(stop, LiteralInteger(1), simplify=True)
 
         return Slice(start, stop, step)
 
     def _print_Slice(self, expr):
-        if expr.start is None or  isinstance(expr.start, Nil):
+        if expr.start is None or isinstance(expr.start, Nil):
             start = ''
         else:
             start = self._print(expr.start)
@@ -2600,11 +2633,11 @@ class FCodePrinter(CodePrinter):
             stop = ''
         else:
             stop = self._print(expr.stop)
-        if expr.step is not None :
+        if expr.step is not None:
             return '{0}:{1}:{2}'.format(start, stop, self._print(expr.step))
         return '{0}:{1}'.format(start, stop)
 
-#=======================================================================================
+    # =======================================================================================
 
     def _print_FunctionCall(self, expr):
         func = expr.funcdef
@@ -2616,37 +2649,37 @@ class FCodePrinter(CodePrinter):
             args = ['{}'.format(self._print(a)) for a in args]
 
             args = ', '.join(args)
-            code = '{name}({args})'.format( name = f_name,
-                                            args = args)
+            code = '{name}({args})'.format(name=f_name,
+                                           args=args)
 
-        elif len(results)>1:
+        elif len(results) > 1:
             if (not self._additional_code):
                 self._additional_code = ''
             out_vars = []
             for r in func.results:
                 var_name = self.parser.get_new_name()
-                var =  r.clone(name = var_name)
+                var = r.clone(name=var_name)
 
                 self.add_vars_to_namespace(var)
 
                 out_vars.append(var)
 
-            self._additional_code = self._additional_code + self._print(Assign(tuple(out_vars),expr)) + '\n'
+            self._additional_code = self._additional_code + self._print(Assign(tuple(out_vars), expr)) + '\n'
             return self._print(tuple(out_vars))
         else:
-            args    = ['{}'.format(self._print(a)) for a in args]
+            args = ['{}'.format(self._print(a)) for a in args]
             if not func.is_header:
                 results = ['{0}={0}'.format(self._print(a)) for a in results]
             else:
                 results = ['{}'.format(self._print(a)) for a in results]
 
-            newargs = ', '.join(args+results)
+            newargs = ', '.join(args + results)
 
-            code = 'call {name}({args})\n'.format( name = f_name,
-                                                 args = newargs )
+            code = 'call {name}({args})\n'.format(name=f_name,
+                                                  args=newargs)
         return code
 
-#=======================================================================================
+    # =======================================================================================
 
     def _print_DottedFunctionCall(self, expr):
         if isinstance(expr.prefix, FunctionCall):
@@ -2658,20 +2691,20 @@ class FCodePrinter(CodePrinter):
 
             self.add_vars_to_namespace(var)
 
-            self._additional_code = self._additional_code + self._print(Assign(var,expr.prefix)) + '\n'
+            self._additional_code = self._additional_code + self._print(Assign(var, expr.prefix)) + '\n'
             expr = DottedFunctionCall(expr.funcdef, expr.args, var)
         return self._print_FunctionCall(expr)
 
-#=======================================================================================
+    # =======================================================================================
 
     def _print_PyccelInternalFunction(self, expr):
         if isinstance(expr, NumpyNewArray):
             return errors.report(FORTRAN_ALLOCATABLE_IN_EXPRESSION,
-                          symbol=expr, severity='fatal')
+                                 symbol=expr, severity='fatal')
         else:
             return self._print_not_supported(expr)
 
-#=======================================================================================
+    # =======================================================================================
 
     def _wrap_fortran(self, lines):
         """Wrap long Fortran lines
@@ -2705,10 +2738,10 @@ class FCodePrinter(CodePrinter):
         result = []
         trailing = ' &'
         for line in lines:
-            if len(line)>72 and ('"' in line[72:] or "'" in line[72:] or '!' in line[:72]):
+            if len(line) > 72 and ('"' in line[72:] or "'" in line[72:] or '!' in line[:72]):
                 result.append(line)
 
-            elif len(line)>72:
+            elif len(line) > 72:
                 # code line
 
                 pos = split_pos_code(line, 72)
@@ -2723,12 +2756,12 @@ class FCodePrinter(CodePrinter):
                     line = line[pos:].lstrip()
                     if line:
                         hunk += trailing
-                    result.append("%s%s"%("      " , hunk))
+                    result.append("%s%s" % ("      ", hunk))
             else:
                 result.append(line)
 
         # make sure that all lines end with a carriage return
-        return [l if l.endswith('\n') else l+'\n' for l in result]
+        return [l if l.endswith('\n') else l + '\n' for l in result]
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
@@ -2739,30 +2772,30 @@ class FCodePrinter(CodePrinter):
         code = [line.lstrip(' \t') for line in code]
 
         increase = [int(inc_regex.match(line) is not None)
-                     for line in code]
+                    for line in code]
         decrease = [int(dec_regex.match(line) is not None)
-                     for line in code]
+                    for line in code]
         continuation = [int(any(map(line.endswith, ['&', '&\n'])))
-                         for line in code]
+                        for line in code]
 
         level = 0
         cont_padding = 0
         tabwidth = self._default_settings['tabwidth']
         new_code = []
         for i, line in enumerate(code):
-            if line in('','\n'):
+            if line in ('', '\n'):
                 new_code.append(line)
                 continue
             level -= decrease[i]
 
-            padding = " "*(level*tabwidth + cont_padding)
+            padding = " " * (level * tabwidth + cont_padding)
 
             line = "%s%s" % (padding, line)
 
             new_code.append(line)
 
             if continuation[i]:
-                cont_padding = 2*tabwidth
+                cont_padding = 2 * tabwidth
             else:
                 cont_padding = 0
             level += increase[i]

--- a/tests/pyccel/scripts/expressions.py
+++ b/tests/pyccel/scripts/expressions.py
@@ -64,6 +64,12 @@ g7 = x==10 and y == 4 and x == 7
 g8 = True and True or False and False
 g9 = False or True and False or True
 
+C_INT = 4.6
+i32 = 5
+i128 = 1337
+f32 = 5.2
+
+
 print(a1)
 print(a2)
 print(a3)
@@ -122,3 +128,8 @@ print(g6)
 print(g7)
 print(g8)
 print(g9)
+
+print(C_INT)
+print(i32)
+print(i128)
+print(f32)

--- a/tests/pyccel/scripts/expressions.py
+++ b/tests/pyccel/scripts/expressions.py
@@ -133,3 +133,4 @@ print(C_INT)
 print(i32)
 print(i128)
 print(f32)
+


### PR DESCRIPTION
This PR aims to resolve issue #856 . The following dictionary will be used instead of the original iso_c_binding dictionary whenever possible:
`iso_c_binding_shortcut = {
    "integer" : {
        1  : 'i8',
        2  : 'i16',
        4  : 'i32',
        8  : 'i64',
        16 : 'i128'}, #no supported yet
    "real"    : {
        4  : 'f32',
        8  : 'f64',
        16 : 'f128'},
    "logical" : {
        4  : "b4"}
}`
Checking if shortcuts can be implemented is done during the initialization of FCodePrinter through a systematic check of all the variable names in the namespace, this result is then stored as an attribute of the aforementioned class as an array of booleans of size 8 in self._namespace_restrictions.
The renaming is done in the print_kind method whenever it is possible.
finally, a line is added to state all the macros used in the module.

As an example, the Python code
```python
import numpy as np

a = np.int32(1) + 2 + 3.5
i32 = 5
print(i32)
print(a)
```
is translated to the Fortran code
```f90
program prog_t


  use, intrinsic :: ISO_C_Binding, only : i64 => C_INT64_T , f64 => &
      C_DOUBLE , C_INT32_T
  implicit none

  real(f64) :: a
  integer(i64) :: i32

  a = 1_C_INT32_T + 2_i64 + 3.5_f64
  i32 = 5_i64
  print *, i32
  print *, a

end program prog_t
```