### PR TITLE
Fix bug in documentation checker

### DIFF
--- a/ci_tools/list_docs_tovalidate.py
+++ b/ci_tools/list_docs_tovalidate.py
@@ -88,6 +88,6 @@ if __name__ == '__main__':
                             child.name = '.'.join([obj_pref, child.name])
                             to_visit.append(child)
 
-        with open(args.output, 'w', encoding="utf-8") as f:
+        with open(args.output, 'a', encoding="utf-8") as f:
             for obj in objects:
                 print(obj, file=f)


### PR DESCRIPTION
The documentation checker is currently only reporting format problems in the last file that it checks. This occurs because the output is written into the file instead of being appended to the file. This PR fixes this oversight