### PR TITLE
Correct nested generators bug

### DIFF
--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -805,7 +805,6 @@ class IndexedElement(PyccelAstNode):
             return
 
         self._dtype = base.dtype
-        self._order = base.order
         self._precision = base.precision
 
         shape = base.shape
@@ -854,6 +853,8 @@ class IndexedElement(PyccelAstNode):
                 if not isinstance(args[i], Slice):
                     new_rank -= 1
             self._rank = new_rank
+
+        self._order = None if self.rank < 2 else base.order
 
     @property
     def base(self):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2608,7 +2608,7 @@ class FCodePrinter(CodePrinter):
         allow_negative_indexes = base.allows_negative_indexes
 
         for i, ind in enumerate(inds):
-            _shape = PyccelArraySize(base, i if expr.order != 'C' else len(inds) - i - 1)
+            _shape = PyccelArraySize(base, i if expr.base.order != 'C' else len(inds) - i - 1)
             if isinstance(ind, Slice):
                 inds[i] = self._new_slice_with_processed_arguments(ind, _shape, allow_negative_indexes)
             elif isinstance(ind, PyccelUnarySub) and isinstance(ind.args[0], LiteralInteger):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -123,9 +123,12 @@ class PythonCodePrinter(CodePrinter):
                 body = list(body.body)
                 while isinstance(body[0], FunctionalFor):
                     func_for = body.pop(0)
+                    # Replace the temporary assign value with the FunctionalFor expression
+                    # so the loop is printed inline
                     for b in body:
                         b.substitute(func_for.lhs, func_for)
                 if len(body) > 1:
+                    # Ensure all assigns assign to the dummy we are searching for and do not introduce unexpected variables
                     if any(not(isinstance(b, Assign) and b.lhs is dummy_var) for b in body[1:]):
                         raise NotImplementedError("Pyccel has introduced unnecessary statements which it cannot yet disambiguate in the python printer")
                 body = body[0]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1344,6 +1344,7 @@ class SemanticParser(BasicParser):
         # Infer the final dtype of the expression
         d_var = self._infere_type(result, **settings)
         dtype = d_var.pop('datatype')
+        d_var['is_temp'] = expr.lhs.is_temp
         lhs = Variable(dtype, lhs_name, **d_var)
         self.namespace.insert_variable(lhs)
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -963,7 +963,7 @@ class SyntaxParser(BasicParser):
 
         name = self._visit(parent.func)
 
-        grandparent = self._scope[-4]
+        grandparent = self._scope[-3]
         if isinstance(grandparent, ast.Assign):
             if len(grandparent.targets) != 1:
                 raise NotImplementedError("Cannot unpack function with generator expression argument")

--- a/tests/epyccel/test_epyccel_generators.py
+++ b/tests/epyccel/test_epyccel_generators.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring/
 import pytest
 import numpy as np
-from numpy.random import randint
+from numpy.random import randint, rand
 
 from pyccel.epyccel import epyccel
 
@@ -139,7 +139,7 @@ def test_nested_generators1(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(sum(a[i,k,o,2] for i in range(5)) for k in range(5)) for o in range(5))
 
-    x = randint(50,size=(5,5,5,5))
+    x = rand(5,5,5,5)*50
 
     f_epyc = epyccel(f, language = language)
 
@@ -149,7 +149,7 @@ def test_nested_generators2(language):
     def f(a : 'float[:,:,:,:]'):
         return min(min(sum(min(max(a[i,k,o,l]*l for i in range(5)) for k in range(5)) for o in range(5)) for l in range(5)),0.)
 
-    x = randint(50,size=(5,5,5,5))
+    x = rand(5,5,5,5)*50
 
     f_epyc = epyccel(f, language = language)
 
@@ -159,7 +159,7 @@ def test_nested_generators3(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
-    x = randint(10,size=(5,5,5,5))
+    x = rand(5,5,5,5)*10
 
     f_epyc = epyccel(f, language = language)
 
@@ -169,7 +169,7 @@ def test_nested_generators4(language):
     def f(a : 'float[:,:,:,:]'):
         return min(max(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
-    x = randint(10,size=(5,5,5,5))
+    x = rand(5,5,5,5)*10
 
     f_epyc = epyccel(f, language = language)
 

--- a/tests/epyccel/test_epyccel_generators.py
+++ b/tests/epyccel/test_epyccel_generators.py
@@ -135,7 +135,7 @@ def test_expression2(language):
 
     assert f(x) == f_epyc(x)
 
-def nested_generators1(language):
+def test_nested_generators1(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(sum(a[i,k,o,2] for i in range(5)) for k in range(5)) for o in range(5))
 
@@ -145,7 +145,7 @@ def nested_generators1(language):
 
     assert f(x) == f_epyc(x)
 
-def nested_generators2(language):
+def test_nested_generators2(language):
     def f(a : 'float[:,:,:,:]'):
         return min(min(sum(min(max(a[i,k,o,l]*l for i in range(5)) for k in range(5)) for o in range(5)) for l in range(5)),0.)
 
@@ -155,9 +155,19 @@ def nested_generators2(language):
 
     assert f(x) == f_epyc(x)
 
-def nested_generators3(language):
+def test_nested_generators3(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(a[i,k,4,2] for i in range(5)) for k in range(5))**2
+
+    x = randint(10,size=(5,5,5,5))
+
+    f_epyc = epyccel(f, language = language)
+
+    assert f(x) == f_epyc(x)
+
+def test_nested_generators4(language):
+    def f(a : 'float[:,:,:,:]'):
+        return min(max(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
     x = randint(10,size=(5,5,5,5))
 


### PR DESCRIPTION
- Fix #1087 (nested generators bug) caused by mismatched order in 0d/1d arrays. See 5e75b2ddc7152c78a7e994da4f5453816ee14fe8
- Correct naming bug which lead to nested generators not being tested
- Fix python printing of nested generators