### PR TITLE
Fix AugAssign with templates and literal rhs

### DIFF
--- a/.dict_custom.txt
+++ b/.dict_custom.txt
@@ -83,3 +83,4 @@ prepend
 uniformise
 incrementation
 Pylint
+templated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+-   #1427 : Fix augmented assignment with a literal right hand side in templated code.
+
 ### Changed
 
 ## \[1.8.0\] - 2023-06-20

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -30,7 +30,14 @@ class Immutable:
 
 #==============================================================================
 class Basic:
-    """Basic class for Pyccel AST."""
+    """
+    Basic class from which all objects in the Pyccel AST inherit.
+
+    This foundational class provides all the functionalities that are common to
+    objects in the Pyccel AST. This includes the construction and navigation of
+    the AST tree as well as an indication of the stage in which the object is
+    valid (syntactic/semantic/etc).
+    """
     __slots__ = ('_user_nodes', '_fst', '_recursion_in_progress' ,'_pyccel_staging')
     _ignored_types = (Immutable, type)
     _attribute_nodes = None

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -11,12 +11,16 @@ They are:
 """
 import ast
 
+from pyccel.utilities.stage   import PyccelStage
+
 __all__ = ('Basic', 'Immutable', 'PyccelAstNode', 'ScopedNode')
 
 dict_keys   = type({}.keys())
 dict_values = type({}.values())
 iterable_types = (list, tuple, dict_keys, dict_values, set)
 iterable = lambda x : isinstance(x, iterable_types)
+
+pyccel_stage = PyccelStage()
 
 #==============================================================================
 class Immutable:
@@ -27,11 +31,12 @@ class Immutable:
 #==============================================================================
 class Basic:
     """Basic class for Pyccel AST."""
-    __slots__ = ('_user_nodes', '_fst', '_recursion_in_progress')
+    __slots__ = ('_user_nodes', '_fst', '_recursion_in_progress' ,'_pyccel_staging')
     _ignored_types = (Immutable, type)
     _attribute_nodes = None
 
     def __init__(self):
+        self._pyccel_staging = pyccel_stage.current_stage
         self._user_nodes = []
         self._fst = []
         self._recursion_in_progress = False
@@ -361,12 +366,12 @@ class Basic:
         assert len(self._user_nodes) == 1
         return self._user_nodes[0]
 
-    def clear_user_nodes(self):
-        """ Delete all information about user nodes. This is useful
+    def clear_syntactic_user_nodes(self):
+        """ Delete all information about syntactic user nodes. This is useful
         if the same node is used for the syntactic and semantic
-        stages, and it should only have 1 user.
+        stages.
         """
-        self._user_nodes = []
+        self._user_nodes = [u for u in self._user_nodes if u.pyccel_staging != 'syntactic']
 
     def remove_user_node(self, user_node, invalidate = True):
         """ Indicate that the current node is no longer used
@@ -400,6 +405,24 @@ class Basic:
         if it isn't
         """
         return self._attribute_nodes # pylint: disable=no-member
+
+    @property
+    def pyccel_staging(self):
+        """
+        Indicate the stage at which the object was created.
+
+        Indicate the stage at which the object was created [syntactic/semantic/codegen/cwrapper].
+        """
+        return self._pyccel_staging
+
+    def update_pyccel_staging(self):
+        """
+        Indicate that an object has been updated and is now valid in the current pyccel stage.
+
+        Indicate that an object has been updated and is now valid in the current pyccel stage.
+        This results in the pyccel_staging being updated to match the current stage.
+        """
+        self._pyccel_staging = pyccel_stage.current_stage
 
 class PyccelAstNode(Basic):
     """Class from which all nodes containing objects inherit

--- a/pyccel/ast/basic.py
+++ b/pyccel/ast/basic.py
@@ -367,7 +367,11 @@ class Basic:
         return self._user_nodes[0]
 
     def clear_syntactic_user_nodes(self):
-        """ Delete all information about syntactic user nodes. This is useful
+        """
+        Delete all information about syntactic user nodes.
+
+        Delete all user nodes which are only valid for the syntactic
+        stage from the list of user nodes. This is useful
         if the same node is used for the syntactic and semantic
         stages.
         """

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1830,11 +1830,6 @@ class SemanticParser(BasicParser):
         expr.update_pyccel_staging()
         return expr
 
-    def _visit_EmptyNode(self, expr):
-        expr.clear_syntactic_user_nodes()
-        expr.update_pyccel_staging()
-        return expr
-
     def _visit_Break(self, expr):
         expr.clear_syntactic_user_nodes()
         expr.update_pyccel_staging()
@@ -1911,10 +1906,7 @@ class SemanticParser(BasicParser):
         expr.clear_syntactic_user_nodes()
         expr.update_pyccel_staging()
         return expr
-    def _visit_PythonComplex(self, expr):
-        expr.clear_syntactic_user_nodes()
-        expr.update_pyccel_staging()
-        return expr
+
     def _visit_Pass(self, expr):
         expr.clear_syntactic_user_nodes()
         expr.update_pyccel_staging()

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1826,31 +1826,38 @@ class SemanticParser(BasicParser):
         return CodeBlock(ls)
 
     def _visit_Nil(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_EmptyNode(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_Break(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_Continue(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_Comment(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_CommentBlock(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_AnnotatedComment(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_OmpAnnotatedComment(self, expr):
@@ -1885,7 +1892,8 @@ class SemanticParser(BasicParser):
                 errors.report(msg, symbol=expr,
                     severity='fatal')
 
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_Omp_End_Clause(self, expr):
@@ -1895,17 +1903,21 @@ class SemanticParser(BasicParser):
                     severity='warning', symbol=expr)
             return EmptyNode()
         else:
-            expr.clear_user_nodes()
+            expr.clear_syntactic_user_nodes()
+            expr.update_pyccel_staging()
             return expr
 
     def _visit_Literal(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
     def _visit_PythonComplex(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
     def _visit_Pass(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_Variable(self, expr):
@@ -3070,18 +3082,21 @@ class SemanticParser(BasicParser):
 
     def _visit_FunctionHeader(self, expr):
         # TODO should we return it and keep it in the AST?
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         self.scope.insert_header(expr)
         return expr
 
     def _visit_Template(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         self.scope.insert_template(expr)
         return expr
 
     def _visit_ClassHeader(self, expr):
         # TODO should we return it and keep it in the AST?
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         self.scope.insert_header(expr)
         return expr
 
@@ -3804,7 +3819,8 @@ class SemanticParser(BasicParser):
         return macro
 
     def _visit_MacroShape(self, expr):
-        expr.clear_user_nodes()
+        expr.clear_syntactic_user_nodes()
+        expr.update_pyccel_staging()
         return expr
 
     def _visit_MacroVariable(self, expr):

--- a/pyccel/utilities/stage.py
+++ b/pyccel/utilities/stage.py
@@ -7,14 +7,17 @@
 from .metaclasses import Singleton
 
 class PyccelStage(metaclass = Singleton):
-    """ Class wrapping a string indicating which treatment stage Pyccel is executing.
+    """
+    Class wrapping a string indicating which treatment stage Pyccel is executing.
+
+    Class wrapping a string indicating which treatment stage Pyccel is executing.
     This string is one of:
      - syntactic
      - semantic
      - codegen
      - cwrapper
 
-    When Pyccel is not executing the stage is None
+    When Pyccel is not executing the stage is None.
     """
     def __init__(self):
         self._stage = None

--- a/pyccel/utilities/stage.py
+++ b/pyccel/utilities/stage.py
@@ -32,3 +32,7 @@ class PyccelStage(metaclass = Singleton):
         """ Indicate that Pyccel has finished running and reset stage to None
         """
         self._stage = None
+
+    @property
+    def current_stage(self):
+        return self._stage

--- a/pyccel/utilities/stage.py
+++ b/pyccel/utilities/stage.py
@@ -35,4 +35,14 @@ class PyccelStage(metaclass = Singleton):
 
     @property
     def current_stage(self):
+        """
+        Get the current stage as a string.
+
+        Returns one of:
+        - syntactic
+        - semantic
+        - codegen
+        - cwrapper
+        indicating the current stage.
+        """
         return self._stage

--- a/tests/epyccel/modules/generic_functions_2.py
+++ b/tests/epyccel/modules/generic_functions_2.py
@@ -138,6 +138,11 @@ def mix_types_3(x, y):
 
 
 @template('T', types=['int64[:]', 'real[:]', 'complex[:]'])
+@types('T')
+def mix_array_scalar(x):
+    x[:] += 1
+
+@template('T', types=['int64[:]', 'real[:]', 'complex[:]'])
 @types('T', 'int')
 def mix_array_1(x, a):
     x[:] += a

--- a/tests/epyccel/modules/generic_functions_2.py
+++ b/tests/epyccel/modules/generic_functions_2.py
@@ -3,29 +3,29 @@ from pyccel.decorators import types
 from pyccel.decorators import template
 
 
-@template('Z', types=['int', 'real'])
+@template('Z', types=['int', 'float'])
 @types('Z', 'Z')
 def tmplt_1(x, y):
     return x + y
 
-@template('Z', types=['int', 'real'])
-@template('Y', types=['int', 'real'])
+@template('Z', types=['int', 'float'])
+@template('Y', types=['int', 'float'])
 @types('Z', 'Z', 'Y')
 def multi_tmplt_1(x, y, z):
     return x + y + z
 
 @types('int', 'int')
-@types('int', 'real')
+@types('int', 'float')
 def multi_heads_1(x, y):
     return x + y
 
-@template(types=['int', 'real'], name = 'Z')
+@template(types=['int', 'float'], name = 'Z')
 @types('Z', 'Z')
 def tmplt_2(x, y):
     return x + y
 
 @template('K', types=['int'])
-@template('G', types=['int', 'real'])
+@template('G', types=['int', 'float'])
 @types('K', 'G')
 def multi_tmplt_2(y, z):
     return y + z
@@ -34,20 +34,20 @@ def multi_tmplt_2(y, z):
 #------------------------------------------------------
 
 @template('K', types=['int'])
-@template('G', types=['int', 'real'])
+@template('G', types=['int', 'float'])
 @types('G', 'K')
 def default_var_1(x , y = 5):
     return x + y
 
 
 @template('K', types=['complex'])
-@template('G', types=['int', 'real'])
+@template('G', types=['int', 'float'])
 @types('G', 'K')
 def default_var_2(x , y = 5j):
     return x + y
 
 @template('K', types=['bool'])
-@template('G', types=['int', 'real'])
+@template('G', types=['int', 'float'])
 @types('G', 'K')
 def default_var_3(x , y = False):
     if y is True:
@@ -55,13 +55,13 @@ def default_var_3(x , y = False):
     return x - 1
 
 @types('int', 'int')
-@types('real', 'int')
+@types('float', 'int')
 def default_var_4(x, y = 5):
     return x + y
 
 
 @template('K', types=['int'])
-@template('G', types=['int', 'real'])
+@template('G', types=['int', 'float'])
 @types('G', 'K')
 def optional_var_1(x , y = None):
     if y is None :
@@ -70,15 +70,15 @@ def optional_var_1(x , y = None):
 
 
 @template('K', types=['complex'])
-@template('G', types=['int', 'real'])
+@template('G', types=['int', 'float'])
 @types('G', 'K')
 def optional_var_2(x , y = None):
     if y is None :
         return x + 1j
     return x + y
 
-@types('int', 'real')
-@types('real', 'real')
+@types('int', 'float')
+@types('float', 'float')
 def optional_var_3(x, y = None):
     if y is None:
         return x / 2.0
@@ -86,7 +86,7 @@ def optional_var_3(x, y = None):
 
 
 @types('complex', 'int')
-@types('real', 'int')
+@types('float', 'int')
 def optional_var_4(x, y = None):
     if y is None:
         return x
@@ -100,7 +100,7 @@ def int_types(x, y):
     return x + y
 
 
-@template('T', types=['real', 'float32', 'float64'])
+@template('T', types=['float', 'float32', 'float64'])
 @types('T', 'T')
 def float_types(x, y):
     return x + y
@@ -121,7 +121,7 @@ def mix_types_1(x, y, z):
     return x - y
 
 
-@template('T', types=['int64', 'int32', 'int16', 'real', 'complex', 'float32'])
+@template('T', types=['int64', 'int32', 'int16', 'float', 'complex', 'float32'])
 @types('T', 'T')
 def mix_types_2(x, y):
     if y != x:
@@ -137,19 +137,19 @@ def mix_types_3(x, y):
     return -x
 
 
-@template('T', types=['int64[:]', 'real[:]', 'complex[:]'])
+@template('T', types=['int64[:]', 'float[:]', 'complex[:]'])
 @types('T')
 def mix_array_scalar(x):
     x[:] += 1
 
-@template('T', types=['int64[:]', 'real[:]', 'complex[:]'])
+@template('T', types=['int64[:]', 'float[:]', 'complex[:]'])
 @types('T', 'int')
 def mix_array_1(x, a):
     x[:] += a
 
 
 @types('complex[:]', 'complex[:]', 'int')
-@types('real[:]', 'int64[:]', 'int')
+@types('float[:]', 'int64[:]', 'int')
 def mix_array_2(x, y, a):
     x[:] += a
     y[:] -= a
@@ -164,17 +164,17 @@ def mix_int_array_1(x, a):
 def mix_int_array_2(x, a):
     x[:] += a
 
-@template('T', types=['real[:]', 'float32[:]'])
-@types('T', 'real')
+@template('T', types=['float[:]', 'float32[:]'])
+@types('T', 'float')
 def mix_float_array_1(x, a):
     x[:] *= a
 
 @template('T', types=['complex[:]', 'complex64[:]'])
-@types('T', 'real')
+@types('T', 'float')
 def mix_complex_array_1(x, a):
     x[:] *= a
 
-#$ header function dup_header(real)
+#$ header function dup_header(float)
 #$ header function dup_header(float64)
 @types('float')
 @types('float64')

--- a/tests/epyccel/test_generic_functions.py
+++ b/tests/epyccel/test_generic_functions.py
@@ -245,6 +245,29 @@ def test_mix_types_3(language):
 # TEST ARRAYS
 #--------------------------------------------------------------------
 
+def test_mix_array_scalar(language):
+    f1 = epyccel(mod2.mix_array_scalar, language = language)
+    f2 = mod2.mix_array_scalar
+
+    a = 5
+    x1 = np.array( [1,2,3], dtype=np.int64)
+    x2 = np.copy(x1)
+    f1(x1, a)
+    f2(x2, a)
+    assert np.array_equal( x1, x2 )
+
+    x1 = np.array( [1.0,2.0,3.0], dtype=np.float64)
+    x2 = np.copy(x1)
+    f1(x1, a)
+    f2(x2, a)
+    assert np.array_equal( x1, x2)
+
+    x1 = np.array( [1+ 2j,5 +2j,3.0 + 3j], dtype=np.complex128)
+    x2 = np.copy(x1)
+    f1(x1, a)
+    f2(x2, a)
+    assert np.array_equal( x1, x2)
+
 def test_mix_array_1(language):
     f1 = epyccel(mod2.mix_array_1, language = language)
     f2 = mod2.mix_array_1

--- a/tests/epyccel/test_generic_functions.py
+++ b/tests/epyccel/test_generic_functions.py
@@ -249,23 +249,22 @@ def test_mix_array_scalar(language):
     f1 = epyccel(mod2.mix_array_scalar, language = language)
     f2 = mod2.mix_array_scalar
 
-    a = 5
     x1 = np.array( [1,2,3], dtype=np.int64)
     x2 = np.copy(x1)
-    f1(x1, a)
-    f2(x2, a)
+    f1(x1)
+    f2(x2)
     assert np.array_equal( x1, x2 )
 
     x1 = np.array( [1.0,2.0,3.0], dtype=np.float64)
     x2 = np.copy(x1)
-    f1(x1, a)
-    f2(x2, a)
+    f1(x1)
+    f2(x2)
     assert np.array_equal( x1, x2)
 
     x1 = np.array( [1+ 2j,5 +2j,3.0 + 3j], dtype=np.complex128)
     x2 = np.copy(x1)
-    f1(x1, a)
-    f2(x2, a)
+    f1(x1)
+    f2(x2)
     assert np.array_equal( x1, x2)
 
 def test_mix_array_1(language):


### PR DESCRIPTION
Add the creation stage to all Pyccel AST objects and use this property to avoid deleting relevant objects from the AST tree when reusing basic objects between the syntactic and semantic stage. Fixes #1427

**Modifications list:**

- Add property `pyccel_staging` and method `update_pyccel_staging` to class `Basic`;
- Replace method `clear_user_nodes` with new method `clear_syntactic_user_nodes` in class `Basic`;
- Add property `current_stage` to class `PyccelStage`;
- In semantic parser replace most calls to `clear_user_nodes()` with successive calls to `clear_syntactic_user_nodes()` and `update_pyccel_staging()`;
- Add unit test to prove that issue #1427 is fixed.