### PR TITLE
Cuda synchronize

### DIFF
--- a/pyccel/ast/cudaext.py
+++ b/pyccel/ast/cudaext.py
@@ -37,7 +37,7 @@ __all__ = (
     'CudaMemCopy',
     'CudaNewArray',
     'CudaArray',
-    'CudaDeviceSynchronize',
+    'CudaSynchronize',
     'CudaInternalVar',
     'CudaThreadIdx',
     'CudaBlockDim',
@@ -137,7 +137,7 @@ class CudaArray(CudaNewArray):
     def memory_location(self):
         return self._memory_location
 
-class CudaDeviceSynchronize(PyccelInternalFunction):
+class CudaSynchronize(PyccelInternalFunction):
     "Represents a call to  Cuda.deviceSynchronize for code generation."
     # pass
     _attribute_nodes = ()
@@ -251,16 +251,14 @@ class CudaGrid(PyccelAstNode)               :
 
 
 cuda_funcs = {
-    # 'deviceSynchronize' : CudaDeviceSynchronize,
     'array'             : PyccelFunctionDef('array'             , CudaArray),
     'copy'              : PyccelFunctionDef('copy'              , CudaCopy),
-    'deviceSynchronize' : PyccelFunctionDef('deviceSynchronize' , CudaDeviceSynchronize),
+    'synchronize'       : PyccelFunctionDef('synchronize'       , CudaSynchronize),
     'threadIdx'         : PyccelFunctionDef('threadIdx'         , CudaThreadIdx),
     'blockDim'          : PyccelFunctionDef('blockDim'          , CudaBlockDim),
     'blockIdx'          : PyccelFunctionDef('blockIdx'          , CudaBlockIdx),
     'gridDim'           : PyccelFunctionDef('gridDim'           , CudaGridDim),
     'grid'              : PyccelFunctionDef('grid'              , CudaGrid)
-
 }
 
 cuda_Internal_Var = {

--- a/pyccel/codegen/printing/ccudacode.py
+++ b/pyccel/codegen/printing/ccudacode.py
@@ -536,7 +536,7 @@ class CcudaCodePrinter(CCodePrinter):
             cpy_data = "cudaMemcpy({0}.raw_data, {1}, {0}.buffer_size, cudaMemcpyHostToDevice);".format(self._print(lhs), dummy_array_name, dtype)
             return  '%s%s\n' % (dummy_array, cpy_data)
 
-    def _print_CudaDeviceSynchronize(self, expr):
+    def _print_CudaSynchronize(self, expr):
         return 'cudaDeviceSynchronize()'
 
     def _print_CudaInternalVar(self, expr):

--- a/pyccel/naming/ccudanameclashchecker.py
+++ b/pyccel/naming/ccudanameclashchecker.py
@@ -41,7 +41,7 @@ class CCudaNameClashChecker(metaclass = Singleton):
         'cuda_array_fill_int32', 'cuda_array_fill_int8',
         'cuda_array_arange_double', 'cuda_array_arange_int64', 
         'cuda_array_arange_int32', 'cuda_array_arange_int8',
-        'cudaMallocManaged', 'cudaDeviceSynchronize'])
+        'cudaMallocManaged', 'cudaSynchronize'])
 
     def has_clash(self, name, symbols):
         """ Indicate whether the proposed name causes any clashes

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -812,7 +812,7 @@ class SemanticParser(BasicParser):
             func = func.cls_name
             if func in (CudaThreadIdx, CudaBlockDim, CudaBlockIdx, CudaGridDim):
                 if 'kernel' not in self.scope.decorators\
-                    or 'device' not in self.scope.decorators:
+                    and 'device' not in self.scope.decorators:
                     errors.report("Cuda internal variables should only be used in Kernel or Device functions",
                         symbol = expr,
                         severity = 'fatal')

--- a/samples/test/test.py
+++ b/samples/test/test.py
@@ -24,5 +24,5 @@ if __name__ == "__main__":
     # b = narray([1, 2, 3], dtype='int', order='C')
     a = cuda.array([1, 2, 3], dtype='int', order='C')
     func[1, 3](a)
-    cuda.deviceSynchronize()
+    cuda.synchronize()
     print(a)

--- a/tests/internal/scripts/ccuda/cuda_array_device.py
+++ b/tests/internal/scripts/ccuda/cuda_array_device.py
@@ -11,6 +11,6 @@ if __name__ == '__main__':
     threads_per_block = 5
     n_blocks = 1
     arr = cuda.array([0,1,2,3,4], memory_location = 'device')
-    cuda.deviceSynchronize()
+    cuda.synchronize()
     square[n_blocks, threads_per_block](arr)
-    cuda.deviceSynchronize()
+    cuda.synchronize()

--- a/tests/internal/scripts/ccuda/cuda_array_managed.py
+++ b/tests/internal/scripts/ccuda/cuda_array_managed.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
     threads_per_block = 5
     n_blocks = 1
     a = cuda.array([0,1,2,3,4], memory_location = 'managed')
-    cuda.deviceSynchronize()
+    cuda.synchronize()
     square[n_blocks, threads_per_block](a)
-    cuda.deviceSynchronize()
+    cuda.synchronize()
     print(a)

--- a/tests/internal/scripts/ccuda/cuda_grid.py
+++ b/tests/internal/scripts/ccuda/cuda_grid.py
@@ -23,10 +23,10 @@ if __name__ == '__main__':
     threads_per_block = 5
     n_blocks = 1
     arr = cuda.array([0, 1, 2, 3, 4])
-    cuda.deviceSynchronize()
+    cuda.synchronize()
     func_1d[n_blocks, threads_per_block](arr)
     # Since we dont support multi-dim n_block / threads_per_block
     # func_2d and func_3d won't compile
     # func_2d[n_blocks, threads_per_block](arr)
     # func_3d[n_blocks, threads_per_block](arr)
-    cuda.deviceSynchronize()
+    cuda.synchronize()

--- a/tests/internal/scripts/ccuda/cupy_array.py
+++ b/tests/internal/scripts/ccuda/cupy_array.py
@@ -12,6 +12,6 @@ if __name__ == '__main__':
     threads_per_block = 5
     n_blocks = 1
     arr = cp.array([0, 1, 2, 3, 4])
-    cuda.deviceSynchronize()
+    cuda.synchronize()
     func[n_blocks, threads_per_block](arr)
-    cuda.deviceSynchronize()
+    cuda.synchronize()

--- a/tests/internal/scripts/ccuda/kernel_launch.py
+++ b/tests/internal/scripts/ccuda/kernel_launch.py
@@ -11,6 +11,6 @@ if __name__ == '__main__':
     threads_per_block = 5
     n_blocks = 1
     arr = cuda.array([0, 1, 2, 3, 4])
-    cuda.deviceSynchronize()
+    cuda.synchronize()
     func[n_blocks, threads_per_block](arr)
-    cuda.deviceSynchronize()
+    cuda.synchronize()


### PR DESCRIPTION
Fixes: #1271.
Renames `cuda.deviceSynchronize` to `cuda.synchronize`.
Fixes a known bug that prevented the creation of a `kernel` or `device` function.