### PR TITLE
Cuda grid implementation

### DIFF
--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -172,7 +172,7 @@ class CudaThreadIdx(CudaInternalVar)        : pass
 class CudaBlockDim(CudaInternalVar)         : pass
 class CudaBlockIdx(CudaInternalVar)         : pass
 class CudaGridDim(CudaInternalVar)          : pass
-class CudaGrid(CudaInternalVar)             :
+class CudaGrid(PyccelAstNode)               :
     def __new__(cls, dim=0):
         if not isinstance(dim, LiteralInteger):
             raise TypeError("dimension need to be an integer")
@@ -180,6 +180,8 @@ class CudaGrid(CudaInternalVar)             :
             raise ValueError("dimension need to be 0, 1 or 2")
         expr = [PyccelAdd(PyccelMul(CudaBlockIdx(d), CudaBlockDim(d)), CudaThreadIdx(d))\
                 for d in range(dim.python_value + 1)]
+        if dim == 0:
+            return expr[0]
         return PythonTuple(*expr)
 
 

--- a/tests/internal/scripts/ccuda/cuda_grid.py
+++ b/tests/internal/scripts/ccuda/cuda_grid.py
@@ -1,0 +1,30 @@
+from pyccel.decorators import kernel, types
+from pyccel import cuda
+
+@kernel
+@types('int[:]')
+def func_1d(a):
+    i = cuda.grid(0)
+    print("1 dim :", a[i])
+
+@kernel
+@types('int[:]')
+def func_2d(a):
+    i, j = cuda.grid(1)
+    print("2 dim :", a[i], a[j])
+
+@kernel
+@types('int[:]')
+def func_3d(a):
+    i, j, k = cuda.grid(2)
+    print("3 dim :", a[i], a[j], a[k])
+
+if __name__ == '__main__':
+    threads_per_block = 5
+    n_blocks = 1
+    arr = cuda.array([0, 1, 2, 3, 4])
+    cuda.deviceSynchronize()
+    # Sice we dont support multi-dim n_block / threads_per_block
+    # func_2d and func_3d won't compile
+    func_1d[n_blocks, threads_per_block](arr)
+    cuda.deviceSynchronize()

--- a/tests/internal/scripts/ccuda/cuda_grid.py
+++ b/tests/internal/scripts/ccuda/cuda_grid.py
@@ -25,6 +25,8 @@ if __name__ == '__main__':
     arr = cuda.array([0, 1, 2, 3, 4])
     cuda.deviceSynchronize()
     func_1d[n_blocks, threads_per_block](arr)
-    func_2d[n_blocks, threads_per_block](arr)
-    func_3d[n_blocks, threads_per_block](arr)
+    # Since we dont support multi-dim n_block / threads_per_block
+    # func_2d and func_3d won't compile
+    # func_2d[n_blocks, threads_per_block](arr)
+    # func_3d[n_blocks, threads_per_block](arr)
     cuda.deviceSynchronize()

--- a/tests/internal/scripts/ccuda/cuda_grid.py
+++ b/tests/internal/scripts/ccuda/cuda_grid.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     n_blocks = 1
     arr = cuda.array([0, 1, 2, 3, 4])
     cuda.deviceSynchronize()
-    # Sice we dont support multi-dim n_block / threads_per_block
-    # func_2d and func_3d won't compile
     func_1d[n_blocks, threads_per_block](arr)
+    func_2d[n_blocks, threads_per_block](arr)
+    func_3d[n_blocks, threads_per_block](arr)
     cuda.deviceSynchronize()


### PR DESCRIPTION
This PR will implement the call the `cuda.grid()` by replacing it call with the corresponding arithmetic operation.

The `python` code:
```Python
from pyccel.decorators import kernel, types
from pyccel import cuda

@kernel
@types('int[:]')
def func(a):
    i,j,k = cuda.grid(2)
```
The `ccuda` code generated:
```cuda
#include "test.h"
#include <stdlib.h>
#include <stdint.h>
#include "ndarrays.h"


/*........................................*/
extern "C" __global__ void func(t_ndarray a)
{
    int64_t i;
    int64_t j;
    int64_t k;
    i = blockIdx.x * blockDim.x + threadIdx.x;
    j = blockIdx.y * blockDim.y + threadIdx.y;
    k = blockIdx.z * blockDim.z + threadIdx.z;
}
/*........................................*/
```