### PR TITLE
Rename Numpy AST nodes

### DIFF
--- a/ci_tools/list_docs_tovalidate.py
+++ b/ci_tools/list_docs_tovalidate.py
@@ -31,7 +31,7 @@ def should_ignore(name):
     if 'SyntaxParser._visit_' in name:
         return True
     #ignore _print_ methods in the codegen.printing module
-    if '_print_' in name and 'pyccel.codegen.printing' in name:
+    if 'Printer._print_' in name:
         return True
     return False
 

--- a/developer_docs/codegen_stage.md
+++ b/developer_docs/codegen_stage.md
@@ -161,8 +161,8 @@ Although this construction ensures that valid code can be written easily, unless
 It is therefore very important to use the AST to represent class objects, so that the pointer differentiation can be handled in as few functions as possible.
 The following objects are very useful for this purpose:
 -   `DottedVariable` : Used to access member variables of a class. It may be necessary to create a `DottedVariable` to print an object such as a member of the `t_ndarray` class.
--   `NumpyArraySize` : The size of an array in a given dimension
--   `PyccelArraySize` : The total size of an array
+-   `NumpyArrayShapeElement` : The size of an array in a given dimension
+-   `NumpyArraySize` : The total size of an array
 
 Finally it is also important to mention the function `is_c_pointer`, which indicates whether or not its argument is accessed via a pointer in the C code.
 If code relies on the AST nodes described above the use of this function should be limited to the printing of a few low level objects.

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -11,7 +11,7 @@ from .datatypes import (NativeBool, NativeInteger, NativeFloat,
                         NativeComplex, NativeString)
 from .numpyext  import (Shape, NumpySum, NumpyAmin, NumpyAmax,
                         NumpyImag, NumpyReal, NumpyTranspose,
-                        NumpyConjugate, NumpyArraySize)
+                        NumpyConjugate, NumpyArrayShapeElement)
 
 __all__ = ('BooleanClass',
         'IntegerClass',
@@ -138,7 +138,7 @@ NumpyArrayClass = ClassDef('numpy.ndarray',
             FunctionDef('shape',[],[],body=[],
                 decorators={'property':'property', 'numpy_wrapper':Shape}),
             FunctionDef('size',[],[],body=[],
-                decorators={'property':'property', 'numpy_wrapper':NumpyArraySize}),
+                decorators={'property':'property', 'numpy_wrapper':NumpyArrayShapeElement}),
             FunctionDef('T',[],[],body=[],
                 decorators={'property':'property', 'numpy_wrapper':NumpyTranspose}),
             FunctionDef('transpose',[],[],body=[],

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -19,7 +19,7 @@ pyccel_stage = PyccelStage()
 
 __all__ = (
     'PrecomputedCode',
-    'PyccelArraySize',
+    'NumpyArraySize',
     'PyccelInternalFunction',
     'PyccelSymbol',
     'Slice',
@@ -53,7 +53,7 @@ class PyccelInternalFunction(PyccelAstNode):
         return False
 
 
-class PyccelArraySize(PyccelInternalFunction):
+class NumpyArraySize(PyccelInternalFunction):
     """
     Class representing a call to a function which would
     return the shape of an object in a given dimension
@@ -105,7 +105,7 @@ class PyccelArraySize(PyccelInternalFunction):
         return 'Shape({},{})'.format(str(self.arg), str(self.index))
 
     def __eq__(self, other):
-        if isinstance(other, PyccelArraySize):
+        if isinstance(other, NumpyArraySize):
             return self.arg == other.arg and self.index == other.index
         else:
             return False

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -30,7 +30,7 @@ from .datatypes      import (dtype_and_precision_registry as dtype_registry,
                              NativeNumeric)
 
 from .internals      import PyccelInternalFunction, Slice, max_precision, get_final_precision
-from .internals      import PyccelArraySize
+from .internals      import NumpyArraySize
 
 from .literals       import LiteralInteger, LiteralFloat, LiteralComplex, LiteralString, convert_to_literal
 from .literals       import LiteralTrue, LiteralFalse
@@ -75,7 +75,7 @@ __all__ = (
     'NumpyAmin',
     'NumpyArange',
     'NumpyArray',
-    'NumpyArraySize',
+    'NumpyArrayShapeElement',
     'NumpyBool',
     'NumpyCountNonZero',
     'NumpyComplex',
@@ -1679,7 +1679,7 @@ class NumpyCountNonZero(PyccelInternalFunction):
         """
         return self._keep_dims
 
-class NumpyArraySize(PyccelInternalFunction):
+class NumpyArrayShapeElement(PyccelInternalFunction):
     """
     Class representing a call to the numpy size function which
     returns the shape of an object in a given dimension
@@ -1703,7 +1703,7 @@ class NumpyArraySize(PyccelInternalFunction):
 
     def __new__(cls, a, axis = None):
         if axis is not None:
-            return PyccelArraySize(a, axis)
+            return NumpyArraySize(a, axis)
         elif not isinstance(a, (list,
                                     tuple,
                                     PyccelAstNode)):
@@ -1756,7 +1756,7 @@ numpy_funcs = {
     'arange'    : PyccelFunctionDef('arange'    , NumpyArange),
     # ...
     'shape'     : PyccelFunctionDef('shape'     , Shape),
-    'size'      : PyccelFunctionDef('size'      , NumpyArraySize),
+    'size'      : PyccelFunctionDef('size'      , NumpyArrayShapeElement),
     'norm'      : PyccelFunctionDef('norm'      , NumpyNorm),
     'int'       : PyccelFunctionDef('int'       , NumpyInt),
     'real'      : PyccelFunctionDef('real'      , NumpyReal),

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -25,7 +25,7 @@ from .literals  import LiteralInteger, LiteralFloat, LiteralComplex
 
 from .datatypes import NativeInteger
 
-from .variable  import Variable, PyccelArraySize
+from .variable  import Variable, NumpyArraySize
 
 __all__ = ('sympy_to_pyccel',
            'pyccel_to_sympy')
@@ -182,7 +182,7 @@ def pyccel_to_sympy(expr, symbol_map, used_names):
         symbol_map[sym] = expr
         return sym
 
-    elif isinstance(expr, PyccelArraySize):
+    elif isinstance(expr, NumpyArraySize):
         sym_name,_ = create_incremented_string(used_names, prefix = 'tmp_size')
         used_names.add(sym_name)
         sym = sp.Symbol(sym_name)

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -16,7 +16,7 @@ from .basic     import Basic, PyccelAstNode
 from .datatypes import (datatype, DataType,
                         NativeInteger, NativeBool, NativeFloat,
                         NativeComplex)
-from .internals import PyccelArraySize, Slice, get_final_precision
+from .internals import NumpyArraySize, Slice, get_final_precision
 from .literals  import LiteralInteger, Nil
 from .operators import (PyccelMinus, PyccelDiv, PyccelMul,
                         PyccelUnarySub, PyccelAdd)
@@ -227,7 +227,7 @@ class Variable(PyccelAstNode):
         required we do not require this expression
         (which can be quite long). This function therefore
         replaces those expressions with calls to
-        PyccelArraySize
+        NumpyArraySize
         """
         if self.rank == 0:
             return None
@@ -238,13 +238,13 @@ class Variable(PyccelAstNode):
         for i,s in enumerate(shape):
             if self.shape_can_change(i):
                 # Shape of a pointer can change
-                new_shape.append(PyccelArraySize(self, LiteralInteger(i)))
+                new_shape.append(NumpyArraySize(self, LiteralInteger(i)))
             elif isinstance(s, LiteralInteger):
                 new_shape.append(s)
             elif isinstance(s, int):
                 new_shape.append(LiteralInteger(s))
             elif s is None or isinstance(s, PyccelAstNode):
-                new_shape.append(PyccelArraySize(self, LiteralInteger(i)))
+                new_shape.append(NumpyArraySize(self, LiteralInteger(i)))
             else:
                 raise TypeError('shape elements cannot be '+str(type(s))+'. They must be one of the following types: LiteralInteger,'
                                 'Variable, Slice, PyccelAstNode, int, Function')
@@ -261,7 +261,7 @@ class Variable(PyccelAstNode):
         Indicate that the exact shape is unknown, e.g. if the allocate is done in
         an If block.
         """
-        self._shape = [PyccelArraySize(self, LiteralInteger(i)) for i in range(self.rank)]
+        self._shape = [NumpyArraySize(self, LiteralInteger(i)) for i in range(self.rank)]
 
     @property
     def name(self):
@@ -274,7 +274,7 @@ class Variable(PyccelAstNode):
         """ Shape of the variable at allocation
 
         The shape used in pyccel is usually simplified to contain
-        only Literals and PyccelArraySizes but the shape for
+        only Literals and NumpyArraySizes but the shape for
         the allocation of x cannot be `Shape(x)`
         """
         return self._alloc_shape

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -33,7 +33,7 @@ from pyccel.ast.core import (Assign, AliasAssign, Declare,
 from pyccel.ast.variable  import (Variable,
                              IndexedElement,
                              InhomogeneousTupleVariable,
-                             DottedName, PyccelArraySize)
+                             DottedName, NumpyArraySize)
 
 from pyccel.ast.operators      import PyccelAdd, PyccelMul, PyccelMinus
 from pyccel.ast.operators      import PyccelMod
@@ -1145,13 +1145,13 @@ class FCodePrinter(CodePrinter):
     def _print_NumpyMod(self, expr):
         return self._print(PyccelMod(*expr.args))
 
-    def _print_NumpyArraySize(self, expr):
+    def _print_NumpyArrayShapeElement(self, expr):
         init_value = self._print(expr.arg)
         prec = self.print_kind(expr)
         return 'size({0}, kind={1})'.format(init_value, prec)
 
     # ======================================================================= #
-    def _print_PyccelArraySize(self, expr):
+    def _print_NumpyArraySize(self, expr):
         init_value = self._print(expr.arg)
         prec = self.print_kind(expr)
 
@@ -2889,7 +2889,7 @@ class FCodePrinter(CodePrinter):
         allow_negative_indexes = base.allows_negative_indexes
 
         for i, ind in enumerate(inds):
-            _shape = PyccelArraySize(base, i if expr.base.order != 'C' else len(inds) - i - 1)
+            _shape = NumpyArraySize(base, i if expr.base.order != 'C' else len(inds) - i - 1)
             if isinstance(ind, Slice):
                 inds[i] = self._new_slice_with_processed_arguments(ind, _shape, allow_negative_indexes)
             elif isinstance(ind, PyccelUnarySub) and isinstance(ind.args[0], LiteralInteger):
@@ -2914,7 +2914,7 @@ class FCodePrinter(CodePrinter):
         ----------
             _slice : Slice
                 slice needed to collect (start, stop, step)
-            array_size : PyccelArraySize
+            array_size : NumpyArraySize
                 call to function size()
             allow_negative_index : Bool
                 True when the decorator allow_negative_index is present

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -424,7 +424,7 @@ class PythonCodePrinter(CodePrinter):
     def _print_PythonPrint(self, expr):
         return 'print({})\n'.format(', '.join(self._print(a) for a in expr.expr))
 
-    def _print_PyccelArraySize(self, expr):
+    def _print_NumpyArraySize(self, expr):
         arg = self._print(expr.arg)
         index = self._print(expr.index)
         name = self._aliases.get(NumpyShape, expr.name)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -1258,11 +1258,11 @@ def test_size_property(language):
     n5 = randint(20)
     x1 = empty(n1,dtype = int)
     x2 = empty((n2,n3), dtype = int)
-    x4 = empty((n2,n3), dtype = int)
+    x3 = empty((n4,n5), dtype = int)
     axis = randint(2)
     assert f1(x1) == test_size_1d(x1)
     assert f2(x2) == test_size_2d(x2)
-    assert f3(x4,axis) == test_size_axis(x4,axis)
+    assert f3(x3,axis) == test_size_axis(x3,axis)
 
 
 def test_full_basic_real(language):

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -1243,10 +1243,12 @@ def test_size_property(language):
 
     @types('int[:]','int')
     def test_size_axis(f, axis):
-        return f.size
+        from numpy import size
+        return size(f,axis)
+
 
     from numpy import empty
-    f1 = epyccel(test_size_1d, language = language)
+    f1 = epyccel(test_size_1d ,language = language)
     f2 = epyccel(test_size_2d, language = language)
     f3 = epyccel(test_size_axis, language = language)
     n1 = randint(20)
@@ -1256,7 +1258,7 @@ def test_size_property(language):
     x1 = empty(n1,dtype = int)
     x2 = empty((n2,n3), dtype = int)
     x4 = empty(n4,dtype = int)
-    axis = randint(2)
+    axis = 0
     assert f1(x1) == test_size_1d(x1)
     assert f2(x2) == test_size_2d(x2)
     assert f3(x4,axis) == test_size_axis(x4,axis)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -1241,7 +1241,7 @@ def test_size_property(language):
     def test_size_2d(f):
         return f.size
 
-    @types('int[:]','int')
+    @types('int[:,:]','int')
     def test_size_axis(f, axis):
         from numpy import size
         return size(f,axis)
@@ -1255,10 +1255,11 @@ def test_size_property(language):
     n2 = randint(20)
     n3 = randint(20)
     n4 = randint(20)
+    n5 = randint(20)
     x1 = empty(n1,dtype = int)
     x2 = empty((n2,n3), dtype = int)
-    x4 = empty(n4,dtype = int)
-    axis = 0
+    x4 = empty((n2,n3), dtype = int)
+    axis = randint(2)
     assert f1(x1) == test_size_1d(x1)
     assert f2(x2) == test_size_2d(x2)
     assert f3(x4,axis) == test_size_axis(x4,axis)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -1241,16 +1241,26 @@ def test_size_property(language):
     def test_size_2d(f):
         return f.size
 
+    @types('int[:]','int')
+    def test_size_axis(f, axis):
+        return f.size
+
     from numpy import empty
     f1 = epyccel(test_size_1d, language = language)
     f2 = epyccel(test_size_2d, language = language)
+    f3 = epyccel(test_size_axis, language = language)
     n1 = randint(20)
     n2 = randint(20)
     n3 = randint(20)
+    n4 = randint(20)
     x1 = empty(n1,dtype = int)
     x2 = empty((n2,n3), dtype = int)
+    x4 = empty(n4,dtype = int)
+    axis = randint(2)
     assert f1(x1) == test_size_1d(x1)
     assert f2(x2) == test_size_2d(x2)
+    assert f3(x4,axis) == test_size_axis(x4,axis)
+
 
 def test_full_basic_real(language):
     @types('int')


### PR DESCRIPTION
This change were suggested in issue #1329 and [comment](https://github.com/pyccel/pyccel/pull/1326#discussion_r1112041778)
1. Renaming the classes and their occurrences:
  `NumpyArraySize` =>  `NumpyArrayShapeElement`
  `PyccelArraySize` => `NumpyArraySize`
2. Updating the developer_docs/codegen_stage.md.
3. Renaming the printing functions. ([doc](https://github.com/pyccel/pyccel/blob/devel/developer_docs/codegen_stage.md#_print))

**TODO:**
- [x] run tests.
- [x] fixing docs and coverage