### PR TITLE
Change debugging output to show type precision

### DIFF
--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -724,7 +724,7 @@ class SemanticParser(BasicParser):
         """
         dtype = var.dtype
         prec  = get_final_precision(var)
-        descr = f'{dtype}{(prec * 2 if dtype == NativeComplex() else prec) * 8 if prec else ""}'
+        descr = f'{dtype}{(prec * 2 if isinstance(dtype, NativeComplex) else prec) * 8 if prec else ""}'
         if include_rank and var.rank>0:
             dims = ','.join(':'*var.rank)
             descr += f'[{dims}]'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -724,7 +724,7 @@ class SemanticParser(BasicParser):
         """
         dtype = var.dtype
         prec  = get_final_precision(var)
-        descr = f'{dtype}{prec * 8 if prec else ""}'
+        descr = f'{dtype}{(prec * 2 if dtype == NativeComplex() else prec) * 8 if prec else ""}'
         if include_rank and var.rank>0:
             dims = ','.join(':'*var.rank)
             descr += f'[{dims}]'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -724,7 +724,7 @@ class SemanticParser(BasicParser):
         """
         dtype = var.dtype
         prec  = get_final_precision(var)
-        descr = f'{dtype}(kind={prec})'
+        descr = f'{dtype}{prec * 8 if prec else ""}'
         if include_rank and var.rank>0:
             dims = ','.join(':'*var.rank)
             descr += f'[{dims}]'


### PR DESCRIPTION
fix #1100

changed the debugging message to show the precision such as `int64` instead of `int(kind(8))` and added conditions for complexes requested by @Hellio404 to print the proper precision since complexes have double size to cover the real and imaginary range.

running this code:
```javascript
import numpy as np
if __name__ == "__main__":
    def a(arg: 'complex128'):
        pass
    a(4)
```

used to show:
`Argument 1 : 4 (int(kind=8), passed to function a is incompatible (expected complex(kind=8)).`

now it shows this instead:
`Argument 1 : 4 (int64), passed to function a is incompatible (expected complex128)`
