### PR TITLE
New lists implementation

### DIFF
--- a/pyccel/stdlib/lists/lists.c
+++ b/pyccel/stdlib/lists/lists.c
@@ -82,6 +82,7 @@ void    free_genericobject(GenericObject *go)
     free(go);
 }
 
+/*recursively copy all the items in src into dest*/
 int pyccel_copylist(PyccelList **src, PyccelList **dest)
 {
     for (size_t i = 0; i < (*src)->noi; i++)
@@ -108,6 +109,7 @@ int pyccel_expandlist(PyccelList **list)
     if ((*list) == NULL)
         return 1;
 
+    //initialize_list will double the given number
     newlist = initialise_list((*list)->capacity);
     pyccel_copylist(list, &newlist);
     free_list(*list);

--- a/pyccel/stdlib/lists/lists.c
+++ b/pyccel/stdlib/lists/lists.c
@@ -1,0 +1,136 @@
+#include "lists.h"
+
+PyccelList *initialise_list(size_t noi)
+{
+    PyccelList *list;
+
+    list = (PyccelList *)malloc(sizeof(PyccelList));
+    list->capacity = noi*2;
+    list->items = (GenericObject **)malloc(sizeof(GenericObject*)*list->capacity);
+    
+    for (size_t i = 0; i < list->capacity; i++)
+    {
+        list->items[i] = (GenericObject *)malloc(sizeof(GenericObject));
+        initialise_genericobject(&(list->items[i]), "v", 0, NULL);
+    }
+
+    list->noi = noi;
+    return list;
+}
+
+void    initialise_genericobject(GenericObject **obj, char  *type, size_t value, void *pointer)
+{
+    (*obj)->type = type;
+    (*obj)->pointer = pointer;
+    (*obj)->value = value;
+}
+
+void print_list(PyccelList *list)
+{
+    size_t i = 0;
+    write(1, "[", 1);
+    while (i < list->noi)
+    {
+        if (!strcmp(list->items[i]->type, "pl"))
+        {
+            print_list(list->items[i]->pointer);
+        }
+        else
+        {
+            printf("%zu", list->items[i]->value);
+            fflush(stdout);
+        }
+        i++;
+        if (i < list->noi)
+            write(1, ",", 1);
+    }
+    write(1, "]", 1);
+}
+
+void fill_itemswithvalues(PyccelList **list, size_t value)
+{
+    size_t i = 0;
+
+    while (i < (*list)->noi)
+    {
+        (*list)->items[i]->value = value;
+        (*list)->items[i]->type = "v";
+        i++;
+    }
+}
+
+void    free_list(PyccelList *list)
+{
+    for (size_t i = 0; i < list->capacity; i++)
+    {
+        if (!strcmp((list)->items[i]->type, "pl"))
+        {
+            free_list(list->items[i]->pointer);
+            free_genericobject(list->items[i]);
+        }
+        else
+        {
+            free_genericobject(list->items[i]);
+        }
+    }
+    free(list->items);
+    free(list);
+}
+
+void    free_genericobject(GenericObject *go)
+{
+    free(go);
+}
+
+int pyccel_copylist(PyccelList **src, PyccelList **dest)
+{
+    for (size_t i = 0; i < (*src)->noi; i++)
+    {
+        if (!strcmp((*src)->items[i]->type, "pl"))
+        {
+            PyccelList *item = (PyccelList *)((*src)->items[i]->pointer);
+            (*dest)->items[i]->pointer = initialise_list(item->noi);
+            (*dest)->items[i]->type = "pl";
+            pyccel_copylist(&item, (PyccelList **)(&((*dest)->items[i]->pointer)));
+        }
+        else
+        {
+            initialise_genericobject(&((*dest)->items[i]), (*src)->items[i]->type, (*src)->items[i]->value, (*src)->items[i]->pointer);
+        }
+    }
+    return 0;
+}
+
+int pyccel_expandlist(PyccelList **list)
+{
+    PyccelList *newlist;
+
+    if ((*list) == NULL)
+        return 1;
+
+    newlist = initialise_list((*list)->capacity);
+    pyccel_copylist(list, &newlist);
+    free_list(*list);
+    *list = newlist;
+
+    return 0;
+}
+
+int pyccel_append(PyccelList **list, size_t value, void *pointer)
+{
+    if (list == NULL)
+        return 1;
+    GenericObject *item_to_fill;
+
+    if ((*list)->capacity == (*list)->noi)
+        pyccel_expandlist(list);
+
+    item_to_fill = (*list)->items[(*list)->noi];
+    if (pointer != NULL)
+        initialise_genericobject(&item_to_fill, "pl", 0, pointer);
+    else
+        initialise_genericobject(&item_to_fill, "v", value, NULL);
+
+    (*list)->noi++;
+    return 0;
+}

--- a/pyccel/stdlib/lists/lists.h
+++ b/pyccel/stdlib/lists/lists.h
@@ -1,0 +1,37 @@
+#ifndef LISTS_H
+#define LISTS_H
+
+#include <stdlib.h>
+#include <Python.h>
+#include <stdio.h>
+#include <strings.h>
+#include <unistd.h>
+
+typedef struct 
+{
+    size_t value;
+    void *pointer;
+    char *type;
+}   GenericObject;
+
+typedef struct
+{
+    GenericObject **items;
+    size_t noi;
+    size_t capacity;
+}   PyccelList;
+
+PyccelList *initialise_list(size_t noi);
+void    initialise_genericobject(GenericObject **obj, char  *type, size_t value, void *pointer);
+
+int     pyccel_append(PyccelList **list, size_t value, void *pointer);
+int     pyccel_expandlist(PyccelList **list);
+int     pyccel_copylist(PyccelList **src, PyccelList **dest);
+
+void    print_list(PyccelList *list);
+void    fill_itemswithvalues(PyccelList **list, size_t value);
+
+void    free_list(PyccelList *list);
+void    free_genericobject(GenericObject *go);
+
+#endif

--- a/pyccel/stdlib/lists/lists_wrapper_tools.c
+++ b/pyccel/stdlib/lists/lists_wrapper_tools.c
@@ -1,0 +1,54 @@
+#include "lists_wrapper_tools.h"
+
+
+int     PyObject_to_PyccelList(PyObject *py_list, PyccelList **pyccel_list)
+{
+    Py_ssize_t py_list_size;
+    PyObject *pyob_item;
+    size_t pyitem;
+
+    py_list_size = PyList_Size(py_list);
+    for (int i = 0; i < py_list_size;i++)
+    {
+        pyob_item = PyList_GetItem(py_list, i);
+        if (PyList_Check(pyob_item))
+        {
+            (*pyccel_list)->items[i]->pointer = initialise_list(PyList_Size(pyob_item));
+            (*pyccel_list)->items[i]->type = "pl";
+            PyObject_to_PyccelList(pyob_item, (PyccelList **)(&((*pyccel_list)->items[i]->pointer)));
+        }
+        else
+        {
+            pyitem = (size_t)PyLong_AsLongLong(pyob_item);
+            initialise_genericobject(&((*pyccel_list)->items[i]), "v", pyitem, NULL);
+        }
+    }
+    return 0;
+}
+
+int PyccelList_to_PyObject(PyccelList *pyccel_list, PyObject **pylist)
+{
+    size_t pyccel_list_size;
+    size_t pyccel_list_item;
+    PyccelList *pyccel_sublist;
+    PyObject *pylist_tmp;
+    
+    pyccel_list_size = pyccel_list->noi;
+    for (size_t i = 0; i < pyccel_list_size; i++)
+    {
+        if (!strcmp(pyccel_list->items[i]->type, "pl"))
+        {
+            pyccel_sublist = (PyccelList *)pyccel_list->items[i]->pointer;
+            pylist_tmp = PyList_New(pyccel_sublist->noi);
+            PyList_SetItem(*pylist, i, pylist_tmp);
+            PyccelList_to_PyObject(pyccel_sublist, &pylist_tmp);
+        }
+        else
+        {
+            pyccel_list_item = pyccel_list->items[i]->value;
+            PyList_SetItem(*pylist, i, PyLong_FromSize_t(pyccel_list_item));
+        }
+    }
+
+    return 0;
+}

--- a/pyccel/stdlib/lists/lists_wrapper_tools.c
+++ b/pyccel/stdlib/lists/lists_wrapper_tools.c
@@ -1,6 +1,6 @@
 #include "lists_wrapper_tools.h"
 
-
+/*Recursively copying all the items in a PyObject that is a list (py_list) into PyccelList (pyccel_list)*/
 int     PyObject_to_PyccelList(PyObject *py_list, PyccelList **pyccel_list)
 {
     Py_ssize_t py_list_size;
@@ -26,6 +26,7 @@ int     PyObject_to_PyccelList(PyObject *py_list, PyccelList **pyccel_list)
     return 0;
 }
 
+/*Recursively do the exact opposite of the above :)*/
 int PyccelList_to_PyObject(PyccelList *pyccel_list, PyObject **pylist)
 {
     size_t pyccel_list_size;

--- a/pyccel/stdlib/lists/lists_wrapper_tools.h
+++ b/pyccel/stdlib/lists/lists_wrapper_tools.h
@@ -1,0 +1,9 @@
+#ifndef LISTS_WRAPPER_TOOLS_H
+#define LISTS_WRAPPER_TOOLS_H
+
+#include "lists.h"
+
+int PyObject_to_PyccelList(PyObject *pylist, PyccelList **pyccel_list);
+int PyccelList_to_PyObject(PyccelList *pyccel_list, PyObject **pylist);
+
+#endif

--- a/pyccel/stdlib/lists/main.c
+++ b/pyccel/stdlib/lists/main.c
@@ -1,0 +1,38 @@
+#include "lists.h"
+
+int main()
+{
+    PyccelList *my_list = initialise_list(3);
+    PyccelList *copy;
+    PyccelList *array_list;
+    PyccelList *mixed_list;
+
+    //manually creating a small list
+    initialise_genericobject(&(my_list->items[0]), "v", 1, NULL);
+    initialise_genericobject(&(my_list->items[1]), "pl", 0, initialise_list(3));
+    initialise_genericobject(&(my_list->items[2]), "pl", 0, initialise_list(2));
+
+
+    //list with only values
+    array_list = my_list->items[1]->pointer;
+    fill_itemswithvalues(&array_list, 2);
+
+    //mixed value,array_list
+    mixed_list = my_list->items[2]->pointer;
+    initialise_genericobject(&(mixed_list->items[0]), "v", 3, NULL);
+    initialise_genericobject(&(mixed_list->items[1]), "pl", 0, initialise_list(4));
+    fill_itemswithvalues((PyccelList **)(&(mixed_list->items[1]->pointer)), 3);
+    
+    //simple stress test
+    for (int i = 0; i<100; i++)
+    {
+        copy = initialise_list(i);
+        fill_itemswithvalues(&copy, i);
+        pyccel_append(&my_list, 0, copy);
+        print_list(my_list);
+        printf("\n");
+    }
+    free_list(my_list);
+
+    return 0;
+}

--- a/pyccel/stdlib/lists/setup.py
+++ b/pyccel/stdlib/lists/setup.py
@@ -1,0 +1,6 @@
+from distutils.core import setup, Extension
+
+module = Extension('pyccel_append', sources=['lists.c', 'wrapper.c', 'lists_wrapper_tools.c'])
+
+setup(name='pyccel_append', version='1.0', ext_modules=[module])
+

--- a/pyccel/stdlib/lists/setup_install_run.sh
+++ b/pyccel/stdlib/lists/setup_install_run.sh
@@ -1,0 +1,10 @@
+
+GREEN="\033[1;32m"
+NOCOLOR="\033[0m"
+
+python setup.py build
+python setup.py install
+
+echo  "${GREEN}"
+python test_lists.py
+echo "${NOCOLOR}"

--- a/pyccel/stdlib/lists/test_lists.py
+++ b/pyccel/stdlib/lists/test_lists.py
@@ -1,0 +1,20 @@
+from pyccel_append import pyccel_append
+
+a = [1,2,3]
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+a = pyccel_append(a,a)
+print(a)

--- a/pyccel/stdlib/lists/wrapper.c
+++ b/pyccel/stdlib/lists/wrapper.c
@@ -1,0 +1,88 @@
+#include "lists.h"
+#include "lists_wrapper_tools.h"
+
+
+static PyObject *pyccel_append_wrapper(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    size_t item;
+    PyccelList *pyccel_list_arg = NULL;
+    PyccelList *pyccel_list = NULL;
+    PyObject *item_tmp;
+    PyObject *pylist_tmp;
+    PyObject *newpylist;
+    static char *kwlist[] = {
+        "list",
+        "item",
+        NULL
+    };
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO", kwlist, &pylist_tmp, &item_tmp))
+    {
+        return NULL;
+    }
+    if (!PyList_Check(pylist_tmp))
+    {
+        PyErr_SetString(PyExc_TypeError, "\"First argument must be a list\"");
+        return NULL;
+    }
+    if (PyLong_CheckExact(item_tmp))
+    {
+        item = (size_t)PyLong_AsLongLong(item_tmp);
+    }
+    else if (PyList_Check(item_tmp))
+    {
+        size_t item_tmp_size = PyList_Size(item_tmp);
+        pyccel_list_arg = initialise_list(item_tmp_size);
+        PyObject_to_PyccelList(item_tmp, &pyccel_list_arg);
+    }
+    else
+    {
+        PyErr_SetString(PyExc_TypeError, "\"Second argument must be native int or a list\"");
+        return NULL;
+
+    }
+
+    size_t pylist_size = PyList_Size(pylist_tmp);
+    pyccel_list = initialise_list(pylist_size);
+    PyObject_to_PyccelList(pylist_tmp, &pyccel_list);
+
+    if (pyccel_list_arg == NULL)
+        pyccel_append(&pyccel_list, item, NULL);
+    else
+        pyccel_append(&pyccel_list, 0, pyccel_list_arg);
+
+    size_t pyccel_list_size = pyccel_list->noi;
+    newpylist = PyList_New(pyccel_list_size);
+    PyccelList_to_PyObject(pyccel_list, &newpylist);
+
+    free_list(pyccel_list);
+    return newpylist;
+}
+
+
+static PyMethodDef pyccel_append_methods[] = {
+    {
+        "pyccel_append",
+        (PyCFunction)pyccel_append_wrapper,
+        METH_VARARGS | METH_KEYWORDS,
+        ""
+    },
+    { NULL, NULL, 0, NULL}
+};
+
+
+static struct PyModuleDef pyccel_append_module = {
+    PyModuleDef_HEAD_INIT,
+    /* name of module */
+    "pyccel_append",
+    /* module documentation, may be NULL */
+    NULL,
+    /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+    -1,
+    pyccel_append_methods,
+};
+
+PyMODINIT_FUNC PyInit_pyccel_append(void)
+{
+    return PyModule_Create(&pyccel_append_module);
+}


### PR DESCRIPTION
This pull request concerns a new lists implementation that introduces a data structure that is similar in Cpython,
As you may know, every object in Python can be represented with PyObject object which is a generic type for python's object, here is the definition of the PyObject struct from the current Cpython:
```C
struct _object {
    _PyObject_HEAD_EXTRA
    union {
       Py_ssize_t ob_refcnt;
#if SIZEOF_VOID_P > 4
       PY_UINT32_T ob_refcnt_split[2];
#endif
    };
    PyTypeObject *ob_type;
};
```
In short, PyObject contains only the reference count and the type of the object, `_PyObject_HEAD_EXTRA` is for debugging purposes, for more details PyObject is defined [here](
https://github.com/python/cpython/blob/ce4eecf989e23fa26c033de78f1ca8b035a979cb/Include/object.h#L166) explained [here](https://github.com/python/cpython/blob/ce4eecf989e23fa26c033de78f1ca8b035a979cb/Include/object.h#L166) and renamed (its original name is _object) [here](https://github.com/python/cpython/blob/ce4eecf989e23fa26c033de78f1ca8b035a979cb/Include/pytypedefs.h#L18).

a list in Python is represented by the following struct [here](https://github.com/python/cpython/blob/ce4eecf989e23fa26c033de78f1ca8b035a979cb/Include/cpython/listobject.h#L5):
```C
typedef struct {
    PyObject_VAR_HEAD
    /* Vector of pointers to list elements.  list[0] is ob_item[0], etc. */
    PyObject **ob_item;

    /* ob_item contains space for 'allocated' elements.  The number
     * currently in use is ob_size.
     * Invariants:
     *     0 <= ob_size <= allocated
     *     len(list) == ob_size
     *     ob_item == NULL implies ob_size == allocated == 0
     * list.sort() temporarily sets allocated to -1 to detect mutations.
     *
     * Items must normally not be NULL, except during construction when
     * the list is not yet visible outside the function that builds it.
     */
    Py_ssize_t allocated;
} PyListObject;
```
`PyObject_VAR_HEAD` contains the number of items in a variable object (list in this case). [here](https://github.com/python/cpython/blob/main/Include/object.h#L180)

you can notice that manipulating lists in Cpython involves recursion and every item in the list can be any object including lists themselves. In the same way i suggest to make a similar approach with the following:
```C
typedef struct 
{
    size_t value;
    void *pointer;
    char *type;
}   GenericObject;
```
This struct can represent a single value of any type (to be supported) or any other objects (lists for now), So it is not that abstracting but it serves the goal. In Cpython you can get the actual value of an`int` object through `PyObject` casted to `PyIntObject`
```C
typedef struct {
    PyObject_HEAD
    long ob_ival;
} PyIntObject;
```
and then ob_ival.

for lists i suggest the following:
```C
typedef struct
{
    GenericObject **items;
    size_t noi;
    size_t capacity;
}   PyccelList;
```
With this approach, we have more convenience in converting PyListObject's to PyccelList's and vice versa, plus more readability considering the simplicity of the two structs, For performance, We can always enhance our functions to parallel operation on `GenericObject **items` that is in addition to the C code, I'm also thinking of making the conversion in wrapping parallel.

NOTE: the C code (lib, C wrapping) can be tested standalone for now.

what to be merged:
- [ ] basic functions for handling the data structure (allocating, freeing, filling).
- [ ] append function.
- [ ] the C wrapping of the append function.
- [ ] add `list` as a new supported dtype by pyccel.
