### PR TITLE
Change byteflag definition to determine Interface

### DIFF
--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -531,23 +531,3 @@ def scalar_object_check(py_object, c_object):
                     results   = [Variable(dtype=NativeBool(), name = 'r')])
 
     return FunctionCall(check_func, [py_object])
-
-# This registry is used for interface management,
-# mapping each data type to a given flag
-# Those flags are used in a bitset #TODO
-flags_registry = {
-    (NativeInteger(), 4)       : 1,
-    (NativeInteger(), 8)       : 2,
-    (NativeInteger(), 2)       : 3,
-    (NativeInteger(), 1)       : 4,
-    (NativeInteger(), -1)      : 5,
-    (NativeFloat(), 8)         : 6,
-    (NativeFloat(), 4)         : 7,
-    (NativeFloat(), -1)        : 8,
-    (NativeComplex(), 4)       : 9,
-    (NativeComplex(), 8)       : 10,
-    (NativeComplex(), -1)      : 11,
-    (NativeBool(), 4)          : 12,
-    (NativeBool(), -1)         : 12,
-    (NativeString(), 0)        : 13
-}

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -1105,6 +1105,12 @@ class CWrapperCodePrinter(CCodePrinter):
         """
         Generate the function which determines the relevant interface.
 
+        Creates a function which tests each of the arguments passed to the function.
+        For each of the arguments it checks if it has one of the expected types. If
+        this is not the case, then an error is raised, otherwise the received type is
+        saved into a byte flag. This flag is then used to determine exactly which
+        function in the interface is being called.
+
         Parameters
         ----------
         check_var : Variable
@@ -1123,7 +1129,7 @@ class CWrapperCodePrinter(CCodePrinter):
         Returns
         -------
         FunctionDef
-            The function which determines the Interface key
+            The function which determines the Interface key.
         """
         check_func_body = []
         step = 1

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -1185,7 +1185,6 @@ class CWrapperCodePrinter(CCodePrinter):
         """
         Generate the function which determines the relevant interface.
 
-
         Creates a FunctionDef which tests each of the arguments passed to the Interface.
         For each of the arguments it checks if it has one of the expected types.
         This function is necessary when wrapping an Interface in order to determine which

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -1091,7 +1091,7 @@ class CWrapperCodePrinter(CCodePrinter):
 
         # Errors / Types management
         # Creating check_type function
-        check_func_def = self._create_wrapper_check(check_var, parse_args, types_dict)
+        check_func_def = self._create_wrapper_check(check_var, parse_args, types_dict, funcs[0].name)
         funcs_def.append(check_func_def)
 
         # Create the wrapper body with collected informations

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -39,7 +39,7 @@ from pyccel.ast.numpy_wrapper   import pyarray_to_ndarray
 from pyccel.ast.numpy_wrapper   import array_get_data, array_get_dim
 
 from pyccel.ast.operators import PyccelEq, PyccelNot, PyccelOr, PyccelAssociativeParenthesis
-from pyccel.ast.operators import PyccelIsNot, PyccelLt, PyccelUnarySub, PyccelNe
+from pyccel.ast.operators import PyccelIsNot, PyccelLt, PyccelUnarySub
 
 from pyccel.ast.variable  import Variable, DottedVariable
 
@@ -1069,7 +1069,7 @@ class CWrapperCodePrinter(CCodePrinter):
         funcs_def.append(check_func_def)
 
         # Create the wrapper body with collected informations
-        body_tmp = [IfSection(PyccelNe(check_var, PyccelUnarySub(LiteralInteger(1))), [Return([Nil()])])] + body_tmp
+        body_tmp = [IfSection(PyccelEq(check_var, PyccelUnarySub(LiteralInteger(1))), [Return([Nil()])])] + body_tmp
         body_tmp.append(IfSection(LiteralTrue(),
             [PyErr_SetString('PyExc_TypeError', '"This combination of arguments is not valid"'),
             Return([Nil()])]))

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -1154,8 +1154,8 @@ class CWrapperCodePrinter(CCodePrinter):
         Creates a function which tests each of the arguments passed to the function.
         For each of the arguments it checks if it has one of the expected types. If
         this is not the case, then an error is raised, otherwise the received type is
-        saved into a byte flag. This flag is then used to determine exactly which
-        function in the interface is being called.
+        used to increment a type flag. This flag is then used to determine exactly which
+        function in the interface is being called (see _determine_interface_flags for more detail).
 
         Parameters
         ----------

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -1006,7 +1006,7 @@ class CWrapperCodePrinter(CCodePrinter):
         parse_args = [self.get_PyArgParseType(a.var) for a in funcs[0].arguments]
 
         # Determine flags which indicate argument type
-        argument_type_flags = self._determine_interface_flags(funcs, parse_args)
+        argument_type_flags = self._determine_interface_flags(funcs)
 
         # Managing the body of wrapper
         for func in funcs :

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.7.2"
+__version__ = "1.7.3"


### PR DESCRIPTION
Change byte flag to depend on the possible types which can be passed to the Interface instead of depending on `flags_registry` (a list of all possible types which each argument could have). This decreases the value of the flags and fixes #1337 