### PR TITLE
Tell PyPI that package description uses Markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup_args = dict(
     version              = VERSION,
     description          = DESCR,
     long_description     = open('README.md').read(),
+    long_description_content_type = 'text/markdown',
     author               = AUTHOR,
     author_email         = EMAIL,
     license              = LICENSE,


### PR DESCRIPTION
As described in the Python Packaging User Guide, we set `long_description_content_type = 'text/markdown'` in `setup.py` in order to render the upload's description with Markdown format instead of the default reStructuredText.