### PR TITLE
Correct indenting

### DIFF
--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -185,7 +185,7 @@ type_to_print_format = {
 
 inc_keyword = (r'do\b', r'if\b',
                r'else\b', r'type\b\s*[^\(]',
-               r'(recursive )?(pure )?(elemental )?((subroutine)|(function))\b',
+               r'(recursive )?(elemental )?(pure )?((subroutine)|(function))\b',
                r'interface\b',r'module\b(?! *procedure)',r'program\b')
 inc_regex = re.compile('|'.join('({})'.format(i) for i in inc_keyword))
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -185,7 +185,7 @@ type_to_print_format = {
 
 inc_keyword = (r'do\b', r'if\b',
                r'else\b', r'type\b\s*[^\(]',
-               r'(recursive )?(elemental )?(pure )?((subroutine)|(function))\b',
+               r'(elemental )?(pure )?(recursive )?((subroutine)|(function))\b',
                r'interface\b',r'module\b(?! *procedure)',r'program\b')
 inc_regex = re.compile('|'.join('({})'.format(i) for i in inc_keyword))
 
@@ -1877,12 +1877,12 @@ class FCodePrinter(CodePrinter):
             if i in out_args:
                 out_args.remove(i)
 
-        # treate case of pure function
+        # treat case of pure function
         sig = '{0}{1} {2}'.format(rec, func_type, name)
         if is_pure:
             sig = 'pure {}'.format(sig)
 
-        # treate case of elemental function
+        # treat case of elemental function
         if is_elemental:
             sig = 'elemental {}'.format(sig)
 


### PR DESCRIPTION
The indenting regex doesn't match the printing order which leads to incorrect printing if `@pure` and `@elemental` are used. This PR swaps the order to match what is done in `_print_FunctionDef`.