### PR TITLE
Bot fixes

### DIFF
--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -1,6 +1,6 @@
 """ File containing the class Bot and all functions useful for bot reactions.
 """
-import datetime
+from datetime import datetime
 import json
 import os
 import platform

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -1,10 +1,12 @@
 """ File containing the class Bot and all functions useful for bot reactions.
 """
+import datetime
 import json
 import os
 import platform
 import shutil
 import subprocess
+import time
 from .github_api_interactions import GitHubAPIInteractions
 
 default_python_versions = {
@@ -270,6 +272,11 @@ class Bot:
         force_run : bool, default=False
             Force the tests to run even if they are not necessary.
 
+        Returns
+        -------
+        list of str
+            A list containing the state of each test.
+
         See Also
         --------
         Bot.run_test
@@ -277,12 +284,14 @@ class Bot:
         """
         if any(t not in default_python_versions for t in tests):
             self._GAI.create_comment(self._pr_id, "There are unrecognised tests.\n"+message_from_file('show_tests.txt'))
+            return []
         else:
             check_runs = self._GAI.get_check_runs(self._ref)['check_runs']
             already_triggered = [c["name"] for c in check_runs if c['status'] in ('completed', 'in_progress')]
             already_triggered_names = [self.get_name_key(t) for t in already_triggered]
             already_programmed = {c["name"]:c for c in check_runs if c['status'] == 'queued'}
             print(already_triggered)
+            states = []
 
             if not force_run:
                 # Get a list of all commits on this branch
@@ -303,8 +312,9 @@ class Bot:
                 if any(key in a for a in already_triggered):
                     continue
                 name = f"{test_names[t]} {key}"
-                if not force_run and not self.is_test_required(commit_log, name, t):
+                if not force_run and not self.is_test_required(commit_log, name, t, states):
                     continue
+                states.append('queued')
                 if key not in already_programmed:
                     posted = self._GAI.prepare_run(self._ref, name)
                 else:
@@ -319,6 +329,7 @@ class Bot:
                         workflow_ids = [int(r['details_url'].split('/')[-1]) for r in check_runs if r['conclusion'] == "success" and '(' in r['name']]
                     print("Running test")
                     self.run_test(t, pv, posted["id"], workflow_ids)
+            return states
 
     def run_test(self, test, python_version, check_run_id, workflow_ids = None):
         """
@@ -358,6 +369,12 @@ class Bot:
             possible_artifacts = self._GAI.get_artifacts('coverage-artifact')['artifacts']
             print("possible_artifacts : ", possible_artifacts)
             acceptable_urls = [a['archive_download_url'] for a in possible_artifacts if a['workflow_run']['id'] in workflow_ids]
+            while len(acceptable_urls) == 0:
+                # Occasionally artifacts are not available immediately after linux concludes
+                time.sleep(10)
+                possible_artifacts = self._GAI.get_artifacts('coverage-artifact')['artifacts']
+                print("possible_artifacts : ", possible_artifacts)
+                acceptable_urls = [a['archive_download_url'] for a in possible_artifacts if a['workflow_run']['id'] in workflow_ids]
             print("acceptable_urls: ", acceptable_urls)
             inputs['artifact_urls'] = ' '.join(acceptable_urls)
             inputs['pr_id'] = str(self._pr_id)
@@ -367,7 +384,7 @@ class Bot:
         print("Post workflow")
         self._GAI.run_workflow(f'{test}.yml', inputs)
 
-    def is_test_required(self, commit_log, name, key):
+    def is_test_required(self, commit_log, name, key, state):
         """
         Check if a costly test is required.
 
@@ -385,6 +402,9 @@ class Bot:
 
         key : str
             The key which identifies the test.
+
+        state : list of str
+            A list to which the state should be appended if found.
 
         Returns
         -------
@@ -425,6 +445,7 @@ class Bot:
                     if key == 'coverage' and conclusion == 'failure':
                         return True
                     self._GAI.create_run_from_old(self._ref, name, previous_state['details_url'], conclusion)
+                    state.append(conclusion)
                     return False
         return True
 
@@ -501,14 +522,22 @@ class Bot:
             self.mark_as_draft()
             return False
 
-        self.run_tests(pr_test_keys)
+        states = self.run_tests(pr_test_keys)
 
-        cmds = [github_cli, 'pr', 'ready', str(self._pr_id)]
+        if 'failure' in states:
+            self.draft_due_to_failure()
+            return False
+        else:
+            cmds = [github_cli, 'pr', 'ready', str(self._pr_id)]
 
-        with subprocess.Popen(cmds) as p:
-            _, err = p.communicate()
-        print(err)
-        return True
+            with subprocess.Popen(cmds) as p:
+                _, err = p.communicate()
+            print(err)
+
+            if all(s == 'success' for s in states):
+                self.mark_as_ready(False)
+
+            return True
 
     def mark_as_ready(self, following_review):
         """

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -679,7 +679,9 @@ class Bot:
             whose values are dictionaries describing the reviews which either
             approved or requested changes.
         """
-        reviews = {r['user']['login'] : r for r in self._GAI.get_reviews(self._pr_id) if r['user']['type'] != 'Bot' and r['state'] in ('APPROVED', 'CHANGES_REQUESTED')}
+        all_reviews = [r for r in self._GAI.get_reviews(self._pr_id) if r['user']['type'] != 'Bot' and r['state'] in ('APPROVED', 'CHANGES_REQUESTED')]
+        all_reviews.sort(key=lambda r: datetime.fromisoformat(r['submitted_at'].strip('Z')))
+        reviews = {r['user']['login'] : r for r in all_reviews}
         if any(reviewer in senior_reviewer and r["state"] == 'APPROVED' for reviewer, r in reviews.items()):
             return "Ready_to_merge", reviews
 

--- a/ci_tools/summarise_doccoverage.py
+++ b/ci_tools/summarise_doccoverage.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     added_mod = [mod for mod in results['compare_no_mod'] if mod not in results['base_no_mod']]
     added_obj = {(mod, cls): methods for mod, obj in results['compare_no_obj'].items() \
                                      for cls, methods in obj.items() \
-                                     if methods != results['base_no_obj'].get(mod, {}).get(cls, None)}
+                                     if any(m not in results['base_no_obj'].get(mod, {}).get(cls, []) for m in methods)}
 
     base_folder = os.path.abspath(args.base[:-4])
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2296,10 +2296,6 @@ class Return(Basic):
         super().__init__()
 
     @property
-    def expr(self):
-        return self._expr
-
-    @property
     def stmt(self):
         return self._stmt
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2296,6 +2296,10 @@ class Return(Basic):
         super().__init__()
 
     @property
+    def expr(self):
+        return self._expr
+
+    @property
     def stmt(self):
         return self._stmt
 


### PR DESCRIPTION
Try to fix additional bot problems:

1. Sort reviews before filtering them by author (hopefully will fix the stage determination failing in #1280 and #1457). This should result in only the most recent review being preserved.
2. Set flags if tests are already passing. If the tests were run before marking the PR as draft the bot doesn't check the status and update the flags as this was only done in the clean up. (Bug seen in #1457)
3. Fix a bug in the documentation test where it failed when a function is removed from a class. (Bug seen in #1457)