### PR TITLE
Fix slow pyccel behaviour

### DIFF
--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -40,7 +40,7 @@ class Basic:
 
             from pyccel.ast.literals import convert_to_literal
 
-            if Basic._ignore(self, c):
+            if Basic._ignore(c):
                 continue
 
             elif isinstance(c, (int, float, complex, str, bool)):
@@ -51,7 +51,7 @@ class Basic:
             elif iterable(c):
                 size = len(c)
                 c = tuple(ci if (not isinstance(ci, (int, float, complex, str, bool)) \
-                                 or self._ignore(ci)) \
+                                 or Basic._ignore(ci)) \
                         else convert_to_literal(ci) for ci in c if not iterable(ci))
                 if len(c) != size:
                     raise TypeError("Basic child cannot be a tuple of tuples")
@@ -63,15 +63,16 @@ class Basic:
 
             if isinstance(c, tuple):
                 for ci in c:
-                    if not Basic._ignore(self, ci):
+                    if not Basic._ignore(ci):
                         ci.set_current_user_node(self)
             else:
                 c.set_current_user_node(self)
 
-    def _ignore(self, c):
+    @classmethod
+    def _ignore(cls, c):
         """ Indicates if a node should be ignored when recursing
         """
-        return c is None or isinstance(c, self._ignored_types)
+        return c is None or isinstance(c, cls._ignored_types)
 
     def invalidate_node(self):
         """ Indicate that this node is temporary.

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -40,7 +40,7 @@ class Basic:
 
             from pyccel.ast.literals import convert_to_literal
 
-            if self._ignore(c):
+            if Basic._ignore(self, c):
                 continue
 
             elif isinstance(c, (int, float, complex, str, bool)):
@@ -63,7 +63,7 @@ class Basic:
 
             if isinstance(c, tuple):
                 for ci in c:
-                    if not self._ignore(ci):
+                    if not Basic._ignore(self, ci):
                         ci.set_current_user_node(self)
             else:
                 c.set_current_user_node(self)

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -40,7 +40,7 @@ class Basic:
 
             from pyccel.ast.literals import convert_to_literal
 
-            if self.ignore(c):
+            if self._ignore(c):
                 continue
 
             elif isinstance(c, (int, float, complex, str, bool)):
@@ -51,7 +51,7 @@ class Basic:
             elif iterable(c):
                 size = len(c)
                 c = tuple(ci if (not isinstance(ci, (int, float, complex, str, bool)) \
-                                 or self.ignore(ci)) \
+                                 or self._ignore(ci)) \
                         else convert_to_literal(ci) for ci in c if not iterable(ci))
                 if len(c) != size:
                     raise TypeError("Basic child cannot be a tuple of tuples")
@@ -63,12 +63,12 @@ class Basic:
 
             if isinstance(c, tuple):
                 for ci in c:
-                    if not self.ignore(ci):
+                    if not self._ignore(ci):
                         ci.set_current_user_node(self)
             else:
                 c.set_current_user_node(self)
 
-    def ignore(self, c):
+    def _ignore(self, c):
         """ Indicates if a node should be ignored when recursing
         """
         return c is None or isinstance(c, self._ignored_types)
@@ -81,10 +81,10 @@ class Basic:
         for c_name in self._my_attribute_nodes:
             c = getattr(self, c_name)
 
-            if self.ignore(c):
+            if self._ignore(c):
                 continue
             elif isinstance(c, tuple):
-                _ = [ci.remove_user_node(self) for ci in c if not self.ignore(ci)]
+                _ = [ci.remove_user_node(self) for ci in c if not self._ignore(ci)]
             else:
                 c.remove_user_node(self)
 
@@ -112,7 +112,7 @@ class Basic:
             results  = [p for p in self._user_nodes if     isinstance(p, search_type) and \
                                                        not isinstance(p, excluded_nodes)]
 
-            results += [r for p in self._user_nodes if not self.ignore(p) and \
+            results += [r for p in self._user_nodes if not self._ignore(p) and \
                                                        not isinstance(p, (search_type, excluded_nodes)) \
                           for r in p.get_user_nodes(search_type, excluded_nodes = excluded_nodes)]
             self._recursion_in_progress = False
@@ -154,11 +154,11 @@ class Basic:
                         continue
                     elif isinstance(vi, search_type):
                         results.append(vi)
-                    elif not self.ignore(vi):
+                    elif not self._ignore(vi):
                         results.extend(vi.get_attribute_nodes(
                             search_type, excluded_nodes=excluded_nodes))
 
-            elif not self.ignore(v):
+            elif not self._ignore(v):
                 results.extend(v.get_attribute_nodes(
                     search_type, excluded_nodes = excluded_nodes))
 
@@ -208,7 +208,7 @@ class Basic:
             elif isinstance(v, excluded_nodes):
                 continue
 
-            elif not self.ignore(v):
+            elif not self._ignore(v):
                 res = self.is_user_of(v, excluded_nodes=excluded_nodes)
                 if res:
                     node.toggle_recursion()
@@ -250,12 +250,12 @@ class Basic:
             rep = replacement[idx]
             if iterable(rep):
                 for r in rep:
-                    if not self.ignore(r):
+                    if not self._ignore(r):
                         r.set_current_user_node(self)
             else:
-                if not self.ignore(rep):
+                if not self._ignore(rep):
                     rep.set_current_user_node(self)
-            if not self.ignore(found_node):
+            if not self._ignore(found_node):
                 found_node.remove_user_node(self, invalidate)
             return rep
 
@@ -275,14 +275,14 @@ class Basic:
                     if not isinstance(vi, excluded_nodes):
                         if vi in original:
                             new_vi = prepare_sub(vi)
-                        elif not self.ignore(vi):
+                        elif not self._ignore(vi):
                             vi.substitute(original, replacement, excluded_nodes, invalidate)
                     if iterable(new_vi):
                         new_v.extend(new_vi)
                     else:
                         new_v.append(new_vi)
                 setattr(self, n, tuple(new_v))
-            elif not self.ignore(v):
+            elif not self._ignore(v):
                 v.substitute(original, replacement, excluded_nodes, invalidate)
         self._recursion_in_progress = False
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2050,10 +2050,11 @@ class FunctionCall(PyccelAstNode):
     def __repr__(self):
         return '{}({})'.format(self.func_name, ', '.join(str(a) for a in self.args))
 
-    def _ignore(self, c):
+    @classmethod
+    def _ignore(cls, c):
         """ Indicates if a node should be ignored when recursing
         """
-        return c is None or isinstance(c, (FunctionDef, *self._ignored_types))
+        return c is None or isinstance(c, (FunctionDef, *cls._ignored_types))
 
 class DottedFunctionCall(FunctionCall):
     """

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2050,6 +2050,11 @@ class FunctionCall(PyccelAstNode):
     def __repr__(self):
         return '{}({})'.format(self.func_name, ', '.join(str(a) for a in self.args))
 
+    def _ignore(self, c):
+        """ Indicates if a node should be ignored when recursing
+        """
+        return c is None or isinstance(c, (FunctionDef, *self._ignored_types))
+
 class DottedFunctionCall(FunctionCall):
     """
     Represents a function call in the code where

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -360,7 +360,7 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
 
         if (isinstance(line, Assign) and
                 not isinstance(line.rhs, (array_creator_types, Nil)) and # not creating array
-                not line.rhs.get_attribute_nodes(array_creator_types, excluded_nodes = (FunctionDef)) and # not creating array
+                not line.rhs.get_attribute_nodes(array_creator_types) and # not creating array
                 not is_function_call(line.rhs)): # not a basic function call
 
             # Collect lhs variable
@@ -394,12 +394,10 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
                                                                           IndexedElement,
                                                                           VariableAddress))]
             variables      += [v for f in elemental_func_calls \
-                                 for v in f.get_attribute_nodes((Variable, IndexedElement, VariableAddress),
-                                                            excluded_nodes = (FunctionDef))]
+                                 for v in f.get_attribute_nodes((Variable, IndexedElement, VariableAddress))]
             transposed_vars = [v for v in notable_nodes if isinstance(v, NumpyTranspose)] \
                                 + [v for f in elemental_func_calls \
-                                     for v in f.get_attribute_nodes(NumpyTranspose,
-                                                            excluded_nodes = (FunctionDef))]
+                                     for v in f.get_attribute_nodes(NumpyTranspose)]
 
             is_checks = [n for n in notable_nodes if isinstance(n, PyccelIs)]
 
@@ -422,8 +420,7 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
             # Collect all variables for which values other than the value indexed in the loop are important
             # E.g. x = np.sum(a) has a dependence on a
             dependencies = set(v for f in chain(funcs, internal_funcs) \
-                                 for v in f.get_attribute_nodes((Variable, IndexedElement, VariableAddress),
-                                     excluded_nodes = (FunctionDef)))
+                                 for v in f.get_attribute_nodes((Variable, IndexedElement, VariableAddress)))
 
             # Replace function calls with temporary variables
             # This ensures that the function is only called once and stops problems
@@ -480,8 +477,8 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
             # Replace variable expressions with Indexed versions
             line.substitute(variables, new_vars, excluded_nodes = (FunctionCall, PyccelInternalFunction))
             line.substitute(transposed_vars, new_vars_t, excluded_nodes = (FunctionCall))
-            _ = [f.substitute(variables, new_vars, excluded_nodes = (FunctionDef)) for f in elemental_func_calls]
-            _ = [f.substitute(transposed_vars, new_vars_t, excluded_nodes = (FunctionDef)) for f in elemental_func_calls]
+            _ = [f.substitute(variables, new_vars) for f in elemental_func_calls]
+            _ = [f.substitute(transposed_vars, new_vars_t) for f in elemental_func_calls]
 
             # Recurse through result tree to save line with lines which need
             # the same set of for loops
@@ -646,7 +643,7 @@ def expand_inhomog_tuple_assignments(block, language_has_vectors = False):
                             order = a.lhs.order,
                             status="unknown"), a)
                     for a in allocs_to_unravel]
-        block.substitute(allocs_to_unravel, new_allocs, excluded_nodes=(FunctionDef,))
+        block.substitute(allocs_to_unravel, new_allocs)
 
     assigns = [a for a in block.get_attribute_nodes(Assign) \
                 if isinstance(a.lhs, InhomogeneousTupleVariable) \

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -646,7 +646,7 @@ def expand_inhomog_tuple_assignments(block, language_has_vectors = False):
                             order = a.lhs.order,
                             status="unknown"), a)
                     for a in allocs_to_unravel]
-        block.substitute(allocs_to_unravel, new_allocs)
+        block.substitute(allocs_to_unravel, new_allocs, excluded_nodes=(FunctionDef,))
 
     assigns = [a for a in block.get_attribute_nodes(Assign) \
                 if isinstance(a.lhs, InhomogeneousTupleVariable) \

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1500,7 +1500,7 @@ class CCodePrinter(CodePrinter):
             else:
                 # make sure that stmt contains one assign node.
                 last_assign = last_assign[-1]
-                variables = last_assign.rhs.get_attribute_nodes(Variable, excluded_nodes=(FunctionDef,))
+                variables = last_assign.rhs.get_attribute_nodes(Variable)
                 unneeded_var = not any(b in vars_in_deallocate_nodes for b in variables)
                 if unneeded_var:
                     code = ''.join(self._print(a) for a in expr.stmt.body if a is not last_assign)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -323,7 +323,7 @@ class FCodePrinter(CodePrinter):
             code = self._print(body)
         else:
             # Search for the return and replace it with an empty node
-            result = body.get_attribute_nodes(Return, excluded_nodes = (FunctionDef,))[0]
+            result = body.get_attribute_nodes(Return)[0]
             empty_return = EmptyNode()
             body.substitute(result, empty_return, invalidate = False)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2846,7 +2846,7 @@ class SemanticParser(BasicParser):
                 errors.report("Determination of main module is too complicated to handle",
                         symbol=expr, severity='error')
 
-        allocations = [arg.get_attribute_nodes(Allocate) for arg in args]
+        allocations = [arg.get_attribute_nodes(Allocate, excluded_nodes=(FunctionDef,)) for arg in args]
 
         var_shapes = [{a.variable : a.shape for a in allocs} for allocs in allocations]
         variables = [v for branch in var_shapes for v in branch]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -977,7 +977,7 @@ class SemanticParser(BasicParser):
                             bounding_box=(self._current_fst_node.lineno,
                                 self._current_fst_node.col_offset))
                         if (isinstance(a, Variable) and not a.is_argument) \
-                                or not all([b.is_argument for b in a.get_attribute_nodes(Variable, excluded_nodes=FunctionDef)]):
+                                or not all([b.is_argument for b in a.get_attribute_nodes(Variable)]):
                             errors.report(STACK_ARRAY_UNKNOWN_SHAPE, symbol=name,
                             severity='error',
                             bounding_box=(self._current_fst_node.lineno,
@@ -2034,7 +2034,7 @@ class SemanticParser(BasicParser):
         return self._handle_function(expr, func, (arg,), **settings)
 
     def _visit_Lambda(self, expr, **settings):
-        expr_names = set(str(a) for a in expr.expr.get_attribute_nodes(PyccelSymbol, excluded_nodes = FunctionDef))
+        expr_names = set(str(a) for a in expr.expr.get_attribute_nodes(PyccelSymbol))
         var_names = map(str, expr.variables)
         missing_vars = expr_names.difference(var_names)
         if len(missing_vars) > 0:
@@ -2847,7 +2847,7 @@ class SemanticParser(BasicParser):
                 errors.report("Determination of main module is too complicated to handle",
                         symbol=expr, severity='error')
 
-        allocations = [arg.get_attribute_nodes(Allocate, excluded_nodes=(FunctionDef,)) for arg in args]
+        allocations = [arg.get_attribute_nodes(Allocate) for arg in args]
 
         var_shapes = [{a.variable : a.shape for a in allocs} for allocs in allocations]
         variables = [v for branch in var_shapes for v in branch]

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.5.0"
+__version__ = "1.5.1"


### PR DESCRIPTION
When calling `get_attribute_nodes` or `substitute` we must always exclude `FunctionDef` unless we are searching for a `FunctionDef`. Otherwise pyccel will search through all the contents of any functions called within the context. This is the cause of the bug in issue #1114 .

This PR fixes #1114 by redefining the class method `ignore` for `FunctionClass` so it never recurses into a `FunctionDef`.
Redundant ` excluded_nodes=(FunctionDef,)` commands are removed