### PR TITLE
Fix forked PR coverage check

### DIFF
--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -21,8 +21,8 @@ jobs:
         uses: ./.github/actions/pip_installation
       - name: Coverage install
         uses: ./.github/actions/coverage_install
-      #- name: Fortran/C tests with pytest
-      #  uses: ./.github/actions/pytest_run
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
       - name: Python tests with pytest
         uses: ./.github/actions/pytest_run_python
       - name: Parallel tests with pytest
@@ -45,75 +45,75 @@ jobs:
           path: cobertura.xml
           retention-days: 1
 
-  #Windows:
+  Windows:
 
-  #  runs-on: windows-latest
+    runs-on: windows-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - name: Setup Python 3.9
-  #      uses: actions/setup-python@v4
-  #      with:
-  #          # The second most recent version is used as
-  #          # setup-python installs the most recent patch
-  #          # which leads to linking problems as there are
-  #          # 2 versions of python3X.a and the wrong one
-  #          # is chosen
-  #          python-version: 3.9
-  #    # Uncomment to examine DLL requirements with 'objdump -x FILE'
-  #    #- name: Install mingw tools
-  #    #  uses: msys2/setup-msys2@v2
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/windows_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v4
+        with:
+            # The second most recent version is used as
+            # setup-python installs the most recent patch
+            # which leads to linking problems as there are
+            # 2 versions of python3X.a and the wrong one
+            # is chosen
+            python-version: 3.9
+      # Uncomment to examine DLL requirements with 'objdump -x FILE'
+      #- name: Install mingw tools
+      #  uses: msys2/setup-msys2@v2
+      - name: Install dependencies
+        uses: ./.github/actions/windows_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
 
-  #MacOSX:
+  MacOSX:
 
-  #  runs-on: macos-latest
+    runs-on: macos-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - name: Set up Python 3.10
-  #      uses: actions/setup-python@v4
-  #      with:
-  #        python-version: '3.10'
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/macos_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        uses: ./.github/actions/macos_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Fortran/C tests with pytest
+        uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
 
-  #Linter:
+  Linter:
 
-  #  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - name: Set up Python 3.7
-  #      uses: actions/setup-python@v4
-  #      with:
-  #        python-version: 3.7
-  #    - name: Install python dependencies
-  #      run: |
-  #        python -m pip install --upgrade pip
-  #        python -m pip install pylint
-  #      shell: bash
-  #    - name: Pylint
-  #      run: |
-  #          python -m pylint --rcfile=.pylintrc pyccel/parser/semantic.py
-  #      shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pylint
+        shell: bash
+      - name: Pylint
+        run: |
+            python -m pylint --rcfile=.pylintrc pyccel/parser/semantic.py
+        shell: bash
 
   CoverageChecker:
 

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,45 +5,45 @@ on:
     branches: [ master ]
 
 jobs:
-  #Linux:
+  Linux:
 
-  #  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - name: Set up Python 3.7
-  #      uses: actions/setup-python@v4
-  #      with:
-  #        python-version: 3.7
-  #    - name: Install dependencies
-  #      uses: ./.github/actions/linux_install
-  #    - name: Install python dependencies
-  #      uses: ./.github/actions/pip_installation
-  #    - name: Coverage install
-  #      uses: ./.github/actions/coverage_install
-  #    - name: Fortran/C tests with pytest
-  #      uses: ./.github/actions/pytest_run
-  #    - name: Python tests with pytest
-  #      uses: ./.github/actions/pytest_run_python
-  #    - name: Parallel tests with pytest
-  #      uses: ./.github/actions/pytest_parallel
-  #    - name: Test with valgrind for memory leaks
-  #      uses: ./.github/actions/valgrind_run
-  #    - name: Collect coverage information
-  #      continue-on-error: True
-  #      uses: ./.github/actions/coverage_collection
-  #    - name: Run codacy-coverage-reporter
-  #      uses: codacy/codacy-coverage-reporter-action@master
-  #      continue-on-error: True
-  #      with:
-  #        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-  #        coverage-reports: cobertura.xml
-  #    - name: Save code coverage report
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: coverage-artifact
-  #        path: cobertura.xml
-  #        retention-days: 1
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        uses: ./.github/actions/linux_install
+      - name: Install python dependencies
+        uses: ./.github/actions/pip_installation
+      - name: Coverage install
+        uses: ./.github/actions/coverage_install
+      #- name: Fortran/C tests with pytest
+      #  uses: ./.github/actions/pytest_run
+      - name: Python tests with pytest
+        uses: ./.github/actions/pytest_run_python
+      - name: Parallel tests with pytest
+        uses: ./.github/actions/pytest_parallel
+      - name: Test with valgrind for memory leaks
+        uses: ./.github/actions/valgrind_run
+      - name: Collect coverage information
+        continue-on-error: True
+        uses: ./.github/actions/coverage_collection
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@master
+        continue-on-error: True
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: cobertura.xml
+      - name: Save code coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-artifact
+          path: cobertura.xml
+          retention-days: 1
 
   #Windows:
 

--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -5,115 +5,115 @@ on:
     branches: [ master ]
 
 jobs:
-  Linux:
+  #Linux:
 
-    runs-on: ubuntu-latest
+  #  runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-      - name: Install dependencies
-        uses: ./.github/actions/linux_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Coverage install
-        uses: ./.github/actions/coverage_install
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
-      - name: Test with valgrind for memory leaks
-        uses: ./.github/actions/valgrind_run
-      - name: Collect coverage information
-        continue-on-error: True
-        uses: ./.github/actions/coverage_collection
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@master
-        continue-on-error: True
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: cobertura.xml
-      - name: Save code coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-artifact
-          path: cobertura.xml
-          retention-days: 1
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - name: Set up Python 3.7
+  #      uses: actions/setup-python@v4
+  #      with:
+  #        python-version: 3.7
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/linux_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Coverage install
+  #      uses: ./.github/actions/coverage_install
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
+  #    - name: Test with valgrind for memory leaks
+  #      uses: ./.github/actions/valgrind_run
+  #    - name: Collect coverage information
+  #      continue-on-error: True
+  #      uses: ./.github/actions/coverage_collection
+  #    - name: Run codacy-coverage-reporter
+  #      uses: codacy/codacy-coverage-reporter-action@master
+  #      continue-on-error: True
+  #      with:
+  #        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  #        coverage-reports: cobertura.xml
+  #    - name: Save code coverage report
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: coverage-artifact
+  #        path: cobertura.xml
+  #        retention-days: 1
 
-  Windows:
+  #Windows:
 
-    runs-on: windows-latest
+  #  runs-on: windows-latest
 
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v4
-        with:
-            # The second most recent version is used as
-            # setup-python installs the most recent patch
-            # which leads to linking problems as there are
-            # 2 versions of python3X.a and the wrong one
-            # is chosen
-            python-version: 3.9
-      # Uncomment to examine DLL requirements with 'objdump -x FILE'
-      #- name: Install mingw tools
-      #  uses: msys2/setup-msys2@v2
-      - name: Install dependencies
-        uses: ./.github/actions/windows_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - name: Setup Python 3.9
+  #      uses: actions/setup-python@v4
+  #      with:
+  #          # The second most recent version is used as
+  #          # setup-python installs the most recent patch
+  #          # which leads to linking problems as there are
+  #          # 2 versions of python3X.a and the wrong one
+  #          # is chosen
+  #          python-version: 3.9
+  #    # Uncomment to examine DLL requirements with 'objdump -x FILE'
+  #    #- name: Install mingw tools
+  #    #  uses: msys2/setup-msys2@v2
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/windows_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
 
-  MacOSX:
+  #MacOSX:
 
-    runs-on: macos-latest
+  #  runs-on: macos-latest
 
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Install dependencies
-        uses: ./.github/actions/macos_install
-      - name: Install python dependencies
-        uses: ./.github/actions/pip_installation
-      - name: Fortran/C tests with pytest
-        uses: ./.github/actions/pytest_run
-      - name: Python tests with pytest
-        uses: ./.github/actions/pytest_run_python
-      - name: Parallel tests with pytest
-        uses: ./.github/actions/pytest_parallel
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - name: Set up Python 3.10
+  #      uses: actions/setup-python@v4
+  #      with:
+  #        python-version: '3.10'
+  #    - name: Install dependencies
+  #      uses: ./.github/actions/macos_install
+  #    - name: Install python dependencies
+  #      uses: ./.github/actions/pip_installation
+  #    - name: Fortran/C tests with pytest
+  #      uses: ./.github/actions/pytest_run
+  #    - name: Python tests with pytest
+  #      uses: ./.github/actions/pytest_run_python
+  #    - name: Parallel tests with pytest
+  #      uses: ./.github/actions/pytest_parallel
 
-  Linter:
+  #Linter:
 
-    runs-on: ubuntu-latest
+  #  runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-      - name: Install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pylint
-        shell: bash
-      - name: Pylint
-        run: |
-            python -m pylint --rcfile=.pylintrc pyccel/parser/semantic.py
-        shell: bash
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - name: Set up Python 3.7
+  #      uses: actions/setup-python@v4
+  #      with:
+  #        python-version: 3.7
+  #    - name: Install python dependencies
+  #      run: |
+  #        python -m pip install --upgrade pip
+  #        python -m pip install pylint
+  #      shell: bash
+  #    - name: Pylint
+  #      run: |
+  #          python -m pylint --rcfile=.pylintrc pyccel/parser/semantic.py
+  #      shell: bash
 
   CoverageChecker:
 

--- a/ci_tools/check_new_coverage.py
+++ b/ci_tools/check_new_coverage.py
@@ -29,7 +29,7 @@ with open(args.gitEvent, encoding="utf-8") as pr_data_file:
 
 print(pr_data)
 
-cov.print_markdown_summary(new_untested, file_contents, pr_data["after"], args.output)
+cov.print_markdown_summary(new_untested, file_contents, pr_data["pull_request"]["base"]["sha"], args.output)
 
 cov.show_results(new_untested)
 

--- a/ci_tools/check_new_coverage.py
+++ b/ci_tools/check_new_coverage.py
@@ -22,12 +22,8 @@ untested, file_contents = cov.get_untested_lines(args.coverageFile)
 
 new_untested = cov.allow_untested_error_calls(cov.compare_coverage_to_diff(untested, diff))
 
-print("a")
-
 with open(args.gitEvent, encoding="utf-8") as pr_data_file:
     pr_data = json.load(pr_data_file)
-
-print(pr_data)
 
 cov.print_markdown_summary(new_untested, file_contents, pr_data["pull_request"]["base"]["sha"], args.output)
 

--- a/ci_tools/check_new_coverage.py
+++ b/ci_tools/check_new_coverage.py
@@ -25,6 +25,8 @@ new_untested = cov.allow_untested_error_calls(cov.compare_coverage_to_diff(untes
 with open(args.gitEvent, encoding="utf-8") as pr_data_file:
     pr_data = json.load(pr_data_file)
 
+print(pr_data)
+
 cov.print_markdown_summary(new_untested, file_contents, pr_data["after"], args.output)
 
 cov.show_results(new_untested)

--- a/ci_tools/check_new_coverage.py
+++ b/ci_tools/check_new_coverage.py
@@ -22,6 +22,8 @@ untested, file_contents = cov.get_untested_lines(args.coverageFile)
 
 new_untested = cov.allow_untested_error_calls(cov.compare_coverage_to_diff(untested, diff))
 
+print("a")
+
 with open(args.gitEvent, encoding="utf-8") as pr_data_file:
     pr_data = json.load(pr_data_file)
 


### PR DESCRIPTION
The coverage check was using the "push" webhook payload to determine the relevant commit on the master branch when it should have been using the "pull_request" webhook payload. This corrects the key error arising when the test is not triggered on a push