### PR TITLE
Avoid roundoff errors when testing generators

### DIFF
--- a/tests/epyccel/test_epyccel_generators.py
+++ b/tests/epyccel/test_epyccel_generators.py
@@ -139,7 +139,7 @@ def test_nested_generators1(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(sum(a[i,k,o,2] for i in range(5)) for k in range(5)) for o in range(5))
 
-    x = rand(5,5,5,5)*50
+    x = randint(0, 50, shape=(5,5,5,5), dtype=float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -149,7 +149,7 @@ def test_nested_generators2(language):
     def f(a : 'float[:,:,:,:]'):
         return min(min(sum(min(max(a[i,k,o,l]*l for i in range(5)) for k in range(5)) for o in range(5)) for l in range(5)),0.)
 
-    x = rand(5,5,5,5)*50
+    x = randint(0, 50, shape=(5,5,5,5), dtype=float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -159,7 +159,7 @@ def test_nested_generators3(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
-    x = rand(5,5,5,5)*10
+    x = randint(0, 10, shape=(5,5,5,5), dtype=float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -169,7 +169,7 @@ def test_nested_generators4(language):
     def f(a : 'float[:,:,:,:]'):
         return min(max(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
-    x = rand(5,5,5,5)*10
+    x = randint(0, 10, shape=(5,5,5,5), dtype=float)
 
     f_epyc = epyccel(f, language = language)
 

--- a/tests/epyccel/test_epyccel_generators.py
+++ b/tests/epyccel/test_epyccel_generators.py
@@ -139,7 +139,7 @@ def test_nested_generators1(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(sum(a[i,k,o,2] for i in range(5)) for k in range(5)) for o in range(5))
 
-    x = randint(0, 50, shape=(5,5,5,5), dtype=float)
+    x = randint(0, 50, size=(5,5,5,5), dtype=float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -149,7 +149,7 @@ def test_nested_generators2(language):
     def f(a : 'float[:,:,:,:]'):
         return min(min(sum(min(max(a[i,k,o,l]*l for i in range(5)) for k in range(5)) for o in range(5)) for l in range(5)),0.)
 
-    x = randint(0, 50, shape=(5,5,5,5), dtype=float)
+    x = randint(0, 50, size=(5,5,5,5), dtype=float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -159,7 +159,7 @@ def test_nested_generators3(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
-    x = randint(0, 10, shape=(5,5,5,5), dtype=float)
+    x = randint(0, 10, size=(5,5,5,5), dtype=float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -169,7 +169,7 @@ def test_nested_generators4(language):
     def f(a : 'float[:,:,:,:]'):
         return min(max(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
-    x = randint(0, 10, shape=(5,5,5,5), dtype=float)
+    x = randint(0, 10, size=(5,5,5,5), dtype=float)
 
     f_epyc = epyccel(f, language = language)
 

--- a/tests/epyccel/test_epyccel_generators.py
+++ b/tests/epyccel/test_epyccel_generators.py
@@ -139,7 +139,7 @@ def test_nested_generators1(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(sum(a[i,k,o,2] for i in range(5)) for k in range(5)) for o in range(5))
 
-    x = randint(0, 50, size=(5,5,5,5), dtype=float)
+    x = randint(0, 50, size=(5,5,5,5)).astype(float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -149,7 +149,7 @@ def test_nested_generators2(language):
     def f(a : 'float[:,:,:,:]'):
         return min(min(sum(min(max(a[i,k,o,l]*l for i in range(5)) for k in range(5)) for o in range(5)) for l in range(5)),0.)
 
-    x = randint(0, 50, size=(5,5,5,5), dtype=float)
+    x = randint(0, 50, size=(5,5,5,5)).astype(float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -159,7 +159,7 @@ def test_nested_generators3(language):
     def f(a : 'float[:,:,:,:]'):
         return sum(sum(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
-    x = randint(0, 10, size=(5,5,5,5), dtype=float)
+    x = randint(0, 10, size=(5,5,5,5)).astype(float)
 
     f_epyc = epyccel(f, language = language)
 
@@ -169,7 +169,7 @@ def test_nested_generators4(language):
     def f(a : 'float[:,:,:,:]'):
         return min(max(a[i,k,4,2] for i in range(5)) for k in range(5))**2
 
-    x = randint(0, 10, size=(5,5,5,5), dtype=float)
+    x = randint(0, 10, size=(5,5,5,5)).astype(float)
 
     f_epyc = epyccel(f, language = language)
 


### PR DESCRIPTION
Use `randint` instead of `rand`, in order to avoid the effect of roundoff errors on the final result