### PR TITLE
In C files, never import inside a function

### DIFF
--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,65 +5,65 @@ on:
     branches: [ master ]
 
 jobs:
-  Linux:
+  #Linux:
 
-    runs-on: ubuntu-latest
+  #  runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-      - name: Install dependencies
-        uses: ./.github/actions/linux_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Coverage install
-        uses: ./.github/actions/coverage_install
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
-      - name: Test with valgrind for memory leaks
-        uses: ./.github/actions/valgrind_run
-      - name: Collect coverage information
-        continue-on-error: True
-        uses: ./.github/actions/coverage_collection
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
-        continue-on-error: True
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: cobertura.xml
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Set up Python 3.6
+  #      uses: actions/setup-python@v2
+  #      with:
+  #        python-version: 3.6
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/linux_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Coverage install
+  #      uses: ./.github/actions/coverage_install
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
+  #    - name: Test with valgrind for memory leaks
+  #      uses: ./.github/actions/valgrind_run
+  #    - name: Collect coverage information
+  #      continue-on-error: True
+  #      uses: ./.github/actions/coverage_collection
+  #    - name: Run codacy-coverage-reporter
+  #      uses: codacy/codacy-coverage-reporter-action@master
+  #      continue-on-error: True
+  #      with:
+  #        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  #        coverage-reports: cobertura.xml
 
-  Windows:
+  #Windows:
 
-    runs-on: windows-latest
+  #  runs-on: windows-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.7
-        uses: actions/setup-python@v2
-        with:
-            # The second most recent version is used as
-            # setup-python installs the most recent patch
-            # which leads to linking problems as there are
-            # 2 versions of python3X.a and the wrong one
-            # is chosen
-            python-version: 3.7
-      - name: Install dependencies
-        uses: ./.github/actions/windows_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - name: Setup Python 3.7
+  #      uses: actions/setup-python@v2
+  #      with:
+  #          # The second most recent version is used as
+  #          # setup-python installs the most recent patch
+  #          # which leads to linking problems as there are
+  #          # 2 versions of python3X.a and the wrong one
+  #          # is chosen
+  #          python-version: 3.7
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/windows_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
 
   MacOSX:
 
@@ -79,9 +79,14 @@ jobs:
         uses: ./.github/actions/macos_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+      - name: Fortran/C OpenMP tests with pytest
+        run: |
+          python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible)" --ignore=symbolic --ignore=ndarrays -k openmp
+        shell: bash
+        working-directory: ./tests
+      #- name: Fortran/C tests with pytest
+      #  uses: ./.github/actions/pytest_run
+      #- name: Python tests with pytest
+      #  uses: ./.github/actions/pytest_run_python
+      #- name: Parallel tests with pytest
+      #  uses: ./.github/actions/pytest_parallel

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,65 +5,65 @@ on:
     branches: [ master ]
 
 jobs:
-  #Linux:
+  Linux:
 
-  #  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Set up Python 3.6
-  #      uses: actions/setup-python@v2
-  #      with:
-  #        python-version: 3.6
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/linux_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Coverage install
-  #      uses: ./.github/actions/coverage_install
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
-  #    - name: Test with valgrind for memory leaks
-  #      uses: ./.github/actions/valgrind_run
-  #    - name: Collect coverage information
-  #      continue-on-error: True
-  #      uses: ./.github/actions/coverage_collection
-  #    - name: Run codacy-coverage-reporter
-  #      uses: codacy/codacy-coverage-reporter-action@master
-  #      continue-on-error: True
-  #      with:
-  #        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-  #        coverage-reports: cobertura.xml
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        uses: ./.github/actions/linux_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Coverage install
+        uses: ./.github/actions/coverage_install
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
+      - name: Test with valgrind for memory leaks
+        uses: ./.github/actions/valgrind_run
+      - name: Collect coverage information
+        continue-on-error: True
+        uses: ./.github/actions/coverage_collection
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
+        continue-on-error: True
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: cobertura.xml
 
-  #Windows:
+  Windows:
 
-  #  runs-on: windows-latest
+    runs-on: windows-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: Setup Python 3.7
-  #      uses: actions/setup-python@v2
-  #      with:
-  #          # The second most recent version is used as
-  #          # setup-python installs the most recent patch
-  #          # which leads to linking problems as there are
-  #          # 2 versions of python3X.a and the wrong one
-  #          # is chosen
-  #          python-version: 3.7
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/windows_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v2
+        with:
+            # The second most recent version is used as
+            # setup-python installs the most recent patch
+            # which leads to linking problems as there are
+            # 2 versions of python3X.a and the wrong one
+            # is chosen
+            python-version: 3.7
+      - name: Install dependencies
+        uses: ./.github/actions/windows_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
 
   MacOSX:
 
@@ -79,14 +79,9 @@ jobs:
         uses: ./.github/actions/macos_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: Fortran/C OpenMP tests with pytest
-        run: |
-          python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible)" --ignore=symbolic --ignore=ndarrays -k openmp
-        shell: bash
-        working-directory: ./tests
-      #- name: Fortran/C tests with pytest
-      #  uses: ./.github/actions/pytest_run
-      #- name: Python tests with pytest
-      #  uses: ./.github/actions/pytest_run_python
-      #- name: Parallel tests with pytest
-      #  uses: ./.github/actions/pytest_parallel
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -250,7 +250,7 @@ class CCodePrinter(CodePrinter):
 
         super().__init__()
         self.prefix_module = prefix_module
-        self._additional_imports = set([c_imports['stdlib']])
+        self._additional_imports = {'stdlib':c_imports['stdlib']}
         self._parser = parser
         self._additional_code = ''
         self._additional_declare = []
@@ -265,7 +265,11 @@ class CCodePrinter(CodePrinter):
 
     def get_additional_imports(self):
         """return the additional imports collected in printing stage"""
-        return [i.source for i in self._additional_imports]
+        return self._additional_imports.keys()
+
+    def add_import(self, import_obj):
+        if import_obj.source not in self._additional_imports:
+            self._additional_imports[import_obj.source] = import_obj
 
     def _get_statement(self, codestring):
         return "%s;\n" % codestring
@@ -309,7 +313,7 @@ class CCodePrinter(CodePrinter):
             # flattening the args to use them in C initialization.
             arg = self._flatten_list(arg)
 
-        self._additional_imports.add(c_imports['string'])
+        self.add_import(c_imports['string'])
         if isinstance(arg, Variable):
             arg = self._print(arg)
             cpy_data = "memcpy({0}.{2}, {1}.{2}, {0}.buffer_size);\n".format(lhs, arg, dtype)
@@ -380,7 +384,7 @@ class CCodePrinter(CodePrinter):
         array_init = array_init.format(np_dtype, dummy_array_name,
                     shape_init, strides_init, len(var.shape), 'false')
         array_init += 'stack_array_init(&{})'.format(self._print(var))
-        self._additional_imports.add(c_imports['ndarrays'])
+        self.add_import(c_imports['ndarrays'])
         return buffer_array, array_init
 
     def fill_NumpyArange(self, expr, lhs):
@@ -485,7 +489,7 @@ class CCodePrinter(CodePrinter):
 
         if func.global_vars or func.global_funcs:
             mod = func.get_direct_user_nodes(lambda x: isinstance(x, Module))[0]
-            self._additional_imports.add(Import(mod.name, [AsName(v, v.name) \
+            self.add_import(Import(mod.name, [AsName(v, v.name) \
                 for v in (*func.global_vars, *func.global_funcs)]))
             for v in (*func.global_vars, *func.global_funcs):
                 self._parser.used_names.add(v.name)
@@ -496,10 +500,10 @@ class CCodePrinter(CodePrinter):
 
     def _print_PythonAbs(self, expr):
         if expr.arg.dtype is NativeFloat():
-            self._additional_imports.add(c_imports['math'])
+            self.add_import(c_imports['math'])
             func = "fabs"
         elif expr.arg.dtype is NativeComplex():
-            self._additional_imports.add(c_imports['complex'])
+            self.add_import(c_imports['complex'])
             func = "cabs"
         else:
             func = "labs"
@@ -508,7 +512,7 @@ class CCodePrinter(CodePrinter):
     def _print_PythonMin(self, expr):
         arg = expr.args[0]
         if arg.dtype is NativeFloat() and len(arg) == 2:
-            self._additional_imports.add(c_imports['math'])
+            self.add_import(c_imports['math'])
             return "fmin({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         else:
@@ -518,7 +522,7 @@ class CCodePrinter(CodePrinter):
     def _print_PythonMax(self, expr):
         arg = expr.args[0]
         if arg.dtype is NativeFloat() and len(arg) == 2:
-            self._additional_imports.add(c_imports['math'])
+            self.add_import(c_imports['math'])
             return "fmax({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         else:
@@ -531,7 +535,7 @@ class CCodePrinter(CodePrinter):
         return '({0})({1})'.format(type_name, value)
 
     def _print_PythonInt(self, expr):
-        self._additional_imports.add(c_imports['stdint'])
+        self.add_import(c_imports['stdint'])
         value = self._print(expr.arg)
         type_name = self.find_in_dtype_registry('int', expr.precision)
         return '({0})({1})'.format(type_name, value)
@@ -560,7 +564,7 @@ class CCodePrinter(CodePrinter):
         return '({0})({1})'.format(type_name, value)
 
     def _print_LiteralImaginaryUnit(self, expr):
-        self._additional_imports.add(c_imports['complex'])
+        self.add_import(c_imports['complex'])
         return '_Complex_I'
 
     def _print_PythonLen(self, expr):
@@ -583,7 +587,7 @@ class CCodePrinter(CodePrinter):
         global_variables = ''.join(['extern '+self._print(d) for d in expr.module.declarations if not d.variable.is_private])
 
         # Print imports last to be sure that all additional_imports have been collected
-        imports = [*expr.module.imports, *self._additional_imports]
+        imports = [*expr.module.imports, *self._additional_imports.values()]
         imports = ''.join(self._print(i) for i in imports)
 
         return ('#ifndef {name}_H\n'
@@ -606,7 +610,7 @@ class CCodePrinter(CodePrinter):
         global_variables = ''.join([self._print(d) for d in expr.declarations])
 
         # Print imports last to be sure that all additional_imports have been collected
-        imports = [Import(expr.name, Module(expr.name,(),())), *self._additional_imports]
+        imports = [Import(expr.name, Module(expr.name,(),())), *self._additional_imports.values()]
         imports = ''.join(self._print(i) for i in imports)
 
         code = ('{imports}\n'
@@ -697,8 +701,8 @@ class CCodePrinter(CodePrinter):
         return '!{}'.format(a)
 
     def _print_PyccelMod(self, expr):
-        self._additional_imports.add(c_imports['math'])
-        self._additional_imports.add(c_imports['pyc_math_c'])
+        self.add_import(c_imports['math'])
+        self.add_import(c_imports['pyc_math_c'])
 
         first = self._print(expr.args[0])
         second = self._print(expr.args[1])
@@ -719,10 +723,10 @@ class CCodePrinter(CodePrinter):
         if expr.dtype is NativeComplex():
             b = self._print(b if b.dtype is NativeComplex() else PythonComplex(b))
             e = self._print(e if e.dtype is NativeComplex() else PythonComplex(e))
-            self._additional_imports.add(c_imports['complex'])
+            self.add_import(c_imports['complex'])
             return 'cpow({}, {})'.format(b, e)
 
-        self._additional_imports.add(c_imports['math'])
+        self.add_import(c_imports['math'])
         b = self._print(b if b.dtype is NativeFloat() else NumpyFloat(b))
         e = self._print(e if e.dtype is NativeFloat() else NumpyFloat(e))
         code = 'pow({}, {})'.format(b, e)
@@ -796,7 +800,7 @@ class CCodePrinter(CodePrinter):
         return tmp_list
 
     def _print_PythonPrint(self, expr):
-        self._additional_imports.add(c_imports['stdio'])
+        self.add_import(c_imports['stdio'])
         end = '\n'
         sep = ' '
         code = ''
@@ -886,13 +890,13 @@ class CCodePrinter(CodePrinter):
         prec  = expr.precision
         rank  = expr.rank
         if isinstance(expr.dtype, NativeInteger):
-            self._additional_imports.add(c_imports['stdint'])
+            self.add_import(c_imports['stdint'])
         dtype = self.find_in_dtype_registry(dtype, prec)
         if rank > 0:
             if expr.is_ndarray or isinstance(expr, HomogeneousTupleVariable):
                 if expr.rank > 15:
                     errors.report(UNSUPPORTED_ARRAY_RANK, symbol=expr, severity='fatal')
-                self._additional_imports.add(c_imports['ndarrays'])
+                self.add_import(c_imports['ndarrays'])
                 dtype = 't_ndarray'
             else:
                 errors.report(PYCCEL_RESTRICTION_TODO+' (rank>0)', symbol=expr, severity='fatal')
@@ -945,7 +949,7 @@ class CCodePrinter(CodePrinter):
         return preface + declaration
 
     def _print_NativeBool(self, expr):
-        self._additional_imports.add(c_imports['stdbool'])
+        self.add_import(c_imports['stdbool'])
         return 'bool'
 
     def _print_NativeInteger(self, expr):
@@ -958,7 +962,7 @@ class CCodePrinter(CodePrinter):
         return 'void'
 
     def _print_NativeComplex(self, expr):
-        self._additional_imports.add(c_imports['complex'])
+        self.add_import(c_imports['complex'])
         return 'complex'
     def _print_NativeString(self, expr):
         return 'string'
@@ -1127,7 +1131,7 @@ class CCodePrinter(CodePrinter):
             free_code += "{{\n{}}}\n".format(self._print(Deallocate(expr.variable)))
         elif  (expr.status == 'allocated'):
             free_code += self._print(Deallocate(expr.variable))
-        self._additional_imports.add(c_imports['ndarrays'])
+        self.add_import(c_imports['ndarrays'])
         shape = ", ".join(self._print(i) for i in expr.shape)
         dtype = self._print(expr.variable.dtype)
         dtype = self.find_in_ndarray_type_registry(dtype, expr.variable.precision)
@@ -1169,7 +1173,7 @@ class CCodePrinter(CodePrinter):
 
         """
         # add necessary include
-        self._additional_imports.add(c_imports['math'])
+        self.add_import(c_imports['math'])
         type_name = type(expr).__name__
         try:
             func_name = numpy_ufunc_to_c_float[type_name]
@@ -1178,7 +1182,7 @@ class CCodePrinter(CodePrinter):
         args = []
         for arg in expr.args:
             if arg.dtype is NativeComplex():
-                self._additional_imports.add(c_imports['complex'])
+                self.add_import(c_imports['complex'])
                 try:
                     func_name = numpy_ufunc_to_c_complex[type_name]
                     args.append(self._print(arg))
@@ -1219,12 +1223,12 @@ class CCodePrinter(CodePrinter):
             errors.report(PYCCEL_RESTRICTION_TODO, severity='fatal')
 
         if func_name.startswith("pyc"):
-            self._additional_imports.add(c_imports['pyc_math_c'])
+            self.add_import(c_imports['pyc_math_c'])
         else:
             if expr.dtype is NativeComplex():
-                self._additional_imports.add(c_imports['cmath'])
+                self.add_import(c_imports['cmath'])
             else:
-                self._additional_imports.add(c_imports['math'])
+                self.add_import(c_imports['math'])
         args = []
         for arg in expr.args:
             if arg.dtype != NativeFloat() and not func_name.startswith("pyc"):
@@ -1241,7 +1245,7 @@ class CCodePrinter(CodePrinter):
         """Convert a Python expression with a math isfinite function call to C
         function call"""
         # add necessary include
-        self._additional_imports.add(c_imports['math'])
+        self.add_import(c_imports['math'])
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
             code_arg = self._print(NumpyFloat(arg))
@@ -1253,7 +1257,7 @@ class CCodePrinter(CodePrinter):
         """Convert a Python expression with a math isinf function call to C
         function call"""
         # add necessary include
-        self._additional_imports.add(c_imports['math'])
+        self.add_import(c_imports['math'])
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
             code_arg = self._print(NumpyFloat(arg))
@@ -1265,7 +1269,7 @@ class CCodePrinter(CodePrinter):
         """Convert a Python expression with a math isnan function call to C
         function call"""
         # add necessary include
-        self._additional_imports.add(c_imports['math'])
+        self.add_import(c_imports['math'])
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
             code_arg = self._print(NumpyFloat(arg))
@@ -1277,7 +1281,7 @@ class CCodePrinter(CodePrinter):
         """Convert a Python expression with a math trunc function call to C
         function call"""
         # add necessary include
-        self._additional_imports.add(c_imports['math'])
+        self.add_import(c_imports['math'])
         arg = expr.args[0]
         if arg.dtype is NativeInteger():
             code_arg = self._print(NumpyFloat(arg))
@@ -1351,7 +1355,8 @@ class CCodePrinter(CodePrinter):
         sep = self._print(SeparatorComment(40))
         if self._additional_args :
             self._additional_args.pop()
-        self._additional_imports.update(expr.imports)
+        for i in expr.imports:
+            self.add_import(i)
         doc_string = self._print(expr.doc_string) if expr.doc_string else ''
 
         parts = [sep,
@@ -1511,7 +1516,7 @@ class CCodePrinter(CodePrinter):
         return  ' / '.join(self._print(a) for a in args)
 
     def _print_PyccelFloorDiv(self, expr):
-        self._additional_imports.add(c_imports['math'])
+        self.add_import(c_imports['math'])
         # the result type of the floor division is dependent on the arguments
         # type, if all arguments are integers the result is integer otherwise
         # the result type is float
@@ -1767,13 +1772,13 @@ class CCodePrinter(CodePrinter):
 
     def _print_Constant(self, expr):
         if expr == math_constants['inf']:
-            self._additional_imports.add(c_imports['math'])
+            self.add_import(c_imports['math'])
             return 'HUGE_VAL'
         elif expr == math_constants['pi']:
-            self._additional_imports.add(c_imports['math'])
+            self.add_import(c_imports['math'])
             return 'M_PI'
         elif expr == math_constants['e']:
-            self._additional_imports.add(c_imports['math'])
+            self.add_import(c_imports['math'])
             return 'M_E'
         else:
             raise NotImplementedError("Constant not implemented")
@@ -1858,7 +1863,7 @@ class CCodePrinter(CodePrinter):
         decs    = ''.join(self._print(i) for i in decs)
         self._additional_declare.clear()
 
-        imports = [*expr.imports, *self._additional_imports]
+        imports = [*expr.imports, *self._additional_imports.values()]
         imports = ''.join(self._print(i) for i in imports)
 
         return ('{imports}'

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1351,13 +1351,12 @@ class CCodePrinter(CodePrinter):
         sep = self._print(SeparatorComment(40))
         if self._additional_args :
             self._additional_args.pop()
-        imports = ''.join(self._print(i) for i in expr.imports)
+        self._additional_imports.update(expr.imports)
         doc_string = self._print(expr.doc_string) if expr.doc_string else ''
 
         parts = [sep,
                  doc_string,
                 '{signature}\n{{\n'.format(signature=self.function_signature(expr)),
-                 imports,
                  decs,
                  body,
                  '}\n',

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -872,7 +872,7 @@ class CWrapperCodePrinter(CCodePrinter):
         return 'pyobject'
 
     def _print_PyccelPyArrayObject(self, expr):
-        self._additional_imports.add(cwrapper_ndarray_import)
+        self.add_import(cwrapper_ndarray_import)
         return 'pyarrayobject'
 
     def _print_PyArg_ParseTupleNode(self, expr):
@@ -1105,7 +1105,7 @@ class CWrapperCodePrinter(CCodePrinter):
 
         # Print imports last to be sure that all additional_imports have been collected
         imports  = module_imports.copy()
-        imports += self._additional_imports
+        imports += self._additional_imports.values()
         imports  = ''.join(self._print(i) for i in imports)
 
         return ('#define PY_ARRAY_UNIQUE_SYMBOL CWRAPPER_ARRAY_API\n'


### PR DESCRIPTION
Put all imports in a C file at the module level instead of allowing imports in functions. Imports in functions are an anti-pattern and can cause problems as any inline functions in the header file become functions in functions which is not supported in C. This change fixes #1057 .