### PR TITLE
Fix bug preventing exporting arrays with an uppercase letter in the name

### DIFF
--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -343,7 +343,7 @@ def wrap_module_array_var(var, scope, mod):
     func : FunctionDef
             A function which wraps an array and can be called from C
     """
-    func_name = 'bind_c_'+var.name
+    func_name = 'bind_c_'+var.name.lower()
     func_scope = scope.new_child_scope(func_name)
     body, necessary_vars = wrap_array(var, func_scope, True)
     func_scope.insert_variable(necessary_vars[0])

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -790,7 +790,7 @@ class PyccelNe(PyccelComparisonOperator):
     I.e:
         a != b
     is equivalent to:
-        PyccelEq(a, b)
+        PyccelNe(a, b)
 
     Parameters
     ----------

--- a/tests/epyccel/modules/array_consts.py
+++ b/tests/epyccel/modules/array_consts.py
@@ -6,7 +6,7 @@ b = np.array([1,2,3,4,5])
 c = np.zeros((2,3), dtype=np.int32)
 d = np.array([1+2j, 3+4j])
 e = np.empty((2,3,4))
-f = [False for _ in range(5)]
+F = [False for _ in range(5)]
 
 def update_a():
     a[:] = a+1

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -130,7 +130,7 @@ def test_module_7(language):
         assert np.array_equal(mod_att, modnew_att)
         assert mod_att.dtype == modnew_att.dtype
 
-    assert np.array_equal(mod.f, modnew.f)
+    assert np.array_equal(mod.F, modnew.F)
 
     modnew.update_a()
     mod.update_a()


### PR DESCRIPTION
Fortran is case-insensitive, hence all symbols are saved in the .o file as lower case values. When calling a Fortran function from C, which is case sensitive, everything needs to be lower case. This was not done in function `wrap_module_array_var` of our `bind_c` files, which led to linker errors.

**List of changes**

- Bug-fix: ensure that `bind_c` names only contain lower case letters
- Add a unit test