### PR TITLE
Add JOSS link and missing link in developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to Pyccel
 
- [![master_tests](https://github.com/pyccel/pyccel/actions/workflows/master.yml/badge.svg)](https://github.com/pyccel/pyccel/actions/workflows/master.yml) [![codacy](https://app.codacy.com/project/badge/Grade/9723f47b95db491886a0e78339bd4698)](https://www.codacy.com/gh/pyccel/pyccel?utm_source=github.com&utm_medium=referral&utm_content=pyccel/pyccel&utm_campaign=Badge_Grade)
+ [![master_tests](https://github.com/pyccel/pyccel/actions/workflows/master.yml/badge.svg)](https://github.com/pyccel/pyccel/actions/workflows/master.yml) [![codacy](https://app.codacy.com/project/badge/Grade/9723f47b95db491886a0e78339bd4698)](https://www.codacy.com/gh/pyccel/pyccel?utm_source=github.com&utm_medium=referral&utm_content=pyccel/pyccel&utm_campaign=Badge_Grade) [![DOI](https://joss.theoj.org/papers/10.21105/joss.04991/status.svg)](https://doi.org/10.21105/joss.04991)
 
 **Pyccel** stands for Python extension language using accelerators.
 

--- a/developer_docs/overview.md
+++ b/developer_docs/overview.md
@@ -8,7 +8,7 @@ Pyccel's development is split into 4 main stages:
 
 -   [Syntactic Stage](#Syntactic-stage) (for more details see [syntactic stage](syntactic_stage.md))
 -   [Semantic Stage](#Semantic-stage) (for more details see [semantic stage](semantic_stage.md))
--   [Code Generation Stage](#Code-generation-stage)
+-   [Code Generation Stage](#Code-generation-stage) (for more details see [codegen stage](codegen_stage.md))
 -   [Wrapping Stage](#Wrapping-stage)
 -   [Compilation Stage](#Compilation-stage)
 


### PR DESCRIPTION
Add JOSS link to provide an easily cite-able reference. Add a link to the codegen docs in the developer docs overview