### PR TITLE
Fix compilation problems on macOS

### DIFF
--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -8,7 +8,8 @@ runs:
         brew install open-mpi
         brew install libomp
         if [[ ! -f "/usr/local/bin/gfortran" ]]; then
-          ln -s /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
+          gfort=$(ls /usr/local/bin/gfortran-* | tail -n 1)
+          ln -s ${gfort} /usr/local/bin/gfortran
         fi
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/pytest_parallel/action.yml
+++ b/.github/actions/pytest_parallel/action.yml
@@ -10,8 +10,8 @@ runs:
   steps:
     - name: Test with pytest
       run: |
-        mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rx
-        #mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel -v -m parallel -rx
+        mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rX
+        #mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel -v -m parallel -rX
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
 

--- a/.github/actions/pytest_parallel/action.yml
+++ b/.github/actions/pytest_parallel/action.yml
@@ -10,8 +10,8 @@ runs:
   steps:
     - name: Test with pytest
       run: |
-        mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rX
-        #mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel -v -m parallel -rX
+        mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel/test_parallel_epyccel.py -v -m parallel -rXx
+        #mpiexec -n 4 ${MPI_OPTS} python -m pytest epyccel -v -m parallel -rXx
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
 

--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -12,13 +12,13 @@ runs:
     - name: Test with pytest
       run: |
         which python
-        python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rX -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rXx -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rXx -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
-        python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and not (c or python)" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rX -m "xdist_incompatible and not parallel and not (c or python)" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rXx -m "not (parallel or xdist_incompatible) and not (c or python)" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rXx -m "xdist_incompatible and not parallel and not (c or python)" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
-        python -m pytest ndarrays/ -rX
+        python -m pytest ndarrays/ -rXx
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/.github/actions/pytest_run_python/action.yml
+++ b/.github/actions/pytest_run_python/action.yml
@@ -10,8 +10,8 @@ runs:
   steps:
     - name: Python tests with pytest
       run: |
-        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rx -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rX -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/.github/actions/pytest_run_python/action.yml
+++ b/.github/actions/pytest_run_python/action.yml
@@ -10,8 +10,8 @@ runs:
   steps:
     - name: Python tests with pytest
       run: |
-        python -m pytest -n auto -rX -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rX -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rXx -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rXx -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -112,6 +112,8 @@ gcc_info = {'exec' : 'gcc',
 if sys.platform == "darwin":
     gcc_info['openmp']['flags'] = ("-Xpreprocessor",'-fopenmp')
     gcc_info['openmp']['libs'] = ('omp',)
+    gcc_info['openmp']['libdirs'] = ('/usr/local/opt/libomp/lib',)
+    gcc_info['openmp']['includes'] = ('/usr/local/opt/libomp/include',)
 elif sys.platform == "win32":
     gcc_info['mpi_exec'] = 'gcc'
     gcc_info['mpi']['flags']    = ('-D','USE_MPI_MODULE')

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.6.0"
+__version__ = "1.6.1"


### PR DESCRIPTION
Update usage of compiler and runtime libraries installed by Homebrew:
* Find most recent gfortran
* Add OpenMP include and library directories to default options for C compiler (assuming Clang)

Further changes:
* Let Pytest report XPASS and XFAIL tests
* Update Pyccel library version to 1.6.1