### PR TITLE
Correct function call keyword to handle name collisions correctly

### DIFF
--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2987,10 +2987,6 @@ class FCodePrinter(CodePrinter):
         else:
             results_strs = []
 
-        args = [a if a.keyword is None else \
-                FunctionCallArgument(a.value, func.scope.get_expected_name(a.keyword)) \
-                for a in args]
-
         if func.is_inline:
             if len(func_results)>1:
                 code = self._handle_inline_func_call(expr, args, assign_lhs = results)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2987,6 +2987,10 @@ class FCodePrinter(CodePrinter):
         else:
             results_strs = []
 
+        args = [a if a.keyword is None else \
+                FunctionCallArgument(a.value, func.scope.get_expected_name(a.keyword)) \
+                for a in args]
+
         if func.is_inline:
             if len(func_results)>1:
                 code = self._handle_inline_func_call(expr, args, assign_lhs = results)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2172,7 +2172,7 @@ class SemanticParser(BasicParser):
         # Correct keyword names if scope is available
         # The scope is only available if the function body has been parsed
         # (i.e. not for headers or builtin functions)
-        if func and func.scope:
+        if isinstance(func, FunctionDef) and func.scope:
             args = [a if a.keyword is None else \
                     FunctionCallArgument(a.value, func.scope.get_expected_name(a.keyword)) \
                     for a in args]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -842,7 +842,7 @@ class SemanticParser(BasicParser):
                 relevant_args = [a for a in args[nargs:] if a.keyword == key]
                 assert len(relevant_args) <= 1
                 if len(relevant_args) == 0 and ka.has_default:
-                    input_kwargs.append(FunctionCallArgument(Nil(), key))
+                    input_kwargs.append(ka.default_call_arg)
                 else:
                     input_kwargs.append(relevant_args[0])
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -755,21 +755,6 @@ class SemanticParser(BasicParser):
                         get_final_precision(i_arg) != get_final_precision(f_arg) or
                         i_arg.rank != f_arg.rank)
 
-        # Sort arguments to match the order in the function definition
-        input_no_kwargs = [a for a in input_args if a.keyword is None]
-        nargs = len(input_no_kwargs)
-        input_kwargs = []
-        for ka in func_args[nargs:]:
-            key = ka.name
-            relevant_args = [a for a in input_args[nargs:] if a.keyword == key]
-            assert len(relevant_args) <= 1
-            if len(relevant_args) == 0 and ka.has_default:
-                input_kwargs.append(FunctionCallArgument(Nil(), key))
-            else:
-                input_kwargs.append(relevant_args[0])
-
-        input_args = input_no_kwargs + input_kwargs
-
         # Compare each set of arguments
         for idx, (i_arg, f_arg) in enumerate(zip(input_args, func_args)):
             i_arg = i_arg.value
@@ -846,6 +831,22 @@ class SemanticParser(BasicParser):
                 errors.report("Too many arguments passed in function call",
                         symbol = expr,
                         severity='fatal')
+
+            # Sort arguments to match the order in the function definition
+            input_no_kwargs = [a for a in args if a.keyword is None]
+            nargs = len(input_no_kwargs)
+            input_kwargs = []
+            func_args = func.arguments
+            for ka in func_args[nargs:]:
+                key = ka.name
+                relevant_args = [a for a in args[nargs:] if a.keyword == key]
+                assert len(relevant_args) <= 1
+                if len(relevant_args) == 0 and ka.has_default:
+                    input_kwargs.append(FunctionCallArgument(Nil(), key))
+                else:
+                    input_kwargs.append(relevant_args[0])
+
+            args = input_no_kwargs + input_kwargs
             new_expr = FunctionCall(func, args, self._current_function)
             if None in new_expr.args:
                 errors.report("Too few arguments passed in function call",

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2169,9 +2169,10 @@ class SemanticParser(BasicParser):
                 return getattr(self, annotation_method)(expr, **settings)
 
         args = self._handle_function_args(expr.args, **settings)
-        args = [a if a.keyword is None else \
-                FunctionCallArgument(a.value, func.scope.get_expected_name(a.keyword)) \
-                for a in args]
+        if not isinstance(func, PyccelFunctionDef):
+            args = [a if a.keyword is None else \
+                    FunctionCallArgument(a.value, func.scope.get_expected_name(a.keyword)) \
+                    for a in args]
 
 
         if name == 'lambdify':

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -832,11 +832,11 @@ class SemanticParser(BasicParser):
                         symbol = expr,
                         severity='fatal')
 
+            func_args = func.arguments if isinstance(func, FunctionDef) else func.functions[0].arguments
             # Sort arguments to match the order in the function definition
             input_no_kwargs = [a for a in args if a.keyword is None]
             nargs = len(input_no_kwargs)
             input_kwargs = []
-            func_args = func.arguments
             for ka in func_args[nargs:]:
                 key = ka.name
                 relevant_args = [a for a in args[nargs:] if a.keyword == key]
@@ -847,14 +847,15 @@ class SemanticParser(BasicParser):
                     input_kwargs.append(relevant_args[0])
 
             args = input_no_kwargs + input_kwargs
+
             new_expr = FunctionCall(func, args, self._current_function)
             if None in new_expr.args:
                 errors.report("Too few arguments passed in function call",
                         symbol = expr,
                         severity='error')
             elif isinstance(func, FunctionDef):
-                self._check_argument_compatibility(new_expr.args, func.arguments,
-                        expr, func.is_elemental)
+                self._check_argument_compatibility(args, func_args,
+                            expr, func.is_elemental)
             return new_expr
 
     def _create_variable(self, name, dtype, rhs, d_lhs, arr_in_multirets=False):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2169,7 +2169,10 @@ class SemanticParser(BasicParser):
                 return getattr(self, annotation_method)(expr, **settings)
 
         args = self._handle_function_args(expr.args, **settings)
-        if not isinstance(func, PyccelFunctionDef):
+        # Correct keyword names if scope is available
+        # The scope is only available if the function body has been parsed
+        # (i.e. not for headers or builtin functions)
+        if func.scope:
             args = [a if a.keyword is None else \
                     FunctionCallArgument(a.value, func.scope.get_expected_name(a.keyword)) \
                     for a in args]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -843,7 +843,7 @@ class SemanticParser(BasicParser):
                 assert len(relevant_args) <= 1
                 if len(relevant_args) == 0 and ka.has_default:
                     input_kwargs.append(ka.default_call_arg)
-                else:
+                elif len(relevant_args) == 1:
                     input_kwargs.append(relevant_args[0])
 
             args = input_no_kwargs + input_kwargs

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2172,7 +2172,7 @@ class SemanticParser(BasicParser):
         # Correct keyword names if scope is available
         # The scope is only available if the function body has been parsed
         # (i.e. not for headers or builtin functions)
-        if func.scope:
+        if func and func.scope:
             args = [a if a.keyword is None else \
                     FunctionCallArgument(a.value, func.scope.get_expected_name(a.keyword)) \
                     for a in args]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -834,20 +834,19 @@ class SemanticParser(BasicParser):
 
             func_args = func.arguments if isinstance(func, FunctionDef) else func.functions[0].arguments
             # Sort arguments to match the order in the function definition
-            input_no_kwargs = [a for a in args if a.keyword is None]
-            nargs = len(input_no_kwargs)
-            input_kwargs = []
+            input_args = [a for a in args if a.keyword is None]
+            nargs = len(input_args)
             for ka in func_args[nargs:]:
                 key = ka.name
                 relevant_args = [a for a in args[nargs:] if a.keyword == key]
                 n_relevant_args = len(relevant_args)
                 assert n_relevant_args <= 1
                 if n_relevant_args == 0 and ka.has_default:
-                    input_kwargs.append(ka.default_call_arg)
+                    input_args.append(ka.default_call_arg)
                 elif n_relevant_args == 1:
-                    input_kwargs.append(relevant_args[0])
+                    input_args.append(relevant_args[0])
 
-            args = input_no_kwargs + input_kwargs
+            args = input_args
 
             new_expr = FunctionCall(func, args, self._current_function)
             if None in new_expr.args:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -840,10 +840,11 @@ class SemanticParser(BasicParser):
             for ka in func_args[nargs:]:
                 key = ka.name
                 relevant_args = [a for a in args[nargs:] if a.keyword == key]
-                assert len(relevant_args) <= 1
-                if len(relevant_args) == 0 and ka.has_default:
+                n_relevant_args = len(relevant_args)
+                assert n_relevant_args <= 1
+                if n_relevant_args == 0 and ka.has_default:
                     input_kwargs.append(ka.default_call_arg)
-                elif len(relevant_args) == 1:
+                elif n_relevant_args == 1:
                     input_kwargs.append(relevant_args[0])
 
             args = input_no_kwargs + input_kwargs

--- a/tests/epyccel/modules/call_user_defined_funcs.py
+++ b/tests/epyccel/modules/call_user_defined_funcs.py
@@ -33,3 +33,11 @@ def circle_volume(radius):
     volume = my_mult(my_mult(my_div(3. , 4.), my_pi()), my_cub(radius))
     not_change(volume)
     return volume
+
+def arr_mult_scalar(T: 'int[:]', t: int = 13):
+    return T * t
+
+def alias(T: 'int[:]', t: int):
+    x = arr_mult_scalar(T, t=t)
+    y = arr_mult_scalar(t=t, T=T)
+    return x, y

--- a/tests/epyccel/modules/call_user_defined_funcs.py
+++ b/tests/epyccel/modules/call_user_defined_funcs.py
@@ -35,7 +35,8 @@ def circle_volume(radius):
     return volume
 
 def arr_mult_scalar(T: 'int[:]', t: int = 13):
-    return T * t
+    x = T * t
+    return x
 
 def alias(T: 'int[:]', t: int):
     x = arr_mult_scalar(T, t=t)

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -70,7 +70,18 @@ def test_module_3(language):
     r = 4.5
     x_expected = mod.circle_volume(r)
     x = modnew.circle_volume(r)
-    assert np.isclose( x, x_expected, rtol=1e-14, atol=1e-14 )
+    assert np.isclose( x, x_expected, rtol=RTOL, atol=ATOL )
+
+    i = np.random.randint(4,20)
+    n = np.random.randint(2,8)
+    arr = np.array(100*np.random.random_sample(n), dtype=int)
+    x_expected, y_expected = mod.alias(arr, i)
+    x, y = modnew.alias(arr, i)
+
+    assert np.allclose( x, x_expected, rtol=RTOL, atol=ATOL )
+    assert np.allclose( y, y_expected, rtol=RTOL, atol=ATOL )
+    assert x.dtype is x_expected.dtype
+    assert y.dtype is y_expected.dtype
 
 def test_module_4(language):
     import modules.Module_6 as mod


### PR DESCRIPTION
**Commit Summary**
- Reorder keyword arguments when creating a `FunctionCall` to match the order in the `Function Def` (Fixes an unknown bug in C when calling arguments out of order)
- Get collisionless keyword from scope when creating `FunctionCallArgument`s for `FunctionCall` objects (fixes #1204 )
- Add a test