### PR TITLE
Fix race condition

### DIFF
--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -16,19 +16,27 @@ runs:
     - name: Test with pytest
       run: |
         which python
-        python -m pytest -n auto -rXx -v -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays
+        if [ -n "${{ runner.debug }}" ]
+        then
+          # If running in debug mode
+          export "DEBUG=1"
+          export FLAGS="-xsv --log-cli-level DEBUG"
+        else
+          export FLAGS=""
+        fi
+        python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays
         if [ -n "${SITE_DIR}" ]; then
             echo "Touching"
             # Test ndarray folder update (requires parallel tests to avoid clean)
             touch ${SITE_DIR}/pyccel/stdlib/cwrapper/cwrapper.h
-            python -m pytest -n auto -rXx -v -m c -k test_array_int32_1d_scalar epyccel/test_arrays.py
+            python -m pytest -n auto -rXx ${FLAGS} -m c -k test_array_int32_1d_scalar epyccel/test_arrays.py
         fi
-        python -m pytest -rXx -m "xdist_incompatible and not parallel and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
-        python -m pytest -n auto -rXx -m "not (parallel or xdist_incompatible) and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays
-        python -m pytest -rXx -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays
+        python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays
         pyccel-clean
-        python -m pytest ndarrays/ -rXx
+        python -m pytest ndarrays/ -rXx ${FLAGS}
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+-   Updating stdlib files if they are modified not just accessed.
+
 ### Deprecated
 
 ## \[1.8.1\] - 2023-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
--   Updating stdlib files if they are modified not just accessed.
+-   Updating `stdlib` files if they are modified not just accessed.
 
 ### Deprecated
 

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -233,6 +233,7 @@ class CompileObj:
         Lock the file and its dependencies to prevent race conditions
         """
         self.acquire_simple_lock()
+        self._lock_source.acquire()
         for d in self.dependencies:
             d.acquire_simple_lock()
 
@@ -240,7 +241,6 @@ class CompileObj:
         """
         Lock the file to prevent race conditions but not its dependencies
         """
-        self._lock_source.acquire()
         if self.has_target_file:
             self._lock_target.acquire()
 
@@ -253,6 +253,7 @@ class CompileObj:
         """
         Unlock the file and its dependencies
         """
+        self._lock_source.release()
         self.release_simple_lock()
         for d in self.dependencies:
             d.release_simple_lock()
@@ -261,7 +262,6 @@ class CompileObj:
         """
         Unlock the file
         """
-        self._lock_source.release()
         if self.has_target_file:
             self._lock_target.release()
 

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -221,6 +221,11 @@ class CompileObj:
             raise TypeError("Dependencies require necessary compile information")
         self._dependencies.update({a.module_target:a for a in args})
 
+    def __enter__(self):
+        self.acquire_simple_lock()
+        for d in self.dependencies:
+            d.acquire_simple_lock()
+
     def acquire_lock(self):
         """
         Lock the file and its dependencies to prevent race conditions
@@ -235,6 +240,11 @@ class CompileObj:
         """
         if self.has_target_file:
             self._lock.acquire()
+
+    def __exit__(self):
+        self.release_simple_lock()
+        for d in self.dependencies:
+            d.release_simple_lock()
 
     def release_lock(self):
         """

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -224,9 +224,7 @@ class CompileObj:
         self._dependencies.update({a.module_target:a for a in args})
 
     def __enter__(self):
-        self.acquire_simple_lock()
-        for d in self.dependencies:
-            d.acquire_simple_lock()
+        self.acquire_lock()
 
     def acquire_lock(self):
         """
@@ -245,9 +243,7 @@ class CompileObj:
             self._lock_target.acquire()
 
     def __exit__(self, exc_type, value, traceback):
-        self.release_simple_lock()
-        for d in self.dependencies:
-            d.release_simple_lock()
+        self.release_lock()
 
     def release_lock(self):
         """

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -270,7 +270,7 @@ class CompileObj:
 
     def release_lock(self):
         """
-        Unlock the file and its dependencies
+        Unlock the file and its dependencies.
 
         Release the file locks for the file being compiled, all dependencies needed
         to compile it and the target file which will be generated.

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -103,7 +103,19 @@ class CompileObj:
 
     def reset_folder(self, folder):
         """
-        Change the folder in which the source file is saved (useful for stdlib)
+        Change the folder in which the source file is saved.
+
+        Change the folder in which the source file is saved. Normally the location
+        of the source file should not change during the execution, however when
+        working with the stdlib, the `CompileObj` is created with the folder set
+        to the file's location in the Pyccel instal directory. When the file is
+        used it is copied to the user's folder, at which point the folder of the
+        `CompileObj` must be updated.
+
+        Parameters
+        ----------
+        folder : str
+            The new folder where the source file can be found.
         """
         if self.has_target_file:
             self._includes.remove(self._folder)
@@ -230,7 +242,10 @@ class CompileObj:
 
     def acquire_lock(self):
         """
-        Lock the file and its dependencies to prevent race conditions
+        Lock the file and its dependencies to prevent race conditions.
+
+        Acquire the file locks for the file being compiled, all dependencies needed
+        to compile it and the target file which will be generated.
         """
         self._lock_source.acquire()
         self.acquire_simple_lock()
@@ -239,7 +254,12 @@ class CompileObj:
 
     def acquire_simple_lock(self):
         """
-        Lock the file to prevent race conditions but not its dependencies
+        Lock the file created by this `CompileObj`.
+
+        Acquire the file lock for the file created by this `CompileObj` to prevent
+        race conditions. This function should be called when the created file is a
+        dependency, it is therefore not necessary for it to recurse into its own
+        dependencies.
         """
         if self.has_target_file:
             self._lock_target.acquire()
@@ -251,6 +271,9 @@ class CompileObj:
     def release_lock(self):
         """
         Unlock the file and its dependencies
+
+        Release the file locks for the file being compiled, all dependencies needed
+        to compile it and the target file which will be generated.
         """
         for d in self.dependencies:
             d.release_simple_lock()
@@ -259,7 +282,12 @@ class CompileObj:
 
     def release_simple_lock(self):
         """
-        Unlock the file
+        Unlock the file created by this `CompileObj`.
+
+        Release the file lock for the file created by this `CompileObj` to prevent
+        race conditions. This function should be called when the created file is a
+        dependency, it is therefore not necessary for it to recurse into its own
+        dependencies.
         """
         if self.has_target_file:
             self._lock_target.release()

--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -108,7 +108,7 @@ class CompileObj:
         Change the folder in which the source file is saved. Normally the location
         of the source file should not change during the execution, however when
         working with the stdlib, the `CompileObj` is created with the folder set
-        to the file's location in the Pyccel instal directory. When the file is
+        to the file's location in the Pyccel install directory. When the file is
         used it is copied to the user's folder, at which point the folder of the
         `CompileObj` must be updated.
 

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -415,6 +415,10 @@ class Compiler:
         verbose : bool
             Indicates whether additional output should be shown.
 
+        sharedlib_modname : str, optional
+            The name of the library that should be generated. If none is provided then it
+            defaults to matching the name of the file.
+
         Returns
         -------
         str

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -283,15 +283,15 @@ class Compiler:
 
         Returns
         -------
-        str
+        exec_cmd : str
             The command required to run the executable.
-        iterable of strs
+        inc_flags : iterable of strs
             The include directories required to compile.
-        iterable of strs
+        libs_flags : iterable of strs
             The libraries required to compile.
-        iterable of strs
+        libdirs_flags : iterable of strs
             The directories containing libraries required to compile.
-        iterable of strs
+        m_code : iterable of strs
             The objects required to compile.
         """
 

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -271,7 +271,7 @@ class Compiler:
         """
         Provide all components required for compiling.
 
-        Provide all the different componenets (include directories, libraries, etc
+        Provide all the different componenets (include directories, libraries, etc)
         which are needed in order to compile any file.
 
         Parameters

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -318,12 +318,14 @@ class Compiler:
 
         Parameters
         ----------
-        compile_obj   : CompileObj
-                        Object containing all information about the object to be compiled
+        compile_obj : CompileObj
+            Object containing all information about the object to be compiled.
+
         output_folder : str
-                        The folder where the result should be saved
-        verbose       : bool
-                        Indicates whether additional output should be shown
+            The folder where the result should be saved.
+
+        verbose : bool
+            Indicates whether additional output should be shown.
         """
         accelerators = compile_obj.accelerators
 

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -269,27 +269,30 @@ class Compiler:
 
     def _get_compile_components(self, compile_obj, accelerators = ()):
         """
-        Provide all components required for compiling
+        Provide all components required for compiling.
+
+        Provide all the different componenets (include directories, libraries, etc
+        which are needed in order to compile any file.
 
         Parameters
         ----------
-        compile_obj  : CompileObj
-                       Object containing all information about the object to be compiled
+        compile_obj : CompileObj
+            Object containing all information about the object to be compiled.
         accelerators : iterable of str
-                       Name of all tools used by the code which require additional flags/includes/etc
+            Name of all tools used by the code which require additional flags/includes/etc.
 
-        Results
+        Returns
         -------
-        exec_cmd      : str
-                        The command required to run the executable
-        inc_flags     : iterable of strs
-                        The include directories required to compile
-        libs_flags    : iterable of strs
-                        The libraries required to compile
-        libdirs_flags : iterable of strs
-                        The directories containing libraries required to compile
-        m_code        : iterable of strs
-                        The objects required to compile
+        str
+            The command required to run the executable.
+        iterable of strs
+            The include directories required to compile.
+        iterable of strs
+            The libraries required to compile.
+        iterable of strs
+            The directories containing libraries required to compile.
+        iterable of strs
+            The objects required to compile.
         """
 
         # get includes
@@ -459,14 +462,27 @@ class Compiler:
     @staticmethod
     def run_command(cmd, verbose):
         """
-        Run the provided command and collect the output
+        Run the provided command and collect the output.
+
+        Run the provided compilation command, collect the output and raise any
+        necessary errors if the file does not compile.
 
         Parameters
         ----------
-        cmd     : iterable
-                  The command to run
+        cmd : list of str
+            The command to run.
         verbose : bool
-                  Indicates whether additional output should be shown
+            Indicates whether additional output should be shown.
+
+        Returns
+        -------
+        str
+            The exact command that was run.
+
+        Raises
+        ------
+        RuntimeError
+            Raises `RuntimeError` if the file does not compile.
         """
         cmd = [os.path.expandvars(c) for c in cmd]
         if verbose:

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -312,7 +312,9 @@ class Compiler:
 
     def compile_module(self, compile_obj, output_folder, verbose = False):
         """
-        Compile a module
+        Compile a module.
+
+        Compile a file containing a module to a .o file.
 
         Parameters
         ----------
@@ -350,16 +352,25 @@ class Compiler:
 
     def compile_program(self, compile_obj, output_folder, verbose = False):
         """
-        Compile a program
+        Compile a program.
+
+        Compile a file containing a program to an executable.
 
         Parameters
         ----------
-        compile_obj   : CompileObj
-                        Object containing all information about the object to be compiled
+        compile_obj : CompileObj
+            Object containing all information about the object to be compiled.
+
         output_folder : str
-                        The folder where the result should be saved
-        verbose       : bool
-                        Indicates whether additional output should be shown
+            The folder where the result should be saved.
+
+        verbose : bool
+            Indicates whether additional output should be shown.
+
+        Returns
+        -------
+        str
+            The name of the generated executable.
         """
         accelerators = compile_obj.accelerators
 
@@ -388,21 +399,26 @@ class Compiler:
 
     def compile_shared_library(self, compile_obj, output_folder, verbose = False, sharedlib_modname=None):
         """
-        Compile a module to a shared library
+        Compile a module to a shared library.
+
+        Compile a file containing a module with C-API calls to a shared library which can
+        be called from Python.
 
         Parameters
         ----------
-        compile_obj   : CompileObj
-                        Object containing all information about the object to be compiled
+        compile_obj : CompileObj
+            Object containing all information about the object to be compiled.
+
         output_folder : str
-                        The folder where the result should be saved
-        verbose       : bool
-                        Indicates whether additional output should be shown
+            The folder where the result should be saved.
+
+        verbose : bool
+            Indicates whether additional output should be shown.
 
         Returns
         -------
-        file_out : str
-                   Generated library name
+        str
+            Generated library name.
         """
         # Ensure python options are collected
         accelerators = set(compile_obj.accelerators)

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -346,11 +346,8 @@ class Compiler:
                 *j_code]
 
         with FileLock('.lock_acquisition.lock'):
-            compile_obj.acquire_lock()
-        try:
-            self.run_command(cmd, verbose)
-        finally:
-            compile_obj.release_lock()
+            with compile_obj:
+                self.run_command(cmd, verbose)
 
     def compile_program(self, compile_obj, output_folder, verbose = False):
         """
@@ -386,11 +383,8 @@ class Compiler:
                 *libs_flags, *j_code]
 
         with FileLock('.lock_acquisition.lock'):
-            compile_obj.acquire_lock()
-        try:
-            self.run_command(cmd, verbose)
-        finally:
-            compile_obj.release_lock()
+            with compile_obj:
+                self.run_command(cmd, verbose)
 
         return compile_obj.program_target
 
@@ -439,11 +433,8 @@ class Compiler:
                 '-o', file_out, *libs_flags]
 
         with FileLock('.lock_acquisition.lock'):
-            compile_obj.acquire_lock()
-        try:
-            self.run_command(cmd, verbose)
-        finally:
-            compile_obj.release_lock()
+            with compile_obj:
+                self.run_command(cmd, verbose)
 
         return file_out
 

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -345,9 +345,8 @@ class Compiler:
                 compile_obj.source, '-o', compile_obj.module_target,
                 *j_code]
 
-        with FileLock('.lock_acquisition.lock'):
-            with compile_obj:
-                self.run_command(cmd, verbose)
+        with compile_obj:
+            self.run_command(cmd, verbose)
 
     def compile_program(self, compile_obj, output_folder, verbose = False):
         """
@@ -382,9 +381,8 @@ class Compiler:
                 '-o', compile_obj.program_target,
                 *libs_flags, *j_code]
 
-        with FileLock('.lock_acquisition.lock'):
-            with compile_obj:
-                self.run_command(cmd, verbose)
+        with compile_obj:
+            self.run_command(cmd, verbose)
 
         return compile_obj.program_target
 
@@ -432,9 +430,8 @@ class Compiler:
                 compile_obj.module_target, *m_code,
                 '-o', file_out, *libs_flags]
 
-        with FileLock('.lock_acquisition.lock'):
-            with compile_obj:
-                self.run_command(cmd, verbose)
+        with compile_obj:
+            self.run_command(cmd, verbose)
 
         return file_out
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -76,13 +76,13 @@ def not_a_copy(src_folder, dst_folder, filename):
 #==============================================================================
 def copy_internal_library(lib_folder, pyccel_dirpath, extra_files = None):
     """
-    Copy an internal library to the specified pyccel directory.
+    Copy an internal library to the specified Pyccel directory.
 
-    Copy an internal library from its specified stdlib folder to the pyccel
+    Copy an internal library from its specified stdlib folder to the Pyccel
     directory. The copy is only done if the files are not already present or
     if the files have changed since they were last copied. Extra files can be
     added to the folder if and when the copy occurs (e.g. for specifying
-    the numpy version compatibility).
+    the NumPy version compatibility).
 
     Parameters
     ----------
@@ -183,7 +183,7 @@ def recompile_object(compile_obj,
         The compiler used.
 
     verbose : bool
-        Indicates whethere additional information should be printed.
+        Indicates whether additional information should be printed.
     """
 
     # compile library source files

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -42,10 +42,30 @@ internal_libs["cwrapper_ndarrays"] = ("cwrapper_ndarrays", CompileObj("cwrapper_
 #==============================================================================
 
 def not_a_copy(src_folder, dst_folder, filename):
-    """ Check if the file filename present in src_folder
-    is a copy of the file filename present in dst_folder
-    or if the source file has been updated since the last
-    copy
+    """
+    Check if the file is different between the source and destination folders.
+
+    Check if the file filename present in src_folder is different (not a copy)
+    from the file filename present in dst_folder. This is done by checking if
+    the source file has been modified more recently than the destination file.
+    This would imply that it has been modified since the last copy.
+
+    Parameters
+    ----------
+    src_folder : str
+        The folder where the file was defined.
+
+    dst_folder : str
+        The folder where the file is being used.
+
+    filename : str
+        The name of the file.
+
+    Returns
+    -------
+    bool
+        False if the file in the destination folder is a copy of the file in the
+        source folder, True otherwise.
     """
     abs_src_file = os.path.join(src_folder, filename)
     abs_dst_file = os.path.join(dst_folder, filename)
@@ -56,26 +76,30 @@ def not_a_copy(src_folder, dst_folder, filename):
 #==============================================================================
 def copy_internal_library(lib_folder, pyccel_dirpath, extra_files = None):
     """
+    Copy an internal library to the specified pyccel directory.
+
     Copy an internal library from its specified stdlib folder to the pyccel
     directory. The copy is only done if the files are not already present or
     if the files have changed since they were last copied. Extra files can be
     added to the folder if and when the copy occurs (e.g. for specifying
-    the numpy version compatibility)
+    the numpy version compatibility).
 
     Parameters
     ----------
-    lib_folder     : str
-                     The name of the folder to be copied, relative to the stdlib folder
-    pyccel_dirpath : str
-                     The location that the folder should be copied to
-    extra_files    : dict
-                     A dictionary whose keys are the names of any files to be created
-                     in the folder and whose values are the contents of the file
+    lib_folder : str
+        The name of the folder to be copied, relative to the stdlib folder.
 
-    Results
+    pyccel_dirpath : str
+        The location that the folder should be copied to.
+
+    extra_files : dict
+        A dictionary whose keys are the names of any files to be created
+        in the folder and whose values are the contents of the file.
+
+    Returns
     -------
-    lib_dest_path  : str
-                     The location that the files were copied to
+    str
+        The location that the files were copied to.
     """
     # get lib path (stdlib_path/lib_name)
     lib_path = os.path.join(stdlib_path, lib_folder)
@@ -145,18 +169,21 @@ def recompile_object(compile_obj,
                    compiler,
                    verbose = False):
     """
-    Compile the provided file.
-    If the file has already been compiled then it will only be recompiled
-    if the source has been modified
+    Compile the provided file if necessary.
+
+    Check if the file has already been compiled, if it hasn't or if the source has
+    been modified then compile the file.
 
     Parameters
     ----------
     compile_obj : CompileObj
-                  The object to compile
-    compiler    : str
-                  The compiler used
-    verbose     : bool
-                  Indicates whethere additional information should be printed
+        The object to compile.
+
+    compiler : str
+        The compiler used.
+
+    verbose : bool
+        Indicates whethere additional information should be printed.
     """
 
     # compile library source files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
+import logging
 import os
 import shutil
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,11 @@ import pytest
 from mpi4py import MPI
 from pyccel.commands.pyccel_clean import pyccel_clean
 
-# Uncomment to debug  pytest-xdist errors
-#import sys
-#sys.stdout = sys.stderr
+github_debugging = 'DEBUG' in os.environ
+print("Found : ", github_debugging, os.environ)
+if github_debugging:
+    import sys
+    sys.stdout = sys.stderr
 
 @pytest.fixture( params=[
         pytest.param("fortran", marks = pytest.mark.fortran),
@@ -45,13 +47,17 @@ def pytest_runtest_teardown(item, nextitem):
             comm.Barrier()
 
 def pytest_addoption(parser):
-    parser.addoption("--developer-mode", action="store_true", default=False, help="Show tracebacks when pyccel errors are raised")
+    parser.addoption("--developer-mode", action="store_true", default=github_debugging, help="Show tracebacks when pyccel errors are raised")
 
 def pytest_sessionstart(session):
     # setup_stuff
     if session.config.option.developer_mode:
         from pyccel.errors.errors import ErrorsMode
         ErrorsMode().set_mode('developer')
+
+    if github_debugging:
+        logging.basicConfig()
+        logging.getLogger("filelock").setLevel(logging.DEBUG)
 
     # Clean path before beginning but never delete anything in parallel mode
     path_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from mpi4py import MPI
 from pyccel.commands.pyccel_clean import pyccel_clean
 
 github_debugging = 'DEBUG' in os.environ
-print("Found : ", github_debugging, os.environ)
 if github_debugging:
     import sys
     sys.stdout = sys.stderr

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -5277,22 +5277,42 @@ def test_numpy_matmul_array_like_2x2d(language):
 
     bl = randint(0, 2, size=size, dtype= bool)
 
-    integer8 = randint(min_int8, max_int8, size=size, dtype=np.int8)
-    integer16 = randint(min_int16, max_int16, size=size, dtype=np.int16)
-    integer = randint(min_int, max_int, size=size, dtype=int)
-    integer32 = randint(min_int32, max_int32, size=size, dtype=np.int32)
-    integer64 = randint(min_int64, max_int64, size=size, dtype=np.int64)
+    def calculate_max_values(min_for_type, max_for_type):
+        cast = type(min_for_type)
+        min_test = -np.sqrt(abs(min_for_type) / size[0])
+        max_test = np.sqrt(abs(max_for_type) / size[0])
+        print(min_test, max_test, cast(min_test), cast(max_test))
+        return cast(min_test), cast(max_test)
 
-    fl = uniform(-((abs(min_float) / size[0])**(1/2)), (abs(max_float) / size[0])**(1/2), size = size)
-    fl32 = uniform(-((abs(min_float32) / size[0])**(1/2)), (abs(max_float32) / size[0])**(1/2), size = size)
+    integer8 = randint(*calculate_max_values(min_int8, max_int8), size=size, dtype=np.int8)
+    integer16 = randint(*calculate_max_values(min_int16, max_int16), size=size, dtype=np.int16)
+    integer = randint(*calculate_max_values(min_int, max_int), size=size, dtype=int)
+    integer32 = randint(*calculate_max_values(min_int32, max_int32), size=size, dtype=np.int32)
+    integer64 = randint(*calculate_max_values(min_int64, max_int64), size=size, dtype=np.int64)
+
+    fl = uniform(*calculate_max_values(min_float, max_float), size = size)
+    fl32 = uniform(*calculate_max_values(min_float32, max_float32), size = size)
     fl32 = np.float32(fl32)
-    fl64 = uniform(-((abs(min_float64) / size[0])**(1/2)), (abs(max_float64) / size[0])**(1/2), size = size)
+    fl64 = uniform(*calculate_max_values(min_float64, max_float64), size = size)
 
-    cmplx128_from_float32 = uniform(low=-((abs(min_int) / size[0] * 2)**(1/2)), high=(max_int / size[0] * 2)**(1/2), size=size) + uniform(low=-((abs(min_int) / size[0] * 2)**(1/2)), high=(max_int / size[0] * 2)**(1/2), size=size) * 1j
+    cmplx128_from_float32 = uniform(*calculate_max_values(min_int, max_int), size=size) + uniform(*calculate_max_values(min_int, max_int), size=size) * 1j
     # the result of the last operation is a Python complex type which has 8 bytes in the alignment,
     # that's why we need to convert it to a numpy.complex64 the needed type.
     cmplx64 = np.complex64(cmplx128_from_float32)
-    cmplx128 = uniform(low=-((abs(min_int) / size[0] * 2)**(1/2)), high=(max_int / size[0] * 2)**(1/2), size=size) + uniform(low=-((abs(min_int) / size[0] * 2)**(1/2)), high=(max_int / size[0] * 2)**(1/2), size=size) * 1j
+    cmplx128 = uniform(*calculate_max_values(min_int, max_int), size=size) + uniform(*calculate_max_values(min_int, max_int), size=size) * 1j
+
+    integer8  = np.full(size, calculate_max_values(min_int8, max_int8)[1])
+    integer16 = np.full(size, calculate_max_values(min_int16, max_int16)[1])
+    integer   = np.full(size, calculate_max_values(min_int, max_int)[1])
+    integer32 = np.full(size, calculate_max_values(min_int32, max_int32)[1])
+    integer64 = np.full(size, calculate_max_values(min_int64, max_int64)[1])
+
+    fl   = np.full(size, calculate_max_values(min_float, max_float)[1])
+    fl32 = np.full(size, calculate_max_values(min_float32, max_float32)[1])
+    fl64 = np.full(size, calculate_max_values(min_float64, max_float64)[1])
+
+    cmplx64  = np.full(size, np.complex64(integer + integer * 1j))
+    cmplx128 = np.full(size, integer + integer * 1j)
 
     epyccel_func = epyccel(get_matmul, language=language)
 


### PR DESCRIPTION
The race condition is occurring on Macosx because Pyccel occasionally thinks that the source files in the stdlib folder have been modified. This then creates the following series of concurrent events:


| Thread 1 | Thread 2 |
|--|---|
|Starts compilation process | Still translating |
| Acquires `ndarrays` folder lock | Still translating |
| Checks `ndarrays` folder | Starts compilation process |
| All ok  | Fails to acquire `ndarrays` folder lock. Waiting
| Releases `ndarrays` folder lock | Waiting |
| Acquires locks to compile `ndarrays.o` (`ndarrays.o.lock`) | Acquires `ndarrays` folder lock |
| Compilation in progress | Reads contents of `ndarrays` folder (may see `ndarrays.o.tmp` file created by compilation) |
| Finished compilation. Released locks | Checks access dates for `__pyccel__/ndarrays` folder and `stdlib/ndarrays` folder. **Incorrectly determines folder needs updating** |
| Prints wrapper file | Acquires locks to copy `ndarrays` folder  (`ndarrays.h.lock`, `ndarrays.c.lock`, `ndarrays.o.lock`) |
| Attempts to acquire locks to compile wrapper (including dependencies: `ndarrays.o`, (`ndarrays.h`, `ndarrays.c`) | deletes all files in `ndarrays` folder  |
| Waiting | Copies `ndarrays` folder contents back (only `ndarrays.h`, `ndarrays.c`)  |
| Waiting | Releases `ndarrays` locks |
|Acquires locks | Starts to check if compilation of `ndarrays` is necessary |
| Tries to compile generated file but `ndarrays.o` is missing | Tries to acquire `ndarrys.c.lock` |

The error is therefore not due to a race condition where 2 threads try to do the same thing, but rather due to a bad update condition. I think this is because we are checking when the files were accessed rather than when they were modified.

Additionally the compilation of `ndarrays.o` does not lock `ndarrays.c`. This is corrected in this PR but is not strictly necessary as the `ndarrays.o.lock` is always acquired if `ndarrays.c.lock` is acquired.

**Commit Summary**
- Make `CompileObj` a context manager (with methods `__enter__` and `__exit__`)
- Use `with compile_obj:` constructs to handle locks more compactly
- Ensure the source file is locked during compilation
- Check the modification time not the access time to decide whether a file should be updated
- Don't raise an error if temporary files are found in a folder being updated
- Add detailed flags which are activated when the tests are rerun with debug logging
![image](https://github.com/pyccel/pyccel/assets/25363473/fec5d756-eff0-4a5b-a0be-9051dd40e96f)
- Improve the definition of the min/max bounds on a test that failed. The logic now only needs touching in a single place if the bounds need narrowing

**Testing**
It is quite difficult to test this kind of error, however I have run the full suite of tests with `assert False` in the code which updates the std libraries and macosx no longer seems to go into this section of the code. (Linux triggers the assertion in the [test designed to test this mechanism](https://github.com/pyccel/pyccel/blob/devel/.github/actions/pytest_run/action.yml#L20-L25))