### PR TITLE
Save literal sized tuples on the stack

### DIFF
--- a/ci_tools/check_new_coverage.py
+++ b/ci_tools/check_new_coverage.py
@@ -25,6 +25,8 @@ new_untested = cov.allow_untested_error_calls(cov.compare_coverage_to_diff(untes
 with open(args.gitEvent, encoding="ascii") as pr_data_file:
     pr_data = json.load(pr_data_file)
 
+print(pr_data)
+
 cov.print_markdown_summary(new_untested, file_contents, pr_data["after"], args.output)
 
 cov.show_results(new_untested)

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -1121,11 +1121,13 @@ class IfTernaryOperator(PyccelOperator):
         """
         Sets the shape and rank and the order for IfTernaryOperator
         """
-        shape = value_true.shape
-        rank  = value_true.rank
-        if rank is not None and rank > 1:
-            if value_false.order != value_true.order :
-                errors.report('Ternary Operator results should have the same order', severity='fatal')
+        shape_true  = value_true.shape
+        shape_false = value_false.shape
+        rank_true   = value_true.rank
+        rank_false  = value_false.rank
+        if (rank_true is not None and rank_true > 1) or (rank_false is not None and rank_false > 1):
+            errors.report('Ternary Operator results should have the same order', severity='fatal')
+        shape = shape_true if shape_true == shape_false else None
         return shape, rank
 
     @property

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -1121,13 +1121,11 @@ class IfTernaryOperator(PyccelOperator):
         """
         Sets the shape and rank and the order for IfTernaryOperator
         """
-        shape_true  = value_true.shape
-        shape_false = value_false.shape
-        rank_true   = value_true.rank
-        rank_false  = value_false.rank
-        if (rank_true is not None and rank_true > 1) or (rank_false is not None and rank_false > 1):
-            errors.report('Ternary Operator results should have the same order', severity='fatal')
-        shape = shape_true if shape_true == shape_false else None
+        shape = value_true.shape
+        rank  = value_true.rank
+        if rank is not None and rank > 1:
+            if value_false.order != value_true.order :
+                errors.report('Ternary Operator results should have the same order', severity='fatal')
         return shape, rank
 
     @property

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -515,9 +515,6 @@ class SemanticParser(BasicParser):
             d_var['cls_base'   ] = get_cls_base(expr.dtype, expr.precision, expr.rank)
             return d_var
 
-        elif isinstance(expr, IfTernaryOperator):
-            return self._infere_type(expr.args[0][1].body[0])
-
         elif isinstance(expr, PythonRange):
 
             d_var['datatype'   ] = NativeRange()

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -444,7 +444,7 @@ class SemanticParser(BasicParser):
         elif isinstance(expr, PythonTuple):
             d_var['datatype'       ] = expr.dtype
             d_var['precision'      ] = expr.precision
-            d_var['memory_handling'] = 'stack' if all(isinstance(s, Literal) for s in expr.shape) else 'heap'
+            d_var['memory_handling'] = 'heap'
             d_var['shape'          ] = expr.shape
             d_var['rank'           ] = expr.rank
             d_var['order'          ] = expr.order
@@ -1086,7 +1086,7 @@ class SemanticParser(BasicParser):
                 # ...
 
                 # We cannot allow the definition of a stack array in a loop
-                if lhs.is_stack_array and self.scope.is_loop and not all(isinstance(s, Literal) for s in lhs.shape):
+                if lhs.is_stack_array and self.scope.is_loop:
                     errors.report(STACK_ARRAY_DEFINITION_IN_LOOP, symbol=name,
                         severity='error',
                         bounding_box=(self._current_fst_node.lineno,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -444,7 +444,7 @@ class SemanticParser(BasicParser):
         elif isinstance(expr, PythonTuple):
             d_var['datatype'       ] = expr.dtype
             d_var['precision'      ] = expr.precision
-            d_var['memory_handling'] = 'heap'
+            d_var['memory_handling'] = 'stack' if all(isinstance(s, Literal) for s in expr.shape) else 'heap'
             d_var['shape'          ] = expr.shape
             d_var['rank'           ] = expr.rank
             d_var['order'          ] = expr.order
@@ -1089,7 +1089,7 @@ class SemanticParser(BasicParser):
                 # ...
 
                 # We cannot allow the definition of a stack array in a loop
-                if lhs.is_stack_array and self.scope.is_loop:
+                if lhs.is_stack_array and self.scope.is_loop and not all(isinstance(s, Literal) for s in lhs.shape):
                     errors.report(STACK_ARRAY_DEFINITION_IN_LOOP, symbol=name,
                         severity='error',
                         bounding_box=(self._current_fst_node.lineno,


### PR DESCRIPTION
Save literal sized tuples on the stack. Don't complain about stack arrays of literal size created in loops. This fixes #1232 as the initialisation is done before the loop