### PR TITLE
Addition of valid cudaMemcpyKind to cudaMemcpy

### DIFF
--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -74,11 +74,11 @@ class CudaArray(CudaNewArray):
     arg : list, tuple, PythonList
 
     """
-    __slots__ = ('_arg','_dtype','_precision','_shape','_rank','_order','_memory_location')
+    __slots__ = ('_arg','_dtype','_precision','_shape','_rank','_order','_memory_location', '_current_location')
     _attribute_nodes = ('_arg',)
     name = 'array'
 
-    def __init__(self, arg, dtype=None, order='C', memory_location='managed'):
+    def __init__(self, arg, dtype=None, order='C', memory_location='managed', current_location='host'):
 
         if not isinstance(arg, (PythonTuple, PythonList, Variable)):
             raise TypeError('Unknown type of  %s.' % type(arg))
@@ -125,6 +125,7 @@ class CudaArray(CudaNewArray):
         self._order = order
         self._precision = prec
         self._memory_location = memory_location
+        self._current_location = current_location
         super().__init__()
 
     def __str__(self):
@@ -136,6 +137,10 @@ class CudaArray(CudaNewArray):
     @property
     def memory_location(self):
         return self._memory_location
+
+    @property
+    def current_location(self):
+        return self._current_location
 
 class CudaDeviceSynchronize(PyccelInternalFunction):
     "Represents a call to  Cuda.deviceSynchronize for code generation."

--- a/pyccel/ast/cupyext.py
+++ b/pyccel/ast/cupyext.py
@@ -69,7 +69,7 @@ class CupyArray(CudaNewArray):
     _attribute_nodes = ('_arg',)
     name = 'array'
 
-    def __init__(self, arg, dtype=None, order='C'):
+    def __init__(self, arg, dtype=None, order='C', memory_location='managed', current_location='host'):
 
         if not isinstance(arg, (PythonTuple, PythonList, Variable)):
             raise TypeError('Unknown type of  %s.' % type(arg))
@@ -113,6 +113,8 @@ class CupyArray(CudaNewArray):
         self._dtype = dtype
         self._order = order
         self._precision = prec
+        self._memory_location = memory_location
+        self._current_location = current_location
         super().__init__()
 
     def __str__(self):
@@ -121,6 +123,14 @@ class CupyArray(CudaNewArray):
     @property
     def arg(self):
         return self._arg
+
+    @property
+    def memory_location(self):
+        return self._memory_location
+
+    @property
+    def current_location(self):
+        return self._current_location
 
 #==============================================================================
 class CupyArange(CudaNewArray):

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -61,6 +61,11 @@ class Variable(PyccelAstNode):
         'managed' the variable can be accessed by CPU and GPU and is being managed by the Cuda API (memory transfer is being done implicitly)
         [Default value: 'host']
 
+    current_location: str
+        'host' The current context is in a host function
+        'device' The current context is in a device function
+        [Default value: 'host']
+
     is_target: bool
         if object is pointed to by another variable [Default value: False]
 
@@ -106,8 +111,8 @@ class Variable(PyccelAstNode):
     >>> Variable('int', DottedName('matrix', 'n_rows'))
     matrix.n_rows
     """
-    __slots__ = ('_name', '_alloc_shape', '_memory_handling', '_memory_location', '_is_const',
-            '_is_target', '_is_optional', '_allows_negative_indexes',
+    __slots__ = ('_name', '_alloc_shape', '_memory_handling', '_memory_location','_current_location',
+            '_is_const', '_is_target', '_is_optional', '_allows_negative_indexes',
             '_cls_base', '_is_argument', '_is_kwonly', '_is_temp','_dtype','_precision',
             '_rank','_shape','_order','_is_private')
     _attribute_nodes = ()
@@ -120,6 +125,7 @@ class Variable(PyccelAstNode):
         rank=0,
         memory_handling='stack',
         memory_location='host',
+        current_location='host',
         is_const=False,
         is_target=False,
         is_optional=False,
@@ -158,6 +164,11 @@ class Variable(PyccelAstNode):
         if memory_location not in ('host', 'device', 'managed'):
             raise ValueError("memory_location must be 'host', 'device' or 'managed'")
         self._memory_location = memory_location
+
+        if current_location not in ('host', 'device'):
+            raise ValueError("current_location must be 'host' or 'device'")
+
+        self._current_location = current_location
 
         if not isinstance(is_const, bool):
             raise TypeError('is_const must be a boolean.')
@@ -325,6 +336,12 @@ class Variable(PyccelAstNode):
         if memory_location not in ('host', 'device', 'managed'):
             raise ValueError("memory_location must be 'host', 'device' or 'managed'")
         self._memory_location = memory_location
+
+    @property
+    def current_location(self):
+        """ Gives the current context of the function
+        """
+        return self._current_location
 
     @property
     def on_host(self):

--- a/pyccel/codegen/printing/ccudacode.py
+++ b/pyccel/codegen/printing/ccudacode.py
@@ -520,9 +520,10 @@ class CcudaCodePrinter(CCodePrinter):
         dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
         arg = rhs.arg if isinstance(rhs, (CudaArray, CupyArray)) else rhs
         if rhs.current_location == 'device' and rhs.memory_location == 'host':
-            errors.report("Cannot copy data from device to host", symbol=expr, severity='error')
-        memory_location = 'Host' if rhs.memory_location == 'host' else 'Device'
-        memcpy_kind = "{}To{}".format(str(rhs.current_location).capitalize(), memory_location)
+            errors.report("You can't create a host array from a device function",
+                        symbol=expr, severity='error')
+        end_memory_location = 'Host' if rhs.memory_location == 'host' else 'Device'
+        memcpy_kind = "{}To{}".format(str(rhs.current_location).capitalize(), end_memory_location)
         if rhs.rank > 1:
             # flattening the args to use them in C initialization.
             arg = self._flatten_list(arg)

--- a/pyccel/codegen/printing/ccudacode.py
+++ b/pyccel/codegen/printing/ccudacode.py
@@ -522,8 +522,9 @@ class CcudaCodePrinter(CCodePrinter):
         if rhs.current_location == 'device' and rhs.memory_location == 'host':
             errors.report("You can't create a host array from a device function",
                         symbol=expr, severity='error')
-        end_memory_location = 'Host' if rhs.memory_location == 'host' else 'Device'
-        memcpy_kind = "{}To{}".format(str(rhs.current_location).capitalize(), end_memory_location)
+        memcpy_kind_src = str(rhs.current_location).capitalize()
+        memcpy_kind_dest = 'Host' if rhs.memory_location == 'host' else 'Device'
+        memcpy_kind = "{}To{}".format(memcpy_kind_src, memcpy_kind_dest)
         if rhs.rank > 1:
             # flattening the args to use them in C initialization.
             arg = self._flatten_list(arg)

--- a/pyccel/codegen/printing/ccudacode.py
+++ b/pyccel/codegen/printing/ccudacode.py
@@ -519,6 +519,8 @@ class CcudaCodePrinter(CCodePrinter):
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
         dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
         arg = rhs.arg if isinstance(rhs, (CudaArray, CupyArray)) else rhs
+        memory_location = 'Device' if rhs.memory_location == 'managed' else str(rhs.memory_location).capitalize()
+        memcpy_kind = "{}To{}".format(str(rhs.current_location).capitalize(), memory_location)
         if rhs.rank > 1:
             # flattening the args to use them in C initialization.
             arg = self._flatten_list(arg)
@@ -526,12 +528,12 @@ class CcudaCodePrinter(CCodePrinter):
         self.add_import(c_imports['string'])
         if isinstance(arg, Variable):
             arg = self._print(arg)
-            cpy_data = "cudaMemcpy({0}.raw_data, {1}.{2}, {0}.buffer_size, cudaMemcpyHostToDevice);".format(lhs, arg, dtype)
+            cpy_data = "cudaMemcpy({0}.raw_data, {1}.{2}, {0}.buffer_size, {3});".format(lhs, arg, dtype, memcpy_kind)
             return '%s\n' % (cpy_data)
         else :
             arg = ', '.join(self._print(i) for i in arg)
             dummy_array = "%s %s[] = {%s};\n" % (declare_dtype, dummy_array_name, arg)
-            cpy_data = "cudaMemcpy({0}.raw_data, {1}, {0}.buffer_size, cudaMemcpyHostToDevice);".format(self._print(lhs), dummy_array_name, dtype)
+            cpy_data = "cudaMemcpy({0}.raw_data, {1}, {0}.buffer_size, {3});".format(self._print(lhs), dummy_array_name, dtype, memcpy_kind)
             return  '%s%s\n' % (dummy_array, cpy_data)
 
     def _print_CudaDeviceSynchronize(self, expr):

--- a/pyccel/codegen/printing/ccudacode.py
+++ b/pyccel/codegen/printing/ccudacode.py
@@ -519,7 +519,9 @@ class CcudaCodePrinter(CCodePrinter):
         declare_dtype = self.find_in_dtype_registry(self._print(rhs.dtype), rhs.precision)
         dtype = self.find_in_ndarray_type_registry(self._print(rhs.dtype), rhs.precision)
         arg = rhs.arg if isinstance(rhs, (CudaArray, CupyArray)) else rhs
-        memory_location = 'Device' if rhs.memory_location == 'managed' else str(rhs.memory_location).capitalize()
+        if rhs.current_location == 'device' and rhs.memory_location == 'host':
+            errors.report("Cannot copy data from device to host", symbol=expr, severity='error')
+        memory_location = 'Host' if rhs.memory_location == 'host' else 'Device'
         memcpy_kind = "{}To{}".format(str(rhs.current_location).capitalize(), memory_location)
         if rhs.rank > 1:
             # flattening the args to use them in C initialization.

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -494,7 +494,11 @@ class SemanticParser(BasicParser):
             d_var['datatype'   ] = expr.dtype
             d_var['memory_handling'] = 'heap' if expr.rank > 0 else 'stack'
             d_var['memory_location'] = expr.memory_location
-            d_var['current_location'] = 'device' if 'device' in self.scope.decorators else 'host'
+            if 'device' in self.scope.decorators or\
+                'kernel' in self.scope.decorators:
+                d_var['current_location'] = 'device'
+            else:
+                d_var['current_location'] = 'host'
             d_var['shape'      ] = expr.shape
             d_var['rank'       ] = expr.rank
             d_var['order'      ] = expr.order

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -494,6 +494,7 @@ class SemanticParser(BasicParser):
             d_var['datatype'   ] = expr.dtype
             d_var['memory_handling'] = 'heap' if expr.rank > 0 else 'stack'
             d_var['memory_location'] = expr.memory_location
+            d_var['current_location'] = 'device' if 'device' in self.scope.decorators else 'host'
             d_var['shape'      ] = expr.shape
             d_var['rank'       ] = expr.rank
             d_var['order'      ] = expr.order
@@ -812,7 +813,7 @@ class SemanticParser(BasicParser):
             func = func.cls_name
             if func in (CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim):
                 if 'kernel' not in self.scope.decorators\
-                    or 'device' not in self.scope.decorators:
+                    and 'device' not in self.scope.decorators:
                     errors.report("Cuda internal variables should only be used in Kernel or Device functions",
                         symbol = expr,
                         severity = 'fatal')
@@ -902,11 +903,11 @@ class SemanticParser(BasicParser):
                         symbol = expr,
                         severity='fatal')
             # TODO : type check the NUMBER OF BLOCKS 'numBlocks' and threads per block 'tpblock'
-            if not isinstance(expr.numBlocks, LiteralInteger):
+            if not isinstance(expr.numBlocks, (LiteralInteger, PyccelSymbol)):
                 errors.report("Invalid Block number parameter for Kernel call",
                         symbol = expr,
                         severity='error')
-            if not isinstance(expr.tpblock, LiteralInteger):
+            if not isinstance(expr.tpblock, (LiteralInteger, PyccelSymbol)):
                 errors.report("Invalid Thread per Block parameter for Kernel call",
                         symbol = expr,
                         severity='error')


### PR DESCRIPTION
For now in `copy_CudaArray_Data` the cudaMemcpyKind field of cudaMemcpy is hardcoded, this PR aims to make it so that field can be deduced from the variable's memory location and the current context of the function.