### PR TITLE
Add conjugate methods for ints and floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+-   #1430 : Added conjugate support to integers and floats.
+
 ### Fixed
 
 -   #1427 : Fix augmented assignment with a literal right hand side in templated code.

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -128,14 +128,24 @@ class PythonImag(PythonComplexProperty):
 
 #==============================================================================
 class PythonConjugate(PyccelInternalFunction):
-    """Represents a call to the .conjugate() function
+    """
+    Represents a call to the .conjugate() function.
 
+    Represents a call to the conjugate function which is a member of
+    the builtin types int, float, complex.
+
+    Examples
+    --------
     e.g:
     > a = 1+2j
     > a.conjugate()
     1-2j
 
-    arg : Variable, Literal
+    Parameters
+    ----------
+    arg : PyccelAstNode
+        The variable/expression which was passed to the
+        conjugate function.
     """
     __slots__ = ()
     _dtype = NativeComplex()
@@ -146,7 +156,9 @@ class PythonConjugate(PyccelInternalFunction):
     name = 'conjugate'
 
     def __new__(cls, arg):
-        if arg.dtype is not NativeComplex():
+        if arg.dtype is NativeBool():
+            return PythonInteger(arg)
+        elif arg.dtype is not NativeComplex():
             return arg
         else:
             return super().__new__(cls)

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -155,7 +155,7 @@ class PythonConjugate(PyccelInternalFunction):
 
     def __new__(cls, arg):
         if arg.dtype is NativeBool():
-            return PythonInteger(arg)
+            return PythonInt(arg)
         elif arg.dtype is not NativeComplex():
             return arg
         else:

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -132,11 +132,9 @@ class PythonConjugate(PyccelInternalFunction):
     Represents a call to the .conjugate() function.
 
     Represents a call to the conjugate function which is a member of
-    the builtin types int, float, complex.
+    the builtin types int, float, complex. The conjugate function is
+    called from Python as follows:
 
-    Examples
-    --------
-    e.g:
     > a = 1+2j
     > a.conjugate()
     1-2j

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -145,6 +145,12 @@ class PythonConjugate(PyccelInternalFunction):
     _order = None
     name = 'conjugate'
 
+    def __new__(cls, arg):
+        if arg.dtype is not NativeComplex():
+            return arg
+        else:
+            return super().__new__(cls)
+
     def __init__(self, arg):
         super().__init__(arg)
 

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -43,7 +43,8 @@ FloatClass = ClassDef('float',
                 decorators={'property':'property', 'numpy_wrapper':PythonImag}),
             FunctionDef('real',[],[],body=[],
                 decorators={'property':'property', 'numpy_wrapper':PythonReal}),
-            #conjugate
+            FunctionDef('conjugate',[],[],body=[],
+                decorators={'numpy_wrapper':PythonConjugate}),
             #as_integer_ratio
             #fromhex
             #hex
@@ -58,9 +59,10 @@ IntegerClass = ClassDef('integer',
                 decorators={'property':'property', 'numpy_wrapper':PythonImag}),
             FunctionDef('real',[],[],body=[],
                 decorators={'property':'property', 'numpy_wrapper':PythonReal}),
+            FunctionDef('conjugate',[],[],body=[],
+                decorators={'numpy_wrapper':PythonConjugate}),
             #as_integer_ratio
             #bit_length
-            #conjugate
             #denominator
             #from_bytes
             #numerator

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/tests/epyccel/test_class_expressions.py
+++ b/tests/epyccel/test_class_expressions.py
@@ -150,16 +150,7 @@ def test_int32_conjugate(language):
     assert r == epyc_r
     assert isinstance(r, type(epyc_r))
 
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="Class inheritance not fully implemented"),
-            pytest.mark.c]),
-        pytest.param("fortran", marks = [
-            pytest.mark.xfail(reason="Class inheritance not fully implemented"),
-            pytest.mark.fortran]),
-        pytest.param("python", marks = pytest.mark.python)
-    ]
-)
+@pytest.mark.xfail(reason="Class inheritance not fully implemented")
 def test_bool_conjugate(language):
     def f(a : 'bool', b : 'bool'):
         return (a or b).conjugate()

--- a/tests/epyccel/test_class_expressions.py
+++ b/tests/epyccel/test_class_expressions.py
@@ -150,6 +150,31 @@ def test_int32_conjugate(language):
     assert r == epyc_r
     assert isinstance(r, type(epyc_r))
 
+@pytest.mark.parametrize( 'language', [
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="Class inheritance not fully implemented"),
+            pytest.mark.c]),
+        pytest.param("fortran", marks = [
+            pytest.mark.xfail(reason="Class inheritance not fully implemented"),
+            pytest.mark.fortran]),
+        pytest.param("python", marks = pytest.mark.python)
+    ]
+)
+def test_bool_conjugate(language):
+    def f(a : 'bool', b : 'bool'):
+        return (a or b).conjugate()
+
+    epyc_f = epyccel(f, language=language)
+
+    a = bool(randint(2))
+    b = bool(randint(2))
+
+    r = f(a,b)
+    epyc_r = epyc_f(a,b)
+
+    assert r == epyc_r
+    assert isinstance(r, type(epyc_r))
+
 def test_ndarray_var_from_expr(language):
     def f(x : 'int[:]', y : 'int[:]'):
         z = x + y

--- a/tests/epyccel/test_class_expressions.py
+++ b/tests/epyccel/test_class_expressions.py
@@ -75,7 +75,7 @@ def test_complex_conjugate(language):
     assert r == epyc_r
     assert isinstance(r, type(epyc_r))
 
-def test_complex_conjugate64(language):
+def test_complex64_conjugate(language):
     def f(a : 'complex64', b : 'complex64'):
         return (a+b).conj()
 
@@ -83,6 +83,66 @@ def test_complex_conjugate64(language):
 
     a = np.complex64(randint(20)+1j*randint(20))
     b = np.complex64(randint(20)+1j*randint(20))
+
+    r = f(a,b)
+    epyc_r = epyc_f(a,b)
+
+    assert r == epyc_r
+    assert isinstance(r, type(epyc_r))
+
+def test_float_conjugate(language):
+    def f(a : 'float', b : 'float'):
+        return (a+b).conjugate()
+
+    epyc_f = epyccel(f, language=language)
+
+    a = float(randint(20))
+    b = float(randint(20))
+
+    r = f(a,b)
+    epyc_r = epyc_f(a,b)
+
+    assert r == epyc_r
+    assert isinstance(r, type(epyc_r))
+
+def test_float64_conjugate(language):
+    def f(a : 'float64', b : 'float64'):
+        return (a+b).conj()
+
+    epyc_f = epyccel(f, language=language)
+
+    a = np.float64(randint(20))
+    b = np.float64(randint(20))
+
+    r = f(a,b)
+    epyc_r = epyc_f(a,b)
+
+    assert r == epyc_r
+    assert isinstance(r, type(epyc_r))
+
+def test_int_conjugate(language):
+    def f(a : 'int', b : 'int'):
+        return (a+b).conjugate()
+
+    epyc_f = epyccel(f, language=language)
+
+    a = randint(20)
+    b = randint(20)
+
+    r = f(a,b)
+    epyc_r = epyc_f(a,b)
+
+    assert r == epyc_r
+    assert isinstance(r, type(epyc_r))
+
+def test_int32_conjugate(language):
+    def f(a : 'int32', b : 'int32'):
+        return (a+b).conj()
+
+    epyc_f = epyccel(f, language=language)
+
+    a = randint(20, dtype=np.int32)
+    b = randint(20, dtype=np.int32)
 
     r = f(a,b)
     epyc_r = epyc_f(a,b)


### PR DESCRIPTION
Add a `__new__` method to allow the use of `conjugate` and `conj` with integers and floats. Fixes https://github.com/pyccel/pyccel/issues/1430 and fixes https://github.com/pyccel/pyccel/issues/1429. Bools are not fixed as this requires corrections to the class inheritance handling. Update library version to 1.8.1.