### PR TITLE
Allow None in equality operators

### DIFF
--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -794,7 +794,7 @@ class PyccelNe(PyccelComparisonOperator):
     I.e:
         a != b
     is equivalent to:
-        PyccelEq(a, b)
+        PyccelNe(a, b)
 
     Parameters
     ----------

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -2,8 +2,6 @@
 # This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
 # go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
 #------------------------------------------------------------------------------------------#
-# TODO [EB 12.03.21]: Remove pylint command with PR #797
-# pylint: disable=W0201
 """
 Module handling all python builtin operators
 These operators all have a precision as detailed here:
@@ -781,6 +779,12 @@ class PyccelEq(PyccelComparisonOperator):
     """
     __slots__ = ()
 
+    def __new__(cls, arg1, arg2, simplify = False):
+        if isinstance(arg1, Nil) or isinstance(arg2, Nil):
+            return PyccelIs(arg1, arg2)
+        else:
+            return super().__new__(cls)
+
     def __repr__(self):
         return '{} == {}'.format(self.args[0], self.args[1])
 
@@ -800,6 +804,12 @@ class PyccelNe(PyccelComparisonOperator):
         The second argument passed to the operator
     """
     __slots__ = ()
+
+    def __new__(cls, arg1, arg2, simplify = False):
+        if isinstance(arg1, Nil) or isinstance(arg2, Nil):
+            return PyccelIsNot(arg1, arg2)
+        else:
+            return super().__new__(cls)
 
     def __repr__(self):
         return '{} != {}'.format(self.args[0], self.args[1])

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3463,7 +3463,12 @@ class SemanticParser(BasicParser):
             var1, var2 = var2, var1
 
         if isinstance(var2, Nil):
-            if not var1.is_optional:
+            if not isinstance(var1, Variable):
+                if IsClass == PyccelIsNot:
+                    return LiteralTrue()
+                elif IsClass == PyccelIs:
+                    return LiteralFalse()
+            elif not var1.is_optional:
                 errors.report(PYCCEL_RESTRICTION_OPTIONAL_NONE,
                         bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                         severity='error')

--- a/tests/epyccel/modules/base.py
+++ b/tests/epyccel/modules/base.py
@@ -219,3 +219,12 @@ def use_optional(a : int = None):
     if a:
         b += a
     return b
+
+def none_equality(a : int = None):
+    return a == None, a != None
+
+def none_none_equality():
+    return None == None, None != None
+
+def none_literal_equality():
+    return None == 1, 3.5 != None

--- a/tests/epyccel/modules/base.py
+++ b/tests/epyccel/modules/base.py
@@ -221,10 +221,10 @@ def use_optional(a : int = None):
     return b
 
 def none_equality(a : int = None):
-    return a == None, a != None
+    return a == None, a != None #pylint: disable=singleton-comparison
 
 def none_none_equality():
-    return None == None, None != None
+    return None == None, None != None #pylint: disable=singleton-comparison, comparison-with-itself
 
 def none_literal_equality():
-    return None == 1, 3.5 != None
+    return None == 1, 3.5 != None #pylint: disable=singleton-comparison

--- a/tests/epyccel/test_base.py
+++ b/tests/epyccel/test_base.py
@@ -177,3 +177,16 @@ def test_use_optional(language):
     test = epyccel_test(base.use_optional, lang=language)
     test.compare_epyccel()
     test.compare_epyccel(6)
+
+def test_none_equality(language):
+    test = epyccel_test(base.none_equality, lang=language)
+    test.compare_epyccel()
+    test.compare_epyccel(6)
+
+def test_none_none_equality(language):
+    test = epyccel_test(base.none_none_equality, lang=language)
+    test.compare_epyccel()
+
+def test_none_literal_equality(language):
+    test = epyccel_test(base.none_literal_equality, lang=language)
+    test.compare_epyccel()

--- a/tests/epyccel/utilities.py
+++ b/tests/epyccel/utilities.py
@@ -19,4 +19,4 @@ class epyccel_test:
     def compare_epyccel(self, *args):
         out1 = self._f(*args)
         out2 = self._f2(*args)
-        assert np.equal(out1, out2 )
+        assert np.equal(out1, out2 ).all()


### PR DESCRIPTION
Convert equality operators to `is` operators if one of the arguments is `None`. Allow the case where `None` is compared to a literal