### PR TITLE
Stop bot reacting to comments

### DIFF
--- a/ci_tools/bot_review_react.py
+++ b/ci_tools/bot_review_react.py
@@ -26,5 +26,5 @@ if __name__ == '__main__':
         author = event['pull_request']['user']['login']
         reviewer = event['review']['user']['login']
         bot.draft_due_to_changes_requested(author, reviewer)
-    else:
+    elif decision == 'approved':
         bot.mark_as_ready(following_review = True)

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -556,7 +556,7 @@ class Bot:
                                 reviewers=names, author=author, approved=approved)
                 self._GAI.create_comment(pr_id, message)
                 self._GAI.request_reviewers(pr_id, reviewers=senior_reviewer)
-        elif reviews:
+        elif requested_changes:
             requested = ', '.join(f'@{r}' for r in requested_changes)
             message = message_from_file('rerequest_review.txt').format(
                                             reviewers=requested, author=author)


### PR DESCRIPTION
Stop the bot reacting to comments. It should only react to approvals or requested changes. Also fix a logic error leading to rerequesting a review from nobody.