### PR TITLE
Use pickle's DEFAULT_PROTOCOL

### DIFF
--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -405,7 +405,7 @@ class BasicParser(object):
                     code = self.code.encode('utf-8')
                     hs   = hashlib.md5(code)
                     with open(filename, 'wb') as f:
-                        pickle.dump((hs.hexdigest(), __version__, self), f, pickle.HIGHEST_PROTOCOL)
+                        pickle.dump((hs.hexdigest(), __version__, self), f)
                     print("Created pickle file : ", filename)
                 except (FileNotFoundError, pickle.PickleError):
                     pass

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.4.3"
+__version__ = "1.4.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools < 61",
+    "setuptools >= 61.2",
     "numpy",
     "sympy>=1.2",
     "termcolor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 61.2",
+    "setuptools < 61",
     "numpy",
     "sympy>=1.2",
     "termcolor",


### PR DESCRIPTION
Do not pass `protocol=pickle.HIGHEST_PROTOCOL` to `pickle.dump()`. Hence pickle uses `pickle.DEFAULT_PROTOCOL`, which should be compatible with all supported versions of Python3. This fixes #1083.