### PR TITLE
Stop mac warnings due to incompatible dylib files

### DIFF
--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,65 +5,65 @@ on:
     branches: [ master ]
 
 jobs:
-  Linux:
+  #Linux:
 
-    runs-on: ubuntu-latest
+  #  runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-      - name: Install dependencies
-        uses: ./.github/actions/linux_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Coverage install
-        uses: ./.github/actions/coverage_install
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
-      - name: Test with valgrind for memory leaks
-        uses: ./.github/actions/valgrind_run
-      - name: Collect coverage information
-        continue-on-error: True
-        uses: ./.github/actions/coverage_collection
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
-        continue-on-error: True
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: cobertura.xml
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Set up Python 3.6
+  #      uses: actions/setup-python@v2
+  #      with:
+  #        python-version: 3.6
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/linux_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Coverage install
+  #      uses: ./.github/actions/coverage_install
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
+  #    - name: Test with valgrind for memory leaks
+  #      uses: ./.github/actions/valgrind_run
+  #    - name: Collect coverage information
+  #      continue-on-error: True
+  #      uses: ./.github/actions/coverage_collection
+  #    - name: Run codacy-coverage-reporter
+  #      uses: codacy/codacy-coverage-reporter-action@master
+  #      continue-on-error: True
+  #      with:
+  #        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  #        coverage-reports: cobertura.xml
 
-  Windows:
+  #Windows:
 
-    runs-on: windows-latest
+  #  runs-on: windows-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.7
-        uses: actions/setup-python@v2
-        with:
-            # The second most recent version is used as
-            # setup-python installs the most recent patch
-            # which leads to linking problems as there are
-            # 2 versions of python3X.a and the wrong one
-            # is chosen
-            python-version: 3.7
-      - name: Install dependencies
-        uses: ./.github/actions/windows_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Setup Python 3.7
+  #      uses: actions/setup-python@v2
+  #      with:
+  #          # The second most recent version is used as
+  #          # setup-python installs the most recent patch
+  #          # which leads to linking problems as there are
+  #          # 2 versions of python3X.a and the wrong one
+  #          # is chosen
+  #          python-version: 3.7
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/windows_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
 
   MacOSX:
 

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,65 +5,65 @@ on:
     branches: [ master ]
 
 jobs:
-  #Linux:
+  Linux:
 
-  #  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Set up Python 3.6
-  #      uses: actions/setup-python@v2
-  #      with:
-  #        python-version: 3.6
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/linux_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Coverage install
-  #      uses: ./.github/actions/coverage_install
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
-  #    - name: Test with valgrind for memory leaks
-  #      uses: ./.github/actions/valgrind_run
-  #    - name: Collect coverage information
-  #      continue-on-error: True
-  #      uses: ./.github/actions/coverage_collection
-  #    - name: Run codacy-coverage-reporter
-  #      uses: codacy/codacy-coverage-reporter-action@master
-  #      continue-on-error: True
-  #      with:
-  #        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-  #        coverage-reports: cobertura.xml
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        uses: ./.github/actions/linux_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Coverage install
+        uses: ./.github/actions/coverage_install
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
+      - name: Test with valgrind for memory leaks
+        uses: ./.github/actions/valgrind_run
+      - name: Collect coverage information
+        continue-on-error: True
+        uses: ./.github/actions/coverage_collection
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
+        continue-on-error: True
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: cobertura.xml
 
-  #Windows:
+  Windows:
 
-  #  runs-on: windows-latest
+    runs-on: windows-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Setup Python 3.7
-  #      uses: actions/setup-python@v2
-  #      with:
-  #          # The second most recent version is used as
-  #          # setup-python installs the most recent patch
-  #          # which leads to linking problems as there are
-  #          # 2 versions of python3X.a and the wrong one
-  #          # is chosen
-  #          python-version: 3.7
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/windows_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v2
+        with:
+            # The second most recent version is used as
+            # setup-python installs the most recent patch
+            # which leads to linking problems as there are
+            # 2 versions of python3X.a and the wrong one
+            # is chosen
+            python-version: 3.7
+      - name: Install dependencies
+        uses: ./.github/actions/windows_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
 
   MacOSX:
 

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import subprocess
 import sysconfig
+import platform
 import warnings
 from filelock import FileLock
 from pyccel import __version__ as pyccel_version
@@ -19,10 +20,11 @@ from pyccel.errors.errors import Errors
 
 errors = Errors()
 
-# Set correct deployment target if on mac
-mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
-if mac_target:
-    os.environ['MACOSX_DEPLOYMENT_TARGET'] = mac_target
+if platform.system() == 'Darwin':
+    # Set correct deployment target if on mac
+    mac_target = platform.mac_ver()[0]
+    if mac_target:
+        os.environ['MACOSX_DEPLOYMENT_TARGET'] = mac_target
 
 python_version = sysconfig.get_python_version()
 def different_version(compiler):


### PR DESCRIPTION
Compile files to support the detected version of mac as a minimum deployment target