### PR TITLE
Link Python dynamically for smaller extension modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Use `FunctionDefArgument` to store all argument specific properties.
 -   \[INTERNALS\] Reduce carbon footprint by avoiding unnecessary CI testing.
 -   \[INTERNALS\] Automatise PR labelling and review progress prompts.
+-   Default to linking python dynamically instead of statically
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Use `FunctionDefArgument` to store all argument specific properties.
 -   \[INTERNALS\] Reduce carbon footprint by avoiding unnecessary CI testing.
 -   \[INTERNALS\] Automatise PR labelling and review progress prompts.
--   Default to linking python dynamically instead of statically
+-   Default to linking Python dynamically instead of statically
 
 ### Deprecated
 

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -225,8 +225,8 @@ else:
         # If the proposed library does not exist use different config flags
         # to specify the library
         linker_flags = [change_to_lib_flag(l) for l in
-                        config_vars.get("LIBRARY","").split() + \
-                        config_vars.get("LDSHARED","").split()[1:]]
+                        config_vars.get("LDSHARED","").split() + \
+                        config_vars.get("LIBRARY","").split()[1:]]
         python_info['python']['libs'] = [l[2:] for l in linker_flags if l.startswith('-l')]
         python_info['python']['libdirs'] = [l[2:] for l in linker_flags if l.startswith('-L')] + \
                             config_vars.get("LIBPL","").split()+config_vars.get("LIBDIR","").split()


### PR DESCRIPTION
Default to dynamic linking of Python library instead of static linking. This decreases the size of the generated extension modules, this fixing the execution problem on Python 3.11.