### PR TITLE
Fix wrong complex precision printing

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -884,7 +884,7 @@ class PythonType(Basic):
         str_dtype = str(self.dtype)
         return LiteralString("<class '{dtype}{precision}'>".format(
             dtype = str_dtype,
-            precision = '' if prec in (None, -1) else (prec*8*[1, 2][str_dtype=="complex"])))
+            precision = '' if prec in (None, -1) else (prec * 8 * (2 if str_dtype=="complex" else 1))))
 
 #==============================================================================
 python_builtin_datatypes_dict = {

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -881,9 +881,10 @@ class PythonType(Basic):
         can be used in a print  statement
         """
         prec = self.precision
+        str_dtype = str(self.dtype)
         return LiteralString("<class '{dtype}{precision}'>".format(
-            dtype = str(self.dtype),
-            precision = '' if prec in (None, -1) else prec*8))
+            dtype = str_dtype,
+            precision = '' if prec in (None, -1) else (prec*8*[1, 2][str_dtype=="complex"])))
 
 #==============================================================================
 python_builtin_datatypes_dict = {

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -881,10 +881,9 @@ class PythonType(Basic):
         can be used in a print  statement
         """
         prec = self.precision
-        str_dtype = str(self.dtype)
         return LiteralString("<class '{dtype}{precision}'>".format(
-            dtype = str_dtype,
-            precision = '' if prec in (None, -1) else (prec * 8 * (2 if str_dtype=="complex" else 1))))
+            dtype = str(self.dtype),
+            precision = '' if prec in (None, -1) else (prec * (16 if self.dtype is NativeComplex() else 8))))
 
 #==============================================================================
 python_builtin_datatypes_dict = {

--- a/tests/pyccel/scripts/runtest_type_print.py
+++ b/tests/pyccel/scripts/runtest_type_print.py
@@ -7,3 +7,6 @@ if __name__ == '__main__':
     print(type(np.int64(3)))
     print(type(np.float32(3)))
     print(type(np.float64(3)))
+    print(type(np.complex(3)))
+    print(type(np.complex64(3)))
+    print(type(np.complex128(3)))


### PR DESCRIPTION
Multiplied complex precision by 2.
Now `<class 'complex64'>` is printed instead of `<class 'complex32'>` for the following code:
```python3
import numpy as np
if __name__ == "__main__":
    a = np.complex64(3)
    print(type(a))
```
Fixes https://github.com/pyccel/pyccel/issues/1134