### PR TITLE
Pyccel internal Cuda integration.

### DIFF
--- a/.github/actions/cuda_install/action.yml
+++ b/.github/actions/cuda_install/action.yml
@@ -5,8 +5,11 @@ runs:
   steps:
     - name: add cuda package
       run:
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb   
-        sudo dpkg -i cuda-keyring_1.0-1_all.deb
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+        sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+        wget https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda-repo-ubuntu2004-11-7-local_11.7.1-515.65.01-1_amd64.deb
+        sudo dpkg -i cuda-repo-ubuntu2004-11-7-local_11.7.1-515.65.01-1_amd64.deb
+        sudo cp /var/cuda-repo-ubuntu2004-11-7-local/cuda-*-keyring.gpg /usr/share/keyrings/
       shell: bash
     - name: update the package list
       run:

--- a/.github/actions/cuda_install/action.yml
+++ b/.github/actions/cuda_install/action.yml
@@ -1,0 +1,18 @@
+name: 'Cuda installation commands'
+
+runs:
+  using: "composite"
+  steps:
+    - name: add cuda package
+      run:
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb   
+        sudo dpkg -i cuda-keyring_1.0-1_all.deb
+      shell: bash
+    - name: update the package list
+      run:
+        sudo apt-get update
+      shell: bash
+    - name: install cuda
+      run:
+        sudo apt-get -y install cuda
+      shell: bash

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
     - name: Install Pip
       run:
-        apt-get install python3-pip
+        apt-get -y install python3-pip
       shell: bash
     - name: Install LaPack
       run:

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -14,6 +14,9 @@ runs:
     - name: Install python
       run:
         apt-get -y install python3-dev
+      shell: bash
+    - name: python as python3
+      run:
         apt-get -y install python-is-python3
       shell: bash
     - name: Install LaPack

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -19,6 +19,10 @@ runs:
       run:
         apt-get -y install python-is-python3
       shell: bash
+    - name: Install Pip
+      run:
+        apt-get install python3-pip
+      shell: bash
     - name: Install LaPack
       run:
         apt-get -y install libblas-dev liblapack-dev

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -17,8 +17,7 @@ runs:
       shell: bash
     - name: Install MPI
       run: |
-        DEBIAN_FRONTEND=noninteractive
-        apt-get -y install libopenmpi-dev openmpi-bin
+        DEBIAN_FRONTEND=noninteractive TZ=Africa/Morocco apt-get -y install libopenmpi-dev openmpi-bin
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash
     - name: Install OpenMP

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -11,6 +11,10 @@ runs:
       run:
         apt-get -y install gfortran
       shell: bash
+    - name: Install python
+      run:
+        apt-get -y install python3-dev
+      shell: bash
     - name: Install LaPack
       run:
         apt-get -y install libblas-dev liblapack-dev

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -5,26 +5,26 @@ runs:
   steps:
     - name: update the package list
       run:
-        sudo apt-get update
+        apt-get update
       shell: bash
     - name: Install fortran
       run:
-        sudo apt-get install gfortran
+        apt-get install gfortran
       shell: bash
     - name: Install LaPack
       run:
-        sudo apt-get install libblas-dev liblapack-dev
+        apt-get install libblas-dev liblapack-dev
       shell: bash
     - name: Install MPI
       run: |
-        sudo apt-get install libopenmpi-dev openmpi-bin
+        apt-get install libopenmpi-dev openmpi-bin
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash
     - name: Install OpenMP
       run:
-        sudo apt-get install libomp-dev libomp5
+        apt-get install libomp-dev libomp5
       shell: bash
     - name: Install Valgrind
       run:
-        sudo apt-get install valgrind
+        apt-get install valgrind
       shell: bash

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
     - name: Install MPI
       run: |
-        DEBIAN_FRONTEND=noninteractive TZ=Africa/Morocco apt-get -y install libopenmpi-dev openmpi-bin
+        DEBIAN_FRONTEND=noninteractive apt-get -y install libopenmpi-dev openmpi-bin
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash
     - name: Install OpenMP

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -9,22 +9,22 @@ runs:
       shell: bash
     - name: Install fortran
       run:
-        apt-get install gfortran
+        apt-get -y install gfortran
       shell: bash
     - name: Install LaPack
       run:
-        apt-get install libblas-dev liblapack-dev
+        apt-get -y install libblas-dev liblapack-dev
       shell: bash
     - name: Install MPI
       run: |
-        apt-get install libopenmpi-dev openmpi-bin
+        apt-get -y install libopenmpi-dev openmpi-bin
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash
     - name: Install OpenMP
       run:
-        apt-get install libomp-dev libomp5
+        apt-get -y install libomp-dev libomp5
       shell: bash
     - name: Install Valgrind
       run:
-        apt-get install valgrind
+        apt-get -y install valgrind
       shell: bash

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Install python
       run:
         apt-get -y install python3-dev
-        apt install -y python-is-python3
+        apt-get -y install python-is-python3
       shell: bash
     - name: Install LaPack
       run:

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -14,6 +14,7 @@ runs:
     - name: Install python
       run:
         apt-get -y install python3-dev
+        apt install -y python-is-python3
       shell: bash
     - name: Install LaPack
       run:

--- a/.github/actions/linux_install/action.yml
+++ b/.github/actions/linux_install/action.yml
@@ -17,6 +17,7 @@ runs:
       shell: bash
     - name: Install MPI
       run: |
+        DEBIAN_FRONTEND=noninteractive
         apt-get -y install libopenmpi-dev openmpi-bin
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -15,8 +15,8 @@ runs:
         python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
         python -m pytest -rX -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
-        python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and not (c or python)" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rX -m "xdist_incompatible and not parallel and not (c or python)" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and fortran" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rX -m "xdist_incompatible and not parallel and fortran" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
         python -m pytest ndarrays/ -rX
         pyccel-clean

--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -15,8 +15,8 @@ runs:
         python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
         python -m pytest -rX -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
-        python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and fortran" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rX -m "xdist_incompatible and not parallel and fortran" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and not (c or python)" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rX -m "xdist_incompatible and not parallel and not (c or python)" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
         python -m pytest ndarrays/ -rX
         pyccel-clean

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -10,7 +10,9 @@ runs:
   steps:
     - name: Ccuda tests with pytest
       run: |
+        which python
+        which pyccel
         python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=tests/symbolic --ignore=tests/ndarrays
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
-      working-directory: ./
+      working-directory: ./tests

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -10,7 +10,9 @@ runs:
   steps:
     - name: Ccuda tests with pytest
       run: |
-        ls -R .
         python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
+        ls .
+        pyccel-clean
+        ls .
       shell: ${{ inputs.shell_cmd }}
       working-directory: .

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -12,7 +12,7 @@ runs:
       run: |
         which python
         which pyccel
-        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=tests/symbolic --ignore=tests/ndarrays
+        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -11,8 +11,6 @@ runs:
     - name: Ccuda tests with pytest
       run: |
         python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
-        ls .
         pyccel-clean
-        ls .
       shell: ${{ inputs.shell_cmd }}
-      working-directory: .
+      working-directory: ./tests

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -1,0 +1,16 @@
+name: 'Pyccel pytest commands generating Ccuda'
+inputs:
+  shell_cmd:
+    description: 'Specifies the shell command (different for anaconda)'
+    required: false
+    default: "bash"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Ccuda tests with pytest
+      run: |
+        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
+        pyccel-clean
+      shell: ${{ inputs.shell_cmd }}
+      working-directory: ./tests

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -10,6 +10,7 @@ runs:
   steps:
     - name: Ccuda tests with pytest
       run: |
+        ls -R .
         python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -13,4 +13,4 @@ runs:
         ls -R .
         python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
       shell: ${{ inputs.shell_cmd }}
-      working-directory: ./tests
+      working-directory: .

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -11,6 +11,5 @@ runs:
     - name: Ccuda tests with pytest
       run: |
         python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
-        pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - name: Ccuda tests with pytest
       run: |
-        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=tests/symbolic --ignore=tests/ndarrays
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
-      working-directory: ./tests
+      working-directory: ./

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -21,14 +21,8 @@ jobs:
         uses: ./.github/actions/pip_installation
       - name: Coverage install
         uses: ./.github/actions/coverage_install
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
-      - name: Test with valgrind for memory leaks
-        uses: ./.github/actions/valgrind_run
+      - name: CCUDA Compilation test
+        run: nvcc --version # cuda install check
       - name: Collect coverage information
         continue-on-error: True
         uses: ./.github/actions/coverage_collection

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -17,6 +17,8 @@ jobs:
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
+      - name: paths
+        uses: which python ; which pyccel
       # - name: Fortran/C tests with pytest
       #   uses: ./.github/actions/pytest_run
       - name: Ccuda tests with pytest

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -8,7 +8,7 @@ jobs:
   Linux:
 
     runs-on: ubuntu-latest
-
+    container: nvidia/cuda:11.7.1-base-ubuntu20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7
@@ -17,9 +17,7 @@ jobs:
           python-version: 3.7
       - name: Install dependencies
         uses: ./.github/actions/linux_install
-      - name: CUDA install
-        uses: ./.github/actions/cuda_install
-      - name: CCUDA Compilation test
+      - name: CUDA Version
         run: nvcc --version # cuda install check
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -17,8 +17,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.7
-      # - name: Install dependencies
-      #   uses: ./.github/actions/linux_install
+      - name: Install dependencies
+        uses: ./.github/actions/linux_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
       - name: Coverage install

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -11,14 +11,14 @@ jobs:
     container: nvidia/cuda:11.7.1-devel-ubuntu20.04
     steps:
       - uses: actions/checkout@v2
+      - name: CUDA Version
+        run: nvcc --version # cuda install check
       - name: Set up Python 3.7
         uses: actions/setup-python@v3
         with:
           python-version: 3.7
       # - name: Install dependencies
       #   uses: ./.github/actions/linux_install
-      - name: CUDA Version
-        run: nvcc --version # cuda install check
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
       - name: Coverage install

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -17,12 +17,14 @@ jobs:
           python-version: 3.7
       - name: Install dependencies
         uses: ./.github/actions/linux_install
+      - name: CUDA install
+        uses: ./.github/actions/cuda_install
+      - name: CCUDA Compilation test
+        run: nvcc --version # cuda install check
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
       - name: Coverage install
         uses: ./.github/actions/coverage_install
-      - name: CCUDA Compilation test
-        run: nvcc --version # cuda install check
       - name: Collect coverage information
         continue-on-error: True
         uses: ./.github/actions/coverage_collection
@@ -33,72 +35,72 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: cobertura.xml
 
-  Windows:
+  # Windows:
 
-    runs-on: windows-latest
+  #   runs-on: windows-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v3
-        with:
-            # The second most recent version is used as
-            # setup-python installs the most recent patch
-            # which leads to linking problems as there are
-            # 2 versions of python3X.a and the wrong one
-            # is chosen
-            python-version: 3.9
-      # Uncomment to examine DLL requirements with 'objdump -x FILE'
-      #- name: Install mingw tools
-      #  uses: msys2/setup-msys2@v2
-      - name: Install dependencies
-        uses: ./.github/actions/windows_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Setup Python 3.9
+  #       uses: actions/setup-python@v3
+  #       with:
+  #           # The second most recent version is used as
+  #           # setup-python installs the most recent patch
+  #           # which leads to linking problems as there are
+  #           # 2 versions of python3X.a and the wrong one
+  #           # is chosen
+  #           python-version: 3.9
+  #     # Uncomment to examine DLL requirements with 'objdump -x FILE'
+  #     #- name: Install mingw tools
+  #     #  uses: msys2/setup-msys2@v2
+  #     - name: Install dependencies
+  #       uses: ./.github/actions/windows_install
+  #     - name: Install python dependencies
+  #       uses: ./.github/actions/pip_installation
+  #     - name: Fortran/C tests with pytest
+  #       uses: ./.github/actions/pytest_run
+  #     - name: Python tests with pytest
+  #       uses: ./.github/actions/pytest_run_python
+  #     - name: Parallel tests with pytest
+  #       uses: ./.github/actions/pytest_parallel
 
-  MacOSX:
+  # MacOSX:
 
-    runs-on: macos-latest
+  #   runs-on: macos-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.10'
-      - name: Install dependencies
-        uses: ./.github/actions/macos_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python 3.10
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: '3.10'
+  #     - name: Install dependencies
+  #       uses: ./.github/actions/macos_install
+  #     - name: Install python dependencies
+  #       uses: ./.github/actions/pip_installation
+  #     - name: Fortran/C tests with pytest
+  #       uses: ./.github/actions/pytest_run
+  #     - name: Python tests with pytest
+  #       uses: ./.github/actions/pytest_run_python
+  #     - name: Parallel tests with pytest
+  #       uses: ./.github/actions/pytest_parallel
 
-  Linter:
+  # Linter:
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.7
-      - name: Install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pylint
-        shell: bash
-      - name: Pylint
-        run: |
-            python -m pylint --rcfile=.pylintrc pyccel/parser/semantic.py
-        shell: bash
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python 3.7
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: 3.7
+  #     - name: Install python dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install pylint
+  #       shell: bash
+  #     - name: Pylint
+  #       run: |
+  #           python -m pylint --rcfile=.pylintrc pyccel/parser/semantic.py
+  #       shell: bash

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -17,10 +17,6 @@ jobs:
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: Python path
-        uses: which python
-      - name: Pyccel path
-        uses: which pyccel
       # - name: Fortran/C tests with pytest
       #   uses: ./.github/actions/pytest_run
       - name: Ccuda tests with pytest

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -13,10 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: CUDA Version
         run: nvcc --version # cuda install check
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.7
       - name: Install dependencies
         uses: ./.github/actions/linux_install
       - name: Install python dependencies

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/pip_installation
       - name: Fortran/C tests with pytest
         uses: ./.github/actions/pytest_run
-      - name: cuda tests with pytest
+      - name: Ccuda tests with pytest
         uses: ./.github/actions/pytest_run_cuda
       - name: Python tests with pytest
         uses: ./.github/actions/pytest_run_python

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -17,17 +17,14 @@ jobs:
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: Coverage install
-        uses: ./.github/actions/coverage_install
-      - name: Collect coverage information
-        continue-on-error: True
-        uses: ./.github/actions/coverage_collection
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
-        continue-on-error: True
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: cobertura.xml
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: cuda tests with pytest
+        uses: ./.github/actions/pytest_run_cuda
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
 
   # Windows:
 

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -17,8 +17,10 @@ jobs:
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: paths
-        uses: which python ; which pyccel
+      - name: Python path
+        uses: which python
+      - name: Pyccel path
+        uses: which pyccel
       # - name: Fortran/C tests with pytest
       #   uses: ./.github/actions/pytest_run
       - name: Ccuda tests with pytest

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -8,7 +8,7 @@ jobs:
   Linux:
 
     runs-on: ubuntu-latest
-    container: nvidia/cuda:11.7.1-base-ubuntu20.04
+    container: nvidia/cuda:11.7.1-devel-ubuntu20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -15,8 +15,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.7
-      - name: Install dependencies
-        uses: ./.github/actions/linux_install
+      # - name: Install dependencies
+      #   uses: ./.github/actions/linux_install
       - name: CUDA Version
         run: nvcc --version # cuda install check
       - name: Install python dependencies

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -17,14 +17,14 @@ jobs:
         uses: ./.github/actions/linux_install
       - name: Install python dependencies
         uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
+      # - name: Fortran/C tests with pytest
+      #   uses: ./.github/actions/pytest_run
       - name: Ccuda tests with pytest
         uses: ./.github/actions/pytest_run_cuda
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+      # - name: Python tests with pytest
+      #   uses: ./.github/actions/pytest_run_python
+      # - name: Parallel tests with pytest
+      #   uses: ./.github/actions/pytest_parallel
 
   # Windows:
 

--- a/.github/workflows/Cuda_pytest.yml
+++ b/.github/workflows/Cuda_pytest.yml
@@ -1,0 +1,110 @@
+name: Pyccel CUDA tests
+
+on:
+  pull_request:
+    branches: [ cuda_main ]
+
+jobs:
+  Linux:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        uses: ./.github/actions/linux_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Coverage install
+        uses: ./.github/actions/coverage_install
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
+      - name: Test with valgrind for memory leaks
+        uses: ./.github/actions/valgrind_run
+      - name: Collect coverage information
+        continue-on-error: True
+        uses: ./.github/actions/coverage_collection
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
+        continue-on-error: True
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: cobertura.xml
+
+  Windows:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v3
+        with:
+            # The second most recent version is used as
+            # setup-python installs the most recent patch
+            # which leads to linking problems as there are
+            # 2 versions of python3X.a and the wrong one
+            # is chosen
+            python-version: 3.9
+      # Uncomment to examine DLL requirements with 'objdump -x FILE'
+      #- name: Install mingw tools
+      #  uses: msys2/setup-msys2@v2
+      - name: Install dependencies
+        uses: ./.github/actions/windows_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
+
+  MacOSX:
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        uses: ./.github/actions/macos_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
+
+  Linter:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.7
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pylint
+        shell: bash
+      - name: Pylint
+        run: |
+            python -m pylint --rcfile=.pylintrc pyccel/parser/semantic.py
+        shell: bash

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-include pyccel *.pyh
 recursive-include pyccel *.c
 recursive-include pyccel *.f90
 recursive-include pyccel *.h
+recursive-include pyccel *.cu
 recursive-include pyccel *.pyccel
 
 graft tutorial

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -883,7 +883,7 @@ class PythonType(Basic):
         prec = self.precision
         return LiteralString("<class '{dtype}{precision}'>".format(
             dtype = str(self.dtype),
-            precision = '' if prec in (None, -1) else prec*8))
+            precision = '' if prec in (None, -1) else (prec * (16 if self.dtype is NativeComplex() else 8))))
 
 #==============================================================================
 python_builtin_datatypes_dict = {

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -164,26 +164,10 @@ CudaArrayClass = ClassDef('cuda.ndarray',
         methods=[
             FunctionDef('shape',[],[],body=[],
                 decorators={'property':'property', 'numpy_wrapper':Shape})])
-            # FunctionDef('size',[],[],body=[],
-            #     decorators={'property':'property', 'numpy_wrapper':NumpyArraySize}),
-            # FunctionDef('T',[],[],body=[],
-            #     decorators={'property':'property', 'numpy_wrapper':NumpyTranspose}),
-            # FunctionDef('transpose',[],[],body=[],
-            #     decorators={'numpy_wrapper':NumpyTranspose}),
-            # FunctionDef('sum',[],[],body=[],
-            #     decorators={'numpy_wrapper':NumpySum}),
-            # FunctionDef('min',[],[],body=[],
-            #     decorators={'numpy_wrapper':NumpyAmin}),
-            # FunctionDef('max',[],[],body=[],
-            #     decorators={'numpy_wrapper':NumpyAmax}),
-            # FunctionDef('imag',[],[],body=[],
-            #     decorators={'property':'property', 'numpy_wrapper':NumpyImag}),
-            # FunctionDef('real',[],[],body=[],
-            #     decorators={'property':'property', 'numpy_wrapper':NumpyReal}),
-            # FunctionDef('conj',[],[],body=[],
-            #     decorators={'numpy_wrapper':NumpyConjugate}),
-            # FunctionDef('conjugate',[],[],body=[],
-            #     decorators={'numpy_wrapper':NumpyConjugate})])
+# CupyArrayClass = ClassDef('cupy.ndarray',
+#         methods=[
+#             FunctionDef('shape',[],[],body=[],
+#                 decorators={'property':'property', 'numpy_wrapper':Shape})])
 
 #=======================================================================================
 

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -160,6 +160,33 @@ NumpyArrayClass = ClassDef('numpy.ndarray',
 
 #=======================================================================================
 
+CudaArrayClass = ClassDef('cuda.ndarray',
+        methods=[
+            FunctionDef('shape',[],[],body=[],
+                decorators={'property':'property', 'numpy_wrapper':Shape})])
+            # FunctionDef('size',[],[],body=[],
+            #     decorators={'property':'property', 'numpy_wrapper':NumpyArraySize}),
+            # FunctionDef('T',[],[],body=[],
+            #     decorators={'property':'property', 'numpy_wrapper':NumpyTranspose}),
+            # FunctionDef('transpose',[],[],body=[],
+            #     decorators={'numpy_wrapper':NumpyTranspose}),
+            # FunctionDef('sum',[],[],body=[],
+            #     decorators={'numpy_wrapper':NumpySum}),
+            # FunctionDef('min',[],[],body=[],
+            #     decorators={'numpy_wrapper':NumpyAmin}),
+            # FunctionDef('max',[],[],body=[],
+            #     decorators={'numpy_wrapper':NumpyAmax}),
+            # FunctionDef('imag',[],[],body=[],
+            #     decorators={'property':'property', 'numpy_wrapper':NumpyImag}),
+            # FunctionDef('real',[],[],body=[],
+            #     decorators={'property':'property', 'numpy_wrapper':NumpyReal}),
+            # FunctionDef('conj',[],[],body=[],
+            #     decorators={'numpy_wrapper':NumpyConjugate}),
+            # FunctionDef('conjugate',[],[],body=[],
+            #     decorators={'numpy_wrapper':NumpyConjugate})])
+
+#=======================================================================================
+
 literal_classes = {
         NativeBool()    : BooleanClass,
         NativeInteger() : IntegerClass,

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2095,6 +2095,60 @@ class DottedFunctionCall(FunctionCall):
         """
         return self._prefix
 
+class KernelCall(FunctionCall):
+    """
+    Represents a kernel call
+    (e.g. a[c, b]())
+
+
+
+    Parameters
+    ==========
+    func             : FunctionDef
+                       The definition of the function being called
+    args             : tuple
+                       The arguments being passed to the function
+
+    numBlocks        : NativeInteger
+                       The number of blocks
+    tpblock          : NativeInteger
+                       The number of threads per block
+    """
+    __slots__ = ('_numBlocks','_tpblock', '_func', '_args')
+    _attribute_nodes = (*FunctionCall._attribute_nodes, '_numBlocks', '_tpblock')
+
+    def __init__(self, func, args, numBlocks, tpblock, current_function=None):
+
+        self._func = func
+        self._args = args
+        self._numBlocks = numBlocks
+        self._tpblock = tpblock
+        super().__init__(func, args, current_function)
+
+    @property
+    def func(self):
+        """ The number of blocks in which the kernel will run
+        """
+        return self._func
+
+    @property
+    def args(self):
+        """ The number of blocks in which the kernel will run
+        """
+        return self._args
+
+    @property
+    def numBlocks(self):
+        """ The number of blocks in which the kernel will run
+        """
+        return self._numBlocks
+
+    @property
+    def tpblock(self):
+        """ The number of threads in each block
+        """
+        return self._tpblock
+
 class Return(Basic):
 
     """Represents a function return in the code.

--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -1,0 +1,217 @@
+from functools import reduce
+import operator
+
+import numpy
+
+from pyccel.errors.errors import Errors
+from pyccel.errors.messages import WRONG_LINSPACE_ENDPOINT, NON_LITERAL_KEEP_DIMS, NON_LITERAL_AXIS
+
+from pyccel.utilities.stage import PyccelStage
+
+from .basic          import PyccelAstNode
+from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
+                             PythonComplex, PythonReal, PythonImag, PythonList,
+                             PythonType, PythonConjugate)
+
+from .core           import process_shape, Module, Import, PyccelFunctionDef
+
+from .datatypes      import (dtype_and_precision_registry as dtype_registry,
+                             default_precision, datatype, NativeInteger,
+                             NativeFloat, NativeComplex, NativeBool, str_dtype,
+                             NativeNumeric)
+
+from .internals      import PyccelInternalFunction, Slice, max_precision, get_final_precision
+from .internals      import PyccelArraySize
+
+from .literals       import LiteralInteger, LiteralFloat, LiteralComplex, convert_to_literal
+from .literals       import LiteralTrue, LiteralFalse
+from .literals       import Nil
+from .mathext        import MathCeil
+from .operators      import broadcast, PyccelMinus, PyccelDiv
+from .variable       import (Variable, Constant, HomogeneousTupleVariable)
+
+from .numpyext       import process_dtype
+
+#==============================================================================
+__all__ = (
+    'CudaArray',
+    'CudaMalloc'
+)
+
+
+#------------------------------------------------------------------------------
+# cuda_constants = {
+#         'pi': Constant('float', 'pi', value=cuda.),
+#     }
+#==============================================================================
+class CudaMemCopy():
+    """Represents a call to  cuda malloc for code generation.
+
+    arg : list , tuple , PythonTuple, List, Variable
+    """
+    def __init__(self, x, size):
+        self._shape     = ()
+        self._rank      = 0
+        self._dtype     = x.dtype
+        self._precision = x.precision
+
+    @property
+    def dest(self):
+        return self._args[0]
+    @property
+    def src(self):
+        return self._args[1]
+    @property
+    def size(self):
+        return self._args[2]
+    @property
+    def copy_mode(self):
+        return self._args[3]
+
+
+#==============================================================================
+class CudaNewArray(PyccelInternalFunction):
+    """ Class from which all Cuda functions which imply a call to Allocate
+    inherit
+    """
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _process_order(order):
+
+        if not order:
+            return None
+
+        order = str(order).strip('\'"')
+        if order not in ('C', 'F'):
+            raise ValueError('unrecognized order = {}'.format(order))
+        return order
+
+#==============================================================================
+class CudaMalloc(CudaNewArray):
+    """Represents a call to  cuda malloc for code generation.
+
+     arg : str
+    """
+    # _attribute_nodes = ('_alloct',)
+    def __init__(self, size, alloct, dtype):
+        # Verify dtype and get precision
+        dtype, prec = process_dtype(dtype)
+        self._shape     = process_shape(size)
+        self._alloct       = alloct
+        self._rank      = len(size)
+        self._dtype     = dtype
+        self._precision = prec
+        super().__init__()
+
+    @property
+    def shape(self):
+        return self._shape
+    @property
+    def dtype(self):
+        return self._dtype
+    @property
+    def precision(self):
+        return self._precision
+
+#==============================================================================
+class CudaArray(CudaNewArray):
+    """
+    Represents a call to  cuda.array for code generation.
+
+    arg : list, tuple, PythonList
+
+    """
+    __slots__ = ('_arg','_dtype','_precision','_shape','_rank','_order')
+    _attribute_nodes = ('_arg',)
+    name = 'array'
+
+    def __init__(self, arg, dtype=None, order='C'):
+
+        if not isinstance(arg, (PythonTuple, PythonList, Variable)):
+            raise TypeError('Unknown type of  %s.' % type(arg))
+
+        is_homogeneous_tuple = isinstance(arg, (PythonTuple, PythonList, HomogeneousTupleVariable)) and arg.is_homogeneous
+        is_array = isinstance(arg, Variable) and arg.is_ndarray
+
+        # TODO: treat inhomogenous lists and tuples when they have mixed ordering
+        if not (is_homogeneous_tuple or is_array):
+            raise TypeError('we only accept homogeneous arguments')
+
+        # Verify dtype and get precision
+        if dtype is None:
+            dtype = arg.dtype
+        dtype, prec = process_dtype(dtype)
+        # ... Determine ordering
+        order = str(order).strip("\'")
+
+        if order not in ('K', 'A', 'C', 'F'):
+            raise ValueError("Cannot recognize '{:s}' order".format(order))
+
+        # TODO [YG, 18.02.2020]: set correct order based on input array
+        if order in ('K', 'A'):
+            order = 'C'
+        # ...
+        self._arg   = arg
+        self._shape = process_shape(arg.shape)
+        self._rank  = len(self._shape)
+        self._dtype = dtype
+        self._order = order
+        self._precision = prec
+        super().__init__()
+
+    def __str__(self):
+        return str(self.arg)
+
+    @property
+    def arg(self):
+        return self._arg
+
+class CudaDeviceSynchronize(PyccelAstNode):
+    "Represents a call to  Cuda.deviceSynchronize for code generation."
+    _attribute_nodes = ()
+    pass
+
+class CudaInternalVar(PyccelAstNode):
+    _attribute_nodes = ('_dim',)
+
+    def __init__(self, dim=None):
+        if not isinstance(dim, LiteralInteger):
+            raise TypeError("dimension need to be an integer")
+        if dim not in (0, 1, 2):
+            raise ValueError("dimension need to be 0, 1 or 2")
+        #...
+        self._dim       = dim
+        self._shape     = ()
+        self._rank      = 0
+        self._dtype     = dim.dtype
+        self._precision = dim.precision
+        self._order     = None
+        super().__init__()
+
+    @property
+    def dim(self):
+        return self._dim
+
+class CudaThreadIdx(CudaInternalVar) : pass
+class CudaBlockDim(CudaInternalVar)  : pass
+class CudaBlockIdx(CudaInternalVar)  : pass
+class CudaGridDim(CudaInternalVar)   : pass
+
+
+cuda_funcs = {
+    'cudaMalloc'        : PyccelFunctionDef('cudaMalloc'      , CudaMalloc),
+    # 'deviceSynchronize' : CudaDeviceSynchronize,
+    'array'             : PyccelFunctionDef('array'      , CudaArray),
+    'threadIdx'         : PyccelFunctionDef('threadIdx'      , CudaThreadIdx)
+    # 'blockDim'          : CudaBlockDim,
+    # 'blockIdx'          : CudaBlockIdx,
+    # 'gridDim'           : CudaGridDim
+}
+
+cuda_constants = {
+
+}
+cuda_mod = Module('cuda',
+    variables = cuda_constants.values(),
+    funcs = cuda_funcs.values())

--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -144,15 +144,16 @@ class CudaArray(CudaNewArray):
     def arg(self):
         return self._arg
 
-class CudaDeviceSynchronize(PyccelAstNode):
+class CudaDeviceSynchronize(PyccelInternalFunction):
     "Represents a call to  Cuda.deviceSynchronize for code generation."
-
+    # pass
+    _attribute_nodes = ()
     def __init__(self):
         #...
         self._shape     = ()
         self._rank      = 0
         self._dtype     = NativeInteger()
-        self._precision = 0
+        self._precision = None
         self._order     = None
         super().__init__()
 

--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -146,8 +146,15 @@ class CudaArray(CudaNewArray):
 
 class CudaDeviceSynchronize(PyccelAstNode):
     "Represents a call to  Cuda.deviceSynchronize for code generation."
-    _attribute_nodes = ()
-    pass
+
+    def __init__(self):
+        #...
+        self._shape     = ()
+        self._rank      = 0
+        self._dtype     = NativeInteger()
+        self._precision = 0
+        self._order     = None
+        super().__init__()
 
 class CudaInternalVar(PyccelAstNode):
     _attribute_nodes = ('_dim',)

--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -30,7 +30,7 @@ from .mathext        import MathCeil
 from .operators      import broadcast, PyccelMinus, PyccelDiv
 from .variable       import (Variable, Constant, HomogeneousTupleVariable)
 
-from .numpyext       import process_dtype, NumpyNewArray, process_shape
+from .numpyext       import process_dtype, process_shape
 
 #==============================================================================
 __all__ = (
@@ -50,12 +50,11 @@ class CudaNewArray(PyccelInternalFunction):
     """ Class from which all Cuda functions which imply a call to Allocate
     inherit
     """
-
     #--------------------------------------------------------------------------
     @staticmethod
-    def _process_order(order):
+    def _process_order(rank, order):
 
-        if not order:
+        if rank < 2:
             return None
 
         order = str(order).strip('\'"')

--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -50,6 +50,7 @@ class CudaNewArray(PyccelInternalFunction):
     """ Class from which all Cuda functions which imply a call to Allocate
     inherit
     """
+    __slots__ = ()
     #--------------------------------------------------------------------------
     @staticmethod
     def _process_order(rank, order):
@@ -91,7 +92,11 @@ class CudaArray(CudaNewArray):
         # Verify dtype and get precision
         if dtype is None:
             dtype = arg.dtype
-        dtype, prec = process_dtype(dtype)
+            prec = get_final_precision(arg)
+        else:
+            dtype, prec = process_dtype(dtype)
+        # ... Determine ordering
+        order = str(order).strip("\'")
 
         shape = process_shape(False, arg.shape)
         rank  = len(shape)

--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -30,19 +30,21 @@ from .mathext        import MathCeil
 from .operators      import broadcast, PyccelMinus, PyccelDiv
 from .variable       import (Variable, Constant, HomogeneousTupleVariable)
 
-from .numpyext       import process_dtype
+from .numpyext       import process_dtype, NumpyNewArray
 
 #==============================================================================
 __all__ = (
+    'CudaMemCopy',
+    'CudaNewArray',
     'CudaArray',
-    'CudaMalloc'
+    'CudaDeviceSynchronize',
+    'CudaInternalVar',
+    'CudaThreadIdx',
+    'CudaBlockDim',
+    'CudaBlockIdx',
+    'CudaGridDim'
 )
 
-
-#------------------------------------------------------------------------------
-# cuda_constants = {
-#         'pi': Constant('float', 'pi', value=cuda.),
-#     }
 #==============================================================================
 class CudaMemCopy():
     """Represents a call to  cuda malloc for code generation.
@@ -88,31 +90,6 @@ class CudaNewArray(PyccelInternalFunction):
         return order
 
 #==============================================================================
-class CudaMalloc(CudaNewArray):
-    """Represents a call to  cuda malloc for code generation.
-
-     arg : str
-    """
-    # _attribute_nodes = ('_alloct',)
-    def __init__(self, size, alloct, dtype):
-        # Verify dtype and get precision
-        dtype, prec = process_dtype(dtype)
-        self._shape     = process_shape(size)
-        self._alloct       = alloct
-        self._rank      = len(size)
-        self._dtype     = dtype
-        self._precision = prec
-        super().__init__()
-
-    @property
-    def shape(self):
-        return self._shape
-    @property
-    def dtype(self):
-        return self._dtype
-    @property
-    def precision(self):
-        return self._precision
 
 #==============================================================================
 class CudaArray(CudaNewArray):
@@ -200,13 +177,20 @@ class CudaGridDim(CudaInternalVar)   : pass
 
 
 cuda_funcs = {
-    'cudaMalloc'        : PyccelFunctionDef('cudaMalloc'      , CudaMalloc),
     # 'deviceSynchronize' : CudaDeviceSynchronize,
-    'array'             : PyccelFunctionDef('array'      , CudaArray),
-    'threadIdx'         : PyccelFunctionDef('threadIdx'      , CudaThreadIdx)
-    # 'blockDim'          : CudaBlockDim,
-    # 'blockIdx'          : CudaBlockIdx,
-    # 'gridDim'           : CudaGridDim
+    'array'             : PyccelFunctionDef('array'             , CudaArray),
+    'deviceSynchronize' : PyccelFunctionDef('deviceSynchronize' , CudaDeviceSynchronize),
+    'threadIdx'         : PyccelFunctionDef('threadIdx'         , CudaThreadIdx),
+    'blockDim'          : PyccelFunctionDef('blockDim'          , CudaBlockDim),
+    'blockIdx'          : PyccelFunctionDef('blockIdx'          , CudaBlockIdx),
+    'gridDim'           : PyccelFunctionDef('gridDim'           , CudaGridDim)
+}
+
+cuda_Internal_Var = {
+    'CudaThreadIdx' : 'threadIdx',
+    'CudaBlockDim'  : 'blockDim',
+    'CudaBlockIdx'  : 'blockIdx',
+    'CudaGridDim'   : 'gridDim'
 }
 
 cuda_constants = {

--- a/pyccel/ast/cupyext.py
+++ b/pyccel/ast/cupyext.py
@@ -1,0 +1,470 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
+#------------------------------------------------------------------------------------------#
+""" Module containing objects from the cupy module understood by pyccel
+"""
+
+from functools import reduce
+import operator
+
+from pyccel.errors.errors import Errors
+from pyccel.errors.messages import WRONG_LINSPACE_ENDPOINT, NON_LITERAL_KEEP_DIMS, NON_LITERAL_AXIS
+
+from pyccel.utilities.stage import PyccelStage
+
+from .basic          import PyccelAstNode
+from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
+                             PythonComplex, PythonReal, PythonImag, PythonList,
+                             PythonType, PythonConjugate)
+
+from .core           import Module, Import, PyccelFunctionDef, FunctionCall
+
+from .datatypes      import (dtype_and_precision_registry as dtype_registry,
+                             default_precision, datatype, NativeInteger,
+                             NativeFloat, NativeComplex, NativeBool, str_dtype,
+                             NativeNumeric)
+
+from .internals      import PyccelInternalFunction, Slice, max_precision, get_final_precision
+from .internals      import PyccelArraySize
+
+from .literals       import LiteralInteger, LiteralFloat, LiteralComplex, LiteralString, convert_to_literal
+from .literals       import LiteralTrue, LiteralFalse
+from .literals       import Nil
+from .mathext        import MathCeil
+from .operators      import broadcast, PyccelMinus, PyccelDiv
+from .variable       import (Variable, Constant, HomogeneousTupleVariable)
+from .cudaext        import CudaNewArray, CudaArray
+from .numpyext       import process_dtype, process_shape, DtypePrecisionToCastFunction
+
+errors = Errors()
+pyccel_stage = PyccelStage()
+
+__all__ = (
+    'CupyArray',
+    'CupyEmpty',
+    'CupyEmptyLike',
+    'CupyFull',
+    'CupyFullLike',
+    'CupyArange',
+    'CupyArraySize',
+    'CupyOnes',
+    'CupyOnesLike',
+    'Shape',
+    'CupyZeros',
+    'CupyZerosLike',
+)
+
+#==============================================================================
+class CupyArray(CudaNewArray):
+    """
+    Represents a call to  cupy.array for code generation.
+
+    arg : list, tuple, PythonList
+
+    """
+    __slots__ = ('_arg','_dtype','_precision','_shape','_rank','_order')
+    _attribute_nodes = ('_arg',)
+    name = 'array'
+
+    def __init__(self, arg, dtype=None, order='C'):
+
+        if not isinstance(arg, (PythonTuple, PythonList, Variable)):
+            raise TypeError('Unknown type of  %s.' % type(arg))
+
+        is_homogeneous_tuple = isinstance(arg, (PythonTuple, PythonList, HomogeneousTupleVariable)) and arg.is_homogeneous
+        is_array = isinstance(arg, Variable) and arg.is_ndarray
+
+        # TODO: treat inhomogenous lists and tuples when they have mixed ordering
+        if not (is_homogeneous_tuple or is_array):
+            raise TypeError('we only accept homogeneous arguments')
+
+        # Verify dtype and get precision
+        if dtype is None:
+            dtype = arg.dtype
+            prec = get_final_precision(arg)
+        else:
+            dtype, prec = process_dtype(dtype)
+        # ... Determine ordering
+        order = str(order).strip("\'")
+
+        shape = process_shape(False, arg.shape)
+        rank  = len(shape)
+
+        if rank < 2:
+            order = None
+        else:
+            # ... Determine ordering
+            order = str(order).strip("\'")
+
+            if order not in ('K', 'A', 'C', 'F'):
+                raise ValueError(f"Cannot recognize '{order}' order")
+
+            # TODO [YG, 18.02.2020]: set correct order based on input array
+            if order in ('K', 'A'):
+                order = 'C'
+            # ...
+
+        self._arg   = arg
+        self._shape = shape
+        self._rank  = rank
+        self._dtype = dtype
+        self._order = order
+        self._precision = prec
+        super().__init__()
+
+    def __str__(self):
+        return str(self.arg)
+
+    @property
+    def arg(self):
+        return self._arg
+
+#==============================================================================
+class CupyArange(CudaNewArray):
+    """
+    Represents a call to  cupy.arange for code generation.
+
+    Parameters
+    ----------
+    start : Numeric
+        Start of interval, default value 0
+
+    stop : Numeric
+        End of interval
+
+    step : Numeric
+        Spacing between values, default value 1
+
+    dtype : Datatype
+        The type of the output array, if dtype is not given,
+        infer the data type from the other input arguments.
+    """
+    __slots__ = ('_start','_step','_stop','_dtype','_precision','_shape')
+    _attribute_nodes = ('_start','_step','_stop')
+    _rank = 1
+    _order = None
+    name = 'arange'
+
+    def __init__(self, start, stop = None, step = None, dtype = None):
+
+        if stop is None:
+            self._start = LiteralInteger(0)
+            self._stop = start
+        else:
+            self._start = start
+            self._stop = stop
+        self._step = step if step is not None else LiteralInteger(1)
+
+        if dtype is None:
+            self._dtype = max([i.dtype for i in self.arg], key = NativeNumeric.index)
+            self._precision = max_precision(self.arg, allow_native=False)
+        else:
+            self._dtype, self._precision = process_dtype(dtype)
+
+        self._shape = (MathCeil(PyccelDiv(PyccelMinus(self._stop, self._start), self._step)))
+        self._shape = process_shape(False, self._shape)
+        super().__init__()
+
+    @property
+    def arg(self):
+        return (self._start, self._stop, self._step)
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def stop(self):
+        return self._stop
+
+    @property
+    def step(self):
+        return self._step
+
+#==============================================================================
+
+class Shape(PyccelInternalFunction):
+    """ Represents a call to cupy.shape for code generation
+    """
+    __slots__ = ()
+    name = 'shape'
+    def __new__(cls, arg):
+        if isinstance(arg.shape, PythonTuple):
+            return arg.shape
+        else:
+            return PythonTuple(*arg.shape)
+
+#==============================================================================
+class CupyFull(CudaNewArray):
+    """
+    Represents a call to cupy.full for code generation.
+
+    Parameters
+    ----------
+    shape : int or sequence of ints
+        Shape of the new array, e.g., ``(2, 3)`` or ``2``.
+
+    fill_value : scalar
+        Fill value.
+
+    dtype: str, DataType
+        datatype for the constructed array
+        The default, `None`, means `np.array(fill_value).dtype`.
+
+    order : {'C', 'F'}, optional
+        Whether to store multidimensional data in C- or Fortran-contiguous
+        (row- or column-wise) order in memory.
+
+    """
+    __slots__ = ('_fill_value','_dtype','_precision','_shape','_rank','_order')
+    name = 'full'
+
+    def __init__(self, shape, fill_value, dtype=None, order='C'):
+
+        # Convert shape to PythonTuple
+        shape = process_shape(False, shape)
+        # If there is no dtype, extract it from fill_value
+        # TODO: must get dtype from an annotated node
+        if dtype is None:
+            dtype = fill_value.dtype
+            precision = get_final_precision(fill_value)
+        else:
+            dtype, precision = process_dtype(dtype)
+
+        # Cast fill_value to correct type
+        if fill_value:
+            if fill_value.dtype != dtype or get_final_precision(fill_value) != precision:
+                cast_func = DtypePrecisionToCastFunction[dtype.name][precision]
+                fill_value = cast_func(fill_value)
+        self._shape = shape
+        self._rank  = len(self._shape)
+        self._dtype = dtype
+        self._order = CudaNewArray._process_order(self._rank, order)
+        self._precision = precision
+
+        super().__init__(fill_value)
+
+    #--------------------------------------------------------------------------
+    @property
+    def fill_value(self):
+        return self._args[0]
+
+#==============================================================================
+class CupyAutoFill(CupyFull):
+    """ Abstract class for all classes which inherit from CupyFull but
+        the fill_value is implicitly specified
+    """
+    __slots__ = ()
+    def __init__(self, shape, dtype='float', order='C'):
+        if not dtype:
+            raise TypeError("Data type must be provided")
+        super().__init__(shape, Nil(), dtype, order)
+
+#==============================================================================
+class CupyEmpty(CupyAutoFill):
+    """ Represents a call to cupy.empty for code generation.
+    """
+    __slots__ = ()
+    name = 'empty'
+
+    def __init__(self, shape, dtype='float', order='C'):
+        if dtype in NativeNumeric:
+            precision = default_precision[str_dtype(dtype)]
+            dtype = DtypePrecisionToCastFunction[dtype.name][precision]
+        super().__init__(shape, dtype, order)
+    @property
+    def fill_value(self):
+        return None
+
+
+#==============================================================================
+class CupyZeros(CupyAutoFill):
+    """ Represents a call to cupy.zeros for code generation.
+    """
+    __slots__ = ()
+    name = 'zeros'
+    @property
+    def fill_value(self):
+        dtype = self.dtype
+        if isinstance(dtype, NativeInteger):
+            value = LiteralInteger(0, precision = self.precision)
+        elif isinstance(dtype, NativeFloat):
+            value = LiteralFloat(0, precision = self.precision)
+        elif isinstance(dtype, NativeComplex):
+            value = LiteralComplex(0., 0., precision = self.precision)
+        elif isinstance(dtype, NativeBool):
+            value = LiteralFalse(precision = self.precision)
+        else:
+            raise TypeError('Unknown type')
+        return value
+
+#==============================================================================
+class CupyOnes(CupyAutoFill):
+    """ Represents a call to cupy.ones for code generation.
+    """
+    __slots__ = ()
+    name = 'ones'
+    @property
+    def fill_value(self):
+        dtype = self.dtype
+        if isinstance(dtype, NativeInteger):
+            value = LiteralInteger(1, precision = self.precision)
+        elif isinstance(dtype, NativeFloat):
+            value = LiteralFloat(1., precision = self.precision)
+        elif isinstance(dtype, NativeComplex):
+            value = LiteralComplex(1., 0., precision = self.precision)
+        elif isinstance(dtype, NativeBool):
+            value = LiteralTrue(precision = self.precision)
+        else:
+            raise TypeError('Unknown type')
+        return value
+
+#=======================================================================================
+class CupyFullLike(PyccelInternalFunction):
+    """ Represents a call to cupy.full_like for code generation.
+    """
+    __slots__ = ()
+    name = 'full_like'
+    def __new__(cls, a, fill_value, dtype=None, order='K', subok=True, shape=None):
+
+        # NOTE: we ignore 'subok' argument
+        if dtype is None:
+            dtype = DtypePrecisionToCastFunction[a.dtype.name][a.precision]
+        order = a.order if str(order).strip('\'"') in ('K', 'A') else order
+        shape = Shape(a) if shape is None else shape
+        return CupyFull(shape, fill_value, dtype, order)
+
+#=======================================================================================
+class CupyEmptyLike(PyccelInternalFunction):
+    """ Represents a call to cupy.empty_like for code generation.
+    """
+    __slots__ = ()
+    name = 'empty_like'
+    def __new__(cls, a, dtype=None, order='K', subok=True, shape=None):
+
+        # NOTE: we ignore 'subok' argument
+        if dtype is None:
+            dtype = DtypePrecisionToCastFunction[a.dtype.name][a.precision]
+        order = a.order if str(order).strip('\'"') in ('K', 'A') else order
+        shape = Shape(a) if shape is None else shape
+
+        return CupyEmpty(shape, dtype, order)
+
+#=======================================================================================
+class CupyOnesLike(PyccelInternalFunction):
+    """ Represents a call to cupy.ones_like for code generation.
+    """
+    __slots__ = ()
+    name = 'ones_like'
+    def __new__(cls, a, dtype=None, order='K', subok=True, shape=None):
+
+        # NOTE: we ignore 'subok' argument
+        if dtype is None:
+            dtype = DtypePrecisionToCastFunction[a.dtype.name][a.precision]
+        order = a.order if str(order).strip('\'"') in ('K', 'A') else order
+        shape = Shape(a) if shape is None else shape
+
+        return CupyOnes(shape, dtype, order)
+
+#=======================================================================================
+class CupyZerosLike(PyccelInternalFunction):
+    """ Represents a call to cupy.zeros_like for code generation.
+    """
+    __slots__ = ()
+    name = 'zeros_like'
+    def __new__(cls, a, dtype=None, order='K', subok=True, shape=None):
+
+        # NOTE: we ignore 'subok' argument
+        if dtype is None:
+            dtype = DtypePrecisionToCastFunction[a.dtype.name][a.precision]
+        order = a.order if str(order).strip('\'"') in ('K', 'A') else order
+        shape = Shape(a) if shape is None else shape
+
+        return CupyZeros(shape, dtype, order)
+
+#=======================================================================================
+
+class CupyArraySize(PyccelInternalFunction):
+    """
+    Class representing a call to the cupy size function which
+    returns the shape of an object in a given dimension
+
+    Parameters
+    ==========
+    arg   : PyccelAstNode
+            A PyccelAstNode of unknown shape
+    axis  : int
+            The dimension along which the size is
+            requested
+    """
+    __slots__ = ('_arg',)
+    _attribute_nodes = ('_arg',)
+    name   = 'size'
+    _dtype = NativeInteger()
+    _precision = -1
+    _rank  = 0
+    _shape = None
+    _order = None
+
+    def __new__(cls, a, axis = None):
+        if axis is not None:
+            return PyccelArraySize(a, axis)
+        elif not isinstance(a, (list,
+                                    tuple,
+                                    PyccelAstNode)):
+            raise TypeError('Unknown type of  %s.' % type(a))
+        elif all(isinstance(s, LiteralInteger) for s in a.shape):
+            return LiteralInteger(reduce(operator.mul, [s.python_value for s in a.shape]))
+        else:
+            return super().__new__(cls)
+
+    def __init__(self, a, axis = None):
+        self._arg   = a
+        super().__init__(a)
+
+    @property
+    def arg(self):
+        """ Object whose size is investigated
+        """
+        return self._arg
+
+    def __str__(self):
+        return 'Size({})'.format(str(self.arg))
+
+#==============================================================================
+
+cupy_funcs = {
+    # ... array creation routines
+    'full'      : PyccelFunctionDef('full'      , CupyFull),
+    'empty'     : PyccelFunctionDef('empty'     , CupyEmpty),
+    'zeros'     : PyccelFunctionDef('zeros'     , CupyZeros),
+    'ones'      : PyccelFunctionDef('ones'      , CupyOnes),
+    'full_like' : PyccelFunctionDef('full_like' , CupyFullLike),
+    'empty_like': PyccelFunctionDef('empty_like', CupyEmptyLike),
+    'zeros_like': PyccelFunctionDef('zeros_like', CupyZerosLike),
+    'ones_like' : PyccelFunctionDef('ones_like' , CupyOnesLike),
+    'array'     : PyccelFunctionDef('array'     , CupyArray),
+    'arange'    : PyccelFunctionDef('arange'    , CupyArange),
+    # ...
+    'shape'     : PyccelFunctionDef('shape'     , Shape),
+    'size'      : PyccelFunctionDef('size'      , CupyArraySize),
+}
+
+cuda_constants = {
+}
+
+cupy_mod = Module('cupy',
+    variables = cuda_constants.values(),
+    funcs = cupy_funcs.values())
+
+#==============================================================================
+
+cupy_target_swap = {
+        cupy_funcs['full_like']  : cupy_funcs['full'],
+        cupy_funcs['empty_like'] : cupy_funcs['empty'],
+        cupy_funcs['zeros_like'] : cupy_funcs['zeros'],
+        cupy_funcs['ones_like']  : cupy_funcs['ones']
+    }

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -26,6 +26,7 @@ from .literals      import LiteralInteger, Nil
 from .mathext       import math_mod
 
 from .cudaext       import cuda_mod
+from .cupyext       import cupy_mod
 from .numpyext      import (NumpyEmpty, NumpyArray, numpy_mod,
                             NumpyTranspose, NumpyLinspace)
 from .operators     import PyccelAdd, PyccelMul, PyccelIs, PyccelArithmeticOperator
@@ -85,6 +86,7 @@ pyccel_mod = Module('pyccel',(),(),
 builtin_import_registery = Module('__main__',
         (),(),
         imports = [
+            Import('cupy', AsName(cupy_mod,'cupy')),
             Import('numpy', AsName(numpy_mod,'numpy')),
             Import('scipy', AsName(scipy_mod,'scipy')),
             Import('itertools', AsName(itertools_mod,'itertools')),

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -25,6 +25,7 @@ from .itertoolsext  import itertools_mod
 from .literals      import LiteralInteger, Nil
 from .mathext       import math_mod
 
+from .cudaext       import cuda_mod
 from .numpyext      import (NumpyEmpty, NumpyArray, numpy_mod,
                             NumpyTranspose, NumpyLinspace)
 from .operators     import PyccelAdd, PyccelMul, PyccelIs, PyccelArithmeticOperator
@@ -76,7 +77,9 @@ def builtin_function(expr, args=None):
 decorators_mod = Module('decorators',(),
         funcs = [PyccelFunctionDef(d, PyccelInternalFunction) for d in pyccel_decorators.__all__])
 pyccel_mod = Module('pyccel',(),(),
-        imports = [Import('decorators', decorators_mod)])
+        imports = [Import('decorators', decorators_mod),
+                    Import('cuda', AsName(cuda_mod,'cuda')),
+                    ])
 
 # TODO add documentation
 builtin_import_registery = Module('__main__',

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -8,17 +8,19 @@ import os
 
 from pyccel.codegen.printing.fcode  import FCodePrinter
 from pyccel.codegen.printing.ccode  import CCodePrinter
+from pyccel.codegen.printing.ccudacode  import CcudaCodePrinter
 from pyccel.codegen.printing.pycode import PythonCodePrinter
 
 from pyccel.ast.core      import FunctionDef, Interface, ModuleHeader
 from pyccel.errors.errors import Errors
 from pyccel.utilities.stage import PyccelStage
 
-_extension_registry = {'fortran': 'f90', 'c':'c',  'python':'py'}
-_header_extension_registry = {'fortran': None, 'c':'h',  'python':None}
+_extension_registry = {'fortran': 'f90', 'c':'c',  'python':'py', 'ccuda': 'cu'}
+_header_extension_registry = {'fortran': None, 'c':'h',  'python':None, 'ccuda': 'h'}
 printer_registry    = {
                         'fortran':FCodePrinter,
                         'c':CCodePrinter,
+                        'ccuda':CcudaCodePrinter,
                         'python':PythonCodePrinter
                       }
 
@@ -140,7 +142,7 @@ class Codegen(object):
         language = settings.pop('language', 'fortran')
 
         # Set language
-        if not language in ['fortran', 'c', 'python']:
+        if not language in ['fortran', 'c', 'python', 'ccuda']:
             raise ValueError('{} language is not available'.format(language))
         self._language = language
 

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -379,7 +379,7 @@ class Compiler:
         # Collect compile information
         exec_cmd, includes, libs_flags, libdirs_flags, m_code = \
                 self._get_compile_components(compile_obj, accelerators)
-        linker_libdirs_flags = ['-Wl,-rpath' if l == '-L' else l for l in libdirs_flags]
+        linker_libdirs_flags = ['-Wl,-rpath' if l == '-L' and self._info['exec'] != 'nvcc' else l for l in libdirs_flags]
 
         flags.insert(0,"-shared")
 

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -199,7 +199,7 @@ def execute_pyccel(fname, *,
         compiler = 'GNU'
 
     # Choose cuda compiler
-    if language is 'ccuda':
+    if language == 'ccuda':
         compiler = 'nvidia'
 
     fflags = [] if fflags is None else fflags.split()

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -198,6 +198,9 @@ def execute_pyccel(fname, *,
     if compiler is None:
         compiler = 'GNU'
 
+    # Choose cuda vendor
+    if language == 'ccuda':
+        compiler = 'nvidia'
     fflags = [] if fflags is None else fflags.split()
     wrapper_flags = [] if wrapper_flags is None else wrapper_flags.split()
 

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -198,9 +198,10 @@ def execute_pyccel(fname, *,
     if compiler is None:
         compiler = 'GNU'
 
-    # Choose cuda vendor
-    if language == 'ccuda':
+    # Choose cuda compiler
+    if language is 'ccuda':
         compiler = 'nvidia'
+
     fflags = [] if fflags is None else fflags.split()
     wrapper_flags = [] if wrapper_flags is None else wrapper_flags.split()
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -342,11 +342,12 @@ class CCodePrinter(CodePrinter):
         code_init = ''
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
 
+        ftype = declare_dtype if self._print(rhs.dtype) != 'int' else declare_dtype[:-2]
         if rhs.fill_value is not None:
             if isinstance(rhs.fill_value, Literal):
-                code_init += 'array_fill(({0}){1}, {2});\n'.format(declare_dtype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'array_fill_{0}(({1}){2}, {3});\n'.format(ftype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
             else:
-                code_init += 'array_fill({0}, {1});\n'.format(self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'array_fill_{0}({1}, {2});\n'.format(ftype, self._print(rhs.fill_value), self._print(lhs))
         return code_init
 
     def _init_stack_array(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -341,13 +341,14 @@ class CCodePrinter(CodePrinter):
         lhs = expr.lhs
         code_init = ''
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
-
-        ftype = declare_dtype if self._print(rhs.dtype) != 'int' else declare_dtype[:-2]
+        dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
+        dtype = dtype[3:]
+ 
         if rhs.fill_value is not None:
             if isinstance(rhs.fill_value, Literal):
-                code_init += 'array_fill_{0}(({1}){2}, {3});\n'.format(ftype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'array_fill_{0}(({1}){2}, {3});\n'.format(dtype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
             else:
-                code_init += 'array_fill_{0}({1}, {2});\n'.format(ftype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'array_fill_{0}({1}, {2});\n'.format(dtype, self._print(rhs.fill_value), self._print(lhs))
         return code_init
 
     def _init_stack_array(self, expr):

--- a/pyccel/codegen/printing/ccudacode.py
+++ b/pyccel/codegen/printing/ccudacode.py
@@ -440,12 +440,13 @@ class CcudaCodePrinter(CCodePrinter):
         lhs = expr.lhs
         code_init = ''
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
+        ftype = declare_dtype if self._print(rhs.dtype) != 'int' else declare_dtype[:-2]
 
         if rhs.fill_value is not None:
             if isinstance(rhs.fill_value, Literal):
-                code_init += '_array_fill_{0}(({0}){1}, {2});\n'.format(declare_dtype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'cuda_array_fill_{0}(({1}){2}, {3});\n'.format(ftype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
             else:
-                code_init += '_array_fill_{0}({1}, {2});\n'.format(declare_dtype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'cuda_array_fill_{0}({1}, {2});\n'.format(ftype, self._print(rhs.fill_value), self._print(lhs))
         return code_init
 
     def cuda_Arange(self, expr):
@@ -464,8 +465,10 @@ class CcudaCodePrinter(CCodePrinter):
         lhs = expr.lhs
         code_init = ''
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
+        ftype = declare_dtype if self._print(rhs.dtype) != 'int' else declare_dtype[:-2]
 
-        code_init += 'cuda_array_arange_{0}<<<1,1>>>({1}, {2});\n'.format(declare_dtype, self._print(lhs), self._print(rhs.start))
+        #TODO: calculate best thread number to run the kernel
+        code_init += 'cuda_array_arange_{0}<<<1,32>>>({1}, {2});\n'.format(ftype, self._print(lhs), self._print(rhs.start))
         return code_init
 
     def cuda_arrayFill(self, expr):
@@ -484,12 +487,13 @@ class CcudaCodePrinter(CCodePrinter):
         lhs = expr.lhs
         code_init = ''
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
+        ftype = declare_dtype if self._print(rhs.dtype) != 'int' else declare_dtype[:-2]
 
         if rhs.fill_value is not None:
             if isinstance(rhs.fill_value, Literal):
-                code_init += '_cuda_array_fill_{0}<<<1,1>>>(({0}){1}, {2});\n'.format(declare_dtype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'cuda_array_fill_{0}<<<1,1>>>(({1}){2}, {3});\n'.format(ftype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
             else:
-                code_init += '_cuda_array_fill_{0}<<<1,1>>>({1}, {2});\n'.format(declare_dtype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'cuda_array_fill_{0}<<<1,1>>>({1}, {2});\n'.format(ftype, self._print(rhs.fill_value), self._print(lhs))
         return code_init
 
     def copy_CudaArray_Data(self, expr):

--- a/pyccel/codegen/printing/ccudacode.py
+++ b/pyccel/codegen/printing/ccudacode.py
@@ -440,13 +440,14 @@ class CcudaCodePrinter(CCodePrinter):
         lhs = expr.lhs
         code_init = ''
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
-        ftype = declare_dtype if self._print(rhs.dtype) != 'int' else declare_dtype[:-2]
+        dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
+        dtype = dtype[3:]
 
         if rhs.fill_value is not None:
             if isinstance(rhs.fill_value, Literal):
-                code_init += 'cuda_array_fill_{0}(({1}){2}, {3});\n'.format(ftype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'cuda_array_fill_{0}(({1}){2}, {3});\n'.format(dtype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
             else:
-                code_init += 'cuda_array_fill_{0}({1}, {2});\n'.format(ftype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'cuda_array_fill_{0}({1}, {2});\n'.format(dtype, self._print(rhs.fill_value), self._print(lhs))
         return code_init
 
     def cuda_Arange(self, expr):
@@ -465,10 +466,11 @@ class CcudaCodePrinter(CCodePrinter):
         lhs = expr.lhs
         code_init = ''
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
-        ftype = declare_dtype if self._print(rhs.dtype) != 'int' else declare_dtype[:-2]
+        dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
+        dtype = dtype[3:]
 
         #TODO: calculate best thread number to run the kernel
-        code_init += 'cuda_array_arange_{0}<<<1,32>>>({1}, {2});\n'.format(ftype, self._print(lhs), self._print(rhs.start))
+        code_init += 'cuda_array_arange_{0}<<<1,32>>>({1}, {2});\n'.format(dtype, self._print(lhs), self._print(rhs.start))
         return code_init
 
     def cuda_arrayFill(self, expr):
@@ -487,13 +489,14 @@ class CcudaCodePrinter(CCodePrinter):
         lhs = expr.lhs
         code_init = ''
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
-        ftype = declare_dtype if self._print(rhs.dtype) != 'int' else declare_dtype[:-2]
+        dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
+        dtype = dtype[3:]
 
         if rhs.fill_value is not None:
             if isinstance(rhs.fill_value, Literal):
-                code_init += 'cuda_array_fill_{0}<<<1,1>>>(({1}){2}, {3});\n'.format(ftype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'cuda_array_fill_{0}<<<1,1>>>(({1}){2}, {3});\n'.format(dtype, declare_dtype, self._print(rhs.fill_value), self._print(lhs))
             else:
-                code_init += 'cuda_array_fill_{0}<<<1,1>>>({1}, {2});\n'.format(ftype, self._print(rhs.fill_value), self._print(lhs))
+                code_init += 'cuda_array_fill_{0}<<<1,1>>>({1}, {2});\n'.format(dtype, self._print(rhs.fill_value), self._print(lhs))
         return code_init
 
     def copy_CudaArray_Data(self, expr):

--- a/pyccel/codegen/printing/ccudacode.py
+++ b/pyccel/codegen/printing/ccudacode.py
@@ -453,10 +453,10 @@ class CcudaCodePrinter(CCodePrinter):
             arg = ', '.join(self._print(i) for i in arg)
             dummy_array = "%s %s[] = {%s};\n" % (declare_dtype, dummy_array_name, arg)
             cpy_data = "cudaMemcpy({0}.raw_data, {1}, {0}.buffer_size, cudaMemcpyHostToDevice);".format(self._print(lhs), dummy_array_name, dtype)
-            return  '%s%s' % (dummy_array, cpy_data)
+            return  '%s%s\n' % (dummy_array, cpy_data)
 
     def _print_CudaDeviceSynchronize(self, expr):
-        return 'cudaDeviceSynchronize();'
+        return 'cudaDeviceSynchronize()'
 
     def _print_CudaInternalVar(self, expr):
         var_name = type(expr).__name__

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -224,7 +224,7 @@ class CWrapperCodePrinter(CCodePrinter):
             Signature of the function
         """
         #if target_language is C no need for the binding
-        if self._target_language == 'c':
+        if self._target_language in ('c', 'ccuda'):
             return self.function_signature(expr)
 
         args = [a.var for a in expr.arguments]
@@ -236,6 +236,7 @@ class CWrapperCodePrinter(CCodePrinter):
         else:
             ret_type = self._print(datatype('void')) + ' '
         name = expr.name
+        print(expr.arguments[0].var.is_ndarray)
         if not args:
             arg_code = 'void'
         else:
@@ -293,10 +294,12 @@ class CWrapperCodePrinter(CCodePrinter):
         string
 
         """
+
         dtype = self._print(variable.dtype)
         prec  = variable.precision
 
         dtype = self.find_in_dtype_registry(dtype, prec)
+        print(variable, variable.dtype, variable.is_ndarray, dtype)
 
         if self.stored_in_c_pointer(variable):
             return '{0}*'.format(dtype)

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -239,7 +239,6 @@ class CWrapperCodePrinter(CCodePrinter):
         else:
             ret_type = self._print(datatype('void')) + ' '
         name = expr.name
-        print(expr.arguments[0].var.is_ndarray)
         if not args:
             arg_code = 'void'
         else:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2821,7 +2821,7 @@ class FCodePrinter(CodePrinter):
                     inds[i] = ind[0]
                 if allow_negative_indexes and not isinstance(ind, LiteralInteger):
                     inds[i] = IfTernaryOperator(PyccelLt(ind, LiteralInteger(0)),
-                            PyccelAdd(base_shape[i], ind, simplify = True), ind)
+                            PyccelAdd(_shape, ind, simplify = True), ind)
 
         inds = [self._print(i) for i in inds]
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -184,7 +184,7 @@ type_to_print_format = {
 
 inc_keyword = (r'do\b', r'if\b',
                r'else\b', r'type\b\s*[^\(]',
-               r'(recursive )?(pure )?(elemental )?((subroutine)|(function))\b',
+               r'(elemental )?(pure )?(recursive )?((subroutine)|(function))\b',
                r'interface\b',r'module\b(?! *procedure)',r'program\b')
 inc_regex = re.compile('|'.join('({})'.format(i) for i in inc_keyword))
 
@@ -1876,12 +1876,12 @@ class FCodePrinter(CodePrinter):
             if i in out_args:
                 out_args.remove(i)
 
-        # treate case of pure function
+        # treat case of pure function
         sig = '{0}{1} {2}'.format(rec, func_type, name)
         if is_pure:
             sig = 'pure {}'.format(sig)
 
-        # treate case of elemental function
+        # treat case of elemental function
         if is_elemental:
             sig = 'elemental {}'.format(sig)
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -21,13 +21,14 @@ stdlib_path = os.path.dirname(stdlib_folder.__file__)
 __all__ = ['copy_internal_library','recompile_object']
 
 #==============================================================================
-language_extension = {'fortran':'f90', 'c':'c', 'python':'py'}
+language_extension = {'fortran':'f90', 'c':'c', 'python':'py', 'ccuda':'cu'}
 
 #==============================================================================
 # map internal libraries to their folders inside pyccel/stdlib and their compile objects
 # The compile object folder will be in the pyccel dirpath
 internal_libs = {
     "ndarrays"     : ("ndarrays", CompileObj("ndarrays.c",folder="ndarrays")),
+    "cuda_ndarrays"     : ("cuda_ndarrays", CompileObj("cuda_ndarrays.cu",folder="cuda_ndarrays")),
     "pyc_math_f90" : ("math", CompileObj("pyc_math_f90.f90",folder="math")),
     "pyc_math_c"   : ("math", CompileObj("pyc_math_c.c",folder="math")),
     "cwrapper"     : ("cwrapper", CompileObj("cwrapper.c",folder="cwrapper", accelerators=('python',))),

--- a/pyccel/commands/console.py
+++ b/pyccel/commands/console.py
@@ -60,7 +60,7 @@ def pyccel(files=None, mpi=None, openmp=None, openacc=None, output_dir=None, com
     # ... backend compiler options
     group = parser.add_argument_group('Backend compiler options')
 
-    group.add_argument('--language', choices=('fortran', 'c', 'python'), help='Generated language')
+    group.add_argument('--language', choices=('fortran', 'c', 'python', 'ccuda'), help='Generated language')
 
     group.add_argument('--compiler', help='Compiler family or json file containing a compiler description {GNU,intel,PGI}')
 

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -171,6 +171,16 @@ nvc_info = {'exec' : 'nvc',
             }
 
 #------------------------------------------------------------
+nvcc_info = {'exec' : 'nvcc',
+            'language': 'ccuda',
+            'debug_flags': ("-g",),
+            'release_flags': ("-O3",),
+            'general_flags' : ('--compiler-options', '-fPIC',),
+            'standard_flags' : ('-std=c99',),
+            'family': 'nvidia',
+            }
+
+#------------------------------------------------------------
 def change_to_lib_flag(lib):
     """
     Convert a library to a library flag
@@ -240,6 +250,7 @@ pgcc_info.update(python_info)
 pgfortran_info.update(python_info)
 nvc_info.update(python_info)
 nvfort_info.update(python_info)
+nvcc_info.update(python_info)
 
 available_compilers = {('GNU', 'c') : gcc_info,
                        ('GNU', 'fortran') : gfort_info,
@@ -248,6 +259,7 @@ available_compilers = {('GNU', 'c') : gcc_info,
                        ('PGI', 'c') : pgcc_info,
                        ('PGI', 'fortran') : pgfortran_info,
                        ('nvidia', 'c') : nvc_info,
-                       ('nvidia', 'fortran') : nvfort_info}
+                       ('nvidia', 'fortran') : nvfort_info,
+                       ('nvidia', 'ccuda') : nvcc_info}
 
 vendors = ('GNU','intel','PGI','nvidia')

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -21,6 +21,7 @@ __all__ = (
     'sympy',
     'template',
     'types',
+    'kernel',
 )
 
 def lambdify(f):
@@ -98,3 +99,6 @@ def allow_negative_index(f,*args):
     def identity(f):
         return f
     return identity
+
+def kernel(f):
+    return f

--- a/pyccel/naming/__init__.py
+++ b/pyccel/naming/__init__.py
@@ -10,8 +10,9 @@ for different languages.
 from .fortrannameclashchecker import FortranNameClashChecker
 from .cnameclashchecker import CNameClashChecker
 from .pythonnameclashchecker import PythonNameClashChecker
+from .ccudaNameClashChecker import CCudaNameClashChecker
 
 name_clash_checkers = {'fortran':FortranNameClashChecker(),
         'c':CNameClashChecker(),
-        'ccuda':CNameClashChecker(),
+        'ccuda':CCudaNameClashChecker(),
         'python':PythonNameClashChecker()}

--- a/pyccel/naming/__init__.py
+++ b/pyccel/naming/__init__.py
@@ -13,4 +13,5 @@ from .pythonnameclashchecker import PythonNameClashChecker
 
 name_clash_checkers = {'fortran':FortranNameClashChecker(),
         'c':CNameClashChecker(),
+        'ccuda':CNameClashChecker(),
         'python':PythonNameClashChecker()}

--- a/pyccel/naming/__init__.py
+++ b/pyccel/naming/__init__.py
@@ -10,7 +10,7 @@ for different languages.
 from .fortrannameclashchecker import FortranNameClashChecker
 from .cnameclashchecker import CNameClashChecker
 from .pythonnameclashchecker import PythonNameClashChecker
-from .ccudaNameClashChecker import CCudaNameClashChecker
+from .ccudanameclashchecker import CCudaNameClashChecker
 
 name_clash_checkers = {'fortran':FortranNameClashChecker(),
         'c':CNameClashChecker(),

--- a/pyccel/naming/ccudanameclashchecker.py
+++ b/pyccel/naming/ccudanameclashchecker.py
@@ -9,7 +9,7 @@ Handles name clash problems in Ccuda
 from pyccel.utilities.metaclasses import Singleton
 from pyccel.utilities.strings import create_incremented_string
 
-class CNameClashChecker(metaclass = Singleton):
+class CCudaNameClashChecker(metaclass = Singleton):
     """ Class containing functions to help avoid problematic names in Ccuda
     """
     # Keywords as mentioned on https://en.cppreference.com/w/c/keyword
@@ -33,7 +33,8 @@ class CNameClashChecker(metaclass = Singleton):
         'GET_INDEX_FUNC_H2', 'GET_INDEX_FUNC', 'GET_INDEX',
         'INDEX', 'GET_ELEMENT', 'free_array', 'free_pointer',
         'get_index', 'numpy_to_ndarray_strides',
-        'numpy_to_ndarray_shape', 'get_size'])
+        'numpy_to_ndarray_shape', 'get_size',
+        'cuda_free_array', 'cuda_free_pointer', 'cuda_array_create', 'threadIdx', 'blockIdx'])
 
     def has_clash(self, name, symbols):
         """ Indicate whether the proposed name causes any clashes

--- a/pyccel/naming/ccudanameclashchecker.py
+++ b/pyccel/naming/ccudanameclashchecker.py
@@ -1,0 +1,61 @@
+# coding: utf-8
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
+#------------------------------------------------------------------------------------------#
+"""
+Handles name clash problems in Ccuda
+"""
+from pyccel.utilities.metaclasses import Singleton
+from pyccel.utilities.strings import create_incremented_string
+
+class CNameClashChecker(metaclass = Singleton):
+    """ Class containing functions to help avoid problematic names in Ccuda
+    """
+    # Keywords as mentioned on https://en.cppreference.com/w/c/keyword
+    keywords = set(['auto', 'break', 'case', 'char', 'const',
+        'continue', 'default', 'do', 'double', 'else', 'enum',
+        'extern', 'float', 'for', 'goto', 'if', 'inline', 'int',
+        'long', 'register', 'restrict', 'return', 'short', 'signed',
+        'sizeof', 'static', 'struct', 'switch', 'typedef', 'union',
+        'unsigned', 'void', 'volatile', 'whie', '_Alignas',
+        '_Alignof', '_Atomic', '_Bool', '_Complex', 'Decimal128',
+        '_Decimal32', '_Decimal64', '_Generic', '_Imaginary',
+        '_Noreturn', '_Static_assert', '_Thread_local', 't_ndarray',
+        'array_create', 'new_slice', 'array_slicing', 'alias_assign',
+        'transpose_alias_assign', 'array_fill', 't_slice',
+        'GET_INDEX_EXP1', 'GET_INDEX_EXP2', 'GET_INDEX_EXP2',
+        'GET_INDEX_EXP3', 'GET_INDEX_EXP4', 'GET_INDEX_EXP5',
+        'GET_INDEX_EXP6', 'GET_INDEX_EXP7', 'GET_INDEX_EXP8',
+        'GET_INDEX_EXP9', 'GET_INDEX_EXP10', 'GET_INDEX_EXP11',
+        'GET_INDEX_EXP12', 'GET_INDEX_EXP13', 'GET_INDEX_EXP14',
+        'GET_INDEX_EXP15', 'NUM_ARGS_H1', 'NUM_ARGS',
+        'GET_INDEX_FUNC_H2', 'GET_INDEX_FUNC', 'GET_INDEX',
+        'INDEX', 'GET_ELEMENT', 'free_array', 'free_pointer',
+        'get_index', 'numpy_to_ndarray_strides',
+        'numpy_to_ndarray_shape', 'get_size'])
+
+    def has_clash(self, name, symbols):
+        """ Indicate whether the proposed name causes any clashes
+        """
+        return any(name == k for k in self.keywords) or \
+               any(name == s for s in symbols)
+
+    def get_collisionless_name(self, name, symbols):
+        """ Get the name that will be used in the fortran code
+        """
+        if len(name)>4 and all(name[i] == '_' for i in (0,1,-1,-2)):
+            # Ignore magic methods
+            return name
+        if name[0] == '_':
+            name = 'private'+name
+        prefix = name
+        coll_symbols = self.keywords.copy()
+        coll_symbols.update(s.lower() for s in symbols)
+        if prefix in coll_symbols:
+            counter = 1
+            new_name, counter = create_incremented_string(coll_symbols,
+                    prefix = prefix, counter = counter)
+            name = name+new_name[-5:]
+        return name
+

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -102,7 +102,6 @@ def get_filename_from_import(module,input_folder=''):
 
     filename_pyh = os.path.join(package_dir, filename_pyh)
     filename_py = os.path.join(package_dir, filename_py)
-    print("hemS", filename_py, filename_pyh)
     if os.path.isfile(filename_pyh):
         return filename_pyh
     elif os.path.isfile(filename_py):

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -102,6 +102,7 @@ def get_filename_from_import(module,input_folder=''):
 
     filename_pyh = os.path.join(package_dir, filename_pyh)
     filename_py = os.path.join(package_dir, filename_py)
+    print("hemS", filename_py, filename_pyh)
     if os.path.isfile(filename_pyh):
         return filename_pyh
     elif os.path.isfile(filename_py):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -794,7 +794,7 @@ class SemanticParser(BasicParser):
         =======
         new_expr : FunctionCall or PyccelInternalFunction
         """
-        print('handle func -- ', func, type(func))
+
         if isinstance(func, PyccelFunctionDef):
             func = func.cls_name
             args, kwargs = split_positional_keyword_arguments(*args)
@@ -2222,7 +2222,6 @@ class SemanticParser(BasicParser):
             # first we check if it is a macro, in this case, we will create
             # an appropriate FunctionCall
 
-            print('func call -- ', expr, type(expr))
             macro = self.scope.find(name, 'macros')
             if macro is not None:
                 func = macro.master.funcdef
@@ -2230,7 +2229,6 @@ class SemanticParser(BasicParser):
                 args = macro.apply(args)
             else:
                 func = self.scope.find(name, 'functions')
-                print('func -- ', func, type(func))
             if func is None:
                 return errors.report(UNDEFINED_FUNCTION, symbol=name,
                         bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1956,11 +1956,7 @@ class SemanticParser(BasicParser):
                         symbol=expr,
                         bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                         severity='fatal')
-        from pyccel.ast.cudaext import CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim
-        # if first isinstance():
-        if (first in (CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim)):
-            dim = {'x':0, 'y':1, 'z':2}
-            return first(LiteralInteger(dim[rhs_name]))
+
         d_var = self._infere_type(first)
         if d_var.get('cls_base', None) is None:
             errors.report(f'Attribute {rhs_name} not found',

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -60,7 +60,7 @@ from pyccel.ast.core import Decorator
 from pyccel.ast.core import PyccelFunctionDef
 from pyccel.ast.core import Assert
 
-from pyccel.ast.class_defs import NumpyArrayClass, TupleClass, get_cls_base
+from pyccel.ast.class_defs import NumpyArrayClass, TupleClass, get_cls_base, CudaArrayClass
 
 from pyccel.ast.datatypes import NativeRange, str_dtype
 from pyccel.ast.datatypes import NativeSymbol
@@ -93,6 +93,8 @@ from pyccel.ast.numpyext import NumpyComplex, NumpyComplex64, NumpyComplex128
 from pyccel.ast.numpyext import NumpyTranspose, NumpyConjugate
 from pyccel.ast.numpyext import NumpyNewArray, NumpyNonZero
 from pyccel.ast.numpyext import DtypePrecisionToCastFunction
+
+from pyccel.ast.cudaext import CudaNewArray
 
 from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Construct,
                             OMP_TaskLoop_Construct, OMP_Sections_Construct, Omp_End_Clause,
@@ -486,6 +488,17 @@ class SemanticParser(BasicParser):
             d_var['order'      ] = expr.order
             d_var['precision'  ] = expr.precision
             d_var['cls_base'   ] = NumpyArrayClass
+            return d_var
+
+        elif isinstance(expr, CudaNewArray):
+            d_var['datatype'   ] = expr.dtype
+            d_var['memory_handling'] = 'heap' if expr.rank > 0 else 'stack'
+            d_var['memory_location'] = 'managed'
+            d_var['shape'      ] = expr.shape
+            d_var['rank'       ] = expr.rank
+            d_var['order'      ] = expr.order
+            d_var['precision'  ] = expr.precision
+            d_var['cls_base'   ] = CudaArrayClass
             return d_var
 
         elif isinstance(expr, NumpyTranspose):

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -19,7 +19,7 @@ from sympy.core import cache
 
 from pyccel.ast.basic import Basic
 
-from pyccel.ast.core import FunctionCall, FunctionCallArgument
+from pyccel.ast.core import FunctionCall, FunctionCallArgument, KernelCall
 from pyccel.ast.core import Module
 from pyccel.ast.core import Assign
 from pyccel.ast.core import AugAssign
@@ -899,6 +899,10 @@ class SyntaxParser(BasicParser):
         elif isinstance(func, DottedName):
             func_attr = FunctionCall(func.name[-1], args)
             func = DottedName(*func.name[:-1], func_attr)
+        elif isinstance(func, IndexedElement):
+            if len(func.indices) != 2:
+                raise NotImplementedError
+            func = KernelCall(func.base, args, func.indices[0], func.indices[1])
         else:
             raise NotImplementedError(' Unknown function type {}'.format(str(type(func))))
 

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
@@ -1,7 +1,31 @@
 #include "cuda_ndarrays.h"
 
 __global__
-void cuda_array_arange(t_ndarray arr, int start)
+void cuda_array_arange_int8_t(t_ndarray arr, int start)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x;
+	int stride = gridDim.x * blockDim.x;
+	for(int i = index ; i < arr.length; i+=stride)
+		arr.nd_int8[i] = (i + start);
+}
+__global__
+void cuda_array_arange_int32_t(t_ndarray arr, int start)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x;
+	int stride = gridDim.x * blockDim.x;
+	for(int i = index ; i < arr.length; i+=stride)
+		arr.nd_int32[i] = (i + start);
+}
+__global__
+void cuda_array_arange_int64_t(t_ndarray arr, int start)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x;
+	int stride = gridDim.x * blockDim.x;
+	for(int i = index ; i < arr.length; i+=stride)
+		arr.nd_int64[i] = (i + start);
+}
+__global__
+void cuda_array_arange_double(t_ndarray arr, int start)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	int stride = gridDim.x * blockDim.x;
@@ -10,12 +34,38 @@ void cuda_array_arange(t_ndarray arr, int start)
 }
 
 __global__
-void cuda_array_fill_int(int64_t c, t_ndarray arr)
+void _cuda_array_fill_int8_t(int8_t c, t_ndarray arr)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x;
+	int stride = gridDim.x * blockDim.x;
+	for(int i = index ; i < arr.length; i+=stride)
+		arr.nd_int8[i] = c;
+}
+
+__global__
+void _cuda_array_fill_int32_t(int32_t c, t_ndarray arr)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x;
+	int stride = gridDim.x * blockDim.x;
+	for(int i = index ; i < arr.length; i+=stride)
+		arr.nd_int32[i] = c;
+}
+
+__global__
+void _cuda_array_fill_int64_t(int64_t c, t_ndarray arr)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	int stride = gridDim.x * blockDim.x;
 	for(int i = index ; i < arr.length; i+=stride)
 		arr.nd_int64[i] = c;
+}
+__global__
+void _cuda_array_fill_double(double c, t_ndarray arr)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x;
+	int stride = gridDim.x * blockDim.x;
+	for(int i = index ; i < arr.length; i+=stride)
+		arr.nd_double[i] = c;
 }
 
 t_ndarray   cuda_array_create(int32_t nd, int64_t *shape,
@@ -65,7 +115,6 @@ t_ndarray   cuda_array_create(int32_t nd, int64_t *shape,
         for (int32_t j = i + 1; j < arr.nd; j++)
             arr.strides[i] *= arr.shape[j];
     }
-    printf("abbah");
     if (!is_view)
         cudaMallocManaged(&(arr.raw_data), arr.buffer_size);
     return (arr);

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
@@ -1,21 +1,21 @@
 #include "cuda_ndarrays.h"
 
 __global__
-void cuda_array_arange_int8_t(t_ndarray arr, int start)
+void cuda_array_arange_int8(t_ndarray arr, int start)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	for(int i = index ; i < arr.length; i+=1)
 		arr.nd_int8[i] = (i + start);
 }
 __global__
-void cuda_array_arange_int32_t(t_ndarray arr, int start)
+void cuda_array_arange_int32(t_ndarray arr, int start)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	for(int i = index ; i < arr.length; i+=1)
 		arr.nd_int32[i] = (i + start);
 }
 __global__
-void cuda_array_arange_int64_t(t_ndarray arr, int start)
+void cuda_array_arange_int64(t_ndarray arr, int start)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	for(int i = index ; i < arr.length; i+=1)
@@ -30,7 +30,7 @@ void cuda_array_arange_double(t_ndarray arr, int start)
 }
 
 __global__
-void _cuda_array_fill_int8_t(int8_t c, t_ndarray arr)
+void cuda_array_fill_int8(int8_t c, t_ndarray arr)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	int stride = gridDim.x * blockDim.x;
@@ -39,7 +39,7 @@ void _cuda_array_fill_int8_t(int8_t c, t_ndarray arr)
 }
 
 __global__
-void _cuda_array_fill_int32_t(int32_t c, t_ndarray arr)
+void cuda_array_fill_int32(int32_t c, t_ndarray arr)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	int stride = gridDim.x * blockDim.x;
@@ -48,7 +48,7 @@ void _cuda_array_fill_int32_t(int32_t c, t_ndarray arr)
 }
 
 __global__
-void _cuda_array_fill_int64_t(int64_t c, t_ndarray arr)
+void cuda_array_fill_int64(int64_t c, t_ndarray arr)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	int stride = gridDim.x * blockDim.x;
@@ -56,7 +56,7 @@ void _cuda_array_fill_int64_t(int64_t c, t_ndarray arr)
 		arr.nd_int64[i] = c;
 }
 __global__
-void _cuda_array_fill_double(double c, t_ndarray arr)
+void cuda_array_fill_double(double c, t_ndarray arr)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
 	int stride = gridDim.x * blockDim.x;

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
@@ -4,33 +4,29 @@ __global__
 void cuda_array_arange_int8_t(t_ndarray arr, int start)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
-	int stride = gridDim.x * blockDim.x;
-	for(int i = index ; i < arr.length; i+=stride)
+	for(int i = index ; i < arr.length; i+=1)
 		arr.nd_int8[i] = (i + start);
 }
 __global__
 void cuda_array_arange_int32_t(t_ndarray arr, int start)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
-	int stride = gridDim.x * blockDim.x;
-	for(int i = index ; i < arr.length; i+=stride)
+	for(int i = index ; i < arr.length; i+=1)
 		arr.nd_int32[i] = (i + start);
 }
 __global__
 void cuda_array_arange_int64_t(t_ndarray arr, int start)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
-	int stride = gridDim.x * blockDim.x;
-	for(int i = index ; i < arr.length; i+=stride)
+	for(int i = index ; i < arr.length; i+=1)
 		arr.nd_int64[i] = (i + start);
 }
 __global__
 void cuda_array_arange_double(t_ndarray arr, int start)
 {
 	int index = blockIdx.x * blockDim.x + threadIdx.x;
-	int stride = gridDim.x * blockDim.x;
-	for(int i = index ; i < arr.length; i+=stride)
-		arr.nd_int64[i] = (i + start);
+	for(int i = index ; i < arr.length; i+=1)
+		arr.nd_double[i] = (i + start);
 }
 
 __global__

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
@@ -1,0 +1,94 @@
+#include "cuda_ndarrays.h"
+
+__global__
+void cuda_array_arange(t_ndarray arr, int start)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x;
+	int stride = gridDim.x * blockDim.x;
+	for(int i = index ; i < arr.length; i+=stride)
+		arr.nd_int64[i] = (i + start);
+}
+
+__global__
+void cuda_array_fill_int(int64_t c, t_ndarray arr)
+{
+	int index = blockIdx.x * blockDim.x + threadIdx.x;
+	int stride = gridDim.x * blockDim.x;
+	for(int i = index ; i < arr.length; i+=stride)
+		arr.nd_int64[i] = c;
+}
+
+t_ndarray   cuda_array_create(int32_t nd, int64_t *shape, enum e_types type)
+{
+    t_ndarray arr;
+
+    arr.nd = nd;
+    arr.type = type;
+    switch (type)
+    {
+        case nd_int8:
+            arr.type_size = sizeof(int8_t);
+            break;
+        case nd_int16:
+            arr.type_size = sizeof(int16_t);
+            break;
+        case nd_int32:
+            arr.type_size = sizeof(int32_t);
+            break;
+        case nd_int64:
+            arr.type_size = sizeof(int64_t);
+            break;
+        case nd_float:
+            arr.type_size = sizeof(float);
+            break;
+        case nd_double:
+            arr.type_size = sizeof(double);
+            break;
+        case nd_bool:
+            arr.type_size = sizeof(bool);
+            break;
+    }
+    arr.is_view = false;
+    arr.length = 1;
+    cudaMallocManaged(&(arr.shape), arr.nd * sizeof(int64_t));
+    for (int32_t i = 0; i < arr.nd; i++)
+    {
+        arr.length *= shape[i];
+        arr.shape[i] = shape[i];
+    }
+    arr.buffer_size = arr.length * arr.type_size;
+    cudaMallocManaged(&(arr.strides), nd * sizeof(int64_t));
+    for (int32_t i = 0; i < arr.nd; i++)
+    {
+        arr.strides[i] = 1;
+        for (int32_t j = i + 1; j < arr.nd; j++)
+            arr.strides[i] *= arr.shape[j];
+    }
+    cudaMallocManaged(&(arr.raw_data), arr.buffer_size);
+    return (arr);
+}
+
+int32_t cuda_free_array(t_ndarray arr)
+{
+    if (arr.shape == NULL)
+        return (0);
+    free(arr.raw_data);
+    arr.raw_data = NULL;
+    free(arr.shape);
+    arr.shape = NULL;
+    free(arr.strides);
+    arr.strides = NULL;
+    return (1);
+}
+
+
+int32_t cuda_free_pointer(t_ndarray arr)
+{
+    if (arr.is_view == false || arr.shape == NULL)
+        return (0);
+    free(arr.shape);
+    arr.shape = NULL;
+    free(arr.strides);
+    arr.strides = NULL;
+    return (1);
+}

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
@@ -18,7 +18,8 @@ void cuda_array_fill_int(int64_t c, t_ndarray arr)
 		arr.nd_int64[i] = c;
 }
 
-t_ndarray   cuda_array_create(int32_t nd, int64_t *shape, enum e_types type)
+t_ndarray   cuda_array_create(int32_t nd, int64_t *shape,
+        enum e_types type, bool is_view)
 {
     t_ndarray arr;
 
@@ -48,7 +49,7 @@ t_ndarray   cuda_array_create(int32_t nd, int64_t *shape, enum e_types type)
             arr.type_size = sizeof(bool);
             break;
     }
-    arr.is_view = false;
+    arr.is_view = is_view;
     arr.length = 1;
     cudaMallocManaged(&(arr.shape), arr.nd * sizeof(int64_t));
     for (int32_t i = 0; i < arr.nd; i++)
@@ -64,7 +65,9 @@ t_ndarray   cuda_array_create(int32_t nd, int64_t *shape, enum e_types type)
         for (int32_t j = i + 1; j < arr.nd; j++)
             arr.strides[i] *= arr.shape[j];
     }
-    cudaMallocManaged(&(arr.raw_data), arr.buffer_size);
+    printf("abbah");
+    if (!is_view)
+        cudaMallocManaged(&(arr.raw_data), arr.buffer_size);
     return (arr);
 }
 

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.h
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.h
@@ -3,6 +3,7 @@
 
 #include "../ndarrays/ndarrays.h"
 
+/* mapping the function array_fill to the correct type */
 // enum e_cuda_types
 // {
 //         nd_bool     = 0,
@@ -46,9 +47,23 @@
 // }               t_cuda_ndarray;
 
 __global__
-void cuda_array_arange(t_ndarray arr, int start);
+void cuda_array_arange_int8_t(t_ndarray arr, int start);
 __global__
-void cuda_array_fill(int64_t c, t_ndarray arr);
+void cuda_array_arange_int32_t(t_ndarray arr, int start);
+__global__
+void cuda_array_arange_int64_t(t_ndarray arr, int start);
+__global__
+void cuda_array_arange_double(t_ndarray arr, int start);
+
+__global__
+void _cuda_array_fill_int8_t(int8_t c, t_ndarray arr);
+__global__
+void _cuda_array_fill_int32_t(int32_t c, t_ndarray arr);
+__global__
+void _cuda_array_fill_int64_t(int64_t c, t_ndarray arr);
+__global__
+void _cuda_array_fill_double(double c, t_ndarray arr);
+
 t_ndarray   cuda_array_create(int32_t nd, int64_t *shape, enum e_types type, bool is_view);
 int32_t         cuda_free_array(t_ndarray dump);
 int32_t         cuda_free_pointer(t_ndarray dump);

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.h
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.h
@@ -1,11 +1,55 @@
 #ifndef CUDA_NDARRAYS_H
 # define CUDA_NDARRAYS_H
-# include "../ndarrays/ndarrays.h"
+
+#include "../ndarrays/ndarrays.h"
+
+// enum e_cuda_types
+// {
+//         nd_bool     = 0,
+//         nd_int8     = 1,
+//         nd_int16    = 3,
+//         nd_int32    = 5,
+//         nd_int64    = 7,
+//         nd_float    = 11,
+//         nd_double   = 12
+// };
+
+// typedef struct  s_cuda_ndarray
+// {
+//     /* raw data buffer*/
+//     union {
+//             void            *raw_data;
+//             int8_t          *nd_int8;
+//             int16_t         *nd_int16;
+//             int32_t         *nd_int32;
+//             int64_t         *nd_int64;
+//             float           *nd_float;
+//             double          *nd_double;
+//             bool            *nd_bool;
+//             };
+//     /* number of dimensions */
+//     int32_t                 nd;
+//     /* shape 'size of each dimension' */
+//     int64_t                 *shape;
+//     /* strides 'number of bytes to skip to get the next element' */
+//     int64_t                 *strides;
+//     /* type of the array elements */
+//     enum e_types            type;
+//     /* type size of the array elements */
+//     int32_t                 type_size;
+//     /* number of element in the array */
+//     int32_t                 length;
+//     /* size of the array */
+//     int32_t                 buffer_size;
+//     /* True if the array does not own the data */
+//     bool                    is_view;
+// }               t_cuda_ndarray;
+
 __global__
 void cuda_array_arange(t_ndarray arr, int start);
 __global__
 void cuda_array_fill(int64_t c, t_ndarray arr);
-t_ndarray   cuda_array_create(int32_t nd, int64_t *shape, enum e_types type);
+t_ndarray   cuda_array_create(int32_t nd, int64_t *shape, enum e_types type, bool is_view);
 int32_t         cuda_free_array(t_ndarray dump);
 int32_t         cuda_free_pointer(t_ndarray dump);
 #endif

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.h
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.h
@@ -1,0 +1,11 @@
+#ifndef CUDA_NDARRAYS_H
+# define CUDA_NDARRAYS_H
+# include "../ndarrays/ndarrays.h"
+__global__
+void cuda_array_arange(t_ndarray arr, int start);
+__global__
+void cuda_array_fill(int64_t c, t_ndarray arr);
+t_ndarray   cuda_array_create(int32_t nd, int64_t *shape, enum e_types type);
+int32_t         cuda_free_array(t_ndarray dump);
+int32_t         cuda_free_pointer(t_ndarray dump);
+#endif

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.h
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.h
@@ -3,64 +3,21 @@
 
 #include "../ndarrays/ndarrays.h"
 
-/* mapping the function array_fill to the correct type */
-// enum e_cuda_types
-// {
-//         nd_bool     = 0,
-//         nd_int8     = 1,
-//         nd_int16    = 3,
-//         nd_int32    = 5,
-//         nd_int64    = 7,
-//         nd_float    = 11,
-//         nd_double   = 12
-// };
-
-// typedef struct  s_cuda_ndarray
-// {
-//     /* raw data buffer*/
-//     union {
-//             void            *raw_data;
-//             int8_t          *nd_int8;
-//             int16_t         *nd_int16;
-//             int32_t         *nd_int32;
-//             int64_t         *nd_int64;
-//             float           *nd_float;
-//             double          *nd_double;
-//             bool            *nd_bool;
-//             };
-//     /* number of dimensions */
-//     int32_t                 nd;
-//     /* shape 'size of each dimension' */
-//     int64_t                 *shape;
-//     /* strides 'number of bytes to skip to get the next element' */
-//     int64_t                 *strides;
-//     /* type of the array elements */
-//     enum e_types            type;
-//     /* type size of the array elements */
-//     int32_t                 type_size;
-//     /* number of element in the array */
-//     int32_t                 length;
-//     /* size of the array */
-//     int32_t                 buffer_size;
-//     /* True if the array does not own the data */
-//     bool                    is_view;
-// }               t_cuda_ndarray;
-
 __global__
-void cuda_array_arange_int8_t(t_ndarray arr, int start);
+void cuda_array_arange_int8(t_ndarray arr, int start);
 __global__
-void cuda_array_arange_int32_t(t_ndarray arr, int start);
+void cuda_array_arange_int32(t_ndarray arr, int start);
 __global__
-void cuda_array_arange_int64_t(t_ndarray arr, int start);
+void cuda_array_arange_int64(t_ndarray arr, int start);
 __global__
 void cuda_array_arange_double(t_ndarray arr, int start);
 
 __global__
-void _cuda_array_fill_int8_t(int8_t c, t_ndarray arr);
+void _cuda_array_fill_int8(int8_t c, t_ndarray arr);
 __global__
-void _cuda_array_fill_int32_t(int32_t c, t_ndarray arr);
+void _cuda_array_fill_int32(int32_t c, t_ndarray arr);
 __global__
-void _cuda_array_fill_int64_t(int64_t c, t_ndarray arr);
+void _cuda_array_fill_int64(int64_t c, t_ndarray arr);
 __global__
 void _cuda_array_fill_double(double c, t_ndarray arr);
 

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -42,12 +42,14 @@ t_ndarray   array_create(int32_t nd, int64_t *shape,
         case nd_bool:
             arr.type_size = sizeof(bool);
             break;
+        #ifndef __NVCC__
         case nd_cfloat:
             arr.type_size = sizeof(float complex);
             break;
         case nd_cdouble:
             arr.type_size = sizeof(double complex);
             break;
+        #endif
     }
     arr.is_view = is_view;
     arr.length = 1;
@@ -95,12 +97,14 @@ void    stack_array_init(t_ndarray *arr)
         case nd_bool:
             arr->type_size = sizeof(bool);
             break;
+        #ifndef __NVCC__
         case nd_cfloat:
             arr->type_size = sizeof(float complex);
             break;
         case nd_cdouble:
             arr->type_size = sizeof(double complex);
             break;
+        #endif
     }
     arr->length = 1;
     for (int32_t i = 0; i < arr->nd; i++)
@@ -177,6 +181,7 @@ void   _array_fill_double(double c, t_ndarray arr)
             arr.nd_double[i] = c;
 }
 
+#ifndef __NVCC__
 void   _array_fill_cfloat(float complex c, t_ndarray arr)
 {
     if (c == 0)
@@ -195,6 +200,7 @@ void   _array_fill_cdouble(double complex c, t_ndarray arr)
         for (int32_t i = 0; i < arr.length; i++)
             arr.nd_cdouble[i] = c;
 }
+#endif
 
 /*
 ** deallocation

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -118,7 +118,7 @@ void    stack_array_init(t_ndarray *arr)
     }
 }
 
-void   _array_fill_int8_t(int8_t c, t_ndarray arr)
+void   array_fill_int8(int8_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -127,7 +127,7 @@ void   _array_fill_int8_t(int8_t c, t_ndarray arr)
             arr.nd_int8[i] = c;
 }
 
-void   _array_fill_int16_t(int16_t c, t_ndarray arr)
+void   array_fill_int16(int16_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -136,7 +136,7 @@ void   _array_fill_int16_t(int16_t c, t_ndarray arr)
             arr.nd_int16[i] = c;
 }
 
-void   _array_fill_int32_t(int32_t c, t_ndarray arr)
+void   array_fill_int32(int32_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -145,7 +145,7 @@ void   _array_fill_int32_t(int32_t c, t_ndarray arr)
             arr.nd_int32[i] = c;
 }
 
-void   _array_fill_int64_t(int64_t c, t_ndarray arr)
+void   array_fill_int64(int64_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -154,7 +154,7 @@ void   _array_fill_int64_t(int64_t c, t_ndarray arr)
             arr.nd_int64[i] = c;
 }
 
-void   _array_fill_bool(bool c, t_ndarray arr)
+void   array_fill_bool(bool c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -163,7 +163,7 @@ void   _array_fill_bool(bool c, t_ndarray arr)
             arr.nd_bool[i] = c;
 }
 
-void   _array_fill_float(float c, t_ndarray arr)
+void   array_fill_float(float c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -172,7 +172,7 @@ void   _array_fill_float(float c, t_ndarray arr)
             arr.nd_float[i] = c;
 }
 
-void   _array_fill_double(double c, t_ndarray arr)
+void   array_fill_double(double c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -182,7 +182,7 @@ void   _array_fill_double(double c, t_ndarray arr)
 }
 
 #ifndef __NVCC__
-void   _array_fill_cfloat(float complex c, t_ndarray arr)
+void   array_fill_cfloat(float complex c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -192,7 +192,7 @@ void   _array_fill_cfloat(float complex c, t_ndarray arr)
 }
 
 
-void   _array_fill_cdouble(double complex c, t_ndarray arr)
+void   array_fill_cdouble(double complex c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);

--- a/pyccel/stdlib/ndarrays/ndarrays.c
+++ b/pyccel/stdlib/ndarrays/ndarrays.c
@@ -118,7 +118,7 @@ void    stack_array_init(t_ndarray *arr)
     }
 }
 
-void   _array_fill_int8(int8_t c, t_ndarray arr)
+void   _array_fill_int8_t(int8_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -127,7 +127,7 @@ void   _array_fill_int8(int8_t c, t_ndarray arr)
             arr.nd_int8[i] = c;
 }
 
-void   _array_fill_int16(int16_t c, t_ndarray arr)
+void   _array_fill_int16_t(int16_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -136,7 +136,7 @@ void   _array_fill_int16(int16_t c, t_ndarray arr)
             arr.nd_int16[i] = c;
 }
 
-void   _array_fill_int32(int32_t c, t_ndarray arr)
+void   _array_fill_int32_t(int32_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);
@@ -145,7 +145,7 @@ void   _array_fill_int32(int32_t c, t_ndarray arr)
             arr.nd_int32[i] = c;
 }
 
-void   _array_fill_int64(int64_t c, t_ndarray arr)
+void   _array_fill_int64_t(int64_t c, t_ndarray arr)
 {
     if (c == 0)
         memset(arr.raw_data, 0, arr.buffer_size);

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -106,16 +106,16 @@ typedef struct  s_ndarray
 void        stack_array_init(t_ndarray *arr);
 t_ndarray   array_create(int32_t nd, int64_t *shape,
         enum e_types type, bool is_view);
-void        _array_fill_int8_t(int8_t c, t_ndarray arr);
-void        _array_fill_int16_t(int16_t c, t_ndarray arr);
-void        _array_fill_int32_t(int32_t c, t_ndarray arr);
-void        _array_fill_int64_t(int64_t c, t_ndarray arr);
-void        _array_fill_float(float c, t_ndarray arr);
-void        _array_fill_double(double c, t_ndarray arr);
-void        _array_fill_bool(bool c, t_ndarray arr);
+void        array_fill_int8(int8_t c, t_ndarray arr);
+void        array_fill_int16(int16_t c, t_ndarray arr);
+void        array_fill_int32(int32_t c, t_ndarray arr);
+void        array_fill_int64(int64_t c, t_ndarray arr);
+void        array_fill_float(float c, t_ndarray arr);
+void        array_fill_double(double c, t_ndarray arr);
+void        array_fill_bool(bool c, t_ndarray arr);
 #ifndef __NVCC__
-void        _array_fill_cfloat(float complex c, t_ndarray arr);
-void        _array_fill_cdouble(double complex c, t_ndarray arr);
+void        array_fill_cfloat(float complex c, t_ndarray arr);
+void        array_fill_cdouble(double complex c, t_ndarray arr);
 #endif
 
 /* slicing */

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -10,6 +10,9 @@
 # include <stdbool.h>
 # include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* mapping the function array_fill to the correct type */
 # define array_fill(c, arr) _Generic((c), int64_t : _array_fill_int64,\
                                         int32_t : _array_fill_int32,\
@@ -145,5 +148,9 @@ int64_t         get_index(t_ndarray arr, ...);
 /* data converting between numpy and ndarray */
 int64_t     *numpy_to_ndarray_strides(int64_t *np_strides, int type_size, int nd);
 int64_t     *numpy_to_ndarray_shape(int64_t *np_shape, int nd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -10,6 +10,9 @@
 # include <stdbool.h>
 # include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* mapping the function array_fill to the correct type */
 # define array_fill(c, arr) _Generic((c), int64_t : _array_fill_int64,\
                                         int32_t : _array_fill_int32,\
@@ -66,8 +69,10 @@ enum e_types
         nd_int64    = 7,
         nd_float    = 11,
         nd_double   = 12,
+        #ifndef __NVCC__
         nd_cfloat   = 14,
         nd_cdouble  = 15
+        #endif
 };
 
 typedef struct  s_ndarray
@@ -82,8 +87,10 @@ typedef struct  s_ndarray
             float           *nd_float;
             double          *nd_double;
             bool            *nd_bool;
+            #ifndef __NVCC__
             double complex  *nd_cdouble;
             float  complex  *nd_cfloat;
+            #endif
             };
     /* number of dimensions */
     int32_t                 nd;
@@ -116,8 +123,10 @@ void        _array_fill_int64(int64_t c, t_ndarray arr);
 void        _array_fill_float(float c, t_ndarray arr);
 void        _array_fill_double(double c, t_ndarray arr);
 void        _array_fill_bool(bool c, t_ndarray arr);
+#ifndef __NVCC__
 void        _array_fill_cfloat(float complex c, t_ndarray arr);
 void        _array_fill_cdouble(double complex c, t_ndarray arr);
+#endif
 
 /* slicing */
                 /* creating a Slice object */
@@ -139,5 +148,9 @@ int64_t         get_index(t_ndarray arr, ...);
 /* data converting between numpy and ndarray */
 int64_t     *numpy_to_ndarray_strides(int64_t *np_strides, int type_size, int nd);
 int64_t     *numpy_to_ndarray_shape(int64_t *np_shape, int nd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -10,9 +10,6 @@
 # include <stdbool.h>
 # include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 /* mapping the function array_fill to the correct type */
 # define array_fill(c, arr) _Generic((c), int64_t : _array_fill_int64,\
                                         int32_t : _array_fill_int32,\
@@ -148,9 +145,5 @@ int64_t         get_index(t_ndarray arr, ...);
 /* data converting between numpy and ndarray */
 int64_t     *numpy_to_ndarray_strides(int64_t *np_strides, int type_size, int nd);
 int64_t     *numpy_to_ndarray_shape(int64_t *np_shape, int nd);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -13,16 +13,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-/* mapping the function array_fill to the correct type */
-# define array_fill(c, arr) _Generic((c), int64_t : _array_fill_int64,\
-                                        int32_t : _array_fill_int32,\
-                                        int16_t : _array_fill_int16,\
-                                        int8_t : _array_fill_int8,\
-                                        float : _array_fill_float,\
-                                        double : _array_fill_double,\
-                                        bool : _array_fill_bool,\
-                                        float complex : _array_fill_cfloat,\
-                                        double complex : _array_fill_cdouble)(c, arr)
 
 typedef struct  s_slice
 {
@@ -116,10 +106,10 @@ typedef struct  s_ndarray
 void        stack_array_init(t_ndarray *arr);
 t_ndarray   array_create(int32_t nd, int64_t *shape,
         enum e_types type, bool is_view);
-void        _array_fill_int8(int8_t c, t_ndarray arr);
-void        _array_fill_int16(int16_t c, t_ndarray arr);
-void        _array_fill_int32(int32_t c, t_ndarray arr);
-void        _array_fill_int64(int64_t c, t_ndarray arr);
+void        _array_fill_int8_t(int8_t c, t_ndarray arr);
+void        _array_fill_int16_t(int16_t c, t_ndarray arr);
+void        _array_fill_int32_t(int32_t c, t_ndarray arr);
+void        _array_fill_int64_t(int64_t c, t_ndarray arr);
 void        _array_fill_float(float c, t_ndarray arr);
 void        _array_fill_double(double c, t_ndarray arr);
 void        _array_fill_bool(bool c, t_ndarray arr);

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ markers =
     parallel: test to be run using 'mpiexec'
     fortran: test to generate fortran code
     c: test to generate c code
+    ccuda: test to generate Ccuda code
     python: test to generate python code
     xdist_incompatible: test which compiles a file also compiled by another test
     external: test using an external dll (problematic with conda on Windows)

--- a/samples/test/test.py
+++ b/samples/test/test.py
@@ -5,17 +5,24 @@ from numpy import array as narray
 # from pyccel.stdlib.internal import PyccelthreadIdx
 
 
+@types('int[:]')
+def abbah(z):
+    return z[0]
+
 
 @kernel
 @types('int[:]')
 def func(a):
-    # i = cuda.threadIdx(0)
+    i = cuda.threadIdx(0)
     """
     test test
     """
-    print("Hello World!")
+    print("Hello World! ", a[i])
+    a[i] += 1
 
 if __name__ == "__main__":
-    b = narray([1, 2, 3], dtype='int', order='C')
+    # b = narray([1, 2, 3], dtype='int', order='C')
     a = cuda.array([1, 2, 3], dtype='int', order='C')
-    func[1, 2](a)
+    func[1, 3](a)
+    cuda.deviceSynchronize()
+    print(a)

--- a/samples/test/test.py
+++ b/samples/test/test.py
@@ -1,0 +1,21 @@
+# from numpy import array
+from pyccel.decorators import kernel
+from pyccel import cuda
+from numpy import array as narray
+# from pyccel.stdlib.internal import PyccelthreadIdx
+
+
+
+@kernel
+@types('int[:]')
+def func(a):
+    # i = cuda.threadIdx(0)
+    """
+    test test
+    """
+    print("Hello World!")
+
+if __name__ == "__main__":
+    b = narray([1, 2, 3], dtype='int', order='C')
+    a = cuda.array([1, 2, 3], dtype='int', order='C')
+    func[1, 2](a)

--- a/samples/test/tt.cu
+++ b/samples/test/tt.cu
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+__global__ void func(int *p)
+{
+    p[0] = 5;
+    printf("%s\n", "Hello World!");
+}
+
+int main()
+{
+    int *p1;
+
+    cudaMallocManaged(&p1, 3*sizeof(int));
+    p1[0] = 0;
+    func<<<1,2>>>(p1);
+    cudaDeviceSynchronize();
+    printf("%d\n", p1[0]);
+    return 0;
+}

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -791,6 +791,20 @@ def test_argument_negative_index_2(a, b):
     d = 3
     return a[c], a[d], b[c], b[d]
 
+@allow_negative_index('a', 'b')
+@types('int[:,:]', 'int[:,:]')
+def test_c_order_argument_negative_index(a, b):
+    c = -2
+    d = 2
+    return a[c,0], a[1,d], b[c,1], b[d,0]
+
+@allow_negative_index('a', 'b')
+@types('int[:,:](order=F)', 'int[:,:](order=F)')
+def test_f_order_argument_negative_index(a, b):
+    c = -2
+    d = 3
+    return a[c,0], a[1,d], b[c,1], b[0,d]
+
 #==============================================================================
 # SHAPE INITIALISATION
 #==============================================================================

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -1842,6 +1842,20 @@ def test_argument_negative_index_2(language):
     f2 = epyccel(f1, language = language)
     assert np.array_equal(f1(a, a), f2(a, a))
 
+def test_c_order_argument_negative_index(language):
+    a = np.random.randint(20, size=(3,4))
+
+    f1 = arrays.test_c_order_argument_negative_index
+    f2 = epyccel(f1, language = language)
+    assert np.array_equal(f1(a, a), f2(a, a))
+
+def test_f_order_argument_negative_index(language):
+    a = np.array(np.random.randint(20, size=(3,4)), order='F')
+
+    f1 = arrays.test_f_order_argument_negative_index
+    f2 = epyccel(f1, language = language)
+    assert np.array_equal(f1(a, a), f2(a, a))
+
 #==============================================================================
 # TEST: shape initialisation
 #==============================================================================

--- a/tests/internal/scripts/ccuda/cupy_arange.py
+++ b/tests/internal/scripts/ccuda/cupy_arange.py
@@ -1,0 +1,17 @@
+from pyccel.decorators import kernel, types
+from pyccel import cuda
+import cupy as cp
+
+@kernel
+@types('int[:]')
+def func(a):
+    i = cuda.threadIdx(0) + cuda.blockIdx(0) * cuda.blockDim(0)
+    print("Hello World! ", a[i])
+
+if __name__ == '__main__':
+    threads_per_block = 32
+    n_blocks = 1
+    arr = cp.arange(32)
+    cuda.deviceSynchronize()
+    func[n_blocks, threads_per_block](arr)
+    cuda.deviceSynchronize()

--- a/tests/internal/scripts/ccuda/cupy_array.py
+++ b/tests/internal/scripts/ccuda/cupy_array.py
@@ -1,0 +1,17 @@
+from pyccel.decorators import kernel, types
+from pyccel import cuda
+import cupy as cp
+
+@kernel
+@types('int[:]')
+def func(a):
+    i = cuda.threadIdx(0) + cuda.blockIdx(0) * cuda.blockDim(0)
+    print("Hello World! ", a[i])
+
+if __name__ == '__main__':
+    threads_per_block = 5
+    n_blocks = 1
+    arr = cp.array([0, 1, 2, 3, 4])
+    cuda.deviceSynchronize()
+    func[n_blocks, threads_per_block](arr)
+    cuda.deviceSynchronize()

--- a/tests/internal/scripts/ccuda/kernel.py
+++ b/tests/internal/scripts/ccuda/kernel.py
@@ -1,0 +1,8 @@
+from pyccel.decorators import kernel, types
+from pyccel import cuda
+
+@kernel
+@types('int[:]')
+def func(a):
+    i = cuda.threadIdx(0) + cuda.blockIdx(0) * cuda.blockDim(0)
+    print("Hello World! ", a[i])

--- a/tests/internal/scripts/ccuda/kernel_launch.py
+++ b/tests/internal/scripts/ccuda/kernel_launch.py
@@ -1,0 +1,16 @@
+from pyccel.decorators import kernel, types
+from pyccel import cuda
+
+@kernel
+@types('int[:]')
+def func(a):
+    i = cuda.threadIdx(0) + cuda.blockIdx(0) * cuda.blockDim(0)
+    print("Hello World! ", a[i])
+
+if __name__ == '__main__':
+    threads_per_block = 5
+    n_blocks = 1
+    arr = cuda.array([0, 1, 2, 3, 4])
+    cuda.deviceSynchronize()
+    func[n_blocks, threads_per_block](arr)
+    cuda.deviceSynchronize()

--- a/tests/internal/test_internal.py
+++ b/tests/internal/test_internal.py
@@ -47,7 +47,7 @@ def test_openmp(f, language):
 )
 @pytest.mark.external
 def test_ccuda(f, language):
-    execute_pyccel(f, language=language)
+    execute_pyccel(f, verbose=True, language=language)
 
 #@pytest.mark.parametrize("f", get_files_from_folder('openacc'))
 #@pytest.mark.external

--- a/tests/internal/test_internal.py
+++ b/tests/internal/test_internal.py
@@ -47,7 +47,7 @@ def test_openmp(f, language):
 )
 @pytest.mark.external
 def test_ccuda(f, language):
-    execute_pyccel(f, verbose=True, language=language)
+    execute_pyccel(f, language=language)
 
 #@pytest.mark.parametrize("f", get_files_from_folder('openacc'))
 #@pytest.mark.external

--- a/tests/internal/test_internal.py
+++ b/tests/internal/test_internal.py
@@ -41,6 +41,14 @@ def test_mpi(f):
 def test_openmp(f, language):
     execute_pyccel(f, accelerators=['openmp'], language=language)
 
+@pytest.mark.parametrize("f", get_files_from_folder('ccuda'))
+@pytest.mark.parametrize( 'language',
+        (pytest.param("ccuda", marks = pytest.mark.ccuda),)
+)
+@pytest.mark.external
+def test_ccuda(f, language):
+    execute_pyccel(f, language=language)
+
 #@pytest.mark.parametrize("f", get_files_from_folder('openacc'))
 #@pytest.mark.external
 #def test_openacc():
@@ -98,3 +106,13 @@ if __name__ == '__main__':
 #        print('> testing {0}'.format(str(os.path.basename(f))))
 #        test_openacc(f)
 #    print('\n')
+
+    print('*********************************')
+    print('***                           ***')
+    print('***  TESTING INTERNAL/Cuda ***')
+    print('***                           ***')
+    print('*********************************')
+    for f in get_files_from_folder('ccuda'):
+       print('> testing {0}'.format(str(os.path.basename(f))))
+       test_ccuda(f)
+    print('\n')

--- a/tests/ndarrays/test_ndarrays.c
+++ b/tests/ndarrays/test_ndarrays.c
@@ -609,7 +609,7 @@ int32_t test_array_fill_int64(void)
     int64_t c_value;
 
     x = array_create(2, m_1_shape, nd_int64, false);
-    array_fill((int64_t)32, x);
+    array_fill_int64((int64_t)32, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -633,7 +633,7 @@ int32_t test_array_fill_int32(void)
     int32_t c_value;
 
     x = array_create(2, m_1_shape, nd_int32, false);
-    array_fill((int32_t)32, x);
+    array_fill_int32((int32_t)32, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -657,7 +657,7 @@ int32_t test_array_fill_int16(void)
     int16_t c_value;
 
     x = array_create(2, m_1_shape, nd_int16, false);
-    array_fill((int16_t)32, x);
+    array_fill_int16((int16_t)32, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -681,7 +681,7 @@ int32_t test_array_fill_int8(void)
     int8_t c_value;
 
     x = array_create(2, m_1_shape, nd_int8, false);
-    array_fill((int8_t)32, x);
+    array_fill_int8((int8_t)32, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -705,7 +705,7 @@ int32_t test_array_fill_double(void)
     double c_value;
 
     x = array_create(2, m_1_shape, nd_double, false);
-    array_fill(2., x);
+    array_fill_double(2., x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -729,7 +729,7 @@ int32_t test_array_fill_cdouble(void)
     double complex c_value;
 
     x = array_create(2, m_1_shape, nd_cdouble, false);
-    array_fill(0.3+0.54*I, x);
+    array_fill_cdouble(0.3+0.54*I, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -755,7 +755,7 @@ int32_t test_array_zeros_double(void)
     double c_value;
 
     x = array_create(2, m_1_shape, nd_double, false);
-    array_fill(0, x);
+    array_fill_double(0, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -779,7 +779,7 @@ int32_t test_array_zeros_int32(void)
     int32_t c_value;
 
     x = array_create(2, m_1_shape, nd_int32, false);
-    array_fill(0, x);
+    array_fill_int32(0, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;
@@ -803,7 +803,7 @@ int32_t test_array_zeros_cdouble(void)
     double complex c_value;
 
     x = array_create(2, m_1_shape, nd_cdouble, false);
-    array_fill(0, x);
+    array_fill_cdouble(0, x);
     // testing the index [3, 1]
     index = 3 * x.strides[0] + 1 * x.strides[1];
     c_index = 7;

--- a/tests/pyccel/scripts/runtest_type_print.py
+++ b/tests/pyccel/scripts/runtest_type_print.py
@@ -7,3 +7,6 @@ if __name__ == '__main__':
     print(type(np.int64(3)))
     print(type(np.float32(3)))
     print(type(np.float64(3)))
+    print(type(np.complex(3)))
+    print(type(np.complex64(3)))
+    print(type(np.complex128(3)))


### PR DESCRIPTION
This PR will add some Pyccel internal functions to work as a base to integrate (Cupy, Numba) later.

The PR will focus on adding:

- [x] simple array creation.
- [x] custom kernels: 
                   - Kernelcalls
                   - thread indexing
- [x] cudadeviceSyncronize
- [x] some `Cupy` array creation funcs
- [x] testing compilation for cuda and Cupy functions

with these building blocks we can start expanding on other complex features and support `cupy` and `numpy`.
 
The already existing `CCodePrinter` will be the base of the `CudaCodePrinter` which will save a lot of work from the printing side.

Note: will be using the branch **cuda_main** as the master for now until we have a discussing on how we can proceed to add to the **master** branch.