### PR TITLE
Activate mpi tests on windows

### DIFF
--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -46,11 +46,7 @@ runs:
         #refreshenv
         $MSMPI_INC="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\"
         $MSMPI_LIB64="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x64\\"
-        ls "${MSMPI_LIB64}"
         echo "C:\\Program Files\\Microsoft MPI\\Bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "$env:GITHUB_ENV"
-        echo "$env:PATH"
-        echo "$env:GITHUB_PATH"
         echo "MSMPI_INC=${MSMPI_INC}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "MSMPI_LIB64=${MSMPI_LIB64}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -48,6 +48,8 @@ runs:
         $MSMPI_LIB64="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x64\\"
         echo "C:\\Program Files\\Microsoft MPI\\Bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "$env:GITHUB_ENV"
+        echo "$env:PATH"
+        echo "$env:GITHUB_PATH"
         echo "MSMPI_INC=${MSMPI_INC}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "MSMPI_LIB64=${MSMPI_LIB64}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -46,7 +46,7 @@ runs:
         #refreshenv
         $MSMPI_INC="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\"
         $MSMPI_LIB64="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x64\\"
-        ls "C:\\Program Files\\Microsoft MPI\\Bin"
+        ls "${MSMPI_LIB64}"
         echo "C:\\Program Files\\Microsoft MPI\\Bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "$env:GITHUB_ENV"
         echo "$env:PATH"

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -46,6 +46,7 @@ runs:
         #refreshenv
         $MSMPI_INC="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Include\\"
         $MSMPI_LIB64="C:\\Program Files (x86)\\Microsoft SDKs\\MPI\\Lib\\x64\\"
+        ls "C:\\Program Files\\Microsoft MPI\\Bin"
         echo "C:\\Program Files\\Microsoft MPI\\Bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "$env:GITHUB_ENV"
         echo "$env:PATH"

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -60,7 +60,6 @@ jobs:
         uses: ./.github/actions/pip_installation
       - name: Test MPI
         run: |
-          echo "$PATH"
           python -m pytest internal/test_internal.py::test_mpi -sxv
         shell: bash
         working-directory: ./tests

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/pip_installation
       - name: Test MPI
         run: |
-          echo "$env:GITHUB_PATH"
+          echo "$PATH"
           python -m pytest internal/test_internal.py::test_mpi -sxv
         shell: bash
         working-directory: ./tests

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -58,6 +58,12 @@ jobs:
         uses: ./.github/actions/windows_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
+      - name: Test MPI
+        run: |
+          echo "$env:GITHUB_PATH"
+          python -m pytest internal/test_internal.py::test_mpi -sxv
+        shell: bash
+        working-directory: ./tests
       - name: Fortran/C tests with pytest
         uses: ./.github/actions/pytest_run
       - name: Python tests with pytest

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -58,11 +58,6 @@ jobs:
         uses: ./.github/actions/windows_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: Test MPI
-        run: |
-          python -m pytest internal/test_internal.py::test_mpi -sxv
-        shell: bash
-        working-directory: ./tests
       - name: Fortran/C tests with pytest
         uses: ./.github/actions/pytest_run
       - name: Python tests with pytest

--- a/pyccel/compilers/generate_default.py
+++ b/pyccel/compilers/generate_default.py
@@ -32,9 +32,10 @@ gfort_info = {'exec' : 'gfortran',
               }
 if sys.platform == "win32":
     gfort_info['mpi_exec'] = 'gfortran'
-    gfort_info['mpi']['flags'] = ('-D','USE_MPI_MODULE')
-    gfort_info['mpi']['includes'] = (os.environ["MSMPI_INC"].rstrip('\\'),)
-    gfort_info['mpi']['libdirs'] = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
+    gfort_info['mpi']['flags']        = ('-D','USE_MPI_MODULE')
+    gfort_info['mpi']['libs']         = ('msmpi',)
+    gfort_info['mpi']['includes']     = (os.environ["MSMPI_INC"].rstrip('\\'),)
+    gfort_info['mpi']['libdirs']      = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
     gfort_info['mpi']['dependencies'] = (os.path.join(os.environ["MSMPI_LIB64"], 'libmsmpi.a'),)
 
 #------------------------------------------------------------

--- a/pyccel/compilers/generate_default.py
+++ b/pyccel/compilers/generate_default.py
@@ -34,7 +34,7 @@ if sys.platform == "win32":
     gfort_info['mpi_exec'] = 'gfortran'
     gfort_info['mpi']['flags'] = ('-D','USE_MPI_MODULE')
     gfort_info['mpi']['includes'] = (os.environ["MSMPI_INC"].rstrip('\\'),)
-    gfort_info['mpi']['libs'] = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
+    gfort_info['mpi']['libdirs'] = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
     gfort_info['mpi']['dependencies'] = (os.path.join(os.environ["MSMPI_LIB64"], 'libmsmpi.a'),)
 
 #------------------------------------------------------------

--- a/pyccel/compilers/generate_default.py
+++ b/pyccel/compilers/generate_default.py
@@ -114,12 +114,12 @@ if sys.platform == "darwin":
     gcc_info['openmp']['flags'] = ("-Xpreprocessor",'-fopenmp')
     gcc_info['openmp']['libs'] = ('omp',)
 elif sys.platform == "win32":
-    gfort_info['mpi_exec'] = 'gcc'
-    gfort_info['mpi']['flags']        = ('-D','USE_MPI_MODULE')
-    gfort_info['mpi']['libs']         = ('msmpi',)
-    gfort_info['mpi']['includes']     = (os.environ["MSMPI_INC"].rstrip('\\'),)
-    gfort_info['mpi']['libdirs']      = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
-    gfort_info['mpi']['dependencies'] = (os.path.join(os.environ["MSMPI_LIB64"], 'libmsmpi.a'),)
+    gcc_info['mpi_exec'] = 'gcc'
+    gcc_info['mpi']['flags']        = ('-D','USE_MPI_MODULE')
+    gcc_info['mpi']['libs']         = ('msmpi',)
+    gcc_info['mpi']['includes']     = (os.environ["MSMPI_INC"].rstrip('\\'),)
+    gcc_info['mpi']['libdirs']      = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
+    gcc_info['mpi']['dependencies'] = (os.path.join(os.environ["MSMPI_LIB64"], 'libmsmpi.a'),)
 
 #------------------------------------------------------------
 icc_info = {'exec' : 'icc',

--- a/pyccel/compilers/generate_default.py
+++ b/pyccel/compilers/generate_default.py
@@ -100,6 +100,8 @@ gcc_info = {'exec' : 'gcc',
             'release_flags': ("-O3","-funroll-loops",),
             'general_flags' : ('-fPIC',),
             'standard_flags' : ('-std=c99',),
+            'mpi': {
+                },
             'openmp': {
                 'flags' : ('-fopenmp',),
                 'libs'  : ('gomp',),

--- a/pyccel/compilers/generate_default.py
+++ b/pyccel/compilers/generate_default.py
@@ -113,6 +113,13 @@ gcc_info = {'exec' : 'gcc',
 if sys.platform == "darwin":
     gcc_info['openmp']['flags'] = ("-Xpreprocessor",'-fopenmp')
     gcc_info['openmp']['libs'] = ('omp',)
+elif sys.platform == "win32":
+    gfort_info['mpi_exec'] = 'gcc'
+    gfort_info['mpi']['flags']        = ('-D','USE_MPI_MODULE')
+    gfort_info['mpi']['libs']         = ('msmpi',)
+    gfort_info['mpi']['includes']     = (os.environ["MSMPI_INC"].rstrip('\\'),)
+    gfort_info['mpi']['libdirs']      = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
+    gfort_info['mpi']['dependencies'] = (os.path.join(os.environ["MSMPI_LIB64"], 'libmsmpi.a'),)
 
 #------------------------------------------------------------
 icc_info = {'exec' : 'icc',

--- a/pyccel/compilers/generate_default.py
+++ b/pyccel/compilers/generate_default.py
@@ -31,6 +31,7 @@ gfort_info = {'exec' : 'gfortran',
               'family': 'GNU',
               }
 if sys.platform == "win32":
+    gfort_info['mpi_exec'] = 'gfortran'
     gfort_info['mpi']['flags'] = ('-D','USE_MPI_MODULE')
     gfort_info['mpi']['includes'] = (os.environ["MSMPI_INC"].rstrip('\\'),)
     gfort_info['mpi']['libs'] = (os.environ["MSMPI_LIB64"].rstrip('\\'),)

--- a/pyccel/compilers/generate_default.py
+++ b/pyccel/compilers/generate_default.py
@@ -32,11 +32,10 @@ gfort_info = {'exec' : 'gfortran',
               }
 if sys.platform == "win32":
     gfort_info['mpi_exec'] = 'gfortran'
-    gfort_info['mpi']['flags']        = ('-D','USE_MPI_MODULE')
-    gfort_info['mpi']['libs']         = ('msmpi',)
-    gfort_info['mpi']['includes']     = (os.environ["MSMPI_INC"].rstrip('\\'),)
-    gfort_info['mpi']['libdirs']      = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
-    gfort_info['mpi']['dependencies'] = (os.path.join(os.environ["MSMPI_LIB64"], 'libmsmpi.a'),)
+    gfort_info['mpi']['flags']    = ('-D','USE_MPI_MODULE')
+    gfort_info['mpi']['libs']     = ('msmpi',)
+    gfort_info['mpi']['includes'] = (os.environ["MSMPI_INC"].rstrip('\\'),)
+    gfort_info['mpi']['libdirs']  = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
 
 #------------------------------------------------------------
 ifort_info = {'exec' : 'ifort',
@@ -115,11 +114,10 @@ if sys.platform == "darwin":
     gcc_info['openmp']['libs'] = ('omp',)
 elif sys.platform == "win32":
     gcc_info['mpi_exec'] = 'gcc'
-    gcc_info['mpi']['flags']        = ('-D','USE_MPI_MODULE')
-    gcc_info['mpi']['libs']         = ('msmpi',)
-    gcc_info['mpi']['includes']     = (os.environ["MSMPI_INC"].rstrip('\\'),)
-    gcc_info['mpi']['libdirs']      = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
-    gcc_info['mpi']['dependencies'] = (os.path.join(os.environ["MSMPI_LIB64"], 'libmsmpi.a'),)
+    gcc_info['mpi']['flags']    = ('-D','USE_MPI_MODULE')
+    gcc_info['mpi']['libs']     = ('msmpi',)
+    gcc_info['mpi']['includes'] = (os.environ["MSMPI_INC"].rstrip('\\'),)
+    gcc_info['mpi']['libdirs']  = (os.environ["MSMPI_LIB64"].rstrip('\\'),)
 
 #------------------------------------------------------------
 icc_info = {'exec' : 'icc',

--- a/pyccel/epyccel.py
+++ b/pyccel/epyccel.py
@@ -280,6 +280,10 @@ def epyccel( python_function_or_module, **kwargs ):
         assert isinstance( comm, MPI.Comm )
         assert isinstance( root, int      )
 
+        kwargs.setdefault('accelerators', [])
+        if 'mpi' not in kwargs['accelerators']:
+            kwargs['accelerators'] = [*kwargs['accelerators'], 'mpi']
+
         # Master process calls epyccel
         if comm.rank == root:
             try:

--- a/tests/internal/test_internal.py
+++ b/tests/internal/test_internal.py
@@ -5,7 +5,6 @@
 #      execute the binary file
 
 import os
-import sys
 import pytest
 from pyccel.codegen.pipeline import execute_pyccel
 

--- a/tests/internal/test_internal.py
+++ b/tests/internal/test_internal.py
@@ -25,7 +25,6 @@ def test_blas(f):
 def test_lapack(f):
     execute_pyccel(f, libs=['blas', 'lapack'])
 
-@pytest.mark.skipif(sys.platform == "win32", reason = "Mpi not yet correctly installed")
 @pytest.mark.parametrize("f", get_files_from_folder('mpi'))
 def test_mpi(f):
     execute_pyccel(f, accelerators=['mpi'])


### PR DESCRIPTION
- Remove debugging information
- Correct windows MPI compiler configuration
- Remove skipif flag
- Ensure that files are compiled using `mpif90` when the code is run using `mpi4py` (I am not sure this is necessary, but it was unintentionally removed in PR #928 )