### PR TITLE
Fix index insertion into indexed arrays

### DIFF
--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -279,8 +279,11 @@ def insert_index(expr, pos, index_var):
     elif isinstance(expr, IndexedElement):
         base = expr.base
         indices = list(expr.indices)
-        while -pos<=expr.base.rank and not isinstance(indices[pos], Slice):
-            pos -= 1
+        i = -1
+        while i>=pos and -i<=expr.base.rank:
+            if not isinstance(indices[i], Slice):
+                pos -= 1
+            i -= 1
         if -pos>expr.base.rank:
             return expr
 

--- a/tests/epyccel/test_epyccel_transpose.py
+++ b/tests/epyccel/test_epyccel_transpose.py
@@ -166,3 +166,16 @@ def test_force_transpose(language):
 
     f2_epyc = epyccel(f2, language=language)
     assert f2( x2 ) == f2_epyc( x2 )
+
+def test_transpose_to_inner_indexes(language):
+    def f1(x : 'int[:,:]'):
+        from numpy import transpose, empty
+        n,m = x.shape
+        y = empty((1,m,n,1))
+        y[0,:,:,0] = transpose(x)
+        return y[0,0,0,0], y[0,1,0,0], y[0,0,1,0], y[0,-1,0,0], y[0,0,-1,0]
+
+    x1 = randint(50, size=(2,5))
+
+    f1_epyc = epyccel(f1, language=language)
+    assert f1( x1 ) == f1_epyc( x1 )


### PR DESCRIPTION
Fix index insertion into indexed arrays when the slices are not on contiguous data. Fixes #1077 