### PR TITLE
Support printing tuples in C and improve Fortran printing

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -858,6 +858,8 @@ class CCodePrinter(CodePrinter):
                     args_format = []
                     args = []
                 args = [FunctionCallArgument(print_arg) for tuple_elem in f for print_arg in (tuple_elem, tuple_sep)][:-1]
+                if len(f) == 1:
+                    args.append(FunctionCallArgument(LiteralString(',')))
                 if i + 1 == len(orig_args):
                     end_of_tuple = FunctionCallArgument(LiteralString(end), 'end')
                 else:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -826,6 +826,7 @@ class CCodePrinter(CodePrinter):
         code = ''
         empty_end = FunctionCallArgument(LiteralString(''), 'end')
         space_end = FunctionCallArgument(LiteralString(' '), 'end')
+        empty_sep = FunctionCallArgument(LiteralString(''), 'sep')
         kwargs = [f for f in expr.expr if f.has_keyword]
         for f in kwargs:
             if f.keyword == 'sep'      :   sep = str(f.value)
@@ -845,8 +846,25 @@ class CCodePrinter(CodePrinter):
         if len(orig_args) == 0:
             return formatted_args_to_printf(args_format, args, end)
 
+        tuple_start = FunctionCallArgument(LiteralString('('))
+        tuple_sep   = LiteralString(', ')
+        tuple_end   = FunctionCallArgument(LiteralString(')'))
+
         for i, f in enumerate(orig_args):
             f = f.value
+            if isinstance(f, (InhomogeneousTupleVariable, PythonTuple)):
+                if args_format:
+                    code += formatted_args_to_printf(args_format, args, sep)
+                    args_format = []
+                    args = []
+                args = [FunctionCallArgument(print_arg) for tuple_elem in f for print_arg in (tuple_elem, tuple_sep)][:-1]
+                if i + 1 == len(orig_args):
+                    end_of_tuple = FunctionCallArgument(LiteralString(end), 'end')
+                else:
+                    end_of_tuple = FunctionCallArgument(LiteralString(sep), 'end')
+                code += self._print(PythonPrint([tuple_start, *args, tuple_end, empty_sep, end_of_tuple]))
+                args = []
+                continue
             if isinstance(f, PythonType):
                 f = f.print_string
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -573,6 +573,7 @@ class FCodePrinter(CodePrinter):
         code = ''
         empty_end = FunctionCallArgument(LiteralString(''), 'end')
         space_end = FunctionCallArgument(LiteralString(' '), 'end')
+        empty_sep = FunctionCallArgument(LiteralString(''), 'sep')
         for f in expr.expr:
             if f.has_keyword:
                 if f.keyword == 'sep':
@@ -591,7 +592,7 @@ class FCodePrinter(CodePrinter):
         tuple_sep   = LiteralString(', ')
         tuple_end   = FunctionCallArgument(LiteralString(')'))
 
-        for f in orig_args:
+        for i, f in enumerate(orig_args):
             if f.keyword:
                 continue
             else:
@@ -601,8 +602,12 @@ class FCodePrinter(CodePrinter):
                     code += self._formatted_args_to_print(args_format, args, sep, separator)
                     args_format = []
                     args = []
+                if i + 1 == len(orig_args):
+                    end_of_tuple = empty_end
+                else:
+                    end_of_tuple = FunctionCallArgument(sep, 'end')
                 args = [FunctionCallArgument(print_arg) for tuple_elem in f for print_arg in (tuple_elem, tuple_sep)][:-1]
-                code += self._print(PythonPrint([tuple_start, *args, tuple_end]))
+                code += self._print(PythonPrint([tuple_start, *args, tuple_end, empty_sep, end_of_tuple]))
                 args = []
             elif isinstance(f, PythonType):
                 args_format.append('A')

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -607,6 +607,8 @@ class FCodePrinter(CodePrinter):
                 else:
                     end_of_tuple = FunctionCallArgument(sep, 'end')
                 args = [FunctionCallArgument(print_arg) for tuple_elem in f for print_arg in (tuple_elem, tuple_sep)][:-1]
+                if len(f) == 1:
+                    args.append(FunctionCallArgument(LiteralString(',')))
                 code += self._print(PythonPrint([tuple_start, *args, tuple_end, empty_sep, end_of_tuple]))
                 args = []
             elif isinstance(f, PythonType):

--- a/tests/pyccel/scripts/print_tuples.py
+++ b/tests/pyccel/scripts/print_tuples.py
@@ -1,0 +1,12 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+# ------------------------------- Strings ------------------------------------
+if __name__ == '__main__':
+    print(())
+    print((1,))
+    print((1,2,3))
+    print(((1,2),3))
+    print(((1,2),(3,)))
+    print((((1,),2),(3,)))
+    print((1, True))
+    print((1, True), sep=",")
+    print((1, True), end="!\n")

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -635,6 +635,11 @@ def test_print_strings(language):
     pyccel_test("scripts/print_strings.py", language=language, output_dtype=types)
 
 #------------------------------------------------------------------------------
+def test_print_tuples(language):
+    types = str
+    pyccel_test("scripts/print_tuples.py", language=language, output_dtype=types)
+
+#------------------------------------------------------------------------------
 def test_print_sp_and_end(language):
     types = str
     pyccel_test("scripts/print_sp_and_end.py", language=language, output_dtype=types)


### PR DESCRIPTION
fixes #1189

**Describe the what is added**
- Support the printing of tuples in C language
- Improving the printing of tuples in fortran

```python
print((1, 2), 3, ((4, 5), False) , sep=", ")
```
**Python output**
```
(1, 2), 3, ((4, 5), False)
```

### Before the fix
***C language***
```
ERROR at code generation stage
pyccel:
 |fatal [codegen]: file.py [2,10]| _print_PythonTuple is not yet implemented for language : C
Pyccel has encountered syntax that has not been implemented yet. Please create an issue at https://github.com/pyccel/pyccel/issues and provide a small example of your problem. Do not forget to specify your target language ((1, 2))
```

***Fortran language***
```
( 1 ,  2 )
3, ( ( 4 ,  5 )
,  False )

```

### After the fix

***C/Fortran language***
```
(1, 2), 3, ((4, 5), False)
```