### PR TITLE
Create a pyccel-init script to assist with installation in a read-only system

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include AUTHORS
 include CHANGES
 include LICENSE
-include README.rst
+include README.md
 include TODO.rst
 
 recursive-include pyccel *.tx

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ recursive-include pyccel *.pyh
 recursive-include pyccel *.c
 recursive-include pyccel *.f90
 recursive-include pyccel *.h
+recursive-include pyccel *.pyccel
 
 graft doc
 graft samples

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Any required Python packages will be installed automatically from PyPI.
 
 ### On a read-only system
 
-If the folder where pyccel is saved is read only, it may be necessary to run an additional command:
+If the folder where pyccel is saved is read only, it may be necessary to run an additional command after installation or updating:
 ```sh
 sudo pyccel-init
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If you are eager to try Pyccel out, we recommend reading our [quick-start guide]
 -   [Installation](#Installation)
     -   [From PyPi](#From-PyPi)
     -   [From sources](#From-sources)
+    -   [On a read-only system](#On-a-read-only-system)
 
 -   [Additional packages](#Additional-packages)
 
@@ -263,6 +264,13 @@ for a system-wide installation.
 
 this will install a _python_ library **pyccel** and a _binary_ called **pyccel**.
 Any required Python packages will be installed automatically from PyPI.
+
+### On a read-only system
+
+If the folder where pyccel is saved is read only without sudo privileges an additional command should be run:
+```
+sudo pyccel-init
+```
 
 ## Additional packages
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Any required Python packages will be installed automatically from PyPI.
 ### On a read-only system
 
 If the folder where pyccel is saved is read only without sudo privileges an additional command should be run:
-```
+```sh
 sudo pyccel-init
 ```
 

--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ If the folder where pyccel is saved is read only, it may be necessary to run an 
 sudo pyccel-init
 ```
 
-This step is necessary in order to [pickle header files](.tutorial/header-files.md#Pickling-header-files).
-If this command is not run then pyccel will still run correctly but may be slower when using [OpenMP](.tutoral/openmp.md) or other supported external packages.
+This step is necessary in order to [pickle header files](./tutorial/header-files.md#Pickling-header-files).
+If this command is not run then pyccel will still run correctly but may be slower when using [OpenMP](./tutorial/openmp.md) or other supported external packages.
 A warning, reminding the user to execute this command, will be printed to the screen when pyccelizing files which rely on these packages if the pickling step has not been executed.
 
 ## Additional packages

--- a/README.md
+++ b/README.md
@@ -267,10 +267,14 @@ Any required Python packages will be installed automatically from PyPI.
 
 ### On a read-only system
 
-If the folder where pyccel is saved is read only without sudo privileges an additional command should be run:
+If the folder where pyccel is saved is read only, it may be necessary to run an additional command:
 ```sh
 sudo pyccel-init
 ```
+
+This step is necessary in order to [pickle header files](.tutorial/header-files.md#Pickling-header-files).
+If this command is not run then pyccel will still run correctly but may be slower when using [OpenMP](.tutoral/openmp.md) or other supported external packages.
+A warning, reminding the user to execute this command, will be printed to the screen when pyccelizing files which rely on these packages if the pickling step has not been executed.
 
 ## Additional packages
 

--- a/pyccel/commands/pyccel_init.py
+++ b/pyccel/commands/pyccel_init.py
@@ -6,14 +6,14 @@
 """ Module containing script to pyccelize internal files
 """
 import os
-from pyccel.parser.parser import Parser
 from argparse import ArgumentParser
+from pyccel.parser.parser import Parser
 
 def pyccel_init():
     """ Pickle internal pyccel files
     """
     parser = ArgumentParser(description='Pickle internal pyccel files')
-    args = parser.parse_args()
+    parser.parse_args()
 
     folder = os.path.abspath(os.path.join(os.path.dirname(__file__),'..','stdlib','internal'))
     files = ['blas.pyh', 'dfftpack.pyh', 'fitpack.pyh',

--- a/pyccel/commands/pyccel_init.py
+++ b/pyccel/commands/pyccel_init.py
@@ -17,7 +17,7 @@ def pyccel_init():
 
     folder = os.path.abspath(os.path.join(os.path.dirname(__file__),'..','stdlib','internal'))
     files = ['blas.pyh', 'dfftpack.pyh', 'fitpack.pyh',
-            'lapack.pyh', 'mpiext.py', 'mpi.pyh', 'openacc.pyh', 'openmp.pyh']
+            'lapack.pyh', 'mpi.pyh', 'openacc.pyh', 'openmp.pyh']
 
     for f in files:
         parser = Parser(os.path.join(folder,f), show_traceback=False)

--- a/pyccel/commands/pyccel_init.py
+++ b/pyccel/commands/pyccel_init.py
@@ -20,6 +20,5 @@ def pyccel_init():
             'lapack.pyh', 'mpiext.py', 'mpi.pyh', 'openacc.pyh', 'openmp.pyh']
 
     for f in files:
-        print(f)
         parser = Parser(os.path.join(folder,f), show_traceback=False)
         parser.parse(verbose=False)

--- a/pyccel/commands/pyccel_init.py
+++ b/pyccel/commands/pyccel_init.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
+#------------------------------------------------------------------------------------------#
+""" Module containing script to pyccelize internal files
+"""
+import os
+from pyccel.parser.parser import Parser
+from argparse import ArgumentParser
+
+def pyccel_init():
+    """ Pickle internal pyccel files
+    """
+    parser = ArgumentParser(description='Pickle internal pyccel files')
+    args = parser.parse_args()
+
+    folder = os.path.abspath(os.path.join(os.path.dirname(__file__),'..','stdlib','internal'))
+    files = ['blas.pyh', 'dfftpack.pyh', 'fitpack.pyh',
+            'lapack.pyh', 'mpiext.py', 'mpi.pyh', 'openacc.pyh', 'openmp.pyh']
+
+    for f in files:
+        print(f)
+        parser = Parser(os.path.join(folder,f), show_traceback=False)
+        parser.parse(verbose=False)

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -437,19 +437,22 @@ class BasicParser(object):
         if not filename.split(""".""")[-1] == 'pyccel':
             raise ValueError('Expecting a .pyccel extension')
 
+        possible_pickle_errors = (FileNotFoundError, PermissionError,
+                pickle.PickleError, AttributeError)
+
         try:
             with FileLock(filename+'.lock'):
                 try:
                     with open(filename, 'rb') as f:
                         hs, version, parser = pickle.load(f)
-                except (FileNotFoundError, PermissionError, pickle.PickleError):
+                except possible_pickle_errors:
                     return
         except PermissionError:
             # read/write problems don't need to be avoided on a read-only system
             try:
                 with open(filename, 'rb') as f:
                     hs, version, parser = pickle.load(f)
-            except (FileNotFoundError, PermissionError, pickle.PickleError):
+            except possible_pickle_errors:
                 return
 
         import hashlib

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -402,7 +402,7 @@ class BasicParser(object):
                     hs   = hashlib.md5(code)
                     with open(filename, 'wb') as f:
                         pickle.dump((hs.hexdigest(), __version__, self), f, pickle.HIGHEST_PROTOCOL)
-                except (FileNotFoundError, pickle.PickleError) as e:
+                except (FileNotFoundError, pickle.PickleError):
                     pass
         except PermissionError:
             warnings.warn("Can't pickle files on a read-only system. Please run `sudo pyccel-init`")

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     filelock
 python_requires = >= 3.7
 zip_safe = False
+include_package_data = True
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,27 @@
+[metadata]
+name     = pyccel
+version  = 1.4.1
+author   = Pyccel development team
+email    = pyccel@googlegroups.com
+url      = https://github.com/pyccel/pyccel
+descr    = Python extension language using accelerators.
+keywords = math
+license  = LICENSE
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+packages = find:
+install_requires =
+    numpy
+    sympy>=1.2
+    termcolor
+    textx>=2.2
+    filelock
+python_requires = >= 3.7
+zip_safe = False
+
+[options.entry_points]
+console_scripts =
+    pyccel = pyccel.commands.console:pyccel
+    pyccel-clean = pyccel.commands.pyccel_clean:pyccel_clean_command

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name     = pyccel
-version  = 1.4.1
+version  = attr:pyccel.version.__version__
 author   = Pyccel development team
 email    = pyccel@googlegroups.com
 url      = https://github.com/pyccel/pyccel

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ def setup_package():
     setup(packages=packages, \
           include_package_data=True, \
           install_requires=install_requires, \
-          entry_points={'console_scripts': ['pyccel = pyccel.commands.console:pyccel', 'pyccel-clean = pyccel.commands.pyccel_clean:pyccel_clean_command']}, \
+          entry_points={'console_scripts': ['pyccel = pyccel.commands.console:pyccel',
+              'pyccel-init = pyccel.commands.pyccel_init:pyccel_init',
+              'pyccel-clean = pyccel.commands.pyccel_clean:pyccel_clean_command']}, \
           **setup_args)
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 from setuptools import setup, find_packages
+from setuptools.command.develop import develop
 
 # ...
 # Read library version into '__version__' variable
@@ -45,19 +46,21 @@ install_requires = [
     'filelock'
 ]
 
+class PickleHeaders(develop):
+    def run(self, *args, **kwargs):
+        """Process .pyh headers and store their AST in .pyccel pickle files."""
+        super().run(*args, **kwargs)
+        print("go")
 
-def pickle_headers():
-    """Process .pyh headers and store their AST in .pyccel pickle files."""
+        from pyccel.parser.parser import Parser
 
-    from pyccel.parser.parser import Parser
+        folder = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pyccel', 'stdlib', 'internal'))
+        files = ['blas.pyh', 'dfftpack.pyh', 'fitpack.pyh',
+                'lapack.pyh', 'mpi.pyh', 'openacc.pyh', 'openmp.pyh']
 
-    folder = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pyccel', 'stdlib', 'internal'))
-    files = ['blas.pyh', 'dfftpack.pyh', 'fitpack.pyh',
-            'lapack.pyh', 'mpi.pyh', 'openacc.pyh', 'openmp.pyh']
-
-    for f in files:
-        parser = Parser(os.path.join(folder, f), show_traceback=False)
-        parser.parse(verbose=False)
+        for f in files:
+            parser = Parser(os.path.join(folder, f), show_traceback=False)
+            parser.parse(verbose=False)
 
 
 def setup_package():
@@ -67,9 +70,8 @@ def setup_package():
           entry_points={'console_scripts': ['pyccel = pyccel.commands.console:pyccel',
               'pyccel-init = pyccel.commands.pyccel_init:pyccel_init',
               'pyccel-clean = pyccel.commands.pyccel_clean:pyccel_clean_command']}, \
+          cmdclass = {'develop':PickleHeaders},
           **setup_args)
-
-    pickle_headers()
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,21 @@ install_requires = [
     'filelock'
 ]
 
+
+def pickle_headers():
+    """Process .pyh headers and store their AST in .pyccel pickle files."""
+
+    from pyccel.parser.parser import Parser
+
+    folder = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pyccel', 'stdlib', 'internal'))
+    files = ['blas.pyh', 'dfftpack.pyh', 'fitpack.pyh',
+            'lapack.pyh', 'mpi.pyh', 'openacc.pyh', 'openmp.pyh']
+
+    for f in files:
+        parser = Parser(os.path.join(folder, f), show_traceback=False)
+        parser.parse(verbose=False)
+
+
 def setup_package():
     setup(packages=packages, \
           include_package_data=True, \
@@ -53,6 +68,9 @@ def setup_package():
               'pyccel-init = pyccel.commands.pyccel_init:pyccel_init',
               'pyccel-clean = pyccel.commands.pyccel_clean:pyccel_clean_command']}, \
           **setup_args)
+
+    pickle_headers()
+
 
 if __name__ == "__main__":
     setup_package()

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,14 @@ import setuptools
 from setuptools.command.develop import develop
 
 class PickleHeaders(develop):
+    """ Class to handle post-install step which pickles headers
+    """
     def run(self):
         # Execute the classic develop_data command
         super().run()
 
         # Just add a print for the example
-        """Process .pyh headers and store their AST in .pyccel pickle files."""
+        # Process .pyh headers and store their AST in .pyccel pickle files.
         import os
         from pyccel.parser.parser import Parser
 

--- a/setup.py
+++ b/setup.py
@@ -1,56 +1,16 @@
 # -*- coding: UTF-8 -*-
-#! /usr/bin/python
-
-from pathlib import Path
-from setuptools import setup, find_packages
+#!/usr/bin/env python
+import setuptools
 from setuptools.command.develop import develop
 
-# ...
-# Read library version into '__version__' variable
-path = Path(__file__).parent / 'pyccel' / 'version.py'
-exec(path.read_text())
-# ...
-
-NAME    = 'pyccel'
-VERSION = __version__
-AUTHOR  = 'Pyccel development team'
-EMAIL   = 'pyccel@googlegroups.com'
-URL     = 'https://github.com/pyccel/pyccel'
-DESCR   = 'Python extension language using accelerators.'
-KEYWORDS = ['math']
-LICENSE = "LICENSE"
-
-setup_args = dict(
-    name                 = NAME,
-    version              = VERSION,
-    description          = DESCR,
-    long_description     = open('README.md').read(),
-    long_description_content_type = 'text/markdown',
-    author               = AUTHOR,
-    author_email         = EMAIL,
-    license              = LICENSE,
-    keywords             = KEYWORDS,
-    url                  = URL,
-)
-
-# ...
-packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
-# ...
-
-# Dependencies
-install_requires = [
-    'numpy',
-    'sympy>=1.2',
-    'termcolor',
-    'textx>=2.2',
-    'filelock'
-]
-
 class PickleHeaders(develop):
-    def run(self, *args, **kwargs):
-        """Process .pyh headers and store their AST in .pyccel pickle files."""
-        super().run(*args, **kwargs)
+    def run(self):
+        # Execute the classic develop_data command
+        super().run()
 
+        # Just add a print for the example
+        """Process .pyh headers and store their AST in .pyccel pickle files."""
+        import os
         from pyccel.parser.parser import Parser
 
         folder = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pyccel', 'stdlib', 'internal'))
@@ -62,16 +22,5 @@ class PickleHeaders(develop):
             parser.parse(verbose=False)
 
 
-def setup_package():
-    setup(packages=packages, \
-          include_package_data=True, \
-          install_requires=install_requires, \
-          entry_points={'console_scripts': ['pyccel = pyccel.commands.console:pyccel',
-              'pyccel-init = pyccel.commands.pyccel_init:pyccel_init',
-              'pyccel-clean = pyccel.commands.pyccel_clean:pyccel_clean_command']}, \
-          cmdclass = {'develop':PickleHeaders},
-          **setup_args)
-
-
 if __name__ == "__main__":
-    setup_package()
+    setuptools.setup(cmdclass={"develop": PickleHeaders})

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ class PickleHeaders(develop):
     def run(self, *args, **kwargs):
         """Process .pyh headers and store their AST in .pyccel pickle files."""
         super().run(*args, **kwargs)
-        print("go")
 
         from pyccel.parser.parser import Parser
 


### PR DESCRIPTION
Create a pyccel-init script which pickles all internal files. Fixes #1079 . Clean up installation scripts

**Commit Summary**
- Only output pickle files if the files were not read from pickled files
- Catch `AttributeError`s which are raised when the pickle file was created with an outdated version of pyccel
- Create a `pyccel-init` script which creates all necessary pickle files. This command can then be run with sudo privileges to ensure that pyccel never needs write access to its own folder
- Raise a warning when pyccel tries to write a pickle file to a folder where it doesn't have write access to warn the user to use `pyccel-init`
- Rewrite the setup script to use the new `setup.cfg` workflow and to create the pickle files as a post-install step