### PR TITLE
Allow `import mod` syntax for a header file

### DIFF
--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1584,7 +1584,7 @@ class FCodePrinter(CodePrinter):
             scope = self.parser.namespace.sons_scopes[name]
             for key,f in scope.imports['functions'].items():
                 if isinstance(f, FunctionDef) and f.is_external:
-                    i = Variable(f.results[0].dtype, name=str(key))
+                    i = f.results[0].clone(str(key))
                     dec = Declare(i.dtype, i, external=True)
                     decs[i] = dec
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -247,15 +247,7 @@ class SemanticParser(BasicParser):
         # FunctionDef etc ...
 
         if self.is_header_file:
-            target = []
-
-            for parent in self.parents:
-                for (key, item) in parent.imports.items():
-                    if get_filename_from_import(key) == self.filename:
-                        target += item
-
-            target = set(target)
-            target_headers = target.intersection(self.namespace.headers.keys())
+            target_headers = self.namespace.headers.keys()
             # ARA : issue-999
             is_external = self.metavars.get('external', False)
             for name in list(target_headers):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1947,6 +1947,12 @@ class SemanticParser(BasicParser):
                             imp.define_target(PyccelSymbol(rhs_name))
                         else:
                             imp.define_target(AsName(PyccelSymbol(rhs_name), PyccelSymbol(new_name)))
+                elif isinstance(rhs, FunctionCall):
+                    self.namespace.imports['functions'][new_name] = first[rhs_name]
+                elif isinstance(rhs, ConstructorCall):
+                    self.namespace.imports['classes'][new_name] = first[rhs_name]
+                elif isinstance(rhs, Variable):
+                    self.namespace.imports['variables'][new_name] = rhs
 
                 if isinstance(rhs, FunctionCall):
                     # If object is a function

--- a/tests/internal/scripts/blas/ex5.py
+++ b/tests/internal/scripts/blas/ex5.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
 import numpy as np
 
 def f(x: 'float32[:]'):

--- a/tests/internal/scripts/blas/ex5.py
+++ b/tests/internal/scripts/blas/ex5.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+def f(x: 'float32[:]'):
+    import pyccel.stdlib.internal.blas as blas_mod
+    n = np.int32(x.shape[0])
+    incx = np.int32(1)
+    return blas_mod.sasum (n, x, incx)

--- a/tests/internal/scripts/blas/ex5.py
+++ b/tests/internal/scripts/blas/ex5.py
@@ -6,3 +6,12 @@ def f(x: 'float32[:]'):
     n = np.int32(x.shape[0])
     incx = np.int32(1)
     return blas_mod.sasum (n, x, incx)
+
+def g(vect1 : 'float64[:]', vect2 : 'float64[:]'):
+    import pyccel.stdlib.internal.blas as blas_mod
+
+    sa = 3.5
+    n = np.int32(vect1.shape[0])
+
+    blas_mod.daxpy(n, sa, vect1, np.int32(1), vect2, np.int32(1))
+


### PR DESCRIPTION
Allow `import mod` syntax for a header file. Fixes #1018 

**Commit Summary**
- Add test
- Ensure functions imported with ignore_at_import are correctly added to the namespace
- [BUGFIX] Ensure external function results are printed with correct precision