### PR TITLE
Update Python versions used in CI

### DIFF
--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -45,15 +45,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.9
+      - name: Setup Python 3.7
         uses: actions/setup-python@v2
         with:
-            # A non-default version is used as
+            # The second most recent version is used as
             # setup-python installs the most recent patch
             # which leads to linking problems as there are
             # 2 versions of python3X.a and the wrong one
             # is chosen
-            python-version: 3.9
+            python-version: 3.7
       - name: Install dependencies
         uses: ./.github/actions/windows_install
       - name: Install python dependencies

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -71,10 +71,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         uses: ./.github/actions/macos_install
       - name: Install python dependencies

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.7
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
             # The second most recent version is used as
@@ -53,7 +53,7 @@ jobs:
             # which leads to linking problems as there are
             # 2 versions of python3X.a and the wrong one
             # is chosen
-            python-version: 3.7
+            python-version: 3.8
       - name: Install dependencies
         uses: ./.github/actions/windows_install
       - name: Install python dependencies

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -45,15 +45,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
-            # The second most recent version is used as
+            # A non-default version is used as
             # setup-python installs the most recent patch
             # which leads to linking problems as there are
             # 2 versions of python3X.a and the wrong one
             # is chosen
-            python-version: 3.8
+            python-version: 3.9
       - name: Install dependencies
         uses: ./.github/actions/windows_install
       - name: Install python dependencies

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install dependencies
         uses: ./.github/actions/macos_install
       - name: Install python dependencies

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,15 +47,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
-            # The second most recent version is used as
+            # A non-default version is used as
             # setup-python installs the most recent patch
             # which leads to linking problems as there are
             # 2 versions of python3X.a and the wrong one
             # is chosen
-            python-version: 3.8
+            python-version: 3.9
       - name: Install dependencies
         uses: ./.github/actions/windows_install
       - name: Install python dependencies

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,15 +47,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.9
+      - name: Setup Python 3.7
         uses: actions/setup-python@v2
         with:
-            # A non-default version is used as
+            # The second most recent version is used as
             # setup-python installs the most recent patch
             # which leads to linking problems as there are
             # 2 versions of python3X.a and the wrong one
             # is chosen
-            python-version: 3.9
+            python-version: 3.7
       - name: Install dependencies
         uses: ./.github/actions/windows_install
       - name: Install python dependencies

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6,3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.7
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
             # The second most recent version is used as
@@ -55,7 +55,7 @@ jobs:
             # which leads to linking problems as there are
             # 2 versions of python3X.a and the wrong one
             # is chosen
-            python-version: 3.7
+            python-version: 3.8
       - name: Install dependencies
         uses: ./.github/actions/windows_install
       - name: Install python dependencies


### PR DESCRIPTION
As explained [here](https://endoflife.date/python), Python 3.6 has now reached end-of-life and Python 3.10 has recently been released. This PR updates the versions used in the Continuous Integration testing to only use live versions of Python. This should make very little difference to Pyccel, however it does mean that we no longer need to use `OrderedDict`s as `dict`s are ordered in the standard from Python 3.7