### PR TITLE
Fix review status

### DIFF
--- a/ci_tools/bot_clean_up.py
+++ b/ci_tools/bot_clean_up.py
@@ -4,8 +4,7 @@ import json
 import os
 from bot_tools.bot_funcs import Bot, test_dependencies, pr_test_keys
 
-#pr_all_test_keys = pr_test_keys.copy() + ['Codacy']
-pr_all_test_keys = pr_test_keys.copy()
+pr_all_test_keys = pr_test_keys.copy() + ['Codacy']
 
 if __name__ == '__main__':
     # Parse event payload from $GITHUB_EVENT_PATH variable

--- a/ci_tools/bot_clean_up.py
+++ b/ci_tools/bot_clean_up.py
@@ -2,10 +2,10 @@
 """
 import json
 import os
-from bot_tools.bot_funcs import Bot, test_dependencies
+from bot_tools.bot_funcs import Bot, test_dependencies, pr_test_keys
 
-pr_test_keys = ['linux', 'windows', 'macosx', 'coverage', 'docs', 'pylint',
-                'pyccel_lint', 'spelling', 'Codacy']
+#pr_all_test_keys = pr_test_keys.copy() + ['Codacy']
+pr_all_test_keys = pr_test_keys.copy()
 
 if __name__ == '__main__':
     # Parse event payload from $GITHUB_EVENT_PATH variable
@@ -98,13 +98,13 @@ if __name__ == '__main__':
             print(was_examined, result_ignored)
 
             if was_examined and not result_ignored:
-                print(completed_runs, pr_test_keys, successful_runs)
-                print(all(k in completed_runs for k in pr_test_keys),
-                     all(k in successful_runs for k in pr_test_keys))
+                print(completed_runs, pr_all_test_keys, successful_runs)
+                print(all(k in completed_runs for k in pr_all_test_keys),
+                     all(k in successful_runs for k in pr_all_test_keys))
                 if event['check_run']['conclusion'] == 'failure':
                     bot.draft_due_to_failure()
                 elif event['check_run']['conclusion'] not in ('success', 'skipped'):
                     bot.mark_as_draft()
-                elif all(k in completed_runs for k in pr_test_keys) and \
-                     all(k in successful_runs for k in pr_test_keys):
+                elif all(k in completed_runs for k in pr_all_test_keys) and \
+                     all(k in successful_runs for k in pr_all_test_keys):
                     bot.mark_as_ready(following_review = False)

--- a/ci_tools/bot_clean_up.py
+++ b/ci_tools/bot_clean_up.py
@@ -2,9 +2,9 @@
 """
 import json
 import os
-from bot_tools.bot_funcs import Bot, test_dependencies, pr_test_keys
+from bot_tools.bot_funcs import Bot, test_dependencies, pr_test_keys as bot_pr_test_keys
 
-pr_all_test_keys = pr_test_keys.copy() + ['Codacy']
+pr_test_keys = bot_pr_test_keys.copy() + ['Codacy']
 
 if __name__ == '__main__':
     # Parse event payload from $GITHUB_EVENT_PATH variable
@@ -97,13 +97,13 @@ if __name__ == '__main__':
             print(was_examined, result_ignored)
 
             if was_examined and not result_ignored:
-                print(completed_runs, pr_all_test_keys, successful_runs)
-                print(all(k in completed_runs for k in pr_all_test_keys),
-                     all(k in successful_runs for k in pr_all_test_keys))
+                print(completed_runs, pr_test_keys, successful_runs)
+                print(all(k in completed_runs for k in pr_test_keys),
+                     all(k in successful_runs for k in pr_test_keys))
                 if event['check_run']['conclusion'] == 'failure':
                     bot.draft_due_to_failure()
                 elif event['check_run']['conclusion'] not in ('success', 'skipped'):
                     bot.mark_as_draft()
-                elif all(k in completed_runs for k in pr_all_test_keys) and \
-                     all(k in successful_runs for k in pr_all_test_keys):
+                elif all(k in completed_runs for k in pr_test_keys) and \
+                     all(k in successful_runs for k in pr_test_keys):
                     bot.mark_as_ready(following_review = False)

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -45,7 +45,9 @@ test_dependencies = {'coverage':['linux']}
 
 tests_with_base = ('coverage', 'docs', 'pyccel_lint')
 
-pr_test_keys = ('linux', 'windows', 'macosx', 'coverage', 'docs', 'pylint',
+#pr_test_keys = ('linux', 'windows', 'macosx', 'coverage', 'docs', 'pylint',
+#                'pyccel_lint', 'spelling')
+pr_test_keys = ('docs', 'pylint',
                 'pyccel_lint', 'spelling')
 
 review_stage_labels = ["needs_initial_review", "Ready_for_review", "Ready_to_merge"]

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -45,9 +45,7 @@ test_dependencies = {'coverage':['linux']}
 
 tests_with_base = ('coverage', 'docs', 'pyccel_lint')
 
-#pr_test_keys = ('linux', 'windows', 'macosx', 'coverage', 'docs', 'pylint',
-#                'pyccel_lint', 'spelling')
-pr_test_keys = ('docs', 'pylint',
+pr_test_keys = ('linux', 'windows', 'macosx', 'coverage', 'docs', 'pylint',
                 'pyccel_lint', 'spelling')
 
 review_stage_labels = ["needs_initial_review", "Ready_for_review", "Ready_to_merge"]

--- a/ci_tools/bot_tools/github_api_interactions.py
+++ b/ci_tools/bot_tools/github_api_interactions.py
@@ -403,10 +403,12 @@ class GitHubAPIInteractions:
         url = f"https://api.github.com/repos/{self._org}/{self._repo}/pulls/{pr_id}/comments"
         results = []
         page = 1
-        while exit_status == 200 and len(results)%100 == 0:
+        new_results = [None]
+        while len(new_results) != 0:
             request = self._post_request("GET", url, params={'per_page': '100', 'page': str(page)})
-            results.extend(request.json())
-            exit_status = request.status_code
+            new_results = request.json()
+            results.extend(new_results)
+            page += 1
         return results
 
     def create_comment(self, pr_id, comment, reply_to = None):
@@ -638,7 +640,15 @@ class GitHubAPIInteractions:
             A dictionary describing the reviews.
         """
         url = f"https://api.github.com/repos/{self._org}/{self._repo}/pulls/{pr_id}/reviews"
-        return self._post_request("GET", url).json()
+        results = []
+        page = 1
+        new_results = [None]
+        while len(new_results) != 0:
+            request = self._post_request("GET", url, params={'per_page': '100', 'page': str(page)})
+            new_results = request.json()
+            results.extend(new_results)
+            page += 1
+        return results
 
     def get_events(self, pr_id, page = 1):
         """

--- a/ci_tools/bot_tools/github_api_interactions.py
+++ b/ci_tools/bot_tools/github_api_interactions.py
@@ -21,7 +21,6 @@ def get_authorization():
     str
         A string describing the expiration of the JWT.
     """
-    print(len(os.environ["PEM"]))
     signing_key = jwt.jwk_from_pem(bytes(os.environ["PEM"], "utf-8"))
     # Issued at time
     # JWT expiration time (10 minutes maximum)
@@ -402,7 +401,13 @@ class GitHubAPIInteractions:
             A dictionary containing the comments.
         """
         url = f"https://api.github.com/repos/{self._org}/{self._repo}/pulls/{pr_id}/comments"
-        return self._post_request("GET", url).json()
+        results = []
+        page = 1
+        while exit_status == 200:
+            request = self._post_request("GET", url, params={'per_page': '100', 'page': str(page)})
+            results.extend(request.json())
+            exit_status = request.status_code
+        return results
 
     def create_comment(self, pr_id, comment, reply_to = None):
         """

--- a/ci_tools/bot_tools/github_api_interactions.py
+++ b/ci_tools/bot_tools/github_api_interactions.py
@@ -403,7 +403,7 @@ class GitHubAPIInteractions:
         url = f"https://api.github.com/repos/{self._org}/{self._repo}/pulls/{pr_id}/comments"
         results = []
         page = 1
-        while exit_status == 200:
+        while exit_status == 200 and len(results)%100 == 0:
             request = self._post_request("GET", url, params={'per_page': '100', 'page': str(page)})
             results.extend(request.json())
             exit_status = request.status_code


### PR DESCRIPTION
By default the GitHub API only returns the first 30 reviews. This PR changes that so it collects 100 reviews per page and keeps collecting pages until there are none left. With all the reviews the bot can make a correct decision on whether a review should be re-requested and what is the review state of a PR.
Additionally ci_tools/bot_clean_up.py is modified to avoid duplicating code.

This PR was tested in my fork,