### PR TITLE
Fix anaconda_windows problems

### DIFF
--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -27,58 +27,64 @@ runs:
         echo "FLAGS=${FLAGS}" >> $GITHUB_ENV
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
-    - name: Pytest with options (1)
-      run: python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s1_outfile.out
-      shell: ${{ inputs.shell_cmd }}
-      working-directory: ./tests
-      id: pytest_1
-    - name: if SITE_DIR is set (2)
-      run: |
-         if [ -n "${SITE_DIR}" ]; then
-            echo "Touching"
-            # Test ndarray folder update (requires parallel tests to avoid clean)
-            touch ${SITE_DIR}/pyccel/stdlib/cwrapper/cwrapper.h
-            python -m pytest -n auto -rXx ${FLAGS} -m c -k test_array_int32_1d_scalar epyccel/test_arrays.py 2>&1 | tee s2_outfile.out
-         fi
-      shell: ${{ inputs.shell_cmd }}
-      working-directory: ./tests
-      id: pytest_2
-    - name: pytest with options (3)
-      run: |
-         python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s3_outfile.out
-         pyccel-clean
-      shell: ${{ inputs.shell_cmd }}
-      working-directory: ./tests
-      id: pytest_3
-    - name: pytest with options (4)
-      run: python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s4_outfile.out
-      shell: ${{ inputs.shell_cmd }}
-      working-directory: ./tests
-      id: pytest_4
-    - name: pytest with options (5)
-      run: |
-        python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s5_outfile.out
-        pyccel-clean
-      shell: ${{ inputs.shell_cmd }}
-      working-directory: ./tests
-      id: pytest_5
-    - name: pytest ndarrays (6)
-      run: |
-        python -m pytest ndarrays/ -rXx ${FLAGS} 2>&1 | tee s6_outfile.out
-        pyccel-clean
-      shell: ${{ inputs.shell_cmd }}
-      working-directory: ./tests
-      id: pytest_6
+    #- name: Pytest with options (1)
+    #  run: python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s1_outfile.out
+    #  shell: ${{ inputs.shell_cmd }}
+    #  working-directory: ./tests
+    #  id: pytest_1
+    #- name: if SITE_DIR is set (2)
+    #  run: |
+    #     if [ -n "${SITE_DIR}" ]; then
+    #        echo "Touching"
+    #        # Test ndarray folder update (requires parallel tests to avoid clean)
+    #        touch ${SITE_DIR}/pyccel/stdlib/cwrapper/cwrapper.h
+    #        python -m pytest -n auto -rXx ${FLAGS} -m c -k test_array_int32_1d_scalar epyccel/test_arrays.py 2>&1 | tee s2_outfile.out
+    #     fi
+    #  shell: ${{ inputs.shell_cmd }}
+    #  working-directory: ./tests
+    #  id: pytest_2
+    #- name: pytest with options (3)
+    #  run: |
+    #     python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s3_outfile.out
+    #     pyccel-clean
+    #  shell: ${{ inputs.shell_cmd }}
+    #  working-directory: ./tests
+    #  id: pytest_3
+    #- name: pytest with options (4)
+    #  run: python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s4_outfile.out
+    #  shell: ${{ inputs.shell_cmd }}
+    #  working-directory: ./tests
+    #  id: pytest_4
+    #- name: pytest with options (5)
+    #  run: |
+    #    python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s5_outfile.out
+    #    pyccel-clean
+    #  shell: ${{ inputs.shell_cmd }}
+    #  working-directory: ./tests
+    #  id: pytest_5
+    #- name: pytest ndarrays (6)
+    #  run: |
+    #    python -m pytest ndarrays/ -rXx ${FLAGS} 2>&1 | tee s6_outfile.out
+    #    pyccel-clean
+    #  shell: ${{ inputs.shell_cmd }}
+    #  working-directory: ./tests
+    #  id: pytest_6
     - name: Final step
       if: always()
       id: status
-      run:
-        python ci_tools/json_pytest_output.py -t "Linux Test Summary" --tests "C tests:${{ steps.pytest_1.outcome }}:tests/s1_outfile.out" \
-                       "Verification of stdlib update:${{ steps.pytest_2.outcome }}:tests/s2_outfile.out" \
-                       "Non-parallelisable C tests:${{ steps.pytest_3.outcome }}:tests/s3_outfile.out" \
-                       "Fortran tests:${{ steps.pytest_4.outcome }}:tests/s4_outfile.out" \
-                       "Non-parallelisable Fortran tests:${{ steps.pytest_5.outcome }}:tests/s5_outfile.out" \
-                       "Ndarray tests for C stdlib:${{ steps.pytest_6.outcome }}:tests/s6_outfile.out" 
+      run: |
+        #python ci_tools/json_pytest_output.py -t "Linux Test Summary" --tests "C tests:${{ steps.pytest_1.outcome }}:tests/s1_outfile.out" \
+        #               "Verification of stdlib update:${{ steps.pytest_2.outcome }}:tests/s2_outfile.out" \
+        #               "Non-parallelisable C tests:${{ steps.pytest_3.outcome }}:tests/s3_outfile.out" \
+        #               "Fortran tests:${{ steps.pytest_4.outcome }}:tests/s4_outfile.out" \
+        #               "Non-parallelisable Fortran tests:${{ steps.pytest_5.outcome }}:tests/s5_outfile.out" \
+        #               "Ndarray tests for C stdlib:${{ steps.pytest_6.outcome }}:tests/s6_outfile.out" 
+        python ci_tools/json_pytest_output.py -t "Linux Test Summary" --tests "C tests:success:tests/s1_outfile.out" \
+                       "Verification of stdlib update:success:tests/s2_outfile.out" \
+                       "Non-parallelisable C tests:success:tests/s3_outfile.out" \
+                       "Fortran tests:success:tests/s4_outfile.out" \
+                       "Non-parallelisable Fortran tests:success:tests/s5_outfile.out" \
+                       "Ndarray tests for C stdlib:success:tests/s6_outfile.out" 
                       
       shell: ${{ inputs.shell_cmd }}
 

--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -27,64 +27,58 @@ runs:
         echo "FLAGS=${FLAGS}" >> $GITHUB_ENV
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
-    #- name: Pytest with options (1)
-    #  run: python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s1_outfile.out
-    #  shell: ${{ inputs.shell_cmd }}
-    #  working-directory: ./tests
-    #  id: pytest_1
-    #- name: if SITE_DIR is set (2)
-    #  run: |
-    #     if [ -n "${SITE_DIR}" ]; then
-    #        echo "Touching"
-    #        # Test ndarray folder update (requires parallel tests to avoid clean)
-    #        touch ${SITE_DIR}/pyccel/stdlib/cwrapper/cwrapper.h
-    #        python -m pytest -n auto -rXx ${FLAGS} -m c -k test_array_int32_1d_scalar epyccel/test_arrays.py 2>&1 | tee s2_outfile.out
-    #     fi
-    #  shell: ${{ inputs.shell_cmd }}
-    #  working-directory: ./tests
-    #  id: pytest_2
-    #- name: pytest with options (3)
-    #  run: |
-    #     python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s3_outfile.out
-    #     pyccel-clean
-    #  shell: ${{ inputs.shell_cmd }}
-    #  working-directory: ./tests
-    #  id: pytest_3
-    #- name: pytest with options (4)
-    #  run: python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s4_outfile.out
-    #  shell: ${{ inputs.shell_cmd }}
-    #  working-directory: ./tests
-    #  id: pytest_4
-    #- name: pytest with options (5)
-    #  run: |
-    #    python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s5_outfile.out
-    #    pyccel-clean
-    #  shell: ${{ inputs.shell_cmd }}
-    #  working-directory: ./tests
-    #  id: pytest_5
-    #- name: pytest ndarrays (6)
-    #  run: |
-    #    python -m pytest ndarrays/ -rXx ${FLAGS} 2>&1 | tee s6_outfile.out
-    #    pyccel-clean
-    #  shell: ${{ inputs.shell_cmd }}
-    #  working-directory: ./tests
-    #  id: pytest_6
+    - name: Pytest with options (1)
+      run: python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s1_outfile.out
+      shell: ${{ inputs.shell_cmd }}
+      working-directory: ./tests
+      id: pytest_1
+    - name: if SITE_DIR is set (2)
+      run: |
+         if [ -n "${SITE_DIR}" ]; then
+            echo "Touching"
+            # Test ndarray folder update (requires parallel tests to avoid clean)
+            touch ${SITE_DIR}/pyccel/stdlib/cwrapper/cwrapper.h
+            python -m pytest -n auto -rXx ${FLAGS} -m c -k test_array_int32_1d_scalar epyccel/test_arrays.py 2>&1 | tee s2_outfile.out
+         fi
+      shell: ${{ inputs.shell_cmd }}
+      working-directory: ./tests
+      id: pytest_2
+    - name: pytest with options (3)
+      run: |
+         python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and c ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s3_outfile.out
+         pyccel-clean
+      shell: ${{ inputs.shell_cmd }}
+      working-directory: ./tests
+      id: pytest_3
+    - name: pytest with options (4)
+      run: python -m pytest -n auto -rXx ${FLAGS} -m "not (parallel or xdist_incompatible) and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s4_outfile.out
+      shell: ${{ inputs.shell_cmd }}
+      working-directory: ./tests
+      id: pytest_4
+    - name: pytest with options (5)
+      run: |
+        python -m pytest -rXx ${FLAGS} -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" --ignore=symbolic --ignore=ndarrays 2>&1 | tee s5_outfile.out
+        pyccel-clean
+      shell: ${{ inputs.shell_cmd }}
+      working-directory: ./tests
+      id: pytest_5
+    - name: pytest ndarrays (6)
+      run: |
+        python -m pytest ndarrays/ -rXx ${FLAGS} 2>&1 | tee s6_outfile.out
+        pyccel-clean
+      shell: ${{ inputs.shell_cmd }}
+      working-directory: ./tests
+      id: pytest_6
     - name: Final step
       if: always()
       id: status
-      run: |
-        #python ci_tools/json_pytest_output.py -t "Linux Test Summary" --tests "C tests:${{ steps.pytest_1.outcome }}:tests/s1_outfile.out" \
-        #               "Verification of stdlib update:${{ steps.pytest_2.outcome }}:tests/s2_outfile.out" \
-        #               "Non-parallelisable C tests:${{ steps.pytest_3.outcome }}:tests/s3_outfile.out" \
-        #               "Fortran tests:${{ steps.pytest_4.outcome }}:tests/s4_outfile.out" \
-        #               "Non-parallelisable Fortran tests:${{ steps.pytest_5.outcome }}:tests/s5_outfile.out" \
-        #               "Ndarray tests for C stdlib:${{ steps.pytest_6.outcome }}:tests/s6_outfile.out" 
-        python ci_tools/json_pytest_output.py -t "Linux Test Summary" --tests "C tests:success:tests/s1_outfile.out" \
-                       "Verification of stdlib update:success:tests/s2_outfile.out" \
-                       "Non-parallelisable C tests:success:tests/s3_outfile.out" \
-                       "Fortran tests:success:tests/s4_outfile.out" \
-                       "Non-parallelisable Fortran tests:success:tests/s5_outfile.out" \
-                       "Ndarray tests for C stdlib:success:tests/s6_outfile.out" 
+      run:
+        python ci_tools/json_pytest_output.py -t "Linux Test Summary" --tests "C tests:${{ steps.pytest_1.outcome }}:tests/s1_outfile.out" \
+                       "Verification of stdlib update:${{ steps.pytest_2.outcome }}:tests/s2_outfile.out" \
+                       "Non-parallelisable C tests:${{ steps.pytest_3.outcome }}:tests/s3_outfile.out" \
+                       "Fortran tests:${{ steps.pytest_4.outcome }}:tests/s4_outfile.out" \
+                       "Non-parallelisable Fortran tests:${{ steps.pytest_5.outcome }}:tests/s5_outfile.out" \
+                       "Ndarray tests for C stdlib:${{ steps.pytest_6.outcome }}:tests/s6_outfile.out" 
                       
       shell: ${{ inputs.shell_cmd }}
 

--- a/.github/workflows/anaconda_linux.yml
+++ b/.github/workflows/anaconda_linux.yml
@@ -87,3 +87,4 @@ jobs:
         if: always()
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}
+        shell: 'bash -l {0}'

--- a/.github/workflows/anaconda_linux.yml
+++ b/.github/workflows/anaconda_linux.yml
@@ -40,16 +40,16 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           python-version: ${{ inputs.python_version }}
+      - name: Install python dependencies
+        uses: ./.github/actions/conda_installation
+        with:
+          mpi_type: openmpi
       - name: "Setup"
         id: token
         run: |
           pip install jwt requests
           python ci_tools/setup_check_run.py
         shell: bash -l {0}
-      - name: Install python dependencies
-        uses: ./.github/actions/conda_installation
-        with:
-          mpi_type: openmpi
       - name: Coverage install
         uses: ./.github/actions/coverage_install
         with:

--- a/.github/workflows/anaconda_linux.yml
+++ b/.github/workflows/anaconda_linux.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           pip install jwt requests
           python ci_tools/setup_check_run.py
-        shell: 'bash -l {0}'
+        shell: bash -l {0}
       - name: Install python dependencies
         uses: ./.github/actions/conda_installation
         with:
@@ -87,4 +87,4 @@ jobs:
         if: always()
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}
-        shell: 'bash -l {0}'
+        shell: bash -l {0}

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -43,28 +43,31 @@ jobs:
         run: |
           python -m pip install jwt requests
           python ci_tools/setup_check_run.py
+          which python
         shell: 'bash -l -eo pipefail {0}'
-      - name: Install dependencies
-        uses: ./.github/actions/windows_install
-      - name: Install python dependencies
-        uses: ./.github/actions/conda_installation
-        with:
-          mpi_type: msmpi
-      - name: Fortran/C tests with pytest
-        id: f_c_pytest
-        timeout-minutes: 60
-        uses: ./.github/actions/pytest_run
-        with:
-          shell_cmd: 'bash -l -eo pipefail {0}'
-          pytest_mark: 'and not external'
-      - name: Python tests with pytest
-        id: python_pytest
-        timeout-minutes: 20
-        uses: ./.github/actions/pytest_run_python
-        with:
-          shell_cmd: 'bash -l -eo pipefail {0}'
+      #- name: Install dependencies
+      #  uses: ./.github/actions/windows_install
+      #- name: Install python dependencies
+      #  uses: ./.github/actions/conda_installation
+      #  with:
+      #    mpi_type: msmpi
+      #- name: Fortran/C tests with pytest
+      #  id: f_c_pytest
+      #  timeout-minutes: 60
+      #  uses: ./.github/actions/pytest_run
+      #  with:
+      #    shell_cmd: 'bash -l -eo pipefail {0}'
+      #    pytest_mark: 'and not external'
+      #- name: Python tests with pytest
+      #  id: python_pytest
+      #  timeout-minutes: 20
+      #  uses: ./.github/actions/pytest_run_python
+      #  with:
+      #    shell_cmd: 'bash -l -eo pipefail {0}'
       - name: "Post completed"
         if: always()
         run:
+          which python
+          python --version
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }}
         shell: 'bash -l -eo pipefail {0}'

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: "Setup"
         id: token
         run: |
-          pip install jwt requests
+          python -m pip install jwt requests
           python ci_tools/setup_check_run.py
         shell: 'bash -l -eo pipefail {0}'
       - name: Install dependencies
@@ -67,3 +67,4 @@ jobs:
         if: always()
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }}
+        shell: 'bash -l -eo pipefail {0}'

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -38,19 +38,18 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           python-version: ${{ inputs.python_version }}
-      - name: "Setup"
-        id: token
-        run: |
-          python -m pip install jwt requests
-          python ci_tools/setup_check_run.py
-          which python
-        shell: bash -l -eo pipefail {0}
       - name: Install dependencies
         uses: ./.github/actions/windows_install
       - name: Install python dependencies
         uses: ./.github/actions/conda_installation
         with:
           mpi_type: msmpi
+      - name: "Setup"
+        id: token
+        run: |
+          python -m pip install jwt requests
+          python ci_tools/setup_check_run.py
+        shell: bash -l -eo pipefail {0}
       - name: Fortran/C tests with pytest
         id: f_c_pytest
         timeout-minutes: 60

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -45,25 +45,25 @@ jobs:
           python ci_tools/setup_check_run.py
           which python
         shell: bash -l -eo pipefail {0}
-      #- name: Install dependencies
-      #  uses: ./.github/actions/windows_install
-      #- name: Install python dependencies
-      #  uses: ./.github/actions/conda_installation
-      #  with:
-      #    mpi_type: msmpi
-      #- name: Fortran/C tests with pytest
-      #  id: f_c_pytest
-      #  timeout-minutes: 60
-      #  uses: ./.github/actions/pytest_run
-      #  with:
-      #    shell_cmd: 'bash -l -eo pipefail {0}'
-      #    pytest_mark: 'and not external'
-      #- name: Python tests with pytest
-      #  id: python_pytest
-      #  timeout-minutes: 20
-      #  uses: ./.github/actions/pytest_run_python
-      #  with:
-      #    shell_cmd: 'bash -l -eo pipefail {0}'
+      - name: Install dependencies
+        uses: ./.github/actions/windows_install
+      - name: Install python dependencies
+        uses: ./.github/actions/conda_installation
+        with:
+          mpi_type: msmpi
+      - name: Fortran/C tests with pytest
+        id: f_c_pytest
+        timeout-minutes: 60
+        uses: ./.github/actions/pytest_run
+        with:
+          shell_cmd: 'bash -l -eo pipefail {0}'
+          pytest_mark: 'and not external'
+      - name: Python tests with pytest
+        id: python_pytest
+        timeout-minutes: 20
+        uses: ./.github/actions/pytest_run_python
+        with:
+          shell_cmd: 'bash -l -eo pipefail {0}'
       - name: "Post completed"
         if: always()
         run: |

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -44,7 +44,7 @@ jobs:
           python -m pip install jwt requests
           python ci_tools/setup_check_run.py
           which python
-        shell: 'bash -l -eo pipefail {0}'
+        shell: bash -l -eo pipefail {0}
       #- name: Install dependencies
       #  uses: ./.github/actions/windows_install
       #- name: Install python dependencies
@@ -66,8 +66,8 @@ jobs:
       #    shell_cmd: 'bash -l -eo pipefail {0}'
       - name: "Post completed"
         if: always()
-        run:
+        run: |
           which python
           python --version
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }}
-        shell: 'bash -l -eo pipefail {0}'
+        shell: bash -l -eo pipefail {0}


### PR DESCRIPTION
Fix the shell command to ensure the Python installed by anaconda is used for posting results. Reorder the setup so pip is called after conda (conda does not check pip dependencies). Fixes #1480 