### PR TITLE
[BOT] Fix docs for ci_tools

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,7 +66,6 @@ jobs:
         uses: ./compare/.github/actions/linux_install
       - name: Setup imports
         run: |
-          echo "PYTHONPATH=$(pwd)/compare" >> $GITHUB_ENV
           cd compare
           pip3 install .[test]
           cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,13 +55,15 @@ jobs:
           cd compare
           python ../base/ci_tools/setup_check_run.py
           cd ..
-      - name: Install python dependencies
+      - name: Install python CI dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install docstr-coverage
           python -m pip install numpydoc
           python -m pip install defusedxml requests jwt # All imported modules must be available for numpydoc
         shell: bash
+      - name: Install dependencies
+        uses: ./.github/actions/linux_install
       - name: Setup imports
         run: |
           echo "PYTHONPATH=$(pwd)/compare" >> $GITHUB_ENV

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python_version }}
-      - name: "Setup"
+      - name: "Setup check run"
         id: token
         run: |
           pip install jwt requests
@@ -60,11 +60,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install docstr-coverage
           python -m pip install numpydoc
-          python -m pip install defusedxml requests jwt # All imported modules must be available for numpydoc
+          python -m pip install defusedxml # All imported modules must be available for numpydoc
         shell: bash
       - name: Install dependencies
         uses: ./compare/.github/actions/linux_install
-      - name: Setup imports
+      - name: Install python dependencies for pyccel and tests
         run: |
           cd compare
           pip3 install .[test]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,19 +85,22 @@ jobs:
           git checkout ${{ inputs.base }} # Make sure there is a local copy in case of a branch
           git checkout ${{ env.COMMIT }}
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
-          python ../base/ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt ci_objects.txt
+          python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt ci_objects.txt
           touch report.txt
           while read line; do
-            python -m numpydoc --validate $line >> report.txt 2>&1 || true 
+            echo "python -m numpydoc --validate $line"
+            python -m numpydoc --validate $line 2>&1 | tee report.txt || true 
           done < objects.txt
+          echo "cd ci_tools"
           cd ci_tools
           while read line; do
-            python -m numpydoc --validate $line >> ../report.txt 2>&1 || true 
+            echo "python -m numpydoc --validate $line"
+            python -m numpydoc --validate $line 2>&1 | tee ../report.txt || true 
           done < ../ci_objects.txt
           cd ..
           cat report.txt
           cd ..
-          python base/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
+          python compare/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
         if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -88,20 +88,12 @@ jobs:
           git checkout ${{ inputs.base }} # Make sure there is a local copy in case of a branch
           git checkout ${{ env.COMMIT }}
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
-          python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt ci_objects.txt
+          python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
           while read line; do
             echo "python -m numpydoc --validate $line"
             python -m numpydoc --validate $line 2>&1 | tee report.txt || true 
           done < objects.txt
-          echo "cd ci_tools"
-          cd ci_tools
-          while read line; do
-            echo "python -m numpydoc --validate $line"
-            python -m numpydoc --validate $line 2>&1 | tee ../report.txt || true 
-          done < ../ci_objects.txt
-          cd ..
-          cat report.txt
           cd ..
           python compare/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,7 +63,7 @@ jobs:
           python -m pip install defusedxml requests jwt # All imported modules must be available for numpydoc
         shell: bash
       - name: Install dependencies
-        uses: ./.github/actions/linux_install
+        uses: ./compare/.github/actions/linux_install
       - name: Setup imports
         run: |
           echo "PYTHONPATH=$(pwd)/compare" >> $GITHUB_ENV

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -94,7 +94,7 @@ jobs:
             python -m numpydoc --validate $line 2>&1 | tee report.txt || true 
           done < objects.txt
           cd ..
-          python coverage/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
+          python compare/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
         if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,12 +60,13 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install docstr-coverage
           python -m pip install numpydoc
+          python -m pip install defusedxml requests jwt # All imported modules must be available for numpydoc
         shell: bash
       - name: Setup imports
         run: |
           echo "PYTHONPATH=$(pwd)/compare" >> $GITHUB_ENV
           cd compare
-          pip3 install .
+          pip3 install .[test]
           cd ..
         shell: bash
       - name: Check doc coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,14 +87,14 @@ jobs:
           git checkout ${{ inputs.base }} # Make sure there is a local copy in case of a branch
           git checkout ${{ env.COMMIT }}
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
-          python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
+          python ../base/ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
           while read line; do
             echo "python -m numpydoc --validate $line"
             python -m numpydoc --validate $line 2>&1 | tee report.txt || true 
           done < objects.txt
           cd ..
-          python compare/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
+          python base/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
         if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,14 +87,14 @@ jobs:
           git checkout ${{ inputs.base }} # Make sure there is a local copy in case of a branch
           git checkout ${{ env.COMMIT }}
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
-          python ../base/ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
+          python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
           while read line; do
             echo "python -m numpydoc --validate $line"
             python -m numpydoc --validate $line 2>&1 | tee report.txt || true 
           done < objects.txt
           cd ..
-          python base/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
+          python coverage/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
         if: always()

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -417,17 +417,21 @@ class Bot:
         print("Checking : ", name)
         if key in ('linux', 'windows', 'macosx', 'anaconda_linux', 'anaconda_windows', 'coverage'):
             has_relevant_change = lambda diff: any((f.startswith('pyccel/') or f.startswith('tests/')) \
-                                                    and f.endswith('.py') for f in diff) #pylint: disable=unnecessary-lambda-assignment
+                                                    and f.endswith('.py') and f != 'pyccel/version.py' \
+                                                    for f in diff) #pylint: disable=unnecessary-lambda-assignment
         elif key in ('pyccel_lint'):
-            has_relevant_change = lambda diff: any(f.startswith('pyccel/') and f.endswith('.py') for f in diff) #pylint: disable=unnecessary-lambda-assignment
+            has_relevant_change = lambda diff: any(f.startswith('pyccel/') and f.endswith('.py') \
+                                                    and f != 'pyccel/version.py' for f in diff) #pylint: disable=unnecessary-lambda-assignment
         elif key in ('pylint'):
-            has_relevant_change = lambda diff: any(f.endswith('parser/semantic.py') for f in diff) #pylint: disable=unnecessary-lambda-assignment
+            has_relevant_change = lambda diff: any(f == 'pyccel/parser/semantic.py' for f in diff) #pylint: disable=unnecessary-lambda-assignment
         elif key in ('docs'):
-            has_relevant_change = lambda diff: any(f.endswith('.py') for f in diff) #pylint: disable=unnecessary-lambda-assignment
+            has_relevant_change = lambda diff: any(f.endswith('.py') and f != 'pyccel/version.py' \
+                                                    for f in diff) #pylint: disable=unnecessary-lambda-assignment
         elif key in ('spelling'):
             has_relevant_change = lambda diff: any(f.endswith('.md') for f in diff) #pylint: disable=unnecessary-lambda-assignment
         elif key in ('pickle', 'pickle_wheel', 'editable_pickle'):
-            has_relevant_change = lambda diff: any(f.startswith('pyccel/') and f.endswith('.py') for f in diff) #pylint: disable=unnecessary-lambda-assignment
+            has_relevant_change = lambda diff: any(f.startswith('pyccel/') and f.endswith('.py') \
+                                                    and f != 'pyccel/version.py' for f in diff) #pylint: disable=unnecessary-lambda-assignment
         else:
             raise NotImplementedError(f"Please update for new has_relevant_change : {key}")
 

--- a/ci_tools/coverage_analysis_tools.py
+++ b/ci_tools/coverage_analysis_tools.py
@@ -137,8 +137,8 @@ def allow_untested_error_calls(untested):
     Takes a dictionary describing untested lines and returns an
     equivalent dictionary without lines designed to raise errors.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     untested : dict
             A dictionary whose keys are the files in pyccel with
             untested lines which have been added in this branch
@@ -156,7 +156,10 @@ def allow_untested_error_calls(untested):
         with open(f, encoding="utf-8") as filename:
             f_lines = filename.readlines()
         untested_lines = [(i, f_lines[i-1].strip()) for i in line_nums]
-        lines = [i for i,l in untested_lines if not (l.startswith('raise ') or l.startswith('errors.report(') or l.startswith('return errors.report('))]
+        lines = [i for i,l in untested_lines if not (l.startswith('raise ') or \
+                                                     l.startswith('errors.report(') or \
+                                                     l.startswith('return errors.report(') or \
+                                                     l.startswith('except'))]
         if len(lines):
             reduced_untested[f] = lines
 

--- a/ci_tools/list_docs_tovalidate.py
+++ b/ci_tools/list_docs_tovalidate.py
@@ -72,7 +72,6 @@ if __name__ == '__main__':
             objects = []
             to_visit = list(ast.iter_child_nodes(tree))
             for node in to_visit:
-                print(node)
                 # This loop walks the ast and explores all objects
                 # present in the file.
                 # If the object is an instance of a FunctionDef or

--- a/ci_tools/list_docs_tovalidate.py
+++ b/ci_tools/list_docs_tovalidate.py
@@ -72,14 +72,14 @@ if __name__ == '__main__':
             objects = []
             to_visit = list(ast.iter_child_nodes(tree))
             for node in to_visit:
-                # This loop walks the ast and explores all objects
+                # This loop walks the AST and explores all objects
                 # present in the file.
                 # If the object is an instance of a FunctionDef or
                 # a ClassDef, a check is performed to see if any of
                 # the updated lines are present within the object.
-                # Additionally, The name of all objects present
+                # Additionally, the name of all objects present
                 # inside a function or a class is updated to include
-                # the name of the parent object
+                # the name of the parent object.
                 if isinstance(node, (FunctionDef, ClassDef)):
                     if should_ignore('.'.join([prefix, node.name])):
                         continue

--- a/ci_tools/list_docs_tovalidate.py
+++ b/ci_tools/list_docs_tovalidate.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
                 else:
                     changes[file] = [int(line_no)]
 
-    for changes, output in zip([pkg_changes, ci_changes], [args.output, args.ci_output]):
+    for changes, output, rel_path in zip([pkg_changes, ci_changes], [args.output, args.ci_output], ['', 'ci_tools']):
         with open(output, 'w', encoding="utf-8") as f:
             for file, line_nos in changes.items():
                 with open(file, 'r', encoding="utf-8") as ast_file:
@@ -74,7 +74,7 @@ if __name__ == '__main__':
                 # objects in the file.
                 # for example: the objects in the file pyccel/ast/core.py will
                 # have the prefix pyccel.ast.core
-                prefix = '.'.join(PurePath(file).with_suffix('').parts)
+                prefix = '.'.join(PurePath(file).relative_to(rel_path).with_suffix('').parts)
 
                 objects = []
                 to_visit = list(ast.iter_child_nodes(tree))

--- a/ci_tools/list_docs_tovalidate.py
+++ b/ci_tools/list_docs_tovalidate.py
@@ -45,61 +45,54 @@ if __name__ == '__main__':
                         help='Output of git diff between PR branch and base branch')
     parser.add_argument('output', metavar='output', type=str,
                         help='File to save the output to')
-    parser.add_argument('ci_output', metavar='ci_output', type=str,
-                        help='File to save the output to for the ci_tools folder')
     args = parser.parse_args()
 
     results = get_diff_as_json(args.gitdiff)
-    pkg_changes = {}
-    ci_changes = {}
+    changes = {}
     for file, upds in results.items():
         filepath = PurePath(file)
         if filepath.parts[0] != 'tests' and filepath.suffix == '.py':
-            if filepath.parts[0] == 'ci_tools':
-                changes = ci_changes
-            else:
-                changes = pkg_changes
             for line_no in upds['addition']:
                 if file in changes:
                     changes[file].append(int(line_no))
                 else:
                     changes[file] = [int(line_no)]
 
-    for changes, output, rel_path in zip([pkg_changes, ci_changes], [args.output, args.ci_output], ['', 'ci_tools']):
-        with open(output, 'w', encoding="utf-8") as f:
-            for file, line_nos in changes.items():
-                with open(file, 'r', encoding="utf-8") as ast_file:
-                    tree = ast.parse(ast_file.read())
-                # The prefix variable stores the absolute dotted prefix of all
-                # objects in the file.
-                # for example: the objects in the file pyccel/ast/core.py will
-                # have the prefix pyccel.ast.core
-                prefix = '.'.join(PurePath(file).relative_to(rel_path).with_suffix('').parts)
+    output = args.output
+    with open(output, 'w', encoding="utf-8") as f:
+        for file, line_nos in changes.items():
+            with open(file, 'r', encoding="utf-8") as ast_file:
+                tree = ast.parse(ast_file.read())
+            # The prefix variable stores the absolute dotted prefix of all
+            # objects in the file.
+            # for example: the objects in the file pyccel/ast/core.py will
+            # have the prefix pyccel.ast.core
+            prefix = '.'.join(PurePath(file).with_suffix('').parts)
 
-                objects = []
-                to_visit = list(ast.iter_child_nodes(tree))
-                for node in to_visit:
-                    print(node)
-                    # This loop walks the ast and explores all objects
-                    # present in the file.
-                    # If the object is an instance of a FunctionDef or
-                    # a ClassDef, a check is performed to see if any of
-                    # the updated lines are present within the object.
-                    # Additionally, The name of all objects present
-                    # inside a function or a class is updated to include
-                    # the name of the parent object
-                    if isinstance(node, (FunctionDef, ClassDef)):
-                        if should_ignore('.'.join([prefix, node.name])):
-                            continue
-                        if any((node.lineno <= x <= node.end_lineno
-                                for x in line_nos)):
-                            objects.append('.'.join([prefix, node.name]))
-                        if isinstance(node, ClassDef):
-                            obj_pref = node.name
-                            for child in node.body:
-                                if isinstance(child, (FunctionDef, ClassDef)):
-                                    child.name = '.'.join([obj_pref, child.name])
-                                    to_visit.append(child)
+            objects = []
+            to_visit = list(ast.iter_child_nodes(tree))
+            for node in to_visit:
+                print(node)
+                # This loop walks the ast and explores all objects
+                # present in the file.
+                # If the object is an instance of a FunctionDef or
+                # a ClassDef, a check is performed to see if any of
+                # the updated lines are present within the object.
+                # Additionally, The name of all objects present
+                # inside a function or a class is updated to include
+                # the name of the parent object
+                if isinstance(node, (FunctionDef, ClassDef)):
+                    if should_ignore('.'.join([prefix, node.name])):
+                        continue
+                    if any((node.lineno <= x <= node.end_lineno
+                            for x in line_nos)):
+                        objects.append('.'.join([prefix, node.name]))
+                    if isinstance(node, ClassDef):
+                        obj_pref = node.name
+                        for child in node.body:
+                            if isinstance(child, (FunctionDef, ClassDef)):
+                                child.name = '.'.join([obj_pref, child.name])
+                                to_visit.append(child)
 
-                for obj in objects:
-                    print(obj, file=f)
+            for obj in objects:
+                print(obj, file=f)

--- a/ci_tools/process_results.py
+++ b/ci_tools/process_results.py
@@ -52,8 +52,9 @@ if __name__ == '__main__':
             else:
                 level = None
                 parsing_errors.append(line)
-            print(code, msg)
+            print(code)
             if level == 'failure':
+                print(msg)
                 file, start, end = get_code_file_and_lines(file_name, pyccel_folder = pyccel_folder)
                 # if code isn't "The object does not have a docstring"
                 if code != 'GL08':


### PR DESCRIPTION
Coverage should not raise an issue if an `except` statement is not covered (we do not enforce coverage for error statements such as `raise` and `errors.report`, this is similar and the body of the `except` clause will still raise an issue if anything more complex is used). This PR adds `except` to the exceptions.

Correcting this leads to an error with the documentation. The error arises because `numpydoc` imports all files that it tests so all possible dependencies must be installed. This is corrected in this PR. This issue has previously been misunderstood and fixed by trying to import from different locations. The unnecessary code is therefore removed.

The tests were triggering manually on this branch to ensure it can pass and to test the fix.