### PR TITLE
Enforce checklist completion

### DIFF
--- a/ci_tools/bot_interaction.py
+++ b/ci_tools/bot_interaction.py
@@ -529,7 +529,7 @@ if __name__ == '__main__':
         else:
             leave_comment(pr_id, message_from_file('bot_commands.txt'))
 
-    elif event['action'] == 'opened':
+    elif event['action'] in ('opened', 'reopened'):
         # If new PR (opened trigger)
 
         # Collect id from a pull request event with an opened action

--- a/ci_tools/bot_interaction.py
+++ b/ci_tools/bot_interaction.py
@@ -337,9 +337,18 @@ def start_review_check(pr_id, event, outputs):
     if len(words) < 3:
         leave_comment(pr_id, message_from_file('set_draft_no_description.txt'))
         set_draft(pr_id)
-    else:
-        outputs['cleanup_trigger'] = 'request_review_status'
-        run_tests(pr_id, ['pr_tests'], outputs, event)
+        return
+
+    comments = get_previous_pr_comments(pr_id)
+    checklist = [c for c in comments if c.author == 'github-actions' and '- [ ]' in c.body]
+    print(checklist)
+    if checklist:
+        leave_comment(pr_id, message_from_file('set_draft_checklist_incomplete.txt'))
+        set_draft(pr_id)
+        return
+
+    outputs['cleanup_trigger'] = 'request_review_status'
+    run_tests(pr_id, ['pr_tests'], outputs, event)
 
 def accept_coverage_failure(pr_id):
     """

--- a/ci_tools/bot_interaction.py
+++ b/ci_tools/bot_interaction.py
@@ -341,7 +341,6 @@ def start_review_check(pr_id, event, outputs):
 
     comments = get_previous_pr_comments(pr_id)
     checklist = [c for c in comments if c.author == 'github-actions' and '- [ ]' in c.body]
-    print(checklist)
     if checklist:
         leave_comment(pr_id, message_from_file('set_draft_checklist_incomplete.txt'))
         set_draft(pr_id)

--- a/ci_tools/bot_messages/checklist.txt
+++ b/ci_tools/bot_messages/checklist.txt
@@ -3,4 +3,4 @@
 - [ ] Update documentation if necessary
 - [ ] Update Changelog
 - [ ] Ensure any relevant issues are linked
-- [ ] Ensure tests are passing
+- [ ] Ensure new tests are passing

--- a/ci_tools/bot_messages/set_draft_checklist_incomplete.txt
+++ b/ci_tools/bot_messages/set_draft_checklist_incomplete.txt
@@ -1,0 +1,1 @@
+It seems like you have forgotten to complete your checklist for this pull request. Please could you fix that and let me know when everything is ticked and fixed with `/bot mark as ready`.

--- a/ci_tools/git_evaluation_tools.py
+++ b/ci_tools/git_evaluation_tools.py
@@ -427,8 +427,10 @@ def check_previous_contributions(repo, author):
         returncode = p.returncode
     print(err)
     print(returncode)
+    ntries = 1
     if returncode:
-        while returncode:
+        while returncode and ntries < 10:
+            ntries += 1
             time.sleep(10)
             with subprocess.Popen(cmds, stdout=subprocess.PIPE) as p:
                 result, err = p.communicate()

--- a/ci_tools/git_evaluation_tools.py
+++ b/ci_tools/git_evaluation_tools.py
@@ -423,6 +423,16 @@ def check_previous_contributions(repo, author):
 
     with subprocess.Popen(cmds, stdout=subprocess.PIPE) as p:
         result, err = p.communicate()
+        returncode = p.returncode
     print(err)
+    print(returncode)
+    if returncode:
+        while returncode:
+            sleep(10)
+            with subprocess.Popen(cmds, stdout=subprocess.PIPE) as p:
+                result, err = p.communicate()
+                returncode = p.returncode
+            print("New returncode : ", returncode)
+
 
     return json.loads(result)

--- a/ci_tools/git_evaluation_tools.py
+++ b/ci_tools/git_evaluation_tools.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import json
 import shutil
 import subprocess
+import time
 
 __all__ = ('github_cli',
            'ReviewComment',
@@ -428,7 +429,7 @@ def check_previous_contributions(repo, author):
     print(returncode)
     if returncode:
         while returncode:
-            sleep(10)
+            time.sleep(10)
             with subprocess.Popen(cmds, stdout=subprocess.PIPE) as p:
                 result, err = p.communicate()
                 returncode = p.returncode


### PR DESCRIPTION
Multiple devs have forgotten to complete their checklists before marking the PRs as ready for review. As these checklists are especially important for new contributors and can sometimes be lost it is better to enforce their completion. This PR modifies the bot so that it refuses to mark the PR as ready if the list is not completed and leaves a message telling the user to check the list. This PR has been tested here : https://github.com/EmilyBourne/pyccel/pull/20

An additional improvement was made so that the reopen trigger acts the same as the open trigger.

_Future improvements_
In the future I would like to improve the bot in a few ways using the github api. This will allow me to interact with the PRs more. When this is in place it will be possible to remove all unchecked boxes and reprint them in the new message. This will make it easier to keep track. However currently it is hard to distinguish duplicate checklists and I can't delete old messages so a simple message asking the dev to find the checklist will suffice