### PR TITLE
Fix non-literal negative indexes for C ordered ndarrays

### DIFF
--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2821,7 +2821,7 @@ class FCodePrinter(CodePrinter):
                     inds[i] = ind[0]
                 if allow_negative_indexes and not isinstance(ind, LiteralInteger):
                     inds[i] = IfTernaryOperator(PyccelLt(ind, LiteralInteger(0)),
-                            PyccelAdd(base_shape[i], ind, simplify = True), ind)
+                            PyccelAdd(_shape, ind, simplify = True), ind)
 
         inds = [self._print(i) for i in inds]
 

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -791,6 +791,20 @@ def test_argument_negative_index_2(a, b):
     d = 3
     return a[c], a[d], b[c], b[d]
 
+@allow_negative_index('a', 'b')
+@types('int[:,:]', 'int[:,:]')
+def test_c_order_argument_negative_index(a, b):
+    c = -2
+    d = 2
+    return a[c,0], a[1,d], b[c,1], b[d,0]
+
+@allow_negative_index('a', 'b')
+@types('int[:,:](order=F)', 'int[:,:](order=F)')
+def test_f_order_argument_negative_index(a, b):
+    c = -2
+    d = 3
+    return a[c,0], a[1,d], b[c,1], b[0,d]
+
 #==============================================================================
 # SHAPE INITIALISATION
 #==============================================================================

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1842,6 +1842,20 @@ def test_argument_negative_index_2(language):
     f2 = epyccel(f1, language = language)
     assert np.array_equal(f1(a, a), f2(a, a))
 
+def test_c_order_argument_negative_index(language):
+    a = np.random.randint(20, size=(3,4))
+
+    f1 = arrays.test_c_order_argument_negative_index
+    f2 = epyccel(f1, language = language)
+    assert np.array_equal(f1(a, a), f2(a, a))
+
+def test_f_order_argument_negative_index(language):
+    a = np.array(np.random.randint(20, size=(3,4)), order='F')
+
+    f1 = arrays.test_f_order_argument_negative_index
+    f2 = epyccel(f1, language = language)
+    assert np.array_equal(f1(a, a), f2(a, a))
+
 #==============================================================================
 # TEST: shape initialisation
 #==============================================================================


### PR DESCRIPTION
Fix Fortran printing of non-literal index expressions when `allow_negative_index` decorator is used on C-ordered Numpy arrays (fixes #979). Add tests.