### PR TITLE
Simplify `(x**2)**0.5` style expressions

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -31,6 +31,7 @@ pyccel_stage = PyccelStage()
 __all__ = (
     'PythonReal',
     'PythonImag',
+    'PythonConjugate',
     'PythonBool',
     'PythonComplex',
     'PythonEnumerate',
@@ -60,14 +61,13 @@ class PythonComplexProperty(PyccelInternalFunction):
 
     arg : Variable, Literal
     """
-    __slots__ = ('_precision')
     _dtype = NativeFloat()
+    _precision = -1
     _rank  = 0
     _shape = ()
     _order = None
 
     def __init__(self, arg):
-        self._precision = arg.precision
         super().__init__(arg)
 
     @property
@@ -132,15 +132,14 @@ class PythonConjugate(PyccelInternalFunction):
 
     arg : Variable, Literal
     """
-    __slots__ = ('_precision')
     _dtype = NativeComplex()
+    _precision = -1
     _rank  = 0
     _shape = ()
     _order = None
     name = 'conjugate'
 
     def __init__(self, arg):
-        self._precision = arg.precision
         super().__init__(arg)
 
     @property

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -75,9 +75,6 @@ class PythonComplexProperty(PyccelInternalFunction):
         """Return the variable on which the function was called"""
         return self._args[0]
 
-    def __str__(self):
-        return 'Real({0})'.format(str(self.internal_var))
-
 #==============================================================================
 class PythonReal(PythonComplexProperty):
     """Represents a call to the .real property
@@ -99,6 +96,9 @@ class PythonReal(PythonComplexProperty):
         else:
             return super().__new__(cls)
 
+    def __str__(self):
+        return 'Real({0})'.format(str(self.internal_var))
+
 #==============================================================================
 class PythonImag(PythonComplexProperty):
     """Represents a call to the .imag property
@@ -118,6 +118,38 @@ class PythonImag(PythonComplexProperty):
         else:
             return super().__new__(cls)
 
+    def __str__(self):
+        return 'Imag({0})'.format(str(self.internal_var))
+
+#==============================================================================
+class PythonConjugate(PyccelInternalFunction):
+    """Represents a call to the .conjugate() function
+
+    e.g:
+    > a = 1+2j
+    > a.conjugate()
+    1-2j
+
+    arg : Variable, Literal
+    """
+    __slots__ = ('_precision')
+    _dtype = NativeComplex()
+    _rank  = 0
+    _shape = ()
+    _order = None
+    name = 'conjugate'
+
+    def __init__(self, arg):
+        self._precision = arg.precision
+        super().__init__(arg)
+
+    @property
+    def internal_var(self):
+        """Return the variable on which the function was called"""
+        return self._args[0]
+
+    def __str__(self):
+        return 'Conjugate({0})'.format(str(self.internal_var))
 
 #==============================================================================
 class PythonBool(PyccelAstNode):

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -168,11 +168,11 @@ literal_classes = {
 
 #=======================================================================================
 
-def get_cls_base(dtype, rank):
+def get_cls_base(dtype, precision, rank):
     """
     From the dtype and rank, determine the base class of an object
     """
-    if rank == 0:
+    if precision == -1 and rank == 0:
         return literal_classes[dtype]
     else:
         return NumpyArrayClass

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -10,7 +10,8 @@ from .core      import ClassDef, FunctionDef
 from .datatypes import (NativeBool, NativeInteger, NativeFloat,
                         NativeComplex, NativeString)
 from .numpyext  import (Shape, NumpySum, NumpyAmin, NumpyAmax,
-                        NumpyImag, NumpyReal, NumpyTranspose)
+                        NumpyImag, NumpyReal, NumpyTranspose,
+                        NumpyConjugate)
 
 __all__ = ('BooleanClass',
         'IntegerClass',
@@ -149,7 +150,11 @@ NumpyArrayClass = ClassDef('numpy.ndarray',
             FunctionDef('imag',[],[],body=[],
                 decorators={'property':'property', 'numpy_wrapper':NumpyImag}),
             FunctionDef('real',[],[],body=[],
-                decorators={'property':'property', 'numpy_wrapper':NumpyReal})])
+                decorators={'property':'property', 'numpy_wrapper':NumpyReal}),
+            FunctionDef('conj',[],[],body=[],
+                decorators={'numpy_wrapper':NumpyConjugate}),
+            FunctionDef('conjugate',[],[],body=[],
+                decorators={'numpy_wrapper':NumpyConjugate})])
 
 #=======================================================================================
 

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -5,7 +5,7 @@
 """
 This module contains all types which define a python class which is automatically recognised by pyccel
 """
-from .builtins  import PythonImag, PythonReal
+from .builtins  import PythonImag, PythonReal, PythonConjugate
 from .core      import ClassDef, FunctionDef
 from .datatypes import (NativeBool, NativeInteger, NativeFloat,
                         NativeComplex, NativeString)
@@ -30,7 +30,8 @@ ComplexClass = ClassDef('complex',
                 decorators={'property':'property', 'numpy_wrapper':PythonImag}),
             FunctionDef('real',[],[],body=[],
                 decorators={'property':'property', 'numpy_wrapper':PythonReal}),
-            #conjugate
+            FunctionDef('conjugate',[],[],body=[],
+                decorators={'numpy_wrapper':PythonConjugate}),
             ])
 
 #=======================================================================================

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -1327,6 +1327,30 @@ class NumpyTranspose(NumpyUfuncUnary):
     def is_elemental(self):
         return False
 
+class NumpyConjugate(PythonConjugate):
+    """Represents a call to  numpy.conj for code generation.
+
+    > a = 1+2j
+    > np.conj(a)
+    1-2j
+    """
+    __slots__ = ('_rank','_shape','_order')
+    name = 'conj'
+
+    def __init__(self, arg):
+        super().__init__(arg)
+        self._precision = arg.precision
+        self._order = arg.order
+        self._shape = process_shape(self.internal_var.shape)
+        self._rank  = len(self._shape)
+
+    @property
+    def is_elemental(self):
+        """ Indicates whether the function should be
+        called elementwise for an array argument
+        """
+        return True
+
 #==============================================================================
 # TODO split numpy_functions into multiple dictionaries following
 # https://docs.scipy.org/doc/numpy-1.15.0/reference/routines.array-creation.html
@@ -1361,6 +1385,8 @@ numpy_funcs = {
     'int'       : PyccelFunctionDef('int'       , NumpyInt),
     'real'      : PyccelFunctionDef('real'      , NumpyReal),
     'imag'      : PyccelFunctionDef('imag'      , NumpyImag),
+    'conj'      : PyccelFunctionDef('conj'      , NumpyConjugate),
+    'conjugate' : PyccelFunctionDef('conjugate' , NumpyConjugate),
     'float'     : PyccelFunctionDef('float'     , NumpyFloat),
     'double'    : PyccelFunctionDef('double'    , NumpyFloat64),
     'mod'       : PyccelFunctionDef('mod'       , NumpyMod),

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -181,7 +181,7 @@ class NumpyReal(PythonReal):
     > np.real(a)
     1.0
     """
-    __slots__ = ('_rank','_shape','_order')
+    __slots__ = ('_precision','_rank','_shape','_order')
     name = 'real'
     def __new__(cls, arg):
         if isinstance(arg.dtype, NativeBool):
@@ -212,7 +212,7 @@ class NumpyImag(PythonImag):
     > np.imag(a)
     2.0
     """
-    __slots__ = ('_rank','_shape','_order')
+    __slots__ = ('_precision','_rank','_shape','_order')
     name = 'imag'
     def __new__(cls, arg):
         if not isinstance(arg.dtype, NativeComplex):
@@ -1334,7 +1334,7 @@ class NumpyConjugate(PythonConjugate):
     > np.conj(a)
     1-2j
     """
-    __slots__ = ('_rank','_shape','_order')
+    __slots__ = ('_precision','_rank','_shape','_order')
     name = 'conj'
 
     def __init__(self, arg):

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -17,7 +17,7 @@ from pyccel.utilities.stage import PyccelStage
 from .basic          import PyccelAstNode
 from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
                              PythonComplex, PythonReal, PythonImag, PythonList,
-                             PythonType)
+                             PythonType, PythonConjugate)
 
 from .core           import process_shape, Module, Import, PyccelFunctionDef
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -693,9 +693,6 @@ class PyccelDiv(PyccelArithmeticOperator):
         return dtype, precision
 
     def __repr__(self):
-        return '{} + {}'.format(self.args[0], self.args[1])
-
-    def __repr__(self):
         return '{} / {}'.format(self.args[0], self.args[1])
 
 #==============================================================================

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -505,6 +505,22 @@ class PyccelPow(PyccelArithmeticOperator):
     def __repr__(self):
         return '{} ** {}'.format(self.args[0], self.args[1])
 
+    def _handle_precedence(self, args):
+        precedence = [getattr(a, 'precedence', 17) for a in args]
+
+        if min(precedence) <= self._precedence:
+
+            new_args = []
+
+            for i, (a,p) in enumerate(zip(args, precedence)):
+                if (p < self._precedence or (p == self._precedence and i != 1)):
+                    new_args.append(PyccelAssociativeParenthesis(a))
+                else:
+                    new_args.append(a)
+            args = tuple(new_args)
+
+        return args
+
 #==============================================================================
 
 class PyccelAdd(PyccelArithmeticOperator):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1739,6 +1739,9 @@ class CCodePrinter(CodePrinter):
     def _print_PythonImag(self, expr):
         return 'cimag({})'.format(self._print(expr.internal_var))
 
+    def _print_PythonConjugate(self, expr):
+        return 'conj({})'.format(self._print(expr.internal_var))
+
     def _handle_is_operator(self, Op, expr):
 
         lhs = self._print(expr.lhs)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2922,6 +2922,11 @@ class FCodePrinter(CodePrinter):
 
 #=======================================================================================
 
+    def _print_PythonConjugate(self, expr):
+        return 'conjg( {} )'.format( self._print(expr.internal_var) )
+
+#=======================================================================================
+
     def _wrap_fortran(self, lines):
         """Wrap long Fortran lines
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -402,6 +402,9 @@ class PythonCodePrinter(CodePrinter):
     def _print_PythonImag(self, expr):
         return '({}).imag'.format(self._print(expr.internal_var))
 
+    def _print_PythonConjugate(self, expr):
+        return '({}).conjugate()'.format(self._print(expr.internal_var))
+
     def _print_PythonPrint(self, expr):
         return 'print({})\n'.format(', '.join(self._print(a) for a in expr.expr))
 

--- a/pyccel/naming/fortrannameclashchecker.py
+++ b/pyccel/naming/fortrannameclashchecker.py
@@ -15,6 +15,7 @@ class FortranNameClashChecker(metaclass = Singleton):
     """ Class containing functions to help avoid problematic names in C
     """
     # Keywords as mentioned on https://fortranwiki.org/fortran/show/Keywords
+    # Intrinsic functions as mentioned on https://pages.mtu.edu/~shene/COURSES/cs201/NOTES/chap02/funct.html
     keywords = set(['assign', 'backspace', 'block', 'blockdata',
             'call', 'close', 'common', 'continue', 'data',
             'dimension', 'do', 'else', 'elseif', 'end', 'endfile',
@@ -36,7 +37,9 @@ class FortranNameClashChecker(metaclass = Singleton):
             'nopass', 'pass', 'protected', 'value', 'volatile',
             'wait', 'codimension', 'concurrent', 'contiguous',
             'critical', 'error', 'submodule', 'sync', 'lock',
-            'unlock', 'test'])
+            'unlock', 'test', 'abs', 'sqrt', 'sin', 'cos', 'tan',
+            'asin', 'acos', 'atan', 'exp', 'log', 'int', 'nint',
+            'floor', 'fraction', 'real', 'max', 'mod'])
 
     def has_clash(self, name, symbols):
         """ Indicate whether the proposed name causes any clashes

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2014,6 +2014,21 @@ class SemanticParser(BasicParser):
 
                 # Cast to preserve final dtype
                 return PythonComplex(self._visit(new_call))
+        elif isinstance(arg.value, PyccelPow):
+            base, exponent = arg.value.args
+            base_syn, _ = expr.args[0].value.args
+            if exponent == 2 and base.dtype in (NativeInteger(), NativeFloat()):
+                pyccel_stage.set_stage('syntactic')
+
+                fabs_name = self.scope.get_new_name('fabs')
+                imp_name = AsName('fabs', fabs_name)
+                new_import = Import('math',imp_name)
+                self._visit(new_import)
+                new_call = FunctionCall(fabs_name, [base_syn])
+
+                pyccel_stage.set_stage('semantic')
+
+                return self._visit(new_call)
 
         return self._handle_function(expr, func, (arg,), **settings)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3663,8 +3663,8 @@ class SemanticParser(BasicParser):
 
     def _visit_NumpyMatmul(self, expr, **settings):
         if isinstance(expr, FunctionCall):
-            a = self._visit(expr.args[0])
-            b = self._visit(expr.args[1])
+            a = self._visit(expr.args[0].value)
+            b = self._visit(expr.args[1].value)
         else:
             self.insert_import('numpy', AsName(NumpyMatmul, 'matmul'))
             a = self._visit(expr.a)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1961,7 +1961,7 @@ class SemanticParser(BasicParser):
 
             return self._visit(new_call)
         else:
-            return PyccelPow(first, second)
+            return PyccelPow(base, exponent)
 
     def _visit_MathSqrt(self, expr, **settings):
         func = self.scope.find(expr.funcdef, 'functions')

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -94,7 +94,7 @@ from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Con
                             OMP_Single_Construct)
 
 from pyccel.ast.operators import PyccelIs, PyccelIsNot, IfTernaryOperator, PyccelUnarySub
-from pyccel.ast.operators import PyccelNot, PyccelEq, PyccelAdd, PyccelMul
+from pyccel.ast.operators import PyccelNot, PyccelEq, PyccelAdd, PyccelMul, PyccelPow
 from pyccel.ast.operators import PyccelAssociativeParenthesis
 
 from pyccel.ast.sympy_helper import sympy_to_pyccel, pyccel_to_sympy

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1945,7 +1945,7 @@ class SemanticParser(BasicParser):
 
     def _visit_PyccelPow(self, expr, **settings):
         base, exponent = [self._visit(a, **settings) for a in expr.args]
-        if isinstance(exponent, LiteralInteger) and exponent == 2:
+        if isinstance(exponent, LiteralInteger) and isinstance(base, (Literal, Variable)) and exponent == 2:
             return PyccelMul(base, base)
         elif isinstance(exponent, LiteralFloat) and exponent == 0.5:
             pyccel_stage.set_stage('syntactic')

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1950,12 +1950,14 @@ class SemanticParser(BasicParser):
         elif isinstance(exponent, LiteralFloat) and exponent == 0.5:
             pyccel_stage.set_stage('syntactic')
 
-            new_import = Import('math','sqrt')
+            sqrt_name = self.scope.get_new_name('sqrt')
+            imp_name = AsName('sqrt', sqrt_name)
+            new_import = Import('math',imp_name)
             self._visit(new_import)
             if isinstance(expr.args[0], PyccelAssociativeParenthesis):
-                new_call = FunctionCall(PyccelSymbol('sqrt'), [expr.args[0].args[0]])
+                new_call = FunctionCall(sqrt_name, [expr.args[0].args[0]])
             else:
-                new_call = FunctionCall(PyccelSymbol('sqrt'), [expr.args[0]])
+                new_call = FunctionCall(sqrt_name, [expr.args[0]])
 
             pyccel_stage.set_stage('semantic')
 
@@ -1972,9 +1974,11 @@ class SemanticParser(BasicParser):
             if mul1 is mul2 and mul1.dtype in (NativeInteger(), NativeFloat()):
                 pyccel_stage.set_stage('syntactic')
 
-                new_import = Import('math','fabs')
+                fabs_name = self.scope.get_new_name('fabs')
+                imp_name = AsName('fabs', fabs_name)
+                new_import = Import('math',imp_name)
                 self._visit(new_import)
-                new_call = FunctionCall(PyccelSymbol('fabs'), [mul1_syn])
+                new_call = FunctionCall(fabs_name, [mul1_syn])
 
                 pyccel_stage.set_stage('semantic')
 
@@ -1982,9 +1986,11 @@ class SemanticParser(BasicParser):
             elif isinstance(mul1, (NumpyConjugate, PythonConjugate)) and mul1.internal_var is mul2:
                 pyccel_stage.set_stage('syntactic')
 
-                new_import = Import('numpy','abs')
+                abs_name = self.scope.get_new_name('abs')
+                imp_name = AsName('abs', abs_name)
+                new_import = Import('math',imp_name)
                 self._visit(new_import)
-                new_call = FunctionCall(PyccelSymbol('abs'), [mul2_syn])
+                new_call = FunctionCall(abs_name, [mul2_syn])
 
                 pyccel_stage.set_stage('semantic')
 
@@ -1992,9 +1998,11 @@ class SemanticParser(BasicParser):
             elif isinstance(mul2, (NumpyConjugate, PythonConjugate)) and mul1 is mul2.internal_var:
                 pyccel_stage.set_stage('syntactic')
 
-                new_import = Import('numpy','abs')
+                abs_name = self.scope.get_new_name('abs')
+                imp_name = AsName('abs', abs_name)
+                new_import = Import('math',imp_name)
                 self._visit(new_import)
-                new_call = FunctionCall(PyccelSymbol('abs'), [mul1_syn])
+                new_call = FunctionCall(abs_name, [mul1_syn])
 
                 pyccel_stage.set_stage('semantic')
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -494,7 +494,7 @@ class SemanticParser(BasicParser):
             d_var['rank'       ] = expr.rank
             d_var['order'      ] = expr.order
             d_var['precision'  ] = expr.precision
-            d_var['cls_base'   ] = get_cls_base(expr.dtype, expr.rank)
+            d_var['cls_base'   ] = get_cls_base(expr.dtype, expr.precision, expr.rank)
             return d_var
 
         elif isinstance(expr, IfTernaryOperator):
@@ -3051,7 +3051,7 @@ class SemanticParser(BasicParser):
                         d_var['is_const'] = ah.is_const
                         dtype = d_var.pop('datatype')
                         if not d_var['cls_base']:
-                            d_var['cls_base'] = get_cls_base( dtype, d_var['rank'] )
+                            d_var['cls_base'] = get_cls_base( dtype, d_var['precision'], d_var['rank'] )
 
                         if 'allow_negative_index' in self.scope.decorators:
                             if a.name in decorators['allow_negative_index']:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -23,7 +23,7 @@ from pyccel.ast.basic import Basic, PyccelAstNode, ScopedNode
 from pyccel.ast.builtins import PythonPrint
 from pyccel.ast.builtins import PythonInt, PythonBool, PythonFloat, PythonComplex
 from pyccel.ast.builtins import python_builtin_datatype
-from pyccel.ast.builtins import PythonList
+from pyccel.ast.builtins import PythonList, PythonConjugate
 from pyccel.ast.builtins import (PythonRange, PythonZip, PythonEnumerate,
                                  PythonMap, PythonTuple, Lambda)
 
@@ -85,7 +85,7 @@ from pyccel.ast.numpyext import NumpyWhere, NumpyArray
 from pyccel.ast.numpyext import NumpyInt, NumpyInt8, NumpyInt16, NumpyInt32, NumpyInt64
 from pyccel.ast.numpyext import NumpyFloat, NumpyFloat32, NumpyFloat64
 from pyccel.ast.numpyext import NumpyComplex, NumpyComplex64, NumpyComplex128
-from pyccel.ast.numpyext import NumpyTranspose
+from pyccel.ast.numpyext import NumpyTranspose, NumpyConjugate
 from pyccel.ast.numpyext import NumpyNewArray
 from pyccel.ast.numpyext import DtypePrecisionToCastFunction
 
@@ -94,7 +94,8 @@ from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Con
                             OMP_Single_Construct)
 
 from pyccel.ast.operators import PyccelIs, PyccelIsNot, IfTernaryOperator, PyccelUnarySub
-from pyccel.ast.operators import PyccelNot, PyccelEq, PyccelAdd
+from pyccel.ast.operators import PyccelNot, PyccelEq, PyccelAdd, PyccelMul
+from pyccel.ast.operators import PyccelAssociativeParenthesis
 
 from pyccel.ast.sympy_helper import sympy_to_pyccel, pyccel_to_sympy
 
@@ -964,7 +965,7 @@ class SemanticParser(BasicParser):
                     if 'allow_negative_index' in decorators:
                         if lhs in decorators['allow_negative_index']:
                             d_lhs.update(allows_negative_indexes=True)
-                
+
                 # We cannot allow the definition of a stack array from a shape which
                 # is unknown at the declaration
                 if 'is_stack_array' in d_lhs and d_lhs['is_stack_array']:
@@ -1942,6 +1943,65 @@ class SemanticParser(BasicParser):
             expr_new = self._create_PyccelOperator(expr, args)
         return expr_new
 
+    def _visit_PyccelPow(self, expr, **settings):
+        base, exponent = [self._visit(a, **settings) for a in expr.args]
+        if isinstance(exponent, LiteralInteger) and exponent == 2:
+            return PyccelMul(base, base)
+        elif isinstance(exponent, LiteralFloat) and exponent == 0.5:
+            pyccel_stage.set_stage('syntactic')
+
+            new_import = Import('math','sqrt')
+            self._visit(new_import)
+            if isinstance(expr.args[0], PyccelAssociativeParenthesis):
+                new_call = FunctionCall(PyccelSymbol('sqrt'), [expr.args[0].args[0]])
+            else:
+                new_call = FunctionCall(PyccelSymbol('sqrt'), [expr.args[0]])
+
+            pyccel_stage.set_stage('semantic')
+
+            return self._visit(new_call)
+        else:
+            return PyccelPow(first, second)
+
+    def _visit_MathSqrt(self, expr, **settings):
+        func = self.scope.find(expr.funcdef, 'functions')
+        arg, = self._handle_function_args(expr.args, **settings)
+        if isinstance(arg.value, PyccelMul):
+            mul1, mul2 = arg.value.args
+            mul1_syn, mul2_syn = expr.args[0].value.args
+            if mul1 is mul2 and mul1.dtype in (NativeInteger(), NativeFloat()):
+                pyccel_stage.set_stage('syntactic')
+
+                new_import = Import('math','fabs')
+                self._visit(new_import)
+                new_call = FunctionCall(PyccelSymbol('fabs'), [mul1_syn])
+
+                pyccel_stage.set_stage('semantic')
+
+                return self._visit(new_call)
+            elif isinstance(mul1, (NumpyConjugate, PythonConjugate)) and mul1.internal_var is mul2:
+                pyccel_stage.set_stage('syntactic')
+
+                new_import = Import('numpy','abs')
+                self._visit(new_import)
+                new_call = FunctionCall(PyccelSymbol('abs'), [mul2_syn])
+
+                pyccel_stage.set_stage('semantic')
+
+                return self._visit(new_call)
+            elif isinstance(mul2, (NumpyConjugate, PythonConjugate)) and mul1 is mul2.internal_var:
+                pyccel_stage.set_stage('syntactic')
+
+                new_import = Import('numpy','abs')
+                self._visit(new_import)
+                new_call = FunctionCall(PyccelSymbol('abs'), [mul1_syn])
+
+                pyccel_stage.set_stage('semantic')
+
+                return self._visit(new_call)
+
+        return self._handle_function(expr, func, (arg,), **settings)
+
     def _visit_Lambda(self, expr, **settings):
         expr_names = set(str(a) for a in expr.expr.get_attribute_nodes(PyccelSymbol, excluded_nodes = FunctionDef))
         var_names = map(str, expr.variables)
@@ -1972,12 +2032,13 @@ class SemanticParser(BasicParser):
         except RuntimeError:
             pass
 
-        # Check for specialised method
-        annotation_method = '_visit_' + name
-        if hasattr(self, annotation_method):
-            return getattr(self, annotation_method)(expr, **settings)
-
         func     = self.scope.find(name, 'functions')
+
+        # Check for specialised method
+        if isinstance(func, PyccelFunctionDef):
+            annotation_method = '_visit_' + func.cls_name.__name__
+            if hasattr(self, annotation_method):
+                return getattr(self, annotation_method)(expr, **settings)
 
         args = self._handle_function_args(expr.args, **settings)
 
@@ -2989,8 +3050,8 @@ class SemanticParser(BasicParser):
                         d_var['is_argument'] = True
                         d_var['is_const'] = ah.is_const
                         dtype = d_var.pop('datatype')
-                        if d_var['rank']>0:
-                            d_var['cls_base'] = NumpyArrayClass
+                        if not d_var['cls_base']:
+                            d_var['cls_base'] = get_cls_base( dtype, d_var['rank'] )
 
                         if 'allow_negative_index' in self.scope.decorators:
                             if a.name in decorators['allow_negative_index']:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3662,9 +3662,13 @@ class SemanticParser(BasicParser):
         return StarredArguments([var[i] for i in range(size)])
 
     def _visit_NumpyMatmul(self, expr, **settings):
-        self.insert_import('numpy', AsName(NumpyMatmul, 'matmul'))
-        a = self._visit(expr.a)
-        b = self._visit(expr.b)
+        if isinstance(expr, FunctionCall):
+            a = self._visit(expr.args[0])
+            b = self._visit(expr.args[1])
+        else:
+            self.insert_import('numpy', AsName(NumpyMatmul, 'matmul'))
+            a = self._visit(expr.a)
+            b = self._visit(expr.b)
         return NumpyMatmul(a, b)
 
 #==============================================================================

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.4.4"
+__version__ = "1.5.0"

--- a/tests/epyccel/test_class_expressions.py
+++ b/tests/epyccel/test_class_expressions.py
@@ -35,7 +35,7 @@ def test_complex_imag_expr(language):
 def test_complex_real(language):
     def f():
         a = 1+2j
-        return a.imag
+        return a.real
 
     epyc_f = epyccel(f, language=language)
 
@@ -53,6 +53,36 @@ def test_complex_real_expr(language):
 
     a = randint(20)+1j*randint(20)
     b = randint(20)+1j*randint(20)
+
+    r = f(a,b)
+    epyc_r = epyc_f(a,b)
+
+    assert r == epyc_r
+    assert isinstance(r, type(epyc_r))
+
+def test_complex_conjugate(language):
+    def f(a : 'complex', b : 'complex'):
+        return (a+b).conjugate()
+
+    epyc_f = epyccel(f, language=language)
+
+    a = randint(20)+1j*randint(20)
+    b = randint(20)+1j*randint(20)
+
+    r = f(a,b)
+    epyc_r = epyc_f(a,b)
+
+    assert r == epyc_r
+    assert isinstance(r, type(epyc_r))
+
+def test_complex_conjugate64(language):
+    def f(a : 'complex64', b : 'complex64'):
+        return (a+b).conj()
+
+    epyc_f = epyccel(f, language=language)
+
+    a = np.complex64(randint(20)+1j*randint(20))
+    b = np.complex64(randint(20)+1j*randint(20))
 
     r = f(a,b)
     epyc_r = epyc_f(a,b)

--- a/tests/epyccel/test_epyccel_pow.py
+++ b/tests/epyccel/test_epyccel_pow.py
@@ -145,3 +145,62 @@ def test_pow_chain(language):
         f = epyccel(c, language=language)
         assert(isclose(f(x, y, z), c(x, y, z), rtol=RTOL, atol=ATOL))
         assert isinstance(f(x, y, z), type(c(x, y, z)))
+
+def test_square(language):
+    @types('float')
+    @types('int')
+    def square(x):
+        return x**2
+
+    f = epyccel(square, language=language)
+    x = randint(40)
+    y = uniform()
+
+    assert isclose(f(x), square(x), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(x), type(square(x)))
+    assert isclose(f(y), square(y), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(y), type(square(y)))
+
+def test_sqrt(language):
+    @types('float')
+    @types('int')
+    def sqrt(x):
+        return x**0.5
+
+    f = epyccel(sqrt, language=language)
+    x = randint(40)
+    y = uniform()
+
+    assert isclose(f(x), sqrt(x), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(x), type(sqrt(x)))
+    assert isclose(f(y), sqrt(y), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(y), type(sqrt(y)))
+
+def test_fabs(language):
+    @types('float')
+    @types('int')
+    def fabs(x):
+        return (x*x)**0.5
+
+    f = epyccel(fabs, language=language)
+    x = randint(40)
+    y = uniform()
+
+    assert isclose(f(x), fabs(x), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(x), type(fabs(x)))
+    assert isclose(f(y), fabs(y), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(y), type(fabs(y)))
+
+def test_abs(language):
+    @types('complex')
+    def norm(x):
+        return (x*x.conjugate())**0.5
+
+    f = epyccel(norm, language=language)
+    x = randint(40) + 1j * randint(40)
+    y = randint(40) - 1j * randint(40)
+
+    assert isclose(f(x), norm(x), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(x), type(norm(x)))
+    assert isclose(f(y), norm(y), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(y), type(norm(y)))

--- a/tests/epyccel/test_epyccel_pow.py
+++ b/tests/epyccel/test_epyccel_pow.py
@@ -128,3 +128,20 @@ def test_pow_r_c(language):
     assert(isclose(f(-b, e), pow_r_c(-b, e), rtol=RTOL, atol=ATOL))
     assert(isclose(f(b, -e), pow_r_c(b, -e), rtol=RTOL, atol=ATOL))
     assert(isclose(f(-b, -e), pow_r_c(-b, -e), rtol=RTOL, atol=ATOL))
+
+def test_pow_chain(language):
+    def chain_pow1(x : float, y : float, z : float):
+        return x ** y ** z
+    def chain_pow2(x : float, y : float, z : float):
+        return (x ** y) ** z
+    def chain_pow3(x : float, y : float, z : float):
+        return x ** (y ** z)
+
+    x = uniform(low=min_float, high=50)
+    y = uniform(high=5)
+    z = uniform(high=5)
+
+    for c in (chain_pow1, chain_pow2, chain_pow3):
+        f = epyccel(c, language=language)
+        assert(isclose(f(x, y, z), c(x, y, z), rtol=RTOL, atol=ATOL))
+        assert isinstance(f(x, y, z), type(c(x, y, z)))

--- a/tests/epyccel/test_epyccel_pow.py
+++ b/tests/epyccel/test_epyccel_pow.py
@@ -137,7 +137,7 @@ def test_pow_chain(language):
     def chain_pow3(x : float, y : float, z : float):
         return x ** (y ** z)
 
-    x = uniform(low=min_float, high=50)
+    x = uniform(low=min_float, high=10)
     y = uniform(high=5)
     z = uniform(high=5)
 

--- a/tests/epyccel/test_epyccel_pow.py
+++ b/tests/epyccel/test_epyccel_pow.py
@@ -139,7 +139,7 @@ def test_pow_chain(language):
 
     x = uniform(low=min_float, high=10)
     y = uniform(high=5)
-    z = uniform(high=5)
+    z = uniform(high=1.0)
 
     for c in (chain_pow1, chain_pow2, chain_pow3):
         f = epyccel(c, language=language)

--- a/tests/epyccel/test_epyccel_pow.py
+++ b/tests/epyccel/test_epyccel_pow.py
@@ -204,3 +204,17 @@ def test_abs(language):
     assert isinstance(f(x), type(norm(x)))
     assert isclose(f(y), norm(y), rtol=RTOL, atol=ATOL)
     assert isinstance(f(y), type(norm(y)))
+
+def test_complicated_abs(language):
+    @types('complex')
+    def norm(x):
+        return ((x*x.conjugate()).real**2)**0.5
+
+    f = epyccel(norm, language=language)
+    x = randint(40) + 1j * randint(40)
+    y = randint(40) - 1j * randint(40)
+
+    assert isclose(f(x), norm(x), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(x), type(norm(x)))
+    assert isclose(f(y), norm(y), rtol=RTOL, atol=ATOL)
+    assert isinstance(f(y), type(norm(y)))


### PR DESCRIPTION
**Main changes**

- Correct `PythonPow` precedence by adding correct parentheses and add tests (fixes #1108)
- Add the `conjugate` function and add tests
- Simplify the following expressions:
    - `x**2` -> `x*x` (if `x` is literal or variable)
    - `x**0.5` -> `sqrt(x)`
    - `sqrt(x*x)` -> `fabs(x)` and `sqrt(x**2)` -> `fabs(x)` (if `x` is integer or float)
    - `sqrt(x.conjugate()*x)` / `sqrt(x * x.conjugate())` -> `abs(x)`

**Other bug-fixes**

- Correct `PythonImag` string representation
- Use default Python precision for `PythonReal` and `PythonImag`
- Ensure `cls_base` is set for function arguments
- Correctly identify annotation_method in `_visit_FunctionCall` to allow specialisation of `PyccelFunctionDef` calls
- Extend list of Fortran intrinsic functions to avoid name clashes