### PR TITLE
Fix import of two files that import the same file

### DIFF
--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -209,9 +209,11 @@ class Parser(object):
                 print ('>>> treating :: {}'.format(source))
 
             # get the absolute path corresponding to source
-
-            filename = get_filename_from_import(source, self._input_folder)
-            q = Parser(filename)
+            if source in d_parsers:
+                q = d_parsers[source]
+            else:
+                filename = get_filename_from_import(source, self._input_folder)
+                q = Parser(filename)
             q.parse(d_parsers=d_parsers)
             d_parsers[source] = q
 

--- a/tests/pyccel/project_multi_imports/file1.py
+++ b/tests/pyccel/project_multi_imports/file1.py
@@ -1,0 +1,2 @@
+def hello_world():
+    print("Hello World!")

--- a/tests/pyccel/project_multi_imports/file2.py
+++ b/tests/pyccel/project_multi_imports/file2.py
@@ -1,0 +1,3 @@
+import file1 as f1
+def hello_world():
+    f1.hello_world()

--- a/tests/pyccel/project_multi_imports/file3.py
+++ b/tests/pyccel/project_multi_imports/file3.py
@@ -1,0 +1,3 @@
+import file2 as f2
+def hello_world():
+    f2.hello_world()

--- a/tests/pyccel/project_multi_imports/file4.py
+++ b/tests/pyccel/project_multi_imports/file4.py
@@ -1,0 +1,6 @@
+import file3 as f3
+import file2 as f2
+
+if __name__ == '__main__':
+    f2.hello_world()
+    f3.hello_world()

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -356,6 +356,28 @@ def test_rel_imports_python_accessible_folder(language):
     compare_pyth_fort_output(pyth_out, fort_out)
 
 #------------------------------------------------------------------------------
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("python", marks = pytest.mark.python),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="Collisions are not handled"),
+            pytest.mark.c]
+        )
+    )
+)
+def test_multi_imports_project(language):
+
+    base_dir = os.path.dirname(os.path.realpath(__file__))
+    path_dir = os.path.join(base_dir, "project_multi_imports")
+    dependencies = ['project_multi_imports/file1.py',
+             'project_multi_imports/file2.py',
+             'project_multi_imports/file3.py']
+    pyccel_test("project_multi_imports/file4.py", dependencies,
+            cwd = path_dir,
+            language = language,
+            output_dtype = str)
+
+#------------------------------------------------------------------------------
 @pytest.mark.xdist_incompatible
 def test_imports_compile(language):
     pyccel_test("scripts/runtest_imports.py","scripts/funcs.py",


### PR DESCRIPTION
The `d_parsers` may be updated during the parse stage however this information was not previously taken into account leading to the same file being parsed multiple times and sometimes overwritten.