### PR TITLE
Fix Map, Enumerate and Zip in comprehension list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 -   #1302 : Raise error message in case of empty class
 -   #929 : Allow optional variables when compiling with intel or nvidia.
 -   #1117 : Allow non-contiguous arrays to be passed to Fortran code.
--   #1399 : Fix enumerate and zip in comprehension list
+-   #1399 : Fix enumerate, map and zip in comprehension list
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 -   #1302 : Raise error message in case of empty class
 -   #929 : Allow optional variables when compiling with intel or nvidia.
 -   #1117 : Allow non-contiguous arrays to be passed to Fortran code.
+-   #1399 : Fix enumerate and zip in comprehension list
 
 ### Changed
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -191,7 +191,7 @@ class Variable(PyccelAstNode):
             raise TypeError('rank must be an instance of int.')
 
         if rank == 0:
-            assert shape is None
+            assert shape is None or shape == ()
             assert order is None
 
         elif shape is None:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -97,7 +97,7 @@ from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Con
                             OMP_Single_Construct)
 
 from pyccel.ast.operators import PyccelArithmeticOperator, PyccelIs, PyccelIsNot, IfTernaryOperator, PyccelUnarySub
-from pyccel.ast.operators import PyccelNot, PyccelEq, PyccelAdd, PyccelMul, PyccelPow
+from pyccel.ast.operators import PyccelNot, PyccelEq, PyccelAdd, PyccelMul, PyccelPow, PyccelLt
 from pyccel.ast.operators import PyccelAssociativeParenthesis, PyccelDiv
 
 from pyccel.ast.sympy_helper import sympy_to_pyccel, pyccel_to_sympy
@@ -2853,7 +2853,7 @@ class SemanticParser(BasicParser):
             else:
                 iterator   = indices[i]
             i += 1
-            # a     = self._visit(body.iterable)
+
             new_expr = []
             iterable = Iterable(self._visit(body.iterable))
 
@@ -2902,7 +2902,7 @@ class SemanticParser(BasicParser):
                     elif isinstance(iterable.iterable, PythonZip):
                         stop0 = iterable.iterable.args[0].shape[0]
                         stop1 = iterable.iterable.args[1].shape[0]
-                        if(int(stop0) < int(stop1)):
+                        if(PyccelLt(stop0, stop1)):
                             stop = stop0
                         else:
                             stop = stop1

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2958,8 +2958,6 @@ class SemanticParser(BasicParser):
             else:
                 sp_indices.append(sp_Symbol(idx))
 
-        # sp_indices  = [sp_Symbol(i) for i in indices]
-
         dim = sp_Integer(1)
 
         for i in reversed(range(len(dims))):
@@ -3072,7 +3070,8 @@ class SemanticParser(BasicParser):
             l = l.body.body[-1]
 
         #self.exit_loop_scope()
-        #change the nest tuples in indices to the indices itself
+
+        #change the nested list indices to a normal list to prevent "Basic child cannot be a tuple of tuples" Error
         tmp = []
         for idx in indices:
             if(type(idx) == list):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2921,7 +2921,7 @@ class SemanticParser(BasicParser):
                 if self._infer_type(existing_var) != dvar:
                     errors.report(f"Variable {var} already exists with different type",
                             symbol = expr, severity='error')
-            else:    
+            else:
                 self.scope.insert_variable(var)
                 if(indice_is_tupple):
                     self.scope.insert_variable(var2)

--- a/tests/epyccel/modules/functionals.py
+++ b/tests/epyccel/modules/functionals.py
@@ -62,3 +62,28 @@ def functional_for_2d_range_const():
 def functional_for_3d_range():
     a = [i*j for i in range(1,3) for j in range(i,4) for k in range(i,j)]
     return len(a), a[0], a[1], a[2], a[3]
+
+@types( 'int[:]' )
+def functional_map_on_1d_array( z ):
+    @types( int )
+    def f( y ):
+        return y+5
+    a = [v + 1 for v in map(f,z)]
+    return len(a), a[0], a[1], a[2], a[3]
+
+@types( 'int[:]' )
+def functional_enumerate_on_1d_array( z ):
+    a =  [i * j for i,j in enumerate( z )]
+    return len(a), a[0], a[1], a[2], a[3]
+
+@types( 'int[:]', 'int' )
+def functional_enumerate_on_1d_array_with_start( z, k ):
+    a =  [i * v for i,v in enumerate( z, k )]
+    return len(a), a[0], a[1], a[2], a[3]
+
+@types( 'int' )
+def functional_zip_prod( m ):
+    x = [  i for i in range(m)]
+    y = [2*j for j in range(m)]
+    a = [i1 * i2 for i1, i2 in zip(x, y)]
+    return len(a), a[0], a[1], a[2], a[3]

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 from numpy.random import randint
 from numpy import equal
+from numpy import arange
 
 from pyccel.epyccel import epyccel
 from modules import functionals
@@ -55,3 +56,18 @@ def test_functional_for_2d_array_range_const(language):
 
 def test_functional_for_3d_range(language):
     compare_epyccel(functionals.functional_for_3d_range, language)
+
+def test_functional_map_on_1d_array(language):
+    z = arange( 7 )
+    compare_epyccel(functionals.functional_map_on_1d_array, language, z)
+
+def test_functional_enumerate_on_1d_array(language):
+    z = arange( 7 )
+    compare_epyccel(functionals.functional_enumerate_on_1d_array, language, z)
+
+def test_functional_enumerate_on_1d_array_with_start(language):
+    z = arange( 7 )
+    compare_epyccel(functionals.functional_enumerate_on_1d_array_with_start, language, z, 4)
+
+def test_functional_zip_prod(language):
+    compare_epyccel(functionals.functional_zip_prod, language, 4)


### PR DESCRIPTION
-  Modify line 194 {(if rank == 0)...} to not assert error if shape == (), to consider it as None because of a runtime error.

- Fix Enumerate zip map in comprehension list using Iterate class used in normal for loops.

- Work with nested variable in indices variable to prevent conflict with tuple variables and variables used in nested loops.
    - For example if we have expr.indices = [(a,b), c] or expr.indices = [a,(b,c)].
      To fix this conflict I changed indices to a nested list.
      expr.indices = [(a,b), c] => indices = [[a,b], c]].
      But the problem is an error gets raised at the returning of the codeblock in FunctionalFor
      "Basic child cannot be a tuple of tuples"
       So at the end of FunctionalFor I changed the nested list indices variable to a normal list variable.
