### PR TITLE
Add missing error for wrong ordering

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1835,6 +1835,12 @@ class FunctionCallArgument(Basic):
         else:
             return 'FunctionCallArgument({})'.format(repr(self.value))
 
+    def __str__(self):
+        if self.has_keyword:
+            return '{} = {}'.format(self.keyword, str(self.value))
+        else:
+            return '{}'.format(str(self.value))
+
 class FunctionDefArgument(PyccelAstNode):
 
     """A FunctionDef FunctionDefArgument

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -25,6 +25,7 @@ INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'
 INCOMPATIBLE_REDEFINITION_STACK_ARRAY = 'Cannot change shape of stack array, because it does not support memory reallocation. Avoid redefinition, or use standard heap array.'
 STACK_ARRAY_DEFINITION_IN_LOOP = 'Cannot create stack array in loop, because if does not support memory reallocation. Create array before loop, or use standard heap array.'
 INCOMPATIBLE_ARGUMENT = 'Argument {} : {}, passed to function {} is incompatible (expected {}). Please cast the argument explicitly or overload the function (see https://github.com/pyccel/pyccel/blob/master/tutorial/headers.md for details)'
+INCOMPATIBLE_ORDERING = "Argument {idx} : {arg}, passed to function {func} is incompatible as it has the wrong ordering (expected '{order}'). Please use an argument with '{order}' ordering, explicitly transpose {arg}, or overload the function (see https://github.com/pyccel/pyccel/blob/master/tutorial/headers.md for details)"
 UNRECOGNISED_FUNCTION_CALL = 'Function call cannot be processed. Please ensure that your code runs correctly in python. If this is the case then you may be using function arguments which are not currently supported by pyccel. Please create an issue at https://github.com/pyccel/pyccel/issues and provide a small example of your problem.'
 
 UNSUPPORTED_ARRAY_RETURN_VALUE = 'Array return arguments are currently not supported'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -750,6 +750,10 @@ class SemanticParser(BasicParser):
                 errors.report(INCOMPATIBLE_ARGUMENT.format(idx+1, received, expr.func_name, expected),
                         symbol = expr,
                         severity='error')
+            if f_arg.rank > 1 and i_arg.order != f_arg.order:
+                errors.report(INCOMPATIBLE_ORDERING.format(idx=idx+1, arg=i_arg, func=expr.func_name, order=f_arg.order),
+                        symbol = expr,
+                        severity='error')
 
     def _handle_function(self, expr, func, args, **settings):
         """

--- a/tests/internal/scripts/blas/ex2.py
+++ b/tests/internal/scripts/blas/ex2.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
     n = np.int32(4)
     m = np.int32(5)
 
-    a = np.zeros((n,m))
+    a = np.zeros((n,m), order='F')
     x = np.zeros(m)
     y = np.zeros(n)
 

--- a/tests/internal/scripts/blas/ex3.py
+++ b/tests/internal/scripts/blas/ex3.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
     n = np.int32(4)
     m = np.int32(5)
 
-    a = np.zeros((n,m))
+    a = np.zeros((n,m), order='F')
     x = np.zeros(m)
     y = np.zeros(n)
 

--- a/tests/internal/scripts/blas/ex4.py
+++ b/tests/internal/scripts/blas/ex4.py
@@ -7,9 +7,9 @@ if __name__ == '__main__':
     k = np.int32(5)
     n = np.int32(4)
 
-    a = np.zeros((m,k))
-    b = np.zeros((k,n))
-    c = np.zeros((m,n))
+    a = np.zeros((m,k), order='F')
+    b = np.zeros((k,n), order='F')
+    c = np.zeros((m,n), order='F')
 
     # ...
     a[0,0] = 1.0

--- a/tests/internal/scripts/lapack/ex1.py
+++ b/tests/internal/scripts/lapack/ex1.py
@@ -25,8 +25,8 @@ def test_1():
     mu  = int32(1)
     lda = int32(2 * ml + mu + 1)
 
-    a = zeros((lda,n))
-    b = zeros((1,n))
+    a = zeros((lda,n), order='F')
+    b = zeros((1,n), order='F')
 
     b[0]   = 1.0
     b[n-1] = 1.0
@@ -50,7 +50,7 @@ def test_2():
     n = int32(3)
     lda = n
 
-    a = zeros((lda,n))
+    a = zeros((lda,n), order='F')
 
     a[0,0] = 0.0
     a[0,1] = 1.0
@@ -84,7 +84,7 @@ def test_3():
     n = int32(3)
     lda = n
 
-    a = zeros((lda,n))
+    a = zeros((lda,n), order='F')
 
     a[0,0] = 0.0
     a[0,1] = 1.0
@@ -115,7 +115,7 @@ def test_4():
     n = int32(3)
     lda = n
 
-    a = zeros((lda,n))
+    a = zeros((lda,n), order='F')
 
     a[0,0] = 0.0
     a[0,1] = 1.0
@@ -136,7 +136,7 @@ def test_4():
 #    assert(info == 0)
 
     # Compute the inverse matrix.
-    b = zeros((1,n))
+    b = zeros((1,n), order='F')
     b[0] = 14.0
     b[1] = 32.0
     b[2] = 23.0


### PR DESCRIPTION
Fix #936 by adding an error when the order of a Numpy array passed as argument to a function is incorrect. Correct the ordering in the internal tests.