### PR TITLE
Rename master -> devel in workflow files

### DIFF
--- a/.github/workflows/Github_pytest.yml
+++ b/.github/workflows/Github_pytest.yml
@@ -2,8 +2,8 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: [ master ]
-    types: [ opened, ready_for_review, synchronize, converted_to_draft ]
+    branches: [ devel ]
+    types: [ opened, reopened, ready_for_review, synchronize, converted_to_draft ]
   issue_comment:
     types: [ created ]
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,7 +2,7 @@ name: Benchmarks
 
 on:
   push:
-    branches: [ pyccel/master ]
+    branches: [ pyccel/devel ]
 
 jobs:
 

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -1,8 +1,8 @@
-name: master_tests
+name: devel_tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ devel ]
 
 jobs:
 


### PR DESCRIPTION
Rename `master` to `devel` in the workflow files so they are correctly triggered. Add `reopened` as a trigger for the GitHub Actions welcome message (this allows the message to be triggered if GitHub glitches during the opening as happened with #1384).