### PR TITLE
[BOT] Don't cancel dependent jobs

### DIFF
--- a/ci_tools/bot_clean_up.py
+++ b/ci_tools/bot_clean_up.py
@@ -55,8 +55,6 @@ if __name__ == '__main__':
                 if q_name == 'coverage':
                     workflow_ids = [int(r['details_url'].split('/')[-1]) for r in runs if r['conclusion'] == "success" and '(' in r['name']]
                 bot.run_test(q_name, python_version, q["id"], workflow_ids)
-            elif all(d in completed_runs for d in deps):
-                bot.GAI.update_run(q["id"], {'conclusion':'cancelled', 'status':"completed"})
 
     if pr_id != 0:
         draft = bot.is_pr_draft()


### PR DESCRIPTION
Currently when linux fails or is cancelled, the coverage test is also cancelled. This is problematic when the linux failure was a false positive or the job was cancelled accidentally. In this case the coverage must be triggered manually by providing a large number of parameters. This PR changes that so the coverage tests remains queued permanently. This means it will run whenever the linux test passes