### PR TITLE
Cuda_internal_var can only be used in kernel funcs

### DIFF
--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -94,7 +94,7 @@ from pyccel.ast.numpyext import NumpyTranspose, NumpyConjugate
 from pyccel.ast.numpyext import NumpyNewArray, NumpyNonZero
 from pyccel.ast.numpyext import DtypePrecisionToCastFunction
 
-from pyccel.ast.cudaext import CudaNewArray
+from pyccel.ast.cudaext import CudaNewArray, CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim
 
 from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Construct,
                             OMP_TaskLoop_Construct, OMP_Sections_Construct, Omp_End_Clause,
@@ -810,6 +810,12 @@ class SemanticParser(BasicParser):
 
         if isinstance(func, PyccelFunctionDef):
             func = func.cls_name
+            if func in (CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim):
+                if 'kernel' not in self.scope.decorators:
+                    errors.report("Cuda internal variables should only be used in Kernel or Device functions",
+                        symbol = expr,
+                        severity = 'fatal')
+
             args, kwargs = split_positional_keyword_arguments(*args)
             for a in args:
                 if getattr(a,'dtype',None) == 'tuple':


### PR DESCRIPTION
Adds a check to assure that Cuda_internal_var function can only be used in a function with a kernel decorator.