### PR TITLE
Semantic stage : checks on Kernel calls

### DIFF
--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -160,3 +160,7 @@ INVALID_MACRO_COMPOSITION = 'Invalid macro composition'
 WRONG_LINSPACE_ENDPOINT = 'endpoint argument must be boolean'
 NON_LITERAL_KEEP_DIMS = 'keep_dims argument must be a literal, otherwise rank is unknown'
 NON_LITERAL_AXIS = 'axis argument must be a literal, otherwise pyccel cannot determine which dimension to operate on'
+KERNEL_STACK_ARRAY_ARG = "A variable allocated on the stack can't be passed to a Kernel function"
+NON_KERNEL_FUNCTION_CUDA_VAR = 'Cuda internal variables should only be used in Kernel or Device functions'
+UNVALID_KERNEL_CALL_BLOCK_NUM = 'Invalid Block number parameter for Kernel call'
+UNVALID_KERNEL_CALL_TP_BLOCK = 'Invalid Thread per Block parameter for Kernel call'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -910,12 +910,12 @@ class SemanticParser(BasicParser):
 
             new_expr = KernelCall(func, args, expr.numBlocks, expr.tpblock, self._current_function)
 
-            if len(new_expr.args) is not len(func.arguments):
-                errors.report("The number of passed arguments to the function call does not correspond to the function definition",
-                    symbol = expr,
-                    severity='error')
             for a in new_expr.args:
-                if isinstance(a.value, Variable) and a.value.on_stack:
+                if a is None:
+                    errors.report("Too few arguments passed in function call",
+                        symbol = expr,
+                        severity='error')
+                elif isinstance(a.value, Variable) and a.value.on_stack:
                     errors.report("A variable allocated on the stack can't be passed to a Kernel function",
                         symbol = expr,
                         severity='error')

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -901,6 +901,12 @@ class SemanticParser(BasicParser):
                         symbol = expr,
                         severity='fatal')
             # TODO : type check the NUMBER OF BLOCKS 'numBlocks' and threads per block 'tpblock'
+            if not all(isinstance(param, (LiteralInteger, PythonTuple, PyccelSymbol))\
+                    for param in [expr.numBlocks, expr.tpblock]):
+                errors.report("Invalid parameter for Kernel Block number or Thread per Block",
+                        symbol = expr,
+                        severity='error')
+
             new_expr = KernelCall(func, args, expr.numBlocks, expr.tpblock, self._current_function)
             if None in new_expr.args:
                 errors.report("Too few arguments passed in function call",

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -811,7 +811,8 @@ class SemanticParser(BasicParser):
         if isinstance(func, PyccelFunctionDef):
             func = func.cls_name
             if func in (CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim):
-                if 'kernel' not in self.scope.decorators:
+                if 'kernel' not in self.scope.decorators\
+                    or 'device' not in self.scope.decorators:
                     errors.report("Cuda internal variables should only be used in Kernel or Device functions",
                         symbol = expr,
                         severity = 'fatal')

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -910,6 +910,10 @@ class SemanticParser(BasicParser):
 
             new_expr = KernelCall(func, args, expr.numBlocks, expr.tpblock, self._current_function)
 
+            if len(new_expr.args) is not len(func.arguments):
+                errors.report("The number of passed arguments to the function call does not correspond to the function definition",
+                    symbol = expr,
+                    severity='error')
             for a in new_expr.args:
                 if a is None:
                     errors.report("Too few arguments passed in function call",

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -908,11 +908,18 @@ class SemanticParser(BasicParser):
                         severity='error')
 
             new_expr = KernelCall(func, args, expr.numBlocks, expr.tpblock, self._current_function)
-            if None in new_expr.args:
-                errors.report("Too few arguments passed in function call",
+
+            for a in new_expr.args:
+                if a is None:
+                    errors.report("Too few arguments passed in function call",
                         symbol = expr,
                         severity='error')
-            elif isinstance(func, FunctionDef):
+                elif isinstance(a.value, Variable) and a.value.on_stack:
+                    errors.report("Variable allocated on the stack passed to a Kernel",
+                        symbol = expr,
+                        severity='error')
+
+            if isinstance(func, FunctionDef):
                 self._check_argument_compatibility(new_expr.args, func.arguments,
                         expr, func.is_elemental)
             return new_expr

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -902,9 +902,12 @@ class SemanticParser(BasicParser):
                         symbol = expr,
                         severity='fatal')
             # TODO : type check the NUMBER OF BLOCKS 'numBlocks' and threads per block 'tpblock'
-            if not all(isinstance(param, LiteralInteger)\
-                    for param in [expr.numBlocks, expr.tpblock]):
-                errors.report("Invalid parameter for Kernel Block number or Thread per Block",
+            if not isinstance(expr.numBlocks, LiteralInteger):
+                errors.report("Invalid Block number parameter for Kernel call",
+                        symbol = expr,
+                        severity='error')
+            if not isinstance(expr.tpblock, LiteralInteger):
+                errors.report("Invalid Thread per Block parameter for Kernel call",
                         symbol = expr,
                         severity='error')
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -902,7 +902,7 @@ class SemanticParser(BasicParser):
                         symbol = expr,
                         severity='fatal')
             # TODO : type check the NUMBER OF BLOCKS 'numBlocks' and threads per block 'tpblock'
-            if not all(isinstance(param, (LiteralInteger, PythonTuple, PyccelSymbol))\
+            if not all(isinstance(param, LiteralInteger)\
                     for param in [expr.numBlocks, expr.tpblock]):
                 errors.report("Invalid parameter for Kernel Block number or Thread per Block",
                         symbol = expr,
@@ -919,7 +919,6 @@ class SemanticParser(BasicParser):
                     errors.report("A variable allocated on the stack can't be passed to a Kernel function",
                         symbol = expr,
                         severity='error')
-
             if isinstance(func, FunctionDef):
                 self._check_argument_compatibility(new_expr.args, func.arguments,
                         expr, func.is_elemental)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -94,7 +94,7 @@ from pyccel.ast.numpyext import NumpyTranspose, NumpyConjugate
 from pyccel.ast.numpyext import NumpyNewArray, NumpyNonZero
 from pyccel.ast.numpyext import DtypePrecisionToCastFunction
 
-from pyccel.ast.cudaext import CudaNewArray
+from pyccel.ast.cudaext import CudaNewArray, CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim
 
 from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Construct,
                             OMP_TaskLoop_Construct, OMP_Sections_Construct, Omp_End_Clause,
@@ -810,6 +810,12 @@ class SemanticParser(BasicParser):
 
         if isinstance(func, PyccelFunctionDef):
             func = func.cls_name
+            if func in (CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim):
+                if 'kernel' not in self.scope.decorators:
+                    errors.report("Cuda internal variables should only be used in Kernel or Device functions",
+                        symbol = expr,
+                        severity = 'fatal')
+
             args, kwargs = split_positional_keyword_arguments(*args)
             for a in args:
                 if getattr(a,'dtype',None) == 'tuple':

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -915,12 +915,8 @@ class SemanticParser(BasicParser):
                     symbol = expr,
                     severity='error')
             for a in new_expr.args:
-                if a is None:
-                    errors.report("Too few arguments passed in function call",
-                        symbol = expr,
-                        severity='error')
-                elif isinstance(a.value, Variable) and a.value.on_stack:
-                    errors.report("Variable allocated on the stack passed to a Kernel",
+                if isinstance(a.value, Variable) and a.value.on_stack:
+                    errors.report("A variable allocated on the stack can't be passed to a Kernel function",
                         symbol = expr,
                         severity='error')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ from pyccel.commands.pyccel_clean import pyccel_clean
 @pytest.fixture( params=[
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = pytest.mark.c),
-        pytest.param("python", marks = pytest.mark.python)
+        pytest.param("python", marks = pytest.mark.python),
+        pytest.param("ccuda", marks = pytest.mark.ccuda)
     ],
     scope = "session"
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,7 @@ from pyccel.commands.pyccel_clean import pyccel_clean
 @pytest.fixture( params=[
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = pytest.mark.c),
-        pytest.param("python", marks = pytest.mark.python),
-        pytest.param("ccuda", marks = pytest.mark.ccuda)
+        pytest.param("python", marks = pytest.mark.python)
     ],
     scope = "session"
 )

--- a/tests/cuda_test/test_kernel_semantic.py
+++ b/tests/cuda_test/test_kernel_semantic.py
@@ -12,6 +12,13 @@ from pyccel.errors.messages import (KERNEL_STACK_ARRAY_ARG,
                                     UNVALID_KERNEL_CALL_TP_BLOCK,
                                     )
 
+@pytest.mark.parametrize( 'language', [
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.fortran),
+        pytest.param("ccuda", marks = pytest.mark.ccuda),
+        pytest.param("python", marks = pytest.mark.python)
+    ]
+)
 def test_stack_array_kernel(language):
     @stack_array('arr')
     def kernel_caller():
@@ -38,7 +45,14 @@ def test_stack_array_kernel(language):
     error_info = [*errors.error_info_map.values()][0][0]
     assert error_info.symbol.func  == 'stack_array_kernel'
     assert KERNEL_STACK_ARRAY_ARG == error_info.message
-    
+
+@pytest.mark.parametrize( 'language', [
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.fortran),
+        pytest.param("ccuda", marks = pytest.mark.ccuda),
+        pytest.param("python", marks = pytest.mark.python)
+    ]
+)
 def test_cuda_intern_var_non_kernel(language):
     def non_kernel_function():
         from pyccel import cuda
@@ -61,6 +75,13 @@ def test_cuda_intern_var_non_kernel(language):
     assert error_info.symbol.name[1].func_name  == 'threadIdx'
     assert NON_KERNEL_FUNCTION_CUDA_VAR == error_info.message
 
+@pytest.mark.parametrize( 'language', [
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.fortran),
+        pytest.param("ccuda", marks = pytest.mark.ccuda),
+        pytest.param("python", marks = pytest.mark.python)
+    ]
+)
 def test_unvalid_block_number(language):
     def unvalid_block_number():
         @kernel
@@ -84,6 +105,13 @@ def test_unvalid_block_number(language):
     assert error_info.symbol.func  == 'kernel_call'
     assert UNVALID_KERNEL_CALL_BLOCK_NUM == error_info.message
 
+@pytest.mark.parametrize( 'language', [
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.fortran),
+        pytest.param("ccuda", marks = pytest.mark.ccuda),
+        pytest.param("python", marks = pytest.mark.python)
+    ]
+)
 def test_unvalid_thread_per_block(language):
     def unvalid_thread_per_block():
         @kernel

--- a/tests/cuda_test/test_kernel_semantic.py
+++ b/tests/cuda_test/test_kernel_semantic.py
@@ -13,10 +13,7 @@ from pyccel.errors.messages import (KERNEL_STACK_ARRAY_ARG,
                                     )
 
 @pytest.mark.parametrize( 'language', [
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.fortran),
-        pytest.param("ccuda", marks = pytest.mark.ccuda),
-        pytest.param("python", marks = pytest.mark.python)
+        pytest.param("ccuda", marks = pytest.mark.ccuda)
     ]
 )
 def test_stack_array_kernel(language):
@@ -47,10 +44,7 @@ def test_stack_array_kernel(language):
     assert KERNEL_STACK_ARRAY_ARG == error_info.message
 
 @pytest.mark.parametrize( 'language', [
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.fortran),
-        pytest.param("ccuda", marks = pytest.mark.ccuda),
-        pytest.param("python", marks = pytest.mark.python)
+        pytest.param("ccuda", marks = pytest.mark.ccuda)
     ]
 )
 def test_cuda_intern_var_non_kernel(language):
@@ -76,10 +70,7 @@ def test_cuda_intern_var_non_kernel(language):
     assert NON_KERNEL_FUNCTION_CUDA_VAR == error_info.message
 
 @pytest.mark.parametrize( 'language', [
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.fortran),
-        pytest.param("ccuda", marks = pytest.mark.ccuda),
-        pytest.param("python", marks = pytest.mark.python)
+        pytest.param("ccuda", marks = pytest.mark.ccuda)
     ]
 )
 def test_unvalid_block_number(language):
@@ -106,10 +97,7 @@ def test_unvalid_block_number(language):
     assert UNVALID_KERNEL_CALL_BLOCK_NUM == error_info.message
 
 @pytest.mark.parametrize( 'language', [
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.fortran),
-        pytest.param("ccuda", marks = pytest.mark.ccuda),
-        pytest.param("python", marks = pytest.mark.python)
+        pytest.param("ccuda", marks = pytest.mark.ccuda)
     ]
 )
 def test_unvalid_thread_per_block(language):

--- a/tests/cuda_test/test_kernel_semantic.py
+++ b/tests/cuda_test/test_kernel_semantic.py
@@ -1,0 +1,108 @@
+
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+import pytest
+
+import numpy as np
+from pyccel.epyccel import epyccel
+from pyccel.decorators import stack_array, types, kernel
+from pyccel.errors.errors import Errors, PyccelSemanticError
+from pyccel.errors.messages import (KERNEL_STACK_ARRAY_ARG,
+                                    NON_KERNEL_FUNCTION_CUDA_VAR,
+                                    UNVALID_KERNEL_CALL_BLOCK_NUM,
+                                    UNVALID_KERNEL_CALL_TP_BLOCK,
+                                    )
+
+def test_stack_array_kernel(language):
+    @stack_array('arr')
+    def kernel_caller():
+        from numpy import ones
+        @kernel
+        @types('int[:]')
+        def stack_array_kernel(arr):
+            return arr[0]
+        arr = ones(1, dtype=int)
+        return stack_array_kernel[1,1](arr)
+
+    # Initialize singleton that stores Pyccel errors
+    errors = Errors()
+
+    # epyccel should raise an Exception
+    with pytest.raises(PyccelSemanticError):
+        epyccel(kernel_caller, language=language)
+
+    # Check that we got exactly 1 Pyccel error
+    assert errors.has_errors()
+    assert errors.num_messages() == 1
+
+    # Check that the error is correct
+    error_info = [*errors.error_info_map.values()][0][0]
+    assert error_info.symbol.func  == 'stack_array_kernel'
+    assert KERNEL_STACK_ARRAY_ARG == error_info.message
+    
+def test_cuda_intern_var_non_kernel(language):
+    def non_kernel_function():
+        from pyccel import cuda
+        i = cuda.threadIdx(0) + cuda.blockIdx(0) * cuda.blockDim(0)
+
+    # Initialize singleton that stores Pyccel errors
+    errors = Errors()
+
+    # epyccel should raise an Exception
+    with pytest.raises(PyccelSemanticError):
+        epyccel(non_kernel_function, language=language)
+
+    # Check that we got exactly 1 Pyccel error
+    assert errors.has_errors()
+    assert errors.num_messages() == 1
+
+    # Check that the error is correct
+    error_info = [*errors.error_info_map.values()][0][0]
+    assert error_info.symbol.name[0]            == 'cuda'
+    assert error_info.symbol.name[1].func_name  == 'threadIdx'
+    assert NON_KERNEL_FUNCTION_CUDA_VAR == error_info.message
+
+def test_unvalid_block_number(language):
+    def unvalid_block_number():
+        @kernel
+        def kernel_call():
+            pass
+        kernel_call[1.2,1]()
+
+    # Initialize singleton that stores Pyccel errors
+    errors = Errors()
+
+    # epyccel should raise an Exception
+    with pytest.raises(PyccelSemanticError):
+        epyccel(unvalid_block_number, language=language)
+
+    # Check that we got exactly 1 Pyccel error
+    assert errors.has_errors()
+    assert errors.num_messages() == 1
+
+    # Check that the error is correct
+    error_info = [*errors.error_info_map.values()][0][0]
+    assert error_info.symbol.func  == 'kernel_call'
+    assert UNVALID_KERNEL_CALL_BLOCK_NUM == error_info.message
+
+def test_unvalid_thread_per_block(language):
+    def unvalid_thread_per_block():
+        @kernel
+        def kernel_call():
+            pass
+        kernel_call[1,1.2]()
+
+    # Initialize singleton that stores Pyccel errors
+    errors = Errors()
+
+    # epyccel should raise an Exception
+    with pytest.raises(PyccelSemanticError):
+        epyccel(unvalid_thread_per_block, language=language)
+
+    # Check that we got exactly 1 Pyccel error
+    assert errors.has_errors()
+    assert errors.num_messages() == 1
+
+    # Check that the error is correct
+    error_info = [*errors.error_info_map.values()][0][0]
+    assert error_info.symbol.func  == 'kernel_call'
+    assert UNVALID_KERNEL_CALL_TP_BLOCK == error_info.message


### PR DESCRIPTION
This PR solves multiples issues in Kernel function call:
- Make `cuda_Internal_Var` only usable in can only be used in kernels and device.
- Verify that none of the arguments passed to a kernel function call is a `stackarray`.
- Check type of passed parameter to Kernel Block number and Thread per block.