### PR TITLE
Allow use of argument for size of stack_array 

### DIFF
--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -976,7 +976,8 @@ class SemanticParser(BasicParser):
                             severity='error',
                             bounding_box=(self._current_fst_node.lineno,
                                 self._current_fst_node.col_offset))
-                        if isinstance(a, Variable) or not all([b.is_argument for b in a.get_attribute_nodes(Variable, excluded_nodes=FunctionDef)]):
+                        if (isinstance(a, Variable) and not a.is_argument) \
+                                or not all([b.is_argument for b in a.get_attribute_nodes(Variable, excluded_nodes=FunctionDef)]):
                             errors.report(STACK_ARRAY_UNKNOWN_SHAPE, symbol=name,
                             severity='error',
                             bounding_box=(self._current_fst_node.lineno,

--- a/tests/pyccel/scripts/runtest_degree_in.py
+++ b/tests/pyccel/scripts/runtest_degree_in.py
@@ -6,8 +6,8 @@ from pyccel.decorators import stack_array, pure
 def test_degree(degree : int):
     from numpy import empty
 
-    tmp = empty(degree+1, dtype=float)
-    for i in range(degree+1):
+    tmp = empty(degree, dtype=float)
+    for i in range(degree):
         tmp[i]=0.
     return 1
 


### PR DESCRIPTION
Allow the use of an argument for the size of a `stack_array`. Fixes #1111 