### PR TITLE
Check type of passed parameter to Kernel Block number and Thread per Block number

### DIFF
--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -901,6 +901,12 @@ class SemanticParser(BasicParser):
                         symbol = expr,
                         severity='fatal')
             # TODO : type check the NUMBER OF BLOCKS 'numBlocks' and threads per block 'tpblock'
+            if not all(isinstance(param, (LiteralInteger, PythonTuple, PyccelSymbol))\
+                    for param in [expr.numBlocks, expr.tpblock]):
+                errors.report("Invalid parameter for Kernel Block number or Thread per Block",
+                        symbol = expr,
+                        severity='error')
+
             new_expr = KernelCall(func, args, expr.numBlocks, expr.tpblock, self._current_function)
             if None in new_expr.args:
                 errors.report("Too few arguments passed in function call",

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -94,7 +94,7 @@ from pyccel.ast.numpyext import NumpyTranspose, NumpyConjugate
 from pyccel.ast.numpyext import NumpyNewArray, NumpyNonZero
 from pyccel.ast.numpyext import DtypePrecisionToCastFunction
 
-from pyccel.ast.cudaext import CudaNewArray
+from pyccel.ast.cudaext import CudaNewArray, CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim
 
 from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Construct,
                             OMP_TaskLoop_Construct, OMP_Sections_Construct, Omp_End_Clause,
@@ -810,6 +810,12 @@ class SemanticParser(BasicParser):
 
         if isinstance(func, PyccelFunctionDef):
             func = func.cls_name
+            if func in (CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim):
+                if 'kernel' not in self.scope.decorators:
+                    errors.report("Cuda internal variables should only be used in Kernel or Device functions",
+                        symbol = expr,
+                        severity = 'fatal')
+
             args, kwargs = split_positional_keyword_arguments(*args)
             for a in args:
                 if getattr(a,'dtype',None) == 'tuple':


### PR DESCRIPTION
Verify that the passed argument (`numBlocks`, `tpblock`) to kernel function are valid.