### PR TITLE
Add `pytest` dependencies to setup.cfg.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Finally, Pyccel supports distributed-memory parallel programming through the Mes
 
 We recommend using GFortran/GCC and Open-MPI.
 
-Pyccel also depends on several Python3 packages, which are automatically downloaded by pip, the Python Package Installer, during the installation process. In addition to these, unit tests require the _scipy_, _mpi4py_, _pytest_ and _coverage_ packages, while building the documentation requires [Sphinx](http://www.sphinx-doc.org/).
+Pyccel also depends on several Python3 packages, which are automatically downloaded by pip, the Python Package Installer, during the installation process. In addition to these, unit tests require additional packages which are installed as optional dependencies with pip, while building the documentation requires [Sphinx](http://www.sphinx-doc.org/).
 
 ### Linux Debian-Ubuntu-Mint
 
@@ -285,7 +285,7 @@ for a system-wide installation.
     ```sh
     git clone git@github.com:pyccel/pyccel.git
     cd pyccel
-    pip3 install --user -e .
+    pip3 install --user -e .[test]
     ```
 
 this will install a _python_ library **pyccel** and a _binary_ called **pyccel**.
@@ -307,19 +307,10 @@ A warning, reminding the user to execute this command, will be printed to the sc
 In order to run the unit tests and to get a coverage report, a few additional Python packages should be installed:
 
 ```sh
-pip3 install --user scipy
-pip3 install --user mpi4py
-pip3 install --user tblib
-pip3 install --user pytest
-pip3 install --user astunparse
-pip3 install --user coverage
+pip install --user -e .[test]
 ```
 
-Most of the unit tests can also be run in parallel. This can be done by installing one additional package:
-
-```sh
-pip3 install --user pytest-xdist
-```
+Most of the unit tests can also be run in parallel.
 
 ## Testing
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,16 @@ python_requires = >= 3.7
 zip_safe = False
 include_package_data = True
 
+[options.extras_require]
+test =
+    pytest
+    scipy
+    mpi4py
+    coverage
+    astunparse
+    tblib
+    pytest-xdist
+
 [options.entry_points]
 console_scripts =
     pyccel = pyccel.commands.console:pyccel


### PR DESCRIPTION
JOSS submission [requires](https://joss.readthedocs.io/en/latest/submitting.html#substantial-scholarly-effort) "... that software should be feature-complete (i.e., no half-baked solutions), packaged appropriately according to common community standards for the programming language being used." I identified that, upon installing the defined dependencies (in setup.cfg) with `pip install -e .`, `pytest` was not runnable. The dependencies for `pytest` are listed in [README.md](https://github.com/pyccel/pyccel/blob/8ca23f07fa9aed4ed1974c7b7d6f427bcce7f7df/README.md#requirements), however, this requires manual management of development dependencies to maintain. Therefore, this PR adds the test dependencies to setup.cfg as "optional," which allows them to be installed with `pip install -e .[test]` - thus leaving the "production" dependencies as they are. In addition, the "pytest-xdist," "astunparse," and "tblib" dependencies that are not explicitly mentioned under "Requirements" have been added to setup.cfg. Documentation on how to install these dependencies has been updated.

Related: openjournals/joss-reviews#4991