### PR TITLE
Fix modulo in augassign

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -222,10 +222,6 @@ ndarray_type_registry = {
                   ('int',1)     : 'nd_int8',
                   ('bool',4)    : 'nd_bool'}
 
-modulo_fmod = {
-    'double': 'fmod',
-    'float' : 'fmodf'}
-
 import_dict = {'omp_lib' : 'omp' }
 
 c_imports = {n : Import(n, Module(n, (), ())) for n in

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1642,7 +1642,7 @@ class CCodePrinter(CodePrinter):
 
         lhs_code = self._print(lhs)
         rhs_code = self._print(rhs)
-        return '{} {}= {};\n'.format(lhs_code, op, rhs_code)
+        return f'{lhs_code} {op}= {rhs_code};\n'
 
     def _print_Assign(self, expr):
         prefix_code = ''

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1636,22 +1636,8 @@ class CCodePrinter(CodePrinter):
         return '-{}'.format(self._print(expr.args[0]))
 
     def _print_AugAssign(self, expr):
-        op = expr.op
-        lhs = expr.lhs
-        rhs = expr.rhs
-        lhs_code = self._print(lhs)
-        rhs_code = self._print(rhs)
-        if op == '%':
-            # Two cases where this works: (NativeFloat and NativeFloat), (NativeFloat and NativeInt)
-            # The case (NativeInt and NativeFloat) would cause a type change error.
-            if isinstance(lhs.dtype, NativeFloat) or isinstance(rhs.dtype, NativeFloat):
-                self.add_import(c_imports['math'])
-                # Get (dtype, precision) pair for dtype_registry
-                key  = (str(lhs.dtype), get_final_precision(lhs))
-                # Get the proper modulo function (fmod for doubles, fmodf for floats)
-                func = modulo_fmod[dtype_registry[key]]
-                return "{0} = {1}({0}, {2});\n".format(lhs_code, func, rhs_code)
-        return "{0} {1}= {2};\n".format(self._print(lhs), op, self._print(rhs))
+        _expr = expr.to_basic_assign()
+        return self._print(_expr)
 
     def _print_Assign(self, expr):
         prefix_code = ''

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1636,8 +1636,17 @@ class CCodePrinter(CodePrinter):
         return '-{}'.format(self._print(expr.args[0]))
 
     def _print_AugAssign(self, expr):
-        _expr = expr.to_basic_assign()
-        return self._print(_expr)
+        op = expr.op
+        lhs = expr.lhs
+        rhs = expr.rhs
+
+        if op == '%' and isinstance(lhs.dtype, NativeFloat):
+            _expr = expr.to_basic_assign()
+            return self._print(_expr)
+
+        lhs_code = self._print(lhs)
+        rhs_code = self._print(rhs)
+        return '{} {}= {};\n'.format(lhs_code, op, rhs_code)
 
     def _print_Assign(self, expr):
         prefix_code = ''

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -287,6 +287,10 @@ def array_real_1d_scalar_mul( x, a ):
 def array_real_1d_scalar_div( x, a ):
     x[:] /= a
 
+@types( 'real[:]', 'real')
+def array_real_1d_scalar_mod( x, a ):
+    x[:] %= a
+
 @types( 'real[:]', 'real' )
 def array_real_1d_scalar_idiv( x, a ):
     x[:] = x // a
@@ -306,6 +310,10 @@ def array_real_1d_mul( x, y ):
 @types( 'real[:]', 'real[:]' )
 def array_real_1d_div( x, y ):
     x[:] /= y
+
+@types( 'real[:]', 'real[:]')
+def array_real_1d_mod( x, y ):
+    x[:] %= y
 
 @types( 'real[:]', 'real[:]' )
 def array_real_1d_idiv( x, y ):
@@ -331,6 +339,10 @@ def array_real_2d_C_scalar_mul( x, a ):
 def array_real_2d_C_scalar_div( x, a ):
     x[:,:] /= a
 
+@types( 'real[:,:]', 'real' )
+def array_real_2d_C_scalar_mod( x, a ):
+    x[:,:] %= a
+
 @types( 'real[:,:]', 'real[:,:]' )
 def array_real_2d_C_add( x, y ):
     x[:,:] += y
@@ -346,6 +358,10 @@ def array_real_2d_C_mul( x, y ):
 @types( 'real[:,:]', 'real[:,:]' )
 def array_real_2d_C_div( x, y ):
     x[:,:] /= y
+
+@types( 'real[:,:]', 'real[:,:]' )
+def array_real_2d_C_mod( x, y ):
+    x[:,:] %= y
 
 @types('real[:,:]')
 def array_real_2d_C_array_initialization(a):
@@ -393,6 +409,10 @@ def array_real_2d_F_scalar_mul( x, a ):
 def array_real_2d_F_scalar_div( x, a ):
     x[:,:] /= a
 
+@types( 'real[:,:](order=F)', 'real' )
+def array_real_2d_F_scalar_mod( x, a ):
+    x[:,:] %= a
+
 @types( 'real[:,:](order=F)', 'real[:,:](order=F)' )
 def array_real_2d_F_add( x, y ):
     x[:,:] += y
@@ -408,6 +428,10 @@ def array_real_2d_F_mul( x, y ):
 @types( 'real[:,:](order=F)', 'real[:,:](order=F)' )
 def array_real_2d_F_div( x, y ):
     x[:,:] /= y
+
+@types( 'real[:,:](order=F)', 'real[:,:](order=F)' )
+def array_real_2d_F_mod( x, y ):
+    x[:,:] %= y
 
 @types('real[:,:](order=F)')
 def array_real_2d_F_array_initialization(a):

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -873,6 +873,19 @@ def test_array_real_1d_scalar_div(language):
 
     assert np.array_equal( x1, x2 )
 
+def test_array_real_1d_scalar_mod(language):
+    f1 = arrays.array_real_1d_scalar_mod
+    f2 = epyccel( f1 , language = language)
+
+    x1 = np.array( [1.,2.,3.] )
+    x2 = np.copy(x1)
+    a = 5.
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
 def test_array_real_1d_scalar_idiv(language):
 
     f1 = arrays.array_real_1d_scalar_idiv
@@ -942,6 +955,20 @@ def test_array_real_1d_div(language):
     f2(x2, a)
 
     assert np.array_equal( x1, x2 )
+
+def test_array_real_1d_mod(language):
+
+    f1 = arrays.array_real_1d_mod
+    f2 = epyccel( f1 , language = language)
+
+    x1 = np.array( [1.,2.,3.] )
+    x2 = np.copy(x1)
+    a  = np.array( [1.,2.,3.] )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2)
 
 def test_array_real_1d_idiv(language):
 
@@ -1017,6 +1044,20 @@ def test_array_real_2d_C_scalar_div(language):
 
     assert np.array_equal( x1, x2 )
 
+def test_array_real_2d_C_scalar_mod(language):
+
+    f1 = arrays.array_real_2d_C_scalar_mod
+    f2 = epyccel( f1 , language = language)
+
+    x1 = np.array( [[1.,2.,3.], [4.,5.,6.]] )
+    x2 = np.copy(x1)
+    a = 5.
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
 def test_array_real_2d_C_add(language):
 
     f1 = arrays.array_real_2d_C_add
@@ -1062,6 +1103,20 @@ def test_array_real_2d_C_mul(language):
 def test_array_real_2d_C_div(language):
 
     f1 = arrays.array_real_2d_C_div
+    f2 = epyccel( f1 , language = language)
+
+    x1 = np.array( [[1.,2.,3.], [4.,5.,6.]] )
+    x2 = np.copy(x1)
+    a  = np.array( [[-1.,-2.,-3.], [-4.,-5.,-6.]] )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
+def test_array_real_2d_C_mod(language):
+
+    f1 = arrays.array_real_2d_C_mod
     f2 = epyccel( f1 , language = language)
 
     x1 = np.array( [[1.,2.,3.], [4.,5.,6.]] )
@@ -1206,6 +1261,20 @@ def test_array_real_2d_F_scalar_div(language):
 
     assert np.array_equal( x1, x2 )
 
+def test_array_real_2d_F_scalar_mod(language):
+
+    f1 = arrays.array_real_2d_F_scalar_mod
+    f2 = epyccel( f1 , language = language)
+
+    x1 = np.array( [[1.,2.,3.], [4.,5.,6.]], order='F' )
+    x2 = np.copy(x1)
+    a = 5.
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
 def test_array_real_2d_F_add(language):
 
     f1 = arrays.array_real_2d_F_add
@@ -1251,6 +1320,20 @@ def test_array_real_2d_F_mul(language):
 def test_array_real_2d_F_div(language):
 
     f1 = arrays.array_real_2d_F_div
+    f2 = epyccel( f1 , language = language)
+
+    x1 = np.array( [[1.,2.,3.], [4.,5.,6.]], order='F' )
+    x2 = np.copy(x1)
+    a  = np.array( [[-1.,-2.,-3.], [-4.,-5.,-6.]], order='F' )
+
+    f1(x1, a)
+    f2(x2, a)
+
+    assert np.array_equal( x1, x2 )
+
+def test_array_real_2d_F_mod(language):
+
+    f1 = arrays.array_real_2d_F_mod
     f2 = epyccel( f1 , language = language)
 
     x1 = np.array( [[1.,2.,3.], [4.,5.,6.]], order='F' )


### PR DESCRIPTION
Fix #1172: C printer now supports `%=` operation with doubles and floats using `fmod` and `fmodf` functions.