### PR TITLE
Improve test reliability

### DIFF
--- a/.github/actions/coverage_install/action.yml
+++ b/.github/actions/coverage_install/action.yml
@@ -13,5 +13,6 @@ runs:
         SITE_DIR=$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
         echo -e "import coverage; coverage.process_startup()" > ${SITE_DIR}/pyccel_cov.pth
         echo -e "[run]\nparallel = True\nsource = ${INSTALL_DIR}\ndata_file = $(pwd)/.coverage\n[report]\ninclude = ${INSTALL_DIR}/*\n[xml]\noutput = cobertura.xml" > .coveragerc
+        echo "SITE_DIR=${SITE_DIR}" >> $GITHUB_ENV
         echo "COVERAGE_PROCESS_START=$(pwd)/.coveragerc" >> $GITHUB_ENV
       shell: bash

--- a/tests/epyccel/recognised_functions/test_epyccel_pyc_math.py
+++ b/tests/epyccel/recognised_functions/test_epyccel_pyc_math.py
@@ -7,6 +7,9 @@ from numpy import isclose
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
 
+RTOL = 2e-14
+ATOL = 1e-15
+
 # -----------------------------------------------------------------------------
 
 def test_call_gcd(language):
@@ -61,8 +64,8 @@ def test_call_radians(language):
     f = epyccel(call_radians, language=language)
     x = uniform(low=0.0, high=1e6)
 
-    assert isclose(f(x), call_radians(x), rtol=1e-14, atol=1e-14)
-    assert isclose(f(-x), call_radians(-x), rtol=1e-14, atol=1e-14)
+    assert isclose(f(x), call_radians(x), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x), call_radians(-x), rtol=RTOL, atol=ATOL)
 
 # -----------------------------------------------------------------------------
 
@@ -75,8 +78,8 @@ def test_call_degrees(language):
     f = epyccel(call_degrees, language=language)
     x = uniform(low=0.0, high=1e6)
 
-    assert isclose(f(x), call_degrees(x), rtol=1e-14, atol=1e-14)
-    assert isclose(f(-x), call_degrees(-x), rtol=1e-14, atol=1e-14)
+    assert isclose(f(x), call_degrees(x), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x), call_degrees(-x), rtol=RTOL, atol=ATOL)
 # -----------------------------------------------------------------------------
 
 def test_call_degrees_i(language):
@@ -88,7 +91,7 @@ def test_call_degrees_i(language):
     f = epyccel(call_degrees_i, language=language)
     x = randint(1e6)
 
-    assert isclose(f(x), call_degrees_i(x), rtol=1e-14, atol=1e-14)
-    assert isclose(f(-x), call_degrees_i(-x), rtol=1e-14, atol=1e-14)
+    assert isclose(f(x), call_degrees_i(x), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x), call_degrees_i(-x), rtol=RTOL, atol=ATOL)
 
 # -----------------------------------------------------------------------------

--- a/tests/epyccel/recognised_functions/test_math_funcs.py
+++ b/tests/epyccel/recognised_functions/test_math_funcs.py
@@ -8,6 +8,9 @@ from pyccel.epyccel import epyccel
 
 import sys
 
+RTOL = 2e-14
+ATOL = 1e-15
+
 max_float = 3.40282e5        # maximum positive float
 min_float = sys.float_info.min  # Minimum positive float
 
@@ -19,7 +22,7 @@ def test_fabs_call(language):
 
     f1 = epyccel(fabs_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  fabs_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  fabs_call(x), rtol=RTOL, atol=ATOL))
 
 def test_fabs_phrase(language):
     @types('real','real')
@@ -31,7 +34,7 @@ def test_fabs_phrase(language):
     f2 = epyccel(fabs_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  fabs_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  fabs_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_fabs_return_type(language):
     @types('int')
@@ -42,7 +45,7 @@ def test_fabs_return_type(language):
 
     f1 = epyccel(fabs_return_type, language = language)
     x = randint(100)
-    assert(isclose(f1(x) ,  fabs_return_type(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  fabs_return_type(x), rtol=RTOL, atol=ATOL))
     assert(type(f1(x))  == type(fabs_return_type(x))) # pylint: disable=unidiomatic-typecheck
 
 def test_sqrt_call(language):
@@ -53,7 +56,7 @@ def test_sqrt_call(language):
 
     f1 = epyccel(sqrt_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  sqrt_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  sqrt_call(x), rtol=RTOL, atol=ATOL))
 
 def test_sqrt_phrase(language):
     @types('real','real')
@@ -65,7 +68,7 @@ def test_sqrt_phrase(language):
     f2 = epyccel(sqrt_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  sqrt_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  sqrt_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_sqrt_return_type(language):
     @types('real')
@@ -76,7 +79,7 @@ def test_sqrt_return_type(language):
 
     f1 = epyccel(sqrt_return_type_real, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  sqrt_return_type_real(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  sqrt_return_type_real(x), rtol=RTOL, atol=ATOL))
     assert(type(f1(x))  == type(sqrt_return_type_real(x))) # pylint: disable=unidiomatic-typecheck
 
 def test_sin_call(language):
@@ -87,7 +90,7 @@ def test_sin_call(language):
 
     f1 = epyccel(sin_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  sin_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  sin_call(x), rtol=RTOL, atol=ATOL))
 
 def test_sin_phrase(language):
     @types('real','real')
@@ -99,7 +102,7 @@ def test_sin_phrase(language):
     f2 = epyccel(sin_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  sin_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  sin_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_cos_call(language):
     @types('real')
@@ -109,7 +112,7 @@ def test_cos_call(language):
 
     f1 = epyccel(cos_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  cos_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  cos_call(x), rtol=RTOL, atol=ATOL))
 
 def test_cos_phrase(language):
     @types('real','real')
@@ -121,7 +124,7 @@ def test_cos_phrase(language):
     f2 = epyccel(cos_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  cos_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  cos_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 
 def test_tan_call(language):
@@ -132,7 +135,7 @@ def test_tan_call(language):
 
     f1 = epyccel(tan_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  tan_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  tan_call(x), rtol=RTOL, atol=ATOL))
 
 
 def test_tan_phrase(language):
@@ -145,7 +148,7 @@ def test_tan_phrase(language):
     f2 = epyccel(tan_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  tan_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  tan_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_exp_call(language):
     @types('real')
@@ -155,7 +158,7 @@ def test_exp_call(language):
 
     f1 = epyccel(exp_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  exp_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  exp_call(x), rtol=RTOL, atol=ATOL))
 
 def test_exp_phrase(language):
     @types('real','real')
@@ -167,7 +170,7 @@ def test_exp_phrase(language):
     f2 = epyccel(exp_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  exp_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  exp_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_log_call(language):
     @types('real')
@@ -177,7 +180,7 @@ def test_log_call(language):
 
     f1 = epyccel(log_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  log_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  log_call(x), rtol=RTOL, atol=ATOL))
 
 def test_log_phrase(language):
     @types('real','real')
@@ -189,7 +192,7 @@ def test_log_phrase(language):
     f2 = epyccel(log_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  log_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  log_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_asin_call(language):
     @types('real')
@@ -199,7 +202,7 @@ def test_asin_call(language):
 
     f1 = epyccel(asin_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  asin_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  asin_call(x), rtol=RTOL, atol=ATOL))
 
 def test_asin_phrase(language):
     @types('real','real')
@@ -211,7 +214,7 @@ def test_asin_phrase(language):
     f2 = epyccel(asin_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  asin_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  asin_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_acos_call(language):
     @types('real')
@@ -221,7 +224,7 @@ def test_acos_call(language):
 
     f1 = epyccel(acos_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  acos_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  acos_call(x), rtol=RTOL, atol=ATOL))
 
 def test_acos_phrase(language):
     @types('real','real')
@@ -233,7 +236,7 @@ def test_acos_phrase(language):
     f2 = epyccel(acos_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  acos_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  acos_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_atan_call(language):
     @types('real')
@@ -243,7 +246,7 @@ def test_atan_call(language):
 
     f1 = epyccel(atan_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  atan_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  atan_call(x), rtol=RTOL, atol=ATOL))
 
 def test_atan_phrase(language):
     @types('real','real')
@@ -255,7 +258,7 @@ def test_atan_phrase(language):
     f2 = epyccel(atan_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  atan_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  atan_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_sinh_call(language):
     @types('real')
@@ -265,7 +268,7 @@ def test_sinh_call(language):
 
     f1 = epyccel(sinh_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  sinh_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  sinh_call(x), rtol=RTOL, atol=ATOL))
 
 def test_sinh_phrase(language):
     @types('real','real')
@@ -277,7 +280,7 @@ def test_sinh_phrase(language):
     f2 = epyccel(sinh_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  sinh_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  sinh_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_cosh_call(language):
     @types('real')
@@ -287,7 +290,7 @@ def test_cosh_call(language):
 
     f1 = epyccel(cosh_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  cosh_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  cosh_call(x), rtol=RTOL, atol=ATOL))
 
 def test_cosh_phrase(language):
     @types('real','real')
@@ -299,7 +302,7 @@ def test_cosh_phrase(language):
     f2 = epyccel(cosh_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  cosh_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  cosh_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_tanh_call(language):
     @types('real')
@@ -309,7 +312,7 @@ def test_tanh_call(language):
 
     f1 = epyccel(tanh_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  tanh_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  tanh_call(x), rtol=RTOL, atol=ATOL))
 
 def test_tanh_phrase(language):
     @types('real','real')
@@ -321,7 +324,7 @@ def test_tanh_phrase(language):
     f2 = epyccel(tanh_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  tanh_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  tanh_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 def test_atan2_call(language):
     @types('real', 'real')
@@ -332,7 +335,7 @@ def test_atan2_call(language):
     f1 = epyccel(atan2_call, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f1(x, y), atan2_call(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x, y), atan2_call(x, y), rtol=RTOL, atol=ATOL))
 
 def test_atan2_phrase(language):
     @types('real', 'real', 'real')
@@ -345,7 +348,7 @@ def test_atan2_phrase(language):
     x = rand()
     y = rand()
     z = rand()
-    assert(isclose(f2(x, y, z), atan2_phrase(x, y, z), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x, y, z), atan2_phrase(x, y, z), rtol=RTOL, atol=ATOL))
 
 #------------------------------- Floor function ------------------------------#
 def test_floor_call(language):
@@ -357,8 +360,8 @@ def test_floor_call(language):
     fflags = "-Werror -Wconversion"
     f1 = epyccel(floor_call, language = language, fflags=fflags)
     x = rand()
-    assert(isclose(f1(x) ,  floor_call(x), rtol=1e-14, atol=1e-15))
-    assert(isclose(f1(-x) ,  floor_call(-x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  floor_call(x), rtol=RTOL, atol=ATOL))
+    assert(isclose(f1(-x) ,  floor_call(-x), rtol=RTOL, atol=ATOL))
 
 def test_floor_phrase(language):
     @types('real','real')
@@ -371,10 +374,10 @@ def test_floor_phrase(language):
     f2 = epyccel(floor_phrase, language = language, fflags=fflags)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  floor_phrase(x,y), rtol=1e-14, atol=1e-15))
-    assert(isclose(f2(-x,y) ,  floor_phrase(-x,y), rtol=1e-14, atol=1e-15))
-    assert(isclose(f2(x,-y) ,  floor_phrase(x,-y), rtol=1e-14, atol=1e-15))
-    assert(isclose(f2(-x,-y) ,  floor_phrase(-x,-y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  floor_phrase(x,y), rtol=RTOL, atol=ATOL))
+    assert(isclose(f2(-x,y) ,  floor_phrase(-x,y), rtol=RTOL, atol=ATOL))
+    assert(isclose(f2(x,-y) ,  floor_phrase(x,-y), rtol=RTOL, atol=ATOL))
+    assert(isclose(f2(-x,-y) ,  floor_phrase(-x,-y), rtol=RTOL, atol=ATOL))
 
 def test_floor_return_type(language):
     @types('int')
@@ -393,16 +396,16 @@ def test_floor_return_type(language):
     f1 = epyccel(floor_return_type_int, language = language, fflags=fflags)
 
     x = randint(100)
-    assert(isclose(f1(x) ,  floor_return_type_int(x), rtol=1e-14, atol=1e-15))
-    assert(isclose(f1(-x) ,  floor_return_type_int(-x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  floor_return_type_int(x), rtol=RTOL, atol=ATOL))
+    assert(isclose(f1(-x) ,  floor_return_type_int(-x), rtol=RTOL, atol=ATOL))
     assert(type(f1(x))  == type(floor_return_type_int(x))) # pylint: disable=unidiomatic-typecheck
 
     fflags = "-Werror -Wconversion"
     f1 = epyccel(floor_return_type_real, language = language, fflags=fflags)
 
     x = uniform(100)
-    assert(isclose(f1(x) ,  floor_return_type_real(x), rtol=1e-14, atol=1e-15))
-    assert(isclose(f1(-x) ,  floor_return_type_real(-x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  floor_return_type_real(x), rtol=RTOL, atol=ATOL))
+    assert(isclose(f1(-x) ,  floor_return_type_real(-x), rtol=RTOL, atol=ATOL))
     assert(type(f1(x))  == type(floor_return_type_real(x))) # pylint: disable=unidiomatic-typecheck
 
 #------------------------------- Ceil function -------------------------------#
@@ -448,10 +451,10 @@ def test_ceil_phrase(language):
 
     x = rand()
     y = rand()
-    assert(isclose(ceil_phrase(x, y), f2(x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(ceil_phrase(-x, y), f2(-x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(ceil_phrase(x, -y), f2(x, -y), rtol=1e-14, atol=1e-15))
-    assert(isclose(ceil_phrase(-x, -y), f2(-x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(ceil_phrase(x, y), f2(x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(ceil_phrase(-x, y), f2(-x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(ceil_phrase(x, -y), f2(x, -y), rtol=RTOL, atol=ATOL))
+    assert(isclose(ceil_phrase(-x, -y), f2(-x, -y), rtol=RTOL, atol=ATOL))
 #------------------------------- copysign function -------------------------------#
 
 def test_copysign_call(language):
@@ -464,14 +467,14 @@ def test_copysign_call(language):
     x = rand()
     y = rand()
     # Same sign
-    assert(isclose(copysign_call(x, y), f1(x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(copysign_call(-x, -y), f1(-x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(copysign_call(x, y), f1(x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(copysign_call(-x, -y), f1(-x, -y), rtol=RTOL, atol=ATOL))
     # Different sign
-    assert(isclose(copysign_call(-x, y), f1(-x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(copysign_call(x, -y), f1(x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(copysign_call(-x, y), f1(-x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(copysign_call(x, -y), f1(x, -y), rtol=RTOL, atol=ATOL))
     # x =/= 0, y = 0 and x = 0, y =/= 0
-    assert(isclose(copysign_call(x, 0.0), f1(x, 0.0), rtol=1e-14, atol=1e-15))
-    assert(isclose(copysign_call(0.0, y), f1(0.0, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(copysign_call(x, 0.0), f1(x, 0.0), rtol=RTOL, atol=ATOL))
+    assert(isclose(copysign_call(0.0, y), f1(0.0, y), rtol=RTOL, atol=ATOL))
 
 def test_copysign_call_zero_case(language):
     @types('int', 'int')
@@ -483,11 +486,11 @@ def test_copysign_call_zero_case(language):
     x = 0
     y = 0
     # Same sign
-    assert(isclose(copysign_zero_case(x, y), f1(x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(copysign_zero_case(-x, -y), f1(-x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(copysign_zero_case(x, y), f1(x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(copysign_zero_case(-x, -y), f1(-x, -y), rtol=RTOL, atol=ATOL))
     # Different sign
-    assert(isclose(copysign_zero_case(-x, y), f1(-x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(copysign_zero_case(x, -y), f1(x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(copysign_zero_case(-x, y), f1(-x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(copysign_zero_case(x, -y), f1(x, -y), rtol=RTOL, atol=ATOL))
 
 def test_copysign_return_type_1(language): # copysign
     '''test type copysign(real, real) => should return real number'''
@@ -666,13 +669,13 @@ def test_ldexp_call(language): # ldexp
     x = rand()
     exp = randint(high)
 
-    assert(isclose(ldexp_call(x, exp), f1(x, exp), rtol=1e-14, atol=1e-15))
+    assert(isclose(ldexp_call(x, exp), f1(x, exp), rtol=RTOL, atol=ATOL))
     # Negative exponent
-    assert(isclose(ldexp_call(x, -exp), f1(x, -exp), rtol=1e-14, atol=1e-15))
+    assert(isclose(ldexp_call(x, -exp), f1(x, -exp), rtol=RTOL, atol=ATOL))
     # Negative value
-    assert(isclose(ldexp_call(-x, exp), f1(-x, exp), rtol=1e-14, atol=1e-15))
+    assert(isclose(ldexp_call(-x, exp), f1(-x, exp), rtol=RTOL, atol=ATOL))
     # Negative value and negative exponent
-    assert(isclose(ldexp_call(-x, -exp), f1(-x, -exp), rtol=1e-14, atol=1e-15))
+    assert(isclose(ldexp_call(-x, -exp), f1(-x, -exp), rtol=RTOL, atol=ATOL))
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("c", marks = pytest.mark.c),
@@ -722,12 +725,12 @@ def test_remainder_call(language): # remainder
     x = rand()
     y = rand() + 1
     # Same sign
-    assert(isclose(remainder_call(x, y), f1(x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(remainder_call(-x, -y), f1(-x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(remainder_call(x, y), f1(x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(remainder_call(-x, -y), f1(-x, -y), rtol=RTOL, atol=ATOL))
 
     # Different sign
-    assert(isclose(remainder_call(x, -y), f1(x, -y), rtol=1e-14, atol=1e-15))
-    assert(isclose(remainder_call(-x, y), f1(-x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(remainder_call(x, -y), f1(x, -y), rtol=RTOL, atol=ATOL))
+    assert(isclose(remainder_call(-x, y), f1(-x, y), rtol=RTOL, atol=ATOL))
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 @pytest.mark.parametrize( 'language', (
@@ -816,7 +819,7 @@ def test_expm1_call(language): # expm1
 
     f1 = epyccel(expm1_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  expm1_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  expm1_call(x), rtol=RTOL, atol=ATOL))
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("c", marks = pytest.mark.c),
@@ -834,7 +837,7 @@ def test_expm1_call_special_case(language): # expm1
     # should give result accurate to full precision better than exp()
     x = 1e-5
     f1 = epyccel(expm1_call, language = language)
-    assert(isclose(f1(x), expm1_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x), expm1_call(x), rtol=RTOL, atol=ATOL))
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("c", marks = pytest.mark.c),
@@ -854,7 +857,7 @@ def test_expm1_phrase(language): # expm1
     f2 = epyccel(expm1_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  expm1_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  expm1_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("c", marks = pytest.mark.c),
@@ -894,7 +897,7 @@ def test_log1p_call(language):
 
     f1 = epyccel(log1p_call, language = language)
     x = rand()
-    assert(isclose(f1(x) ,  log1p_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  log1p_call(x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(log1p_call(x)))
 
 @pytest.mark.parametrize( 'language', (
@@ -915,7 +918,7 @@ def test_log1p_phrase(language):
     f2 = epyccel(log1p_phrase, language = language)
     x = rand()
     y = rand()
-    assert(isclose(f2(x,y) ,  log1p_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  log1p_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 #--------------------------- log2 function ------------------------------#
 @pytest.mark.parametrize( 'language', (
@@ -936,7 +939,7 @@ def test_log2_call(language):
     low = min_float
     high = max_float
     x = uniform(low=low, high=high)
-    assert(isclose(f1(x) ,  log2_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  log2_call(x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(log2_call(x)))
 
 @pytest.mark.parametrize( 'language', (
@@ -959,7 +962,7 @@ def test_log2_phrase(language):
     high = max_float
     x = uniform(low=low, high=high)
     y = uniform(low=low, high=high)
-    assert(isclose(f2(x,y) ,  log2_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  log2_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 #--------------------------- log10 function ------------------------------#
 
@@ -973,7 +976,7 @@ def test_log10_call(language):
     low = min_float
     high = max_float
     x = uniform(low=low, high=high)
-    assert(isclose(f1(x) ,  log10_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  log10_call(x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(log10_call(x)))
 
 def test_log10_phrase(language):
@@ -988,7 +991,7 @@ def test_log10_phrase(language):
     high = max_float
     x = uniform(low=low, high=high)
     y = uniform(low=low, high=high)
-    assert(isclose(f2(x,y) ,  log10_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) ,  log10_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 #--------------------------------- Pow function ------------------------------#
 
@@ -1004,18 +1007,18 @@ def test_pow_call(language):
     # case 1: x > 0
     x = uniform(low=min_float)
     y = uniform(low=-high, high=high)
-    assert(isclose(f1(x, y) , pow_call(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x, y) , pow_call(x, y), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x, y), type(pow_call(x, y)))
 
     # case 2: x = 0 and y > 0
     x = 0.0
     y = uniform(high=high)
-    assert(isclose(f1(x, y), pow_call(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x, y), pow_call(x, y), rtol=RTOL, atol=ATOL))
 
     # case 3: x < 0 and y is integer
     x = uniform(low=-high, high=0)
     y = randint(high)
-    assert(isclose(f1(x, y), pow_call(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x, y), pow_call(x, y), rtol=RTOL, atol=ATOL))
 
 #------------------------------- Hypot function ------------------------------#
 
@@ -1029,7 +1032,7 @@ def test_hypot_call(language):
     high = 10
     x = uniform(low=-high, high=high)
     y = uniform(low=-high, high=high)
-    assert(isclose(f1(x, y), hypot_call(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x, y), hypot_call(x, y), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x, y), type(hypot_call(x, y)))
 
 #------------------------------- Acosh function ------------------------------#
@@ -1043,7 +1046,7 @@ def test_acosh_call(language):
     f1 = epyccel(acosh_call, language = language)
 
     x = uniform(low=1, high=max_float)
-    assert(isclose(f1(x) ,  acosh_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) ,  acosh_call(x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(acosh_call(x)))
 
 def test_acosh_phrase(language):
@@ -1057,7 +1060,7 @@ def test_acosh_phrase(language):
 
     x = uniform(low=1, high=max_float)
     y = uniform(low=1, high=max_float)
-    assert(isclose(f2(x,y) , acosh_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y) , acosh_phrase(x,y), rtol=RTOL, atol=ATOL))
 
 
 #------------------------------- Asinh function ------------------------------#
@@ -1071,11 +1074,11 @@ def test_asinh_call(language):
     f1 = epyccel(asinh_call, language = language)
 
     x = uniform(high=max_float)
-    assert(isclose(f1(x) , asinh_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) , asinh_call(x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(asinh_call(x)))
 
     # Negative value
-    assert(isclose(f1(-x) , asinh_call(-x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(-x) , asinh_call(-x), rtol=RTOL, atol=ATOL))
 
 def test_asinh_phrase(language):
     @types('real','real')
@@ -1087,9 +1090,9 @@ def test_asinh_phrase(language):
     f2 = epyccel(asinh_phrase, language = language)
     x = uniform(high=max_float)
     y = uniform(high=max_float)
-    assert(isclose(f2(x,y), asinh_phrase(x,y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x,y), asinh_phrase(x,y), rtol=RTOL, atol=ATOL))
     # Negative value
-    assert(isclose(f2(-x,-y), asinh_phrase(-x,-y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(-x,-y), asinh_phrase(-x,-y), rtol=RTOL, atol=ATOL))
 
 #------------------------------- Atanh function ------------------------------#
 
@@ -1103,7 +1106,7 @@ def test_atanh_call(language):
     low = -1 + min_float
     high = 1 - min_float
     x = uniform(low=low, high=high)
-    assert(isclose(f1(x) , atanh_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) , atanh_call(x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(atanh_call(x)))
 
 def test_atanh_phrase(language):
@@ -1120,7 +1123,7 @@ def test_atanh_phrase(language):
     high = 1 - min_float
     x = uniform(low=low, high=high)
     y = uniform(low=low, high=high)
-    assert(isclose(f2(x, y), atanh_phrase(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x, y), atanh_phrase(x, y), rtol=RTOL, atol=ATOL))
 
 #--------------------------------- Erf function ------------------------------#
 
@@ -1134,8 +1137,8 @@ def test_erf_call(language):
 
     # Domain ]-inf, +inf[
     x = uniform(high=max_float)
-    assert(isclose(f1(x) , erf_call(x), rtol=1e-14, atol=1e-15))
-    assert(isclose(f1(-x) , erf_call(-x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) , erf_call(x), rtol=RTOL, atol=ATOL))
+    assert(isclose(f1(-x) , erf_call(-x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(erf_call(x)))
 
 def test_erf_phrase(language):
@@ -1150,8 +1153,8 @@ def test_erf_phrase(language):
     # Domain ]-inf, +inf[
     x = uniform(high=max_float)
     y = uniform(high=max_float)
-    assert(isclose(f2(x, y), erf_phrase(x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(f2(-x, -y), erf_phrase(-x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x, y), erf_phrase(x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(f2(-x, -y), erf_phrase(-x, -y), rtol=RTOL, atol=ATOL))
 
 #-------------------------------- Erfc function ------------------------------#
 
@@ -1165,8 +1168,8 @@ def test_erfc_call(language):
 
     # Domain ]-inf, +inf[
     x = uniform(high=max_float)
-    assert(isclose(f1(x) , erfc_call(x), rtol=1e-14, atol=1e-15))
-    assert(isclose(f1(-x) , erfc_call(-x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) , erfc_call(x), rtol=RTOL, atol=ATOL))
+    assert(isclose(f1(-x) , erfc_call(-x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(erfc_call(x)))
 
 def test_erfc_phrase(language):
@@ -1181,8 +1184,8 @@ def test_erfc_phrase(language):
     # Domain ]-inf, +inf[
     x = uniform(high=max_float)
     y = uniform(high=max_float)
-    assert(isclose(f2(x, y), erfc_phrase(x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(f2(-x, -y), erfc_phrase(-x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x, y), erfc_phrase(x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(f2(-x, -y), erfc_phrase(-x, -y), rtol=RTOL, atol=ATOL))
 
 #-------------------------------- gamma function -----------------------------#
 
@@ -1196,12 +1199,12 @@ def test_gamma_call(language):
 
     # Domain ]0, +inf[ || (x < 0 and x.fraction not null)
     x = uniform(low=min_float)
-    assert(isclose(f1(x) , gamma_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) , gamma_call(x), rtol=RTOL, atol=ATOL))
     from math import modf
     # make fractional part different from zero to test negative case
     if modf(x)[0] == 0:
         x += - 0.1
-    assert(isclose(f1(-x) , gamma_call(-x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(-x) , gamma_call(-x), rtol=RTOL, atol=ATOL))
 
     assert isinstance(f1(x), type(gamma_call(x)))
 
@@ -1217,7 +1220,7 @@ def test_gamma_phrase(language):
     # Domain ]0, +inf[ || (x < 0 and fractional part of x not null)
     x = uniform(low=min_float)
     y = uniform(low=min_float)
-    assert(isclose(f2(x, y), gamma_phrase(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x, y), gamma_phrase(x, y), rtol=RTOL, atol=ATOL))
 
 #------------------------------- lgamma function -----------------------------#
 
@@ -1231,13 +1234,13 @@ def test_lgamma_call(language):
 
     # Domain ]0, +inf[ || (x < 0 and x.fraction not null)
     x = uniform(low=min_float)
-    assert(isclose(f1(x) , lgamma_call(x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(x) , lgamma_call(x), rtol=RTOL, atol=ATOL))
     from math import modf
     _, f = modf(x)
     # make fractional part different from zero to test negative case
     if f == 0:
         x += - 0.1
-    assert(isclose(f1(-x) , lgamma_call(-x), rtol=1e-14, atol=1e-15))
+    assert(isclose(f1(-x) , lgamma_call(-x), rtol=RTOL, atol=ATOL))
     assert isinstance(f1(x), type(lgamma_call(x)))
 
 def test_lgamma_phrase(language):
@@ -1252,4 +1255,4 @@ def test_lgamma_phrase(language):
     # Domain ]0, +inf[ || (x < 0 and fractional part of x not null)
     x = uniform(low=min_float)
     y = uniform(low=min_float)
-    assert(isclose(f2(x, y), lgamma_phrase(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f2(x, y), lgamma_phrase(x, y), rtol=RTOL, atol=ATOL))

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -45,7 +45,7 @@ if sys.platform == 'win32':
     RTOL = 1e-13
     ATOL = 1e-14
 else:
-    RTOL = 1e-14
+    RTOL = 2e-14
     ATOL = 1e-15
 
 RTOL32 = 1e-5

--- a/tests/epyccel/test_epyccel_default_args.py
+++ b/tests/epyccel/test_epyccel_default_args.py
@@ -49,14 +49,14 @@ def test_f2(language):
     x_expected = np.zeros(m1)
     f5(x_expected)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=2e-14, atol=1e-15 )
     # ...
 
     f(x, m1 = m1)
 
     f5(x_expected, m1)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=2e-14, atol=1e-15 )
 
 
 #------------------------------------------------------------------------------

--- a/tests/epyccel/test_epyccel_division.py
+++ b/tests/epyccel/test_epyccel_division.py
@@ -7,6 +7,8 @@ from conftest       import *
 from pyccel.epyccel import epyccel
 from pyccel.decorators import types
 
+RTOL = 2e-14
+ATOL = 1e-15
 
 # -------------------- simple division ---------------------- #
 
@@ -19,10 +21,10 @@ def test_call_div_i_i(language):
     x = randint(1e9)
     y = randint(low=1, high= 1e3)
 
-    assert isclose(f(x, y), div_i_i(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_i_i(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_i_i(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_i_i(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_i_i(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_i_i(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_i_i(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_i_i(-x, -y), rtol=RTOL, atol=ATOL)
 
 def test_call_div_i_r(language):
     @types(int, 'real')
@@ -32,10 +34,10 @@ def test_call_div_i_r(language):
     f = epyccel(div_i_r, language=language)
     x = randint(1e9)
     y = uniform(low=1, high= 1e3)
-    assert isclose(f(x, y), div_i_r(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_i_r(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_i_r(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_i_r(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_i_r(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_i_r(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_i_r(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_i_r(-x, -y), rtol=RTOL, atol=ATOL)
 
 def test_call_div_r_i(language):
     @types('real', int)
@@ -45,10 +47,10 @@ def test_call_div_r_i(language):
     f = epyccel(div_r_i, language=language)
     x = uniform(high=1e9)
     y = randint(low=1, high= 1e3)
-    assert isclose(f(x, y), div_r_i(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_r_i(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_r_i(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_r_i(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_r_i(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_r_i(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_r_i(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_r_i(-x, -y), rtol=RTOL, atol=ATOL)
 
 def test_call_div_r_r(language):
     @types('real', 'real')
@@ -58,10 +60,10 @@ def test_call_div_r_r(language):
     f = epyccel(div_r_r, language=language)
     x = uniform(high=1e9)
     y = uniform(low=1e-14, high= 1e3)
-    assert isclose(f(x, y), div_r_r(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_r_r(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_r_r(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_r_r(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_r_r(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_r_r(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_r_r(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_r_r(-x, -y), rtol=RTOL, atol=ATOL)
 
 # -------------------- Complex division ---------------------- #
 
@@ -73,10 +75,10 @@ def test_call_div_c_c(language):
     f = epyccel(div_c_c, language=language)
     x = complex(uniform(high= 1e5), uniform(high= 1e5))
     y = complex(uniform(low=1, high= 1e2), uniform(low=1, high= 1e2))
-    assert isclose(f(x, y), div_c_c(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_c_c(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_c_c(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_c_c(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_c_c(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_c_c(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_c_c(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_c_c(-x, -y), rtol=RTOL, atol=ATOL)
 
 def test_call_div_i_c(language):
     @types(int, 'complex')
@@ -86,10 +88,10 @@ def test_call_div_i_c(language):
     f = epyccel(div_i_c, language=language)
     x = randint(1e5)
     y = complex(uniform(low=1, high= 1e2), uniform(low=1, high= 1e2))
-    assert isclose(f(x, y), div_i_c(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_i_c(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_i_c(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_i_c(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_i_c(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_i_c(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_i_c(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_i_c(-x, -y), rtol=RTOL, atol=ATOL)
 
 def test_call_div_c_i(language):
     @types('complex', int)
@@ -99,10 +101,10 @@ def test_call_div_c_i(language):
     f = epyccel(div_c_i, language=language)
     x = complex(uniform(high= 1e5), uniform(high= 1e5))
     y = randint(low=1, high= 1e2)
-    assert isclose(f(x, y), div_c_i(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_c_i(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_c_i(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_c_i(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_c_i(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_c_i(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_c_i(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_c_i(-x, -y), rtol=RTOL, atol=ATOL)
 
 def test_call_div_r_c(language):
     @types('real', 'complex')
@@ -112,10 +114,10 @@ def test_call_div_r_c(language):
     f = epyccel(div_r_c, language=language)
     x = uniform(high=1e9)
     y = complex(uniform(low=1, high= 1e2), uniform(low=1, high= 1e2))
-    assert isclose(f(x, y), div_r_c(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_r_c(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_r_c(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_r_c(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_r_c(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_r_c(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_r_c(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_r_c(-x, -y), rtol=RTOL, atol=ATOL)
 
 def test_call_div_c_r(language):
     @types('complex', 'real')
@@ -125,10 +127,10 @@ def test_call_div_c_r(language):
     f = epyccel(div_c_r, language=language)
     x = complex(uniform(high= 1e5), uniform(high= 1e5))
     y = uniform(low=1e-14, high= 1e3)
-    assert isclose(f(x, y), div_c_r(x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, y), div_c_r(-x, y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(x, -y), div_c_r(x, -y), rtol=1e-14, atol=1e-15)
-    assert isclose(f(-x, -y), div_c_r(-x, -y), rtol=1e-14, atol=1e-15)
+    assert isclose(f(x, y), div_c_r(x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, y), div_c_r(-x, y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(x, -y), div_c_r(x, -y), rtol=RTOL, atol=ATOL)
+    assert isclose(f(-x, -y), div_c_r(-x, -y), rtol=RTOL, atol=ATOL)
 
 # -------------------- floor division ---------------------- #
 

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -8,6 +8,9 @@ from pyccel.epyccel import epyccel
 from pyccel.decorators import types
 from pyccel.errors.errors import PyccelError
 
+RTOL = 2e-14
+ATOL = 1e-15
+
 def test_func_no_args_1(language):
     '''test function with return value but no args'''
     def free_gift():
@@ -151,7 +154,7 @@ def test_decorator_f5(language):
     x_expected = np.zeros(m1)
     f5(m1, x_expected)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
     # ...
 
 #------------------------------------------------------------------------------
@@ -174,7 +177,7 @@ def test_decorator_f6(language):
     x_expected = np.zeros((m1,m2))
     f6_1(m1, m2, x_expected)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
     # ...
 
 #------------------------------------------------------------------------------
@@ -199,7 +202,7 @@ def test_decorator_f7(language):
     x = np.zeros((m1,m2), order='F')
     f(m1, m2, x)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
     # ...
 
 #------------------------------------------------------------------------------

--- a/tests/epyccel/test_epyccel_mod.py
+++ b/tests/epyccel/test_epyccel_mod.py
@@ -12,7 +12,7 @@ if sys.platform == 'win32':
     RTOL = 1e-13
     ATOL = 1e-14
 else:
-    RTOL = 1e-14
+    RTOL = 2e-14
     ATOL = 1e-15
 
 def test_modulo_int_int(language):

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -2,6 +2,9 @@
 import numpy as np
 from pyccel.epyccel import epyccel
 
+RTOL = 2e-14
+ATOL = 1e-15
+
 def test_module_1(language):
     import modules.Module_1 as mod
 
@@ -19,7 +22,7 @@ def test_module_1(language):
     modnew.f(x)
     modnew.g(x)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
     # ...
 
 def test_local_module_1(language):
@@ -39,7 +42,7 @@ def test_local_module_1(language):
     modnew.f(x)
     modnew.g(x)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
     # ...
 
 def test_module_2(language):
@@ -56,7 +59,7 @@ def test_module_2(language):
     x_expected = np.zeros((m1,m2))
     mod.f6(m1, m2, x_expected)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
     # ...
 
 def test_module_3(language):

--- a/tests/epyccel/test_epyccel_pow.py
+++ b/tests/epyccel/test_epyccel_pow.py
@@ -6,6 +6,9 @@ from numpy import isclose
 from pyccel.decorators import types
 from pyccel.epyccel import epyccel
 
+RTOL = 2e-14
+ATOL = 1e-15
+
 # this smallest positive float number
 min_float = sys.float_info.min
 
@@ -33,8 +36,8 @@ def test_pow_real_real(language):
     x = uniform(low=min_float, high=50)
     y = uniform(high=5)
 
-    assert(isclose(f(x, y), pow_r_r(x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(x, -y), pow_r_r(x, -y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f(x, y), pow_r_r(x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(x, -y), pow_r_r(x, -y), rtol=RTOL, atol=ATOL))
     assert isinstance(f(x, y), type(pow_r_r(x, y)))
 
 def test_pow_real_int(language):
@@ -46,8 +49,8 @@ def test_pow_real_int(language):
     x = uniform(low=min_float, high=50)
     y = randint(5)
 
-    assert(isclose(f(x, y), pow_r_i(x, y), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-x, y), pow_r_i(-x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f(x, y), pow_r_i(x, y), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-x, y), pow_r_i(-x, y), rtol=RTOL, atol=ATOL))
     assert isinstance(f(x, y), type(pow_r_i(x, y)))
 
 def test_pow_int_real(language):
@@ -59,7 +62,7 @@ def test_pow_int_real(language):
     x = randint(40)
     y = uniform()
 
-    assert(isclose(f(x, y), pow_i_r(x, y), rtol=1e-14, atol=1e-15))
+    assert(isclose(f(x, y), pow_i_r(x, y), rtol=RTOL, atol=ATOL))
     assert isinstance(f(x, y), type(pow_i_r(x, y)))
 
 def test_pow_special_cases(language):
@@ -69,8 +72,8 @@ def test_pow_special_cases(language):
 
     f = epyccel(pow_sp, language=language)
     e = uniform(high=1e6)
-    assert(isclose(f(0.0, e), pow_sp(0.0, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(0.0, e), pow_sp(0.0, e), rtol=1e-14, atol=1e-15))
+    assert(isclose(f(0.0, e), pow_sp(0.0, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(0.0, e), pow_sp(0.0, e), rtol=RTOL, atol=ATOL))
 
 # ---------------------------- Complex numbers ----------------------------- #
 
@@ -82,10 +85,10 @@ def test_pow_c_c(language):
     f = epyccel(pow_c_c, language=language)
     b = complex(rand(), rand())
     e = complex(rand(), rand())
-    assert(isclose(f(b, e), pow_c_c(b, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-b, e), pow_c_c(-b, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(b, -e), pow_c_c(b, -e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-b, -e), pow_c_c(-b, -e), rtol=1e-14, atol=1e-15))
+    assert(isclose(f(b, e), pow_c_c(b, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-b, e), pow_c_c(-b, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(b, -e), pow_c_c(b, -e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-b, -e), pow_c_c(-b, -e), rtol=RTOL, atol=ATOL))
 
 def test_pow_c_i(language):
     @types('complex', 'int')
@@ -95,10 +98,10 @@ def test_pow_c_i(language):
     f = epyccel(pow_c_i, language=language)
     b = complex(rand(), rand())
     e = randint(10)
-    assert(isclose(f(b, e), pow_c_i(b, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-b, e), pow_c_i(-b, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(b, -e), pow_c_i(b, -e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-b, -e), pow_c_i(-b, -e), rtol=1e-14, atol=1e-15))
+    assert(isclose(f(b, e), pow_c_i(b, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-b, e), pow_c_i(-b, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(b, -e), pow_c_i(b, -e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-b, -e), pow_c_i(-b, -e), rtol=RTOL, atol=ATOL))
 
 def test_pow_c_r(language):
     @types('complex', 'real')
@@ -108,10 +111,10 @@ def test_pow_c_r(language):
     f = epyccel(pow_c_r, language=language)
     b = complex(rand(), rand())
     e = rand()
-    assert(isclose(f(b, e), pow_c_r(b, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-b, e), pow_c_r(-b, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(b, -e), pow_c_r(b, -e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-b, -e), pow_c_r(-b, -e), rtol=1e-14, atol=1e-15))
+    assert(isclose(f(b, e), pow_c_r(b, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-b, e), pow_c_r(-b, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(b, -e), pow_c_r(b, -e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-b, -e), pow_c_r(-b, -e), rtol=RTOL, atol=ATOL))
 
 def test_pow_r_c(language):
     @types('real', 'complex')
@@ -121,7 +124,7 @@ def test_pow_r_c(language):
     f = epyccel(pow_r_c, language=language)
     b = rand()
     e = complex(rand(), rand())
-    assert(isclose(f(b, e), pow_r_c(b, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-b, e), pow_r_c(-b, e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(b, -e), pow_r_c(b, -e), rtol=1e-14, atol=1e-15))
-    assert(isclose(f(-b, -e), pow_r_c(-b, -e), rtol=1e-14, atol=1e-15))
+    assert(isclose(f(b, e), pow_r_c(b, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-b, e), pow_r_c(-b, e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(b, -e), pow_r_c(b, -e), rtol=RTOL, atol=ATOL))
+    assert(isclose(f(-b, -e), pow_r_c(-b, -e), rtol=RTOL, atol=ATOL))

--- a/tests/epyccel/test_parallel_epyccel.py
+++ b/tests/epyccel/test_parallel_epyccel.py
@@ -5,6 +5,9 @@ import numpy as np
 
 from pyccel.epyccel import epyccel
 
+RTOL = 2e-14
+ATOL = 1e-15
+
 #==============================================================================
 @pytest.mark.parallel
 def test_module_1(language):
@@ -22,7 +25,7 @@ def test_module_1(language):
     modnew.f(x)
     modnew.g(x)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
     # ...
 
 #==============================================================================
@@ -41,7 +44,7 @@ def test_module_2(language):
     x_expected = np.zeros((m1,m2))
     mod.f6(m1, m2, x_expected)
 
-    assert np.allclose( x, x_expected, rtol=1e-15, atol=1e-15 )
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
     # ...
 
 #==============================================================================


### PR DESCRIPTION
- After discussion with @yguclu, increase tolerances slightly for maths tests
- Use the same values for `ATOL`/`RTOL` throughout
- Save `SITE_DIR` environment variable to stop linux returning a non-zero exit status during teardown (doesn't cause tests to fail, it just adds an unnecessary message)