### PR TITLE
Initialise ndarrays at NULL

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -845,6 +845,9 @@ class CCodePrinter(CodePrinter):
 
         if expr.variable.is_stack_array:
             preface, init = self._init_stack_array(expr.variable,)
+        elif declaration_type == 't_ndarray ':
+            preface = ''
+            init    = ' = {.shape = NULL}'
         else:
             preface = ''
             init    = ''

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1377,18 +1377,19 @@ class CCodePrinter(CodePrinter):
             # Check the Assign objects list in case of
             # the user assigns a variable to an object contains IndexedElement object.
             if not last_assign:
-                return 'return {0};\n'.format(self._print(args[0]))
-
-            # make sure that stmt contains one assign node.
-            last_assign = last_assign[-1]
-            variables = last_assign.rhs.get_attribute_nodes(Variable, excluded_nodes=(FunctionDef,))
-            unneeded_var = not any(b in vars_in_deallocate_nodes for b in variables)
-            if unneeded_var:
-                code = ''.join(self._print(a) for a in expr.stmt.body if a is not last_assign)
-                return code + 'return {};\n'.format(self._print(last_assign.rhs))
-            else:
                 code = ''+self._print(expr.stmt)
-                self._additional_declare.append(last_assign.lhs)
+            else:
+                # make sure that stmt contains one assign node.
+                last_assign = last_assign[-1]
+                variables = last_assign.rhs.get_attribute_nodes(Variable, excluded_nodes=(FunctionDef,))
+                unneeded_var = not any(b in vars_in_deallocate_nodes for b in variables)
+                if unneeded_var:
+                    code = ''.join(self._print(a) for a in expr.stmt.body if a is not last_assign)
+                    return code + 'return {};\n'.format(self._print(last_assign.rhs))
+                else:
+                    code = ''+self._print(expr.stmt)
+                    self._additional_declare.append(last_assign.lhs)
+
         return code + 'return {0};\n'.format(self._print(args[0]))
 
     def _print_Pass(self, expr):

--- a/tests/ndarrays/leaks_check.py
+++ b/tests/ndarrays/leaks_check.py
@@ -34,7 +34,7 @@ def conditional_alloc(b1 : bool, b2 : bool):
     else:
         x = zeros(4, dtype=int)
         n = x.shape[0]
-    return 5
+    return n
 
 # testing garbage collecting in a Function
 

--- a/tests/ndarrays/leaks_check.py
+++ b/tests/ndarrays/leaks_check.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
-from numpy import array
+from numpy import array, zeros
 
 def create_array():
     a = array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])# pylint: disable=unused-variable
@@ -24,6 +24,18 @@ def pointer_reassign():
     b = a[1:]
     b = c
 
+def conditional_alloc(b1 : bool, b2 : bool):
+    if b1:
+        if b2:
+            x = zeros(3, dtype=int)
+            n = x.shape[0]
+        else:
+            n = 0
+    else:
+        x = zeros(4, dtype=int)
+        n = x.shape[0]
+    return 5
+
 # testing garbage collecting in a Function
 
 if __name__ == '__main__':
@@ -32,6 +44,9 @@ if __name__ == '__main__':
     view_assign()
     pointer_to_pointer()
     pointer_reassign()
+    conditional_alloc(True,True)
+    conditional_alloc(True,False)
+    conditional_alloc(False,False)
 
     # testing garbage collecting in a Program
 


### PR DESCRIPTION
Avoid potential problems when freeing data by initialising arrays at NULL. Fixes #951

[BUGFIX] Ensure deallocations are printed when avoiding creating unnecessary output variables in C