### PR TITLE
Stop unnecessary loop unrolling

### DIFF
--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -193,7 +193,7 @@ def compatible_operation(*args, language_has_vectors = True):
     if language_has_vectors:
         # If the shapes don't match then an index must be required
         shapes = [a.shape[::-1] if a.order == 'F' else a.shape for a in args if a.shape != ()]
-        shapes = set(tuple(d if isinstance(d, Literal) else -1 for d in s) for s in shapes)
+        shapes = set(tuple(d if d == LiteralInteger(1) else -1 for d in s) for s in shapes)
         order  = set(a.order for a in args if a.order is not None)
         return len(shapes) <= 1 and len(order) <= 1
     else:


### PR DESCRIPTION
When unrolling loops, we check if the shape contains literals in order to correctly handle cases where one of the dimensions is known to be of size 1.
E.g:
```
import numpy as np

def f(a : 'float[:,:]'):
    n = a.shape[1]
    b = np.empty((1,n))
    a[:, :] = b[:,:]
```
in this case the code is correctly translated to:
```
n = size(a, 1_i64, i64)
allocate(b(0:n - 1_i64, 0:0_i64))
do i_0001 = 0_i64, size(a, 2_i64, i64) - 1_i64, 1_i64
  a(:, i_0001) = b(:, 0_i64)
end do
```
However the condition that produces this behaviour is overly enthusiastic. It checks for all literals, rather than just `1`. This leads to the bug described in issue #1008.

To fix this the condition is narrowed to just test for `LiteralInteger(1)`