### PR TITLE
Fix allocation mishandling in CUDA array creation

### DIFF
--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -12,17 +12,17 @@ runs:
     - name: Test with pytest
       run: |
         which python
-        python -m pytest -n auto -rXx -v -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rXx -v -m "not (parallel or xdist_incompatible) and c" --ignore=symbolic --ignore=ndarrays --ignore=cuda_ndarrays
         if [ -n "${SITE_DIR}" ]; then
             echo "Touching"
             # Test ndarray folder update (requires parallel tests to avoid clean)
             touch ${SITE_DIR}/pyccel/stdlib/cwrapper/cwrapper.h
             python -m pytest -n auto -rXx -v -m c -k test_array_int32_1d_scalar epyccel/test_arrays.py
         fi
-        python -m pytest -rXx -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rXx -m "xdist_incompatible and not parallel and c" --ignore=symbolic --ignore=ndarrays --ignore=cuda_ndarrays
         pyccel-clean
-        python -m pytest -n auto -rXx -m "not (parallel or xdist_incompatible) and not (c or python or ccuda)" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rXx -m "xdist_incompatible and not parallel and not (c or python or ccuda)" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rXx -m "not (parallel or xdist_incompatible) and not (c or python or ccuda)" --ignore=symbolic --ignore=ndarrays --ignore=cuda_ndarrays
+        python -m pytest -rXx -m "xdist_incompatible and not parallel and not (c or python or ccuda)" --ignore=symbolic --ignore=ndarrays --ignore=cuda_ndarrays
         pyccel-clean
         python -m pytest ndarrays/ -rXx
         pyccel-clean

--- a/.github/actions/pytest_run_cuda/action.yml
+++ b/.github/actions/pytest_run_cuda/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - name: Ccuda tests with pytest
       run: |
-        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rx -m "not (parallel or xdist_incompatible) and ccuda" --ignore=symbolic --ignore=ndarrays --ignore=cuda_ndarrays
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/.github/actions/pytest_run_python/action.yml
+++ b/.github/actions/pytest_run_python/action.yml
@@ -10,8 +10,8 @@ runs:
   steps:
     - name: Python tests with pytest
       run: |
-        python -m pytest -n auto -rXx -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rXx -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rXx -m "not (parallel or xdist_incompatible) and python" --ignore=symbolic --ignore=ndarrays --ignore=cuda_ndarrays
+        python -m pytest -rXx -m "xdist_incompatible and not parallel and python" --ignore=symbolic --ignore=ndarrays --ignore=cuda_ndarrays
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
@@ -120,7 +120,7 @@ t_ndarray   cuda_array_create(int32_t nd, int64_t *shape,
         arr.shape[i] = shape[i];
     }
     arr.buffer_size = arr.length * arr.type_size;
-     cudaMallocManaged(&(arr.strides), nd * sizeof(int64_t));
+    cudaMallocManaged(&(arr.strides), nd * sizeof(int64_t));
     for (int32_t i = 0; i < arr.nd; i++)
     {
         arr.strides[i] = 1;

--- a/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
+++ b/pyccel/stdlib/cuda_ndarrays/cuda_ndarrays.cu
@@ -64,26 +64,26 @@ void cuda_array_fill_double(double c, t_ndarray arr)
 		arr.nd_double[i] = c;
 }
 
-void    device_memory(void* devPtr, size_t size)
+void    device_memory(void** devPtr, size_t size)
 {
-    cudaMalloc(&devPtr, size);
+    cudaMalloc(devPtr, size);
 }
 
-void    managed_memory(void* devPtr, size_t size)
+void    managed_memory(void** devPtr, size_t size)
 {
-    cudaMallocManaged(&devPtr, size);
+    cudaMallocManaged(devPtr, size);
 }
 
-void    host_memory(void* devPtr, size_t size)
+void    host_memory(void** devPtr, size_t size)
 {
-    cudaMallocHost(&devPtr, size);
+    cudaMallocHost(devPtr, size);
 }
 
 t_ndarray   cuda_array_create(int32_t nd, int64_t *shape,
         enum e_types type, bool is_view, enum e_memory_locations location)
 {
     t_ndarray arr;
-    void (*fun_ptr_arr[])(void*, size_t) = {managed_memory, host_memory, device_memory};
+    void (*fun_ptr_arr[])(void**, size_t) = {managed_memory, host_memory, device_memory};
 
     arr.nd = nd;
     arr.type = type;
@@ -113,14 +113,14 @@ t_ndarray   cuda_array_create(int32_t nd, int64_t *shape,
     }
     arr.is_view = is_view;
     arr.length = 1;
-    (*fun_ptr_arr[location])(&(arr.shape), arr.nd * sizeof(int64_t));
+    cudaMallocManaged(&(arr.shape), arr.nd * sizeof(int64_t));
     for (int32_t i = 0; i < arr.nd; i++)
     {
         arr.length *= shape[i];
         arr.shape[i] = shape[i];
     }
     arr.buffer_size = arr.length * arr.type_size;
-    (*fun_ptr_arr[location])(&(arr.strides), nd * sizeof(int64_t));
+     cudaMallocManaged(&(arr.strides), nd * sizeof(int64_t));
     for (int32_t i = 0; i < arr.nd; i++)
     {
         arr.strides[i] = 1;

--- a/tests/cuda_ndarrays/conftest.py
+++ b/tests/cuda_ndarrays/conftest.py
@@ -12,7 +12,6 @@ NEEDS_FROM_PARENT = hasattr(pytest.Item, "from_parent")
 def pytest_collect_file(parent, path):
     """
     A hook to collect test_*.cu test files.
-
     """
     if path.ext == ".cu" and path.basename.startswith("test_"):
         if NEEDS_FROM_PARENT:
@@ -22,7 +21,6 @@ def pytest_collect_file(parent, path):
 def pytest_collection_modifyitems(items):
     """
     a hook to modify the items before the tests for C Cuda unit test files.
-
     """
     for item in items:
         if item.fspath.ext == ".cu":
@@ -31,7 +29,6 @@ def pytest_collection_modifyitems(items):
 class CTestFile(pytest.File):
     """
     A custom file handler class for C unit test files.
-
     """
 
     @classmethod
@@ -42,7 +39,6 @@ class CTestFile(pytest.File):
         """
         Overridden collect method to collect the results from each
         C unit test executable.
-
         """
         # Run the exe that corresponds to the .c file and capture the output.
         test_exe = os.path.splitext(str(self.fspath))[0]
@@ -96,7 +92,6 @@ class CTestItem(pytest.Item):
     """
     Pytest.Item subclass to handle each test result item. There may be
     more than one test result from a test function.
-
     """
 
     def __init__(self, *, test_result, **kwargs):
@@ -121,7 +116,6 @@ class CTestItem(pytest.Item):
         """
         Called when runtest() raises an exception. The method is used
         to format the output of the failed test result.
-
         """
         if isinstance(exception.value, CTestException):
             return (f"Test failed : {self.test_result['file_name']}:{self.test_result['line_number']} {self.test_result['function_name']} < {self.test_result['DSCR']} >\n INFO : {self.test_result['INFO']}")

--- a/tests/cuda_ndarrays/conftest.py
+++ b/tests/cuda_ndarrays/conftest.py
@@ -1,5 +1,5 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring/
-# pylint: disable=arguments-differ, inconsistent-return-statements, protected-access, abstract-method/
+# pylint: disable=missing-module-docstring/
+# pylint: disable=arguments-differ, inconsistent-return-statements
 import subprocess
 import os
 import pathlib
@@ -18,13 +18,6 @@ def pytest_collect_file(parent, path):
             return CTestFile.from_parent(path=pathlib.Path(path), parent=parent)
         return CTestFile(parent=parent, path=pathlib.Path(path))
 
-def pytest_collection_modifyitems(items):
-    """
-    a hook to modify the items before the tests for C Cuda unit test files.
-    """
-    for item in items:
-        if item.fspath.ext == ".cu":
-            item._nodeid = item.nodeid + " < " + item.test_result["DSCR"] + " >"
 
 class CTestFile(pytest.File):
     """
@@ -81,10 +74,10 @@ class CTestFile(pytest.File):
                 test_results[-1][token] = data
         for test_result in test_results:
             if NEEDS_FROM_PARENT:
-                yield CTestItem.from_parent(name = test_result["function_name"],
+                yield CTestItem.from_parent(name = test_result["function_name"] + " < " + test_result["DSCR"] + " >",
                         parent = self, test_result = test_result)
             else:
-                yield CTestItem(name = test_result["function_name"], parent = self,
+                yield CTestItem(name = test_result["function_name"] + " < " + test_result["DSCR"] + " >", parent = self,
                         test_result = test_result)
 
 

--- a/tests/cuda_ndarrays/conftest.py
+++ b/tests/cuda_ndarrays/conftest.py
@@ -1,0 +1,132 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring/
+# pylint: disable=arguments-differ, inconsistent-return-statements, protected-access, abstract-method/
+import subprocess
+import os
+import pathlib
+import sys
+import shutil
+import pytest
+
+NEEDS_FROM_PARENT = hasattr(pytest.Item, "from_parent")
+
+def pytest_collect_file(parent, path):
+    """
+    A hook to collect test_*.cu test files.
+
+    """
+    if path.ext == ".cu" and path.basename.startswith("test_"):
+        if NEEDS_FROM_PARENT:
+            return CTestFile.from_parent(path=pathlib.Path(path), parent=parent)
+        return CTestFile(parent=parent, path=pathlib.Path(path))
+
+def pytest_collection_modifyitems(items):
+    """
+    a hook to modify the items before the tests for C Cuda unit test files.
+
+    """
+    for item in items:
+        if item.fspath.ext == ".cu":
+            item._nodeid = item.nodeid + " < " + item.test_result["DSCR"] + " >"
+
+class CTestFile(pytest.File):
+    """
+    A custom file handler class for C unit test files.
+
+    """
+
+    @classmethod
+    def from_parent(cls, **kwargs):
+        return super().from_parent(**kwargs)
+
+    def collect(self):
+        """
+        Overridden collect method to collect the results from each
+        C unit test executable.
+
+        """
+        # Run the exe that corresponds to the .c file and capture the output.
+        test_exe = os.path.splitext(str(self.fspath))[0]
+        rootdir = str(self.config.rootdir)
+        test_exe = os.path.relpath(test_exe)
+        ndarray_path =  os.path.join(rootdir , "pyccel", "stdlib", "ndarrays")
+        cuda_ndarray_path = os.path.join(rootdir, "pyccel", "stdlib", "cuda_ndarrays")
+        comp_cmd = [shutil.which("nvcc"), test_exe + ".cu",
+                    os.path.join(ndarray_path, "ndarrays.c"),
+                    os.path.join(cuda_ndarray_path, "cuda_ndarrays.cu"),
+                    "-I", ndarray_path,
+                    "-I", cuda_ndarray_path,
+                    "-o", test_exe,]
+
+        subprocess.run(comp_cmd, check= 'TRUE')
+        if sys.platform.startswith("win"):
+            test_exe += ".exe"
+        test_output = subprocess.check_output("./" + test_exe)
+
+        # Clean up the unit test output and remove non test data lines.
+        lines = test_output.decode().split("\n")
+        lines = [line.strip() for line in lines]
+        lines = [line for line in lines if line.startswith("[")]
+
+        # Extract the test metadata from the unit test output.
+        test_results = []
+        for line in lines:
+            token, data = line.split(" ", 1)
+            token = token[1:-1]
+            if token in ("PASS", "FAIL"):
+                file_name, line_number, function_name = data.split(":")
+                test_results.append({"condition": token,
+                                     "file_name": file_name,
+                                     "function_name": function_name,
+                                     "line_number": int(line_number),
+                                     "INFO" : "no data found",
+                                     "DSCR" : ""
+                                     })
+            elif token in ("INFO", "DSCR"):
+                test_results[-1][token] = data
+        for test_result in test_results:
+            if NEEDS_FROM_PARENT:
+                yield CTestItem.from_parent(name = test_result["function_name"],
+                        parent = self, test_result = test_result)
+            else:
+                yield CTestItem(name = test_result["function_name"], parent = self,
+                        test_result = test_result)
+
+
+class CTestItem(pytest.Item):
+    """
+    Pytest.Item subclass to handle each test result item. There may be
+    more than one test result from a test function.
+
+    """
+
+    def __init__(self, *, test_result, **kwargs):
+        """Overridden constructor to pass test results dict."""
+        super().__init__(**kwargs)
+        self.test_result = test_result
+
+    @classmethod
+    def from_parent(cls, *, test_result, **kwargs):
+        return super().from_parent(test_result=test_result, **kwargs)
+
+    def runtest(self):
+        """The test has already been run. We just evaluate the result."""
+        if self.test_result["condition"] == "FAIL":
+            raise CTestException(self, self.name)
+
+    def reportinfo(self):
+        """"Called to display header information about the test case."""
+        return self.fspath, self.test_result["line_number"], self.name
+
+    def repr_failure(self, exception):
+        """
+        Called when runtest() raises an exception. The method is used
+        to format the output of the failed test result.
+
+        """
+        if isinstance(exception.value, CTestException):
+            return (f"Test failed : {self.test_result['file_name']}:{self.test_result['line_number']} {self.test_result['function_name']} < {self.test_result['DSCR']} >\n INFO : {self.test_result['INFO']}")
+
+
+
+class CTestException(Exception):
+    """Custom exception to distinguish C unit test failures from others."""

--- a/tests/cuda_ndarrays/conftest.py
+++ b/tests/cuda_ndarrays/conftest.py
@@ -53,7 +53,7 @@ class CTestFile(pytest.File):
                     "-I", cuda_ndarray_path,
                     "-o", test_exe,]
 
-        subprocess.run(comp_cmd, check= 'TRUE')
+        subprocess.run(comp_cmd, check=True)
         if sys.platform.startswith("win"):
             test_exe += ".exe"
         test_output = subprocess.check_output("./" + test_exe)

--- a/tests/cuda_ndarrays/conftest.py
+++ b/tests/cuda_ndarrays/conftest.py
@@ -112,7 +112,7 @@ class CTestItem(pytest.Item):
         """
         if isinstance(excinfo.value, CTestException):
             return f"Test failed : {self.test_result['file_name']}:{self.test_result['line_number']} {self.test_result['function_name']} < {self.test_result['DSCR']} >\n INFO : {self.test_result['INFO']}"
-        return None
+        return super().repr_failure(excinfo)
 
 
 

--- a/tests/cuda_ndarrays/conftest.py
+++ b/tests/cuda_ndarrays/conftest.py
@@ -41,8 +41,8 @@ class CTestFile(pytest.File):
         C unit test executable.
         """
         # Run the exe that corresponds to the .c file and capture the output.
-        test_exe = os.path.splitext(str(self.fspath))[0]
-        rootdir = str(self.config.rootdir)
+        test_exe = os.path.splitext(self.fspath.basename)[0]
+        rootdir = self.config.rootdir.strpath
         test_exe = os.path.relpath(test_exe)
         ndarray_path =  os.path.join(rootdir , "pyccel", "stdlib", "ndarrays")
         cuda_ndarray_path = os.path.join(rootdir, "pyccel", "stdlib", "cuda_ndarrays")

--- a/tests/cuda_ndarrays/test_cuda_ndarrays.cu
+++ b/tests/cuda_ndarrays/test_cuda_ndarrays.cu
@@ -5,15 +5,13 @@
 #include "ndarrays.h"
 #include "cuda_ndarrays.h"
 
-#define getname(X) #X
-
 void assert_double(double v1 , double v2, const char *dscr,
         const char * func, const char *file, int32_t line)
 {
     if (v1 != v2)
     {
         printf("[FAIL] %s:%d:%s\n", file, line, func);
-        printf("[INFO] %s:%f != %s:%f\n", getname(v1), v1, getname(v2),v2);
+        printf("[INFO] v1:%f != v2:%f\n", v1, v2);
         printf("[DSCR] %s\n", dscr);
         return ;
     }
@@ -27,7 +25,7 @@ void assert_float(float v1 , float v2, const char *dscr,
     if (v1 != v2)
     {
         printf("[FAIL] %s:%d:%s\n", file, line, func);
-        printf("[INFO] %s:%f != %s:%f\n", getname(v1), v1, getname(v2),v2);
+        printf("[INFO] v1:%f != v2:%f\n", v1, v2);
         printf("[DSCR] %s\n", dscr);
         return ;
     }
@@ -41,7 +39,7 @@ void assert_int64(int64_t v1, int64_t v2, const char *dscr,
     if (v1 != v2)
     {
         printf("[FAIL] %s:%d:%s\n", file, line, func);
-        printf("[INFO] %s:%ld != %s:%ld\n", getname(v1), v1, getname(v2),v2);
+        printf("[INFO] v1:%ld != v2:%ld\n", v1, v2);
         printf("[DSCR] %s\n", dscr);
         return ;
     }
@@ -55,7 +53,7 @@ void assert_int32(int32_t v1 , int32_t v2, const char *dscr,
     if (v1 != v2)
     {
         printf("[FAIL] %s:%d:%s\n", file, line, func);
-        printf("[INFO] %s:%d != %s:%d\n", getname(v1), v1, getname(v2),v2);
+        printf("[INFO] v1:%d != v2:%d\n", v1, v2);
         printf("[DSCR] %s\n", dscr);
         return ;
     }
@@ -69,7 +67,7 @@ void assert_int16(int16_t v1 , int16_t v2, const char *dscr,
     if (v1 != v2)
     {
         printf("[FAIL] %s:%d:%s\n", file, line, func);
-        printf("[INFO] %s:%d != %s:%d\n", getname(v1), v1, getname(v2),v2);
+        printf("[INFO] v1:%d != v2:%d\n", v1, v2);
         printf("[DSCR] %s\n", dscr);
         return ;
     }
@@ -83,7 +81,7 @@ void assert_int8(int8_t v1 , int8_t v2, const char *dscr,
     if (v1 != v2)
     {
         printf("[FAIL] %s:%d:%s\n", file, line, func);
-        printf("[INFO] %s:%d != %s:%d\n", getname(v1), v1, getname(v2),v2);
+        printf("[INFO] v1:%d != v2:%d\n", v1, v2);
         printf("[DSCR] %s\n", dscr);
         return ;
     }

--- a/tests/cuda_ndarrays/test_cuda_ndarrays.cu
+++ b/tests/cuda_ndarrays/test_cuda_ndarrays.cu
@@ -1,0 +1,505 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "ndarrays.h"
+#include "cuda_ndarrays.h"
+
+#define getname(X) #X
+
+void assert_double(double v1 , double v2, const char *dscr,
+        const char * func, const char *file, int32_t line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%f != %s:%f\n", getname(v1), v1, getname(v2),v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
+void assert_float(float v1 , float v2, const char *dscr,
+        const char * func, const char *file, int32_t line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%f != %s:%f\n", getname(v1), v1, getname(v2),v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
+void assert_int64(int64_t v1, int64_t v2, const char *dscr,
+        const char * func, const char *file, int32_t line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%ld != %s:%ld\n", getname(v1), v1, getname(v2),v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
+void assert_int32(int32_t v1 , int32_t v2, const char *dscr,
+        const char * func, const char *file, int32_t line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%d != %s:%d\n", getname(v1), v1, getname(v2),v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n",file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
+void assert_int16(int16_t v1 , int16_t v2, const char *dscr,
+        const char * func, const char *file, int32_t line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%d != %s:%d\n", getname(v1), v1, getname(v2),v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
+void assert_int8(int8_t v1 , int8_t v2, const char *dscr,
+        const char * func, const char *file, int32_t line)
+{
+    if (v1 != v2)
+    {
+        printf("[FAIL] %s:%d:%s\n", file, line, func);
+        printf("[INFO] %s:%d != %s:%d\n", getname(v1), v1, getname(v2),v2);
+        printf("[DSCR] %s\n", dscr);
+        return ;
+    }
+    printf("[PASS] %s:%d:%s\n", file, line, func);
+    printf("[DSCR] %s\n", dscr);
+}
+
+void test_cuda_array_create_host_double()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+
+    arr = cuda_array_create(1, tmp_shape, nd_double, false, allocateMemoryOnHost);
+    double cuda_array_dummy[] = {1.02, 0.25, 5e-05, 1.0, 200.0, 33.0, 5.0, 57.0, 62.0, 70.0, 103.009, 141.0, 122.0, 26.5};
+    cudaMemcpy(arr.nd_double, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_double(arr.nd_double[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free_host(arr);
+}
+
+void test_cuda_array_create_managed_double()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_double, false, managedMemory);
+    double cuda_array_dummy[] = {1.02, 0.25, 5e-05, 1.0, 200.0, 33.0, 5.0, 57.0, 62.0, 70.0, 103.009, 141.0, 122.0, 26.5};
+    cudaMemcpy(arr.nd_double, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_double(arr.nd_double[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+}
+
+void test_cuda_array_create_device_double()
+{
+    t_ndarray arr = {.shape = NULL};
+    t_ndarray b = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_float, false, allocateMemoryOnDevice);
+    double cuda_array_dummy[] = {1.02, 0.25, 5e-05, 1.0, 200.0, 33.0, 5.0, 57.0, 62.0, 70.0, 103.009, 141.0, 122.0, 26.5};
+    cudaMemcpy(arr.nd_double, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+    int64_t tmp_shape_0001[] = {INT64_C(14)};
+    b = cuda_array_create(1, tmp_shape_0001, nd_double, false, allocateMemoryOnHost);
+    cudaMemcpy(b.nd_double, arr.nd_double, b.buffer_size, cudaMemcpyDeviceToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_double(b.nd_double[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+    cuda_free_host(b);
+}
+
+void test_cuda_array_create_host_float()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+
+    arr = cuda_array_create(1, tmp_shape, nd_float, false, allocateMemoryOnHost);
+    float cuda_array_dummy[] = {1.02, 0.25, 5e-05, 1.0, 200.0, 33.0, 5.0, 57.0, 62.0, 70.0, 103.009, 141.0, 122.0, 26.5};
+    cudaMemcpy(arr.nd_float, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_float(arr.nd_float[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free_host(arr);
+}
+
+void test_cuda_array_create_managed_float()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_float, false, managedMemory);
+    float cuda_array_dummy[] = {1.02, 0.25, 5e-05, 1.0, 200.0, 33.0, 5.0, 57.0, 62.0, 70.0, 103.009, 141.0, 122.0, 26.5};
+    cudaMemcpy(arr.nd_float, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_float(arr.nd_float[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+}
+
+void test_cuda_array_create_device_float()
+{
+    t_ndarray arr = {.shape = NULL};
+    t_ndarray b = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_float, false, allocateMemoryOnDevice);
+    float cuda_array_dummy[] = {1.02, 0.25, 5e-05, 1.0, 200.0, 33.0, 5.0, 57.0, 62.0, 70.0, 103.009, 141.0, 122.0, 26.5};
+    cudaMemcpy(arr.nd_float, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+    int64_t tmp_shape_0001[] = {INT64_C(14)};
+    b = cuda_array_create(1, tmp_shape_0001, nd_double, false, allocateMemoryOnHost);
+    cudaMemcpy(b.nd_float, arr.nd_float, b.buffer_size, cudaMemcpyDeviceToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_float(b.nd_float[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+    cuda_free_host(b);
+}
+
+void test_cuda_array_create_host_int64()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+
+    arr = cuda_array_create(1, tmp_shape, nd_int64, false, allocateMemoryOnHost);
+    int64_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_int64, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int64(arr.nd_int64[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free_host(arr);
+}
+
+void test_cuda_array_create_managed_int64()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_int64, false, managedMemory);
+    int64_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_int64, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int64(arr.nd_int64[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+}
+
+void test_cuda_array_create_device_int64()
+{
+    t_ndarray arr = {.shape = NULL};
+    t_ndarray b = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_int64, false, allocateMemoryOnDevice);
+    int64_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_double, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+    int64_t tmp_shape_0001[] = {INT64_C(14)};
+    b = cuda_array_create(1, tmp_shape_0001, nd_int64, false, allocateMemoryOnHost);
+    cudaMemcpy(b.nd_int64, arr.nd_int64, b.buffer_size, cudaMemcpyDeviceToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int64(b.nd_int64[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+    cuda_free_host(b);
+}
+
+
+void test_cuda_array_create_host_int32()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+
+    arr = cuda_array_create(1, tmp_shape, nd_int32, false, allocateMemoryOnHost);
+    int32_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_int32, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int32(arr.nd_int32[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free_host(arr); 
+}
+
+void test_cuda_array_create_managed_int32()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_int32, false, managedMemory);
+    int32_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_int32, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int32(arr.nd_int32[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+}
+
+void test_cuda_array_create_device_int32()
+{
+    t_ndarray arr = {.shape = NULL};
+    t_ndarray b = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_int32, false, allocateMemoryOnDevice);
+    int32_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_int32, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+    int64_t tmp_shape_0001[] = {INT64_C(14)};
+    b = cuda_array_create(1, tmp_shape_0001, nd_int32, false, allocateMemoryOnHost);
+    cudaMemcpy(b.nd_int32, arr.nd_int32, b.buffer_size, cudaMemcpyDeviceToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int32(b.nd_int32[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+    cuda_free_host(b);
+}
+
+void test_cuda_array_create_host_int16()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+
+    arr = cuda_array_create(1, tmp_shape, nd_int16, false, allocateMemoryOnHost);
+    int16_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_int16, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int16(arr.nd_int16[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free_host(arr);
+}
+
+void test_cuda_array_create_managed_int16()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_int16, false, managedMemory);
+    int16_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_int16, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int16(arr.nd_int16[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+}
+
+void test_cuda_array_create_device_int16()
+{
+    t_ndarray arr = {.shape = NULL};
+    t_ndarray b = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_int16, false, allocateMemoryOnDevice);
+    int16_t cuda_array_dummy[] = {1, 0, 0, 1, 200, 33, 5, 57,
+                    62, 70, 103, 141, 122, 26};
+    cudaMemcpy(arr.nd_int16, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+    int64_t tmp_shape_0001[] = {INT64_C(14)};
+    b = cuda_array_create(1, tmp_shape_0001, nd_int16, false, allocateMemoryOnHost);
+    cudaMemcpy(b.nd_int16, arr.nd_int16, b.buffer_size, cudaMemcpyDeviceToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int16(b.nd_int16[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+    cuda_free_host(b);
+}
+
+void test_cuda_array_create_host_int8()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+
+    arr = cuda_array_create(1, tmp_shape, nd_int8, false, allocateMemoryOnHost);
+    int8_t cuda_array_dummy[] = {1, 0, 0, 1, 116, 33, 5, 57,
+                    62, 70, 103, 120, 122, 26};
+    cudaMemcpy(arr.nd_int8, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int8(arr.nd_int8[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free_host(arr); 
+}
+
+void test_cuda_array_create_managed_int8()
+{
+    t_ndarray arr = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_int8, false, managedMemory);
+    int8_t cuda_array_dummy[] = {1, 0, 0, 1, 116, 33, 5, 57,
+                    62, 70, 103, 120, 122, 26};
+    cudaMemcpy(arr.nd_int8, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int8(arr.nd_int8[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+}
+
+void test_cuda_array_create_device_int8()
+{
+    t_ndarray arr = {.shape = NULL};
+    t_ndarray b = {.shape = NULL};
+
+    int64_t tmp_shape[] = {INT64_C(14)};
+    arr = cuda_array_create(1, tmp_shape, nd_int8, false, allocateMemoryOnDevice);
+    int8_t cuda_array_dummy[] = {1, 0, 0, 1, 116, 33, 5, 57,
+                    62, 70, 103, 120, 122, 26};
+    cudaMemcpy(arr.nd_int8, cuda_array_dummy, arr.buffer_size, cudaMemcpyHostToDevice);
+
+    int64_t tmp_shape_0001[] = {INT64_C(14)};
+    b = cuda_array_create(1, tmp_shape_0001, nd_int8, false, allocateMemoryOnHost);
+    cudaMemcpy(b.nd_int8, arr.nd_int8, b.buffer_size, cudaMemcpyDeviceToHost);
+
+    assert_int32(arr.nd, 1, "testing the number of dimensions", __func__, __FILE__, __LINE__);
+    assert_int64(arr.shape[0], tmp_shape[0], "testing the shape", __func__, __FILE__, __LINE__);
+    for(int i = 0; i < tmp_shape[0]; i++)
+    {
+        assert_int8(b.nd_int8[i], cuda_array_dummy[i], "testing the data", __func__, __FILE__, __LINE__);
+    }
+    cuda_free(arr);
+    cuda_free_host(b);
+}
+
+int32_t main(void)
+{
+    /* Cuda array creation tests */
+    test_cuda_array_create_host_double();
+    test_cuda_array_create_managed_double();
+    test_cuda_array_create_device_double();
+
+    test_cuda_array_create_host_float();
+    test_cuda_array_create_managed_float();
+    test_cuda_array_create_device_float();
+
+    test_cuda_array_create_host_int64();
+    test_cuda_array_create_managed_int64();
+    test_cuda_array_create_device_int64();
+
+    test_cuda_array_create_host_int32();
+    test_cuda_array_create_managed_int32();
+    test_cuda_array_create_device_int32();
+
+    test_cuda_array_create_host_int16();
+    test_cuda_array_create_managed_int16();
+    test_cuda_array_create_device_int16();
+
+    test_cuda_array_create_host_int8();
+    test_cuda_array_create_managed_int8();
+    test_cuda_array_create_device_int8();
+
+    return (0);
+}


### PR DESCRIPTION
This PR fixes a bug where the allocation of the CUDA array was not being properly handled. Fixes [pyccel-cuda#2](https://github.com/pyccel/pyccel-cuda/issues/2).

**Changes Made:**
- Fixed the allocation of the CUDA array to prevent segmentation fault.
- Added tests to ensure proper handling of the CUDA array allocation.