### PR TITLE
Correct image type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Pyccel comes with a selection of **extensions** allowing you to convert calls to
 
 Pyccel's acceleration capabilities lead to much faster code. Comparisons of Python vs Pyccel or other tools can be found in the [benchmarks](https://github.com/pyccel/pyccel-benchmarks) repository.
 The results for the master branch currently show the following performance on python 3.10:
-![Pyccel execution times for master branch](https://github.com/pyccel/pyccel-benchmarks/blob/main/version_specific_results/devel_performance_310_execution.png)
+![Pyccel execution times for master branch](https://github.com/pyccel/pyccel-benchmarks/blob/main/version_specific_results/devel_performance_310_execution.svg)
 
 If you are eager to try Pyccel out, we recommend reading our [quick-start guide](./tutorial/quickstart.md)
 


### PR DESCRIPTION
The type of the figures in the pyccel-benchmark repository was changed from .png to .svg which broke pyccel's README. This PR corrects the extension and fixes #1261 