### PR TITLE
Fix AST user tree bug causing problem with AugAssign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
--   #1302 : Raise error message in case of empty class
+-   #1302 : Raise error message in case of empty class.
 -   #1407 : Raise an error if file name matches a Python built-in module.
 -   #929 : Allow optional variables when compiling with intel or nvidia.
 -   #1117 : Allow non-contiguous arrays to be passed to Fortran code.
+-   #1415 : Fix incorrect handling of assignments augmented by function calls.
 
 ### Changed
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1824,6 +1824,7 @@ class CCodePrinter(CodePrinter):
 
         if op == '%' and isinstance(lhs.dtype, NativeFloat):
             _expr = expr.to_basic_assign()
+            expr.invalidate_node()
             return self._print(_expr)
 
         lhs_code = self._print(lhs)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2066,6 +2066,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_AugAssign(self, expr):
         new_expr = expr.to_basic_assign()
+        expr.invalidate_node()
         return self._print(new_expr)
 
     def _print_PythonRange(self, expr):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2656,31 +2656,31 @@ class SemanticParser(BasicParser):
 
         # Examine each assign and determine assign type (Assign, AliasAssign, etc)
         for l, r in zip(lhs,rhs):
-            is_pointer_i = l.is_alias if isinstance(l, Variable) else is_pointer
-
-            new_expr = Assign(l, r)
-
             if isinstance(expr, AugAssign):
-                new_expr.invalidate_node()
                 new_expr = AugAssign(l, expr.op, r)
-            elif is_pointer_i:
-                new_expr = AliasAssign(l, r)
+            else:
+                is_pointer_i = l.is_alias if isinstance(l, Variable) else is_pointer
+                new_expr = Assign(l, r)
 
+                if is_pointer_i:
+                    new_expr = AliasAssign(l, r)
 
-            elif new_expr.is_symbolic_alias:
-                new_expr = SymbolicAssign(l, r)
+                elif new_expr.is_symbolic_alias:
+                    new_expr = SymbolicAssign(l, r)
 
-                # in a symbolic assign, the rhs can be a lambda expression
-                # it is then treated as a def node
+                    # in a symbolic assign, the rhs can be a lambda expression
+                    # it is then treated as a def node
 
-                F = self.scope.find(l, 'symbolic_functions')
-                if F is None:
-                    self.insert_symbolic_function(new_expr)
-                else:
-                    errors.report(PYCCEL_RESTRICTION_TODO,
-                                  bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
-                                  severity='fatal')
+                    F = self.scope.find(l, 'symbolic_functions')
+                    if F is None:
+                        self.insert_symbolic_function(new_expr)
+                    else:
+                        errors.report(PYCCEL_RESTRICTION_TODO,
+                                      bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
+                                      severity='fatal')
+
             new_expressions.append(new_expr)
+
         if (len(new_expressions)==1):
             new_expressions = new_expressions[0]
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -921,7 +921,7 @@ class SemanticParser(BasicParser):
                 if len(func.results)>0 and not isinstance(func.results[0].var, PyccelAstNode):
                     errors.report(RECURSIVE_RESULTS_REQUIRED, symbol=func, severity="fatal")
 
-            parent_assign = expr.get_direct_user_nodes(lambda x: isinstance(x, Assign))
+            parent_assign = expr.get_direct_user_nodes(lambda x: isinstance(x, Assign) and not isinstance(x, AugAssign))
             if not parent_assign and len(func.results) == 1 and func.results[0].var.rank > 0:
                 tmp_var = PyccelSymbol(self.scope.get_new_name())
                 assign = Assign(tmp_var, expr)
@@ -2661,6 +2661,7 @@ class SemanticParser(BasicParser):
             new_expr = Assign(l, r)
 
             if isinstance(expr, AugAssign):
+                new_expr.invalidate_node()
                 new_expr = AugAssign(l, expr.op, r)
             elif is_pointer_i:
                 new_expr = AliasAssign(l, r)

--- a/tests/ast/scripts/math.py
+++ b/tests/ast/scripts/math.py
@@ -5,4 +5,5 @@ def f(a : int, b : int, c: int = 0):
     d = a * b + c
     e = a - b
     g = d + e + a
+    g += b
     return g

--- a/tests/ast/test_basic.py
+++ b/tests/ast/test_basic.py
@@ -20,13 +20,13 @@ def get_functions(filename):
     ast = pyccel.parse()
 
     # Assert syntactic success
-    assert(not errors.has_errors())
+    assert not errors.has_errors()
 
     settings = {}
     ast = pyccel.annotate(**settings)
 
     # Assert semantic success
-    assert(not errors.has_errors())
+    assert not errors.has_errors()
 
     return list(ast.scope.functions.values())
 
@@ -36,7 +36,7 @@ def test_get_attribute_nodes():
     fst = get_functions(filename)[0]
     atts = fst.get_attribute_nodes(Variable)
 
-    assert(all(isinstance(a, Variable) for a in atts))
+    assert all(isinstance(a, Variable) for a in atts)
 
     expected = [Variable('int', 'a'),
                 Variable('int', 'b'),
@@ -46,7 +46,7 @@ def test_get_attribute_nodes():
                 Variable('int', 'g')]
 
     for e in expected:
-        assert(e in atts)
+        assert e in atts
 
 def test_get_attribute_nodes_exclude():
     filename = os.path.join(path_dir, "math.py")
@@ -54,16 +54,16 @@ def test_get_attribute_nodes_exclude():
     fst = get_functions(filename)[0]
     atts = fst.get_attribute_nodes(PyccelOperator, excluded_nodes=(PyccelAdd,))
 
-    assert(all(isinstance(a, PyccelOperator) for a in atts))
-    assert(all(not isinstance(a, PyccelAdd) for a in atts))
-    assert(len(atts)==1)
+    assert all(isinstance(a, PyccelOperator) for a in atts)
+    assert all(not isinstance(a, PyccelAdd) for a in atts)
+    assert len(atts)==1
     minus = atts[0]
-    assert(isinstance(minus, PyccelMinus)==1)
+    assert isinstance(minus, PyccelMinus)==1
 
     a = Variable('int', 'a')
     b = Variable('int', 'b')
-    assert(minus.args[0] == a)
-    assert(minus.args[1] == b)
+    assert minus.args[0] == a
+    assert minus.args[1] == b
 
 def test_get_user_nodes():
     filename = os.path.join(path_dir, "math.py")
@@ -78,9 +78,9 @@ def test_get_user_nodes():
 
     sums = set(a_var.get_user_nodes((PyccelAdd, PyccelMinus)))
 
-    assert(all(isinstance(s, (PyccelAdd, PyccelMinus)) for s in sums))
+    assert all(isinstance(s, (PyccelAdd, PyccelMinus)) for s in sums)
 
-    assert(len(sums) == 3)
+    assert len(sums) == 3
 
 def test_get_user_nodes_excluded():
     filename = os.path.join(path_dir, "math.py")
@@ -94,7 +94,7 @@ def test_get_user_nodes_excluded():
     a_var = atts[0]
 
     plus_assign = a_var.get_user_nodes(Assign, excluded_nodes = PyccelMinus)
-    assert(len(plus_assign)==2)
+    assert len(plus_assign)==2
 
 def test_get_all_user_nodes():
     filename = os.path.join(path_dir, "math.py")
@@ -109,9 +109,9 @@ def test_get_all_user_nodes():
 
     users = set(a_var.get_all_user_nodes())
 
-    assert(all(isinstance(s, (PyccelMul, PyccelMinus, AugAssign, FunctionDefArgument)) for s in users))
+    assert all(isinstance(s, (PyccelMul, PyccelMinus, AugAssign, FunctionDefArgument)) for s in users)
 
-    assert(len(users) == 4)
+    assert len(users) == 4
 
 def test_get_direct_user_nodes():
     filename = os.path.join(path_dir, "math.py")
@@ -126,9 +126,9 @@ def test_get_direct_user_nodes():
 
     sums = set(a_var.get_direct_user_nodes(lambda x : isinstance(x,(PyccelAdd, PyccelMinus))))
 
-    assert(all(isinstance(s, (PyccelAdd, PyccelMinus)) for s in sums))
+    assert all(isinstance(s, (PyccelAdd, PyccelMinus)) for s in sums)
 
-    assert(len(sums) == 2)
+    assert len(sums) == 2
 
 def test_substitute():
     filename = os.path.join(path_dir, "math.py")
@@ -142,15 +142,15 @@ def test_substitute():
 
     a_var = atts[0]
     old_parents = a_var.get_user_nodes(Basic)
-    assert(len(a_var.get_user_nodes(Basic))>0)
+    assert len(a_var.get_user_nodes(Basic))>0
 
     fst.substitute(a_var, new_var)
 
-    assert(len(a_var.get_user_nodes(Basic))==0)
+    assert len(a_var.get_user_nodes(Basic))==0
 
     atts = set(fst.get_attribute_nodes(Variable))
-    assert(new_var in atts)
-    assert(set(new_var.get_user_nodes(Basic)) == set(old_parents))
+    assert new_var in atts
+    assert set(new_var.get_user_nodes(Basic)) == set(old_parents)
 
 def test_substitute_exclude():
     filename = os.path.join(path_dir, "math.py")
@@ -164,18 +164,18 @@ def test_substitute_exclude():
 
     a_var = atts[0]
     old_parents = set(a_var.get_user_nodes(Basic))
-    assert(len(a_var.get_user_nodes(Basic))>0)
+    assert len(a_var.get_user_nodes(Basic))>0
 
     fst.substitute(a_var, new_var, excluded_nodes=(PyccelMinus))
 
-    assert(len(a_var.get_user_nodes(Basic))==1)
+    assert len(a_var.get_user_nodes(Basic))==1
 
     atts = set(fst.get_attribute_nodes(Variable))
-    assert(new_var in atts)
+    assert new_var in atts
 
     new_parents = set(new_var.get_user_nodes(Basic))
-    assert(len(new_parents.difference(old_parents))==0)
-    assert(len(old_parents.difference(new_parents))==1)
+    assert len(new_parents.difference(old_parents))==0
+    assert len(old_parents.difference(new_parents))==1
 
 def test_recursive():
     filename = os.path.join(path_dir, "cyclic_dependence.py")
@@ -183,12 +183,12 @@ def test_recursive():
     fst = get_functions(filename)[0]
 
     atts = fst.get_attribute_nodes(PyccelMinus)
-    assert(len(set(atts))==2)
+    assert len(set(atts))==2
 
     var = atts[0].args[0]
 
     atts = var.get_user_nodes(FunctionDef)
-    assert(len(set(atts))==2) # The actual FunctionDef + the signature version
+    assert len(set(atts))==2 # The actual FunctionDef + the signature version
 
     fst.substitute(LiteralInteger(2), LiteralInteger(3))
 

--- a/tests/ast/test_basic.py
+++ b/tests/ast/test_basic.py
@@ -5,9 +5,9 @@ from pyccel.parser.parser   import Parser
 from pyccel.errors.errors   import Errors
 
 from pyccel.ast.basic       import Basic
-from pyccel.ast.core        import Assign, Return, FunctionDef
+from pyccel.ast.core        import Assign, Return, FunctionDef, AugAssign, FunctionDefArgument
 from pyccel.ast.literals    import LiteralInteger
-from pyccel.ast.operators   import PyccelOperator, PyccelAdd, PyccelMinus
+from pyccel.ast.operators   import PyccelOperator, PyccelAdd, PyccelMinus, PyccelMul
 from pyccel.ast.variable    import Variable
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -95,6 +95,23 @@ def test_get_user_nodes_excluded():
 
     plus_assign = a_var.get_user_nodes(Assign, excluded_nodes = PyccelMinus)
     assert(len(plus_assign)==2)
+
+def test_get_all_user_nodes():
+    filename = os.path.join(path_dir, "math.py")
+
+    interesting_var = Variable('int', 'b')
+
+    fst = get_functions(filename)[0]
+    atts = set(fst.get_attribute_nodes(Variable))
+    atts = [v for v in atts  if v == interesting_var]
+
+    a_var = atts[0]
+
+    users = set(a_var.get_all_user_nodes())
+
+    assert(all(isinstance(s, (PyccelMul, PyccelMinus, AugAssign, FunctionDefArgument)) for s in users))
+
+    assert(len(users) == 4)
 
 def test_get_direct_user_nodes():
     filename = os.path.join(path_dir, "math.py")

--- a/tests/epyccel/modules/augassign.py
+++ b/tests/epyccel/modules/augassign.py
@@ -157,5 +157,10 @@ def augassign_div_2d_complex(a):
 def augassign_func(x : float, y : float):
     def fun1(x: 'float') -> 'float':
         return x + 1
-    x += fun1(y)
+    x %= fun1(y)
     return x
+
+def augassign_array_func(x : 'float[:]', y : 'float[:]'):
+    def fun1(x: 'float[:]') -> 'float[:]':
+        return x + 1
+    x %= fun1(y)

--- a/tests/epyccel/modules/augassign.py
+++ b/tests/epyccel/modules/augassign.py
@@ -153,3 +153,9 @@ def augassign_div_2d_complex(a):
     b = a
     b /= (4.0 + 2.0j)
     return b[0][0]
+
+def augassign_func(x : float, y : float):
+    def fun1(x: 'float') -> 'float':
+        return x + 1
+    x += fun1(y)
+    return x

--- a/tests/epyccel/test_epyccel_augassign.py
+++ b/tests/epyccel/test_epyccel_augassign.py
@@ -3,10 +3,8 @@ import numpy as np
 from numpy.random import random
 import pytest
 
-from pyccel.epyccel import epyccel
-
 import modules.augassign as mod
-
+from pyccel.epyccel import epyccel
 
 # += tests
 

--- a/tests/epyccel/test_epyccel_augassign.py
+++ b/tests/epyccel/test_epyccel_augassign.py
@@ -224,7 +224,7 @@ def test_augassign_func(language):
     func = mod.augassign_func
     func_epyc = epyccel(func, language = language)
 
-    x = random()*100
+    x = random()*100+20
     y = random()*100
 
     z = func(x,y)
@@ -232,3 +232,25 @@ def test_augassign_func(language):
 
     assert z == z_epyc
     assert isinstance(z, type(z_epyc))
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="Function in function not implemented in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_augassign_array_func(language):
+    func = mod.augassign_array_func
+    func_epyc = epyccel(func, language = language)
+
+    x = random(10)*100+20
+    y = random(10)*100
+    x_epyc = x.copy()
+
+    func(x,y)
+    func_epyc(x_epyc,y)
+
+    assert np.array_equal(x, x_epyc)

--- a/tests/epyccel/test_epyccel_augassign.py
+++ b/tests/epyccel/test_epyccel_augassign.py
@@ -1,9 +1,11 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
-
 import numpy as np
-import modules.augassign as mod
+from numpy.random import random
+import pytest
 
 from pyccel.epyccel import epyccel
+
+import modules.augassign as mod
 
 
 # += tests
@@ -210,3 +212,25 @@ def test_augassign_div_2d(language):
 
     assert y1_float == y2_float and np.array_equal(x1_float, x2_float)
     assert y1_complex == y2_complex and np.array_equal(x1_complex, x2_complex)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="Function in function not implemented in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_augassign_func(language):
+    func = mod.augassign_func
+    func_epyc = epyccel(func, language = language)
+
+    x = random()*100
+    y = random()*100
+
+    z = func(x,y)
+    z_epyc = func_epyc(x,y)
+
+    assert z == z_epyc
+    assert isinstance(z, type(z_epyc))


### PR DESCRIPTION
When handling `AugAssign` objects temporary `Assign` objects are sometimes created. These nodes were not invalidated once they were deemed to be unnecessary. As a result during the printing of a `FunctionCall` the printer saw this parent here:
https://github.com/pyccel/pyccel/blob/d6fea05ce9e2e45d9dc2496f0a599e40f0b406e2/pyccel/codegen/printing/fcode.py#L2956
This leads to the function `f1(y)` being printed as `x = f1(y)`.

This PR corrects the AST user tree by reordering expressions and invalidating unused nodes. This fixes #1415 .

Tests are added to ensure that the AST user tree is correct and that the issue is fixed