### PR TITLE
Fix Product iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 ## \[Unreleased\]
 
 ### Added
+
+### Fixed
+
+### Changed
+
+## \[1.8.0\] - 2023-06-20
+
+### Added
 -   #1400 : Added flags to Pyccel for managing conda PATH warnings.
+
 ### Fixed
 
 -   #1404 : Bug preventing printing of some functions in a `print()` call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 -   #929 : Allow optional variables when compiling with intel or nvidia.
 -   #1117 : Allow non-contiguous arrays to be passed to Fortran code.
 -   #1415 : Fix incorrect handling of assignments augmented by function calls.
+-   #1418 : Fix `itertools.product` implementation.
 
 ### Changed
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2742,7 +2742,6 @@ class SemanticParser(BasicParser):
                    bounding_box=(self._current_fst_node.lineno, self._current_fst_node.col_offset),
                    severity='error')
 
-
         body = self._visit(expr.body)
 
         self.exit_loop_scope()
@@ -2751,8 +2750,13 @@ class SemanticParser(BasicParser):
             for_expr = body
             scopes = self.scope.create_product_loop_scope(scope, len(target))
 
-            for t, r, s in zip(target, iterable.get_range(), scopes[::-1]):
-                for_expr = For(t, r, for_expr, scope=s)
+            for t, i, r, s in zip(target[::-1], iterable.loop_counters[::-1], iterable.get_target_from_range()[::-1], scopes[::-1]):
+                # Create Variable iterable
+                loop_iter = Iterable(r.base)
+                loop_iter.set_loop_counter(i)
+
+                # Create a For loop for each level of the Product
+                for_expr = For(t, loop_iter, for_expr, scope=s)
                 for_expr.end_annotation = expr.end_annotation
                 for_expr = [for_expr]
             for_expr = for_expr[0]

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.7.4"
+__version__ = "1.8.0"

--- a/tests/epyccel/modules/loops.py
+++ b/tests/epyccel/modules/loops.py
@@ -96,6 +96,19 @@ def product_loop_on_2d_array_F( z ):
         z[i,j] = i-j
 
 # ...
+def product_loop( z : 'float[:]', m : int, n : int ):
+
+    from itertools import product
+
+    x = [i*3+2 for i in range(m)]
+    y = [j*7+6 for j in range(n)]
+
+    k = 0
+    for i,j in product( x, y ):
+        z[k] = i-j
+        k += 1
+
+# ...
 @types( 'int[:]' )
 def map_on_1d_array( z ):
 

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -100,6 +100,18 @@ def test_product_loop_on_2d_array_F(language):
     f2( y )
     assert np.array_equal( x, y )
 
+def test_product_loop(language):
+
+    f1 = loops.product_loop
+    f2 = epyccel(f1, language=language)
+
+    x = np.zeros( (44), dtype=float )
+    y = np.zeros( (44), dtype=float )
+
+    f1( x, 4, 11 )
+    f2( y, 4, 11 )
+    assert np.array_equal( x, y )
+
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [


### PR DESCRIPTION
The `Product` iterable created all the necessary `Variable`s. However the nested `For`s were created incorrectly. As a result the  implementation did not work (except for cases such as the one used in the tests where the arguments are all equivalent to the ranges which are generated). This PR fixes the creation of the nested `For`s necessary for `itertools.product` and adds a more complex test. Fixes #1418.