### PR TITLE
Cleanup builtin_import_registery

### DIFF
--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -99,8 +99,21 @@ else:
 recognised_libs = python_builtin_libs | builtin_import_registry.keys()
 
 def recognised_source(source_name):
-    """ Determine whether the imported source is recognised by pyccel.
-    If it is not recognised then it should be imported and translated
+    """
+    Determine whether the imported source is recognised by pyccel.
+
+    Determine whether the imported source is recognised by pyccel.
+    If it is not recognised then it will need to be imported and translated.
+
+    Parameters
+    ----------
+    source_name : str
+        The name of the imported module.
+
+    Returns
+    -------
+    bool
+        True if the source is recognised, False otherwise.
     """
     source = str(source_name).split('.')
     if source[0] in python_builtin_libs and source[0] not in builtin_import_registry.keys():
@@ -140,7 +153,24 @@ def collect_relevant_imports(module, targets):
     return imports
 
 def builtin_import(expr):
-    """Returns a builtin pyccel-extension function/object from an import."""
+    """
+    Return a Pyccel-extension function/object from an import of a recognised module.
+
+    Examine an Import object which imports something which is recognised by
+    Pyccel internally. The object(s) imported are then returned for use in the
+    code.
+
+    Parameters
+    ----------
+    expr : Import
+        The expression which imports the module.
+
+    Returns
+    -------
+    list
+        A list of 2-tuples. The first element is the name of the imported object,
+        the second element is the object itself.
+    """
 
     if not isinstance(expr, Import):
         raise TypeError('Expecting an Import expression')

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -84,12 +84,12 @@ pyccel_mod = Module('pyccel',(),(),
 builtin_import_registry = Module('__main__',
         (),(),
         imports = [
-            Import('numpy', AsName(numpy_mod,'numpy')),
-            Import('scipy', AsName(scipy_mod,'scipy')),
-            Import('itertools', AsName(itertools_mod,'itertools')),
-            Import('math', AsName(math_mod,'math')),
-            Import('pyccel', AsName(pyccel_mod,'pyccel')),
-            Import('sys', AsName(sys_mod,'sys')),
+            Import('numpy', numpy_mod),
+            Import('scipy', scipy_mod),
+            Import('itertools', itertools_mod),
+            Import('math', math_mod),
+            Import('pyccel', pyccel_mod),
+            Import('sys', sys_mod),
             ])
 if sys.version_info < (3, 10):
     from .builtin_imports import python_builtin_libs

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -41,7 +41,7 @@ __all__ = (
     'LoopCollection',
     'builtin_function',
     'builtin_import',
-    'builtin_import_registery',
+    'builtin_import_registry',
     'split_positional_keyword_arguments',
 )
 
@@ -81,7 +81,7 @@ pyccel_mod = Module('pyccel',(),(),
         imports = [Import('decorators', decorators_mod)])
 
 # TODO add documentation
-builtin_import_registery = Module('__main__',
+builtin_import_registry = Module('__main__',
         (),(),
         imports = [
             Import('numpy', AsName(numpy_mod,'numpy')),
@@ -96,17 +96,17 @@ if sys.version_info < (3, 10):
 else:
     python_builtin_libs = set(sys.stdlib_module_names) # pylint: disable=no-member
 
-recognised_libs = python_builtin_libs | builtin_import_registery.keys()
+recognised_libs = python_builtin_libs | builtin_import_registry.keys()
 
 def recognised_source(source_name):
     """ Determine whether the imported source is recognised by pyccel.
     If it is not recognised then it should be imported and translated
     """
     source = str(source_name).split('.')
-    if source[0] in python_builtin_libs and source[0] not in builtin_import_registery.keys():
+    if source[0] in python_builtin_libs and source[0] not in builtin_import_registry.keys():
         return True
     else:
-        return source_name in builtin_import_registery
+        return source_name in builtin_import_registry
 
 #==============================================================================
 def collect_relevant_imports(module, targets):
@@ -150,13 +150,13 @@ def builtin_import(expr):
     else:
         source = str(expr.source)
 
-    if source in builtin_import_registery:
+    if source in builtin_import_registry:
         if expr.target:
-            return collect_relevant_imports(builtin_import_registery[source], expr.target)
+            return collect_relevant_imports(builtin_import_registry[source], expr.target)
         elif isinstance(expr.source, AsName):
-            return [(expr.source.target, builtin_import_registery[source])]
+            return [(expr.source.target, builtin_import_registry[source])]
         else:
-            return [(expr.source, builtin_import_registery[source])]
+            return [(expr.source, builtin_import_registry[source])]
 
     return []
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -72,7 +72,7 @@ from pyccel.ast.numpyext import NumpySign
 from pyccel.ast.numpyext import Shape
 from pyccel.ast.numpyext import DtypePrecisionToCastFunction
 
-from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
+from pyccel.ast.utilities import builtin_import_registry as pyccel_builtin_import_registry
 from pyccel.ast.utilities import expand_to_loops
 
 from pyccel.errors.errors import Errors
@@ -536,7 +536,7 @@ class FCodePrinter(CodePrinter):
             source = self._print(source)
 
         # importing of pyccel extensions is not printed
-        if source in pyccel_builtin_import_registery:
+        if source in pyccel_builtin_import_registry:
             return ''
 
         if expr.source_module:

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -17,7 +17,7 @@ from pyccel.ast.numpyext   import Shape as NumpyShape, numpy_target_swap
 from pyccel.ast.numpyext   import NumpyArray, NumpyNonZero
 from pyccel.ast.numpyext   import DtypePrecisionToCastFunction
 from pyccel.ast.variable   import DottedName, HomogeneousTupleVariable, Variable
-from pyccel.ast.utilities  import builtin_import_registery as pyccel_builtin_import_registery
+from pyccel.ast.utilities  import builtin_import_registry as pyccel_builtin_import_registry
 from pyccel.ast.utilities  import decorators_mod
 
 from pyccel.codegen.printing.codeprinter import CodePrinter
@@ -482,8 +482,8 @@ class PythonCodePrinter(CodePrinter):
                 target = [AsName(i.object, import_target_swap[source].get(i.target,i.target)) for i in target]
 
             target = list(set(target))
-            if source in pyccel_builtin_import_registery:
-                self._aliases.update([(pyccel_builtin_import_registery[source][t.name].cls_name, t.target) for t in target if t.name != t.target])
+            if source in pyccel_builtin_import_registry:
+                self._aliases.update([(pyccel_builtin_import_registry[source][t.name].cls_name, t.target) for t in target if t.name != t.target])
 
             if expr.source_module:
                 if expr.source_module.init_func:

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -53,7 +53,18 @@ import_source_swap = {
         }
 
 class PythonCodePrinter(CodePrinter):
-    """A printer to convert pyccel expressions to strings of Python code"""
+    """
+    A printer for printing code in Python.
+
+    A printer to convert Pyccel's AST to strings of Python code.
+    As for all printers the navigation of this file is done via _print_X
+    functions.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file being pyccelised.
+    """
     printmethod = "_pycode"
     language = "python"
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -104,7 +104,7 @@ from pyccel.ast.sympy_helper import sympy_to_pyccel, pyccel_to_sympy
 
 from pyccel.ast.utilities import builtin_function as pyccel_builtin_function
 from pyccel.ast.utilities import builtin_import as pyccel_builtin_import
-from pyccel.ast.utilities import builtin_import_registery as pyccel_builtin_import_registery
+from pyccel.ast.utilities import builtin_import_registry as pyccel_builtin_import_registry
 from pyccel.ast.utilities import split_positional_keyword_arguments
 from pyccel.ast.utilities import recognised_source
 
@@ -3615,7 +3615,7 @@ class SemanticParser(BasicParser):
             source        = str(expr.source)
             source_target = source
 
-        if source in pyccel_builtin_import_registery:
+        if source in pyccel_builtin_import_registry:
             imports = pyccel_builtin_import(expr)
 
             def _insert_obj(location, target, obj):
@@ -3634,7 +3634,7 @@ class SemanticParser(BasicParser):
             if expr.target:
                 for t in expr.target:
                     t_name = t.name if isinstance(t, AsName) else t
-                    if t_name not in pyccel_builtin_import_registery[source]:
+                    if t_name not in pyccel_builtin_import_registry[source]:
                         errors.report(f"Function '{t}' from module '{source}' is not currently supported by pyccel",
                                 symbol=expr,
                                 severity='error')


### PR DESCRIPTION
Fix spelling mistake in `builtin_import_registery`->`builtin_import_registry`.

As discussed in [pyccel-cuda#12(comment)](https://github.com/pyccel/pyccel-cuda/pull/12#discussion_r1156213648) the `AsName` object is not necessary in this context