### PR TITLE
Add warnings to Type specification deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to this project will be documented in this file.
 
 ### Deprecated
 
+-   Using a `@types` decorator will raise a `FutureWarning` as this will be deprecated in a future version.
+-   Using a type sepcification header will raise a `FutureWarning` as this will be deprecated in a future version.
 -   \[INTERNALS\] Removed `obsolete` folder.
 -   \[INTERNALS\] Removed out of date `samples` folder.
 -   \[INTERNALS\] Removed out of date `doc` folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 
 -   Using a `@types` decorator will raise a `FutureWarning` as this will be deprecated in a future version.
--   Using a type sepcification header will raise a `FutureWarning` as this will be deprecated in a future version.
+-   Using a type specification header will raise a `FutureWarning` as this will be deprecated in a future version.
 -   \[INTERNALS\] Removed `obsolete` folder.
 -   \[INTERNALS\] Removed out of date `samples` folder.
 -   \[INTERNALS\] Removed out of date `doc` folder.

--- a/docs/function-pointers-as-arguments.md
+++ b/docs/function-pointers-as-arguments.md
@@ -79,16 +79,6 @@ module boo
 end module boo
 ```
 
-Here is the version using a function-header:
-
-```Python
-#$ header function high_int_int_1((int)(int), (int)(int), int)
-def high_int_int_1(function1, function2, a):
-    x = function1(a)
-    y = function2(a)
-    return x + y
-```
-
 Here is the generated C code:
 
 ```C

--- a/docs/header-files.md
+++ b/docs/header-files.md
@@ -1,5 +1,7 @@
 # Header files
 
+**Warning** : We intend to replace header files with [stub files](https://www.python.org/dev/peps/pep-0484/#stub-files) at some point.
+
 ## Using header files
 
 A header file in Pyccel is a file with a name ending with `.pyh`, which contains function/variable declarations, macro definitions, templates and metavariable declarations.\

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,76 +1,32 @@
 # Headers and Decorators
 
 ## Template
-### Templates using header comments
 A **template** in Pyccel, is used to allow the same function to take arguments of different types from a selection of types the user specifies.
 #### The usage
 In this example the argument **a**, could either be an integer or float, and the same for the argument **b**:
 ```python
-#$ header template T(int|real)
-#$ header template Z(int|real)
-#$ header function f(T, Z)
-def f(a,b):
-	pass
+from pyccel.decorators import template
+@template('T', types=[int, float])
+@template('Z', types=[int, float])
+def f(a : 'T', b : 'Z'):
+    pass
 ```
 In this example The arguments **a** and **b**, should both be integers or floats at the same time:
 ```python
-#$ header template T(int|real)
-#$ header function f(T, T)
-def f(a,b):
-	pass
+from pyccel.decorators import template
+@template('T', types=[int, float])
+def f(a : 'T', b : 'T'):
+    pass
 ```
-When a function is declared using a header comment as above:
--   The function can access the templates declared in its parent's scopes.
--   A template declared in the same scope as the function overrides any template with the same name in the parent's scopes.
-#### Examples
-In this example the template **T** can be used to define the arguments types of the nested function **f2**:
-```python
-#$ header template T(int|real)
-def f1():
-	#$ header f2(T, T)
-	def f2(a, b):
-		pass
-	pass
-```
-In this example the arguments of **f2** can either be boolean or complex, they can not be integer or float:
-```python
-#$ header template T(int|real)
-def f1():
-	#$ header template T(bool|complex)
-	#$ header f2(T, T)
-	def f2(a, b):
-		pass
-	pass
-```
-### Templates using decorators
-#### The usage
-```python
-from pyccel.decorators import types, template
-@types('T', 'T')
-@template(name='T', types=['int','real'])
-def f(a,b):
-	pass
-```
-Arguments:
--   name: the name of the template
--   types: the types the template represents.
----
-*Note:*
-The arguments **name** and **types** could also be passed of the form
-`@template(T, types=['int', 'real'])` without specifying the keywords.and the order in which the decorators are called is not important.
-
----
 When  a function is decorated with the template decorator:
 -   The templates are only available to the decorated function.
--   The templates overrides any existing templates with the same name (declared as header comment).
 -   If the function is decorated with two templates with the same name, the first one gets overridden.
 ##### Examples
 In this example the arguments of **f** can either be boolean or complex, they can not be integer or float.
 ```python
-from pyccel.decorators import types, template
-#$ header template T(int|real)
-@types('T', 'T')
+from pyccel.decorators import template
+@template(name='T', types=['int','float'])
 @template(name='T', types=['bool','complex'])
-def f(a,b):
-  pass
+def f(a : 'T', b : 'T'):
+    pass
 ```

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -9,7 +9,7 @@ In this example the argument **a**, could either be an integer or float, and the
 from pyccel.decorators import template
 @template(name='T', types=['int','float'])
 @template(name='Z', types=['int','float'])
-def f(a : 'T', b : 'T'):
+def f(a : 'T', b : 'Z'):
 	pass
 ```
 In this example the arguments **a** and **b**, should both be integers or floats at the same time:

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -53,7 +53,11 @@ def types(*args, results = None):
     results : str or type, optional
         The return type of the function.
     """
-    warnings.warn("The @types decorator will be removed in a future version of Pyccel. Please use type hints. The @template decorator can be used to specify multiple types", FutureWarning)
+    warnings.warn("The @types decorator will be removed in a future version of " +
+                  "Pyccel. Please use type hints. The @template decorator can be " +
+                  "used to specify multiple types. See the documentation at " +
+                  "https://github.com/pyccel/pyccel/blob/devel/docs/quickstart.md#type-annotations"
+                  "for examples.", FutureWarning)
     def identity(f):
         return f
     return identity

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -52,6 +52,11 @@ def types(*args, results = None):
 
     results : str or type, optional
         The return type of the function.
+
+    Returns
+    -------
+    decorator
+        The identity decorator which will not modify the function.
     """
     warnings.warn("The @types decorator will be removed in a future version of " +
                   "Pyccel. Please use type hints. The @template decorator can be " +

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -6,8 +6,7 @@
 """
 This module contains all the provided decorator methods.
 """
-
-#TODO use pycode and call exec after that in lambdify
+import warnings
 
 __all__ = (
     'allow_negative_index',
@@ -40,7 +39,21 @@ def sympy(f):
 def bypass(f):
     return f
 
-def types(*args,**kw):
+def types(*args, results = None):
+    """
+    Specify the types passed to the function.
+
+    Specify the types passed to the function.
+
+    Parameters
+    ----------
+    *args : tuple of str or types
+        The types of the arguments of the function.
+
+    results : str or type, optional
+        The return type of the function.
+    """
+    warnings.warn("The @types decorator will be removed in a future version of Pyccel. Please use type hints. The @template decorator can be used to specify multiple types", FutureWarning)
     def identity(f):
         return f
     return identity

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3075,8 +3075,9 @@ class SemanticParser(BasicParser):
     def _visit_VariableHeader(self, expr):
         warnings.warn("Support for specifying types via headers will be removed in " +
                       "a future version of Pyccel. This annotation may be unnecessary " +
-                      "in your code. If you find it is necessary please open an issue " +
-                      "so we do not remove support until an alternative is in place.", FutureWarning)
+                      "in your code. If you find it is necessary please open a discussion " +
+                      "at https://github.com/pyccel/pyccel/discussions so we do not " +
+                      "remove support until an alternative is in place.", FutureWarning)
 
         # TODO improve
         #      move it to the ast like create_definition for FunctionHeader?

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3094,7 +3094,10 @@ class SemanticParser(BasicParser):
     def _visit_FunctionHeader(self, expr):
         warnings.warn("Support for specifying types via headers will be removed in a " +
                       "future version of Pyccel. Please use type hints. The @template " +
-                      "decorator can be used to specify multiple types", FutureWarning)
+                      "decorator can be used to specify multiple types. See the " +
+                      "documentation at " +
+                      "https://github.com/pyccel/pyccel/blob/devel/docs/quickstart.md#type-annotations " +
+                      "for examples.", FutureWarning)
         # TODO should we return it and keep it in the AST?
         expr.clear_syntactic_user_nodes()
         expr.update_pyccel_staging()
@@ -3103,7 +3106,10 @@ class SemanticParser(BasicParser):
 
     def _visit_Template(self, expr):
         warnings.warn("Support for specifying templates via headers will be removed in " +
-                      "a future version of Pyccel. Please use the @template decorator", FutureWarning)
+                      "a future version of Pyccel. Please use the @template decorator. " +
+                      "See the documentatiosn at " +
+                      "https://github.com/pyccel/pyccel/blob/devel/docs/templates.md " +
+                      "for examples.", FutureWarning)
         expr.clear_syntactic_user_nodes()
         expr.update_pyccel_staging()
         self.scope.insert_template(expr)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -8,6 +8,7 @@ See the developer docs for more details
 """
 
 from itertools import chain
+import warnings
 
 from sympy.utilities.iterables import iterable as sympy_iterable
 
@@ -3072,6 +3073,10 @@ class SemanticParser(BasicParser):
             return IfTernaryOperator(cond, value_true, value_false)
 
     def _visit_VariableHeader(self, expr):
+        warnings.warn("Support for specifying types via headers will be removed in " +
+                      "a future version of Pyccel. This annotation may be unnecessary " +
+                      "in your code. If you find it is necessary please open an issue " +
+                      "so we do not remove support until an alternative is in place.", FutureWarning)
 
         # TODO improve
         #      move it to the ast like create_definition for FunctionHeader?
@@ -3086,6 +3091,9 @@ class SemanticParser(BasicParser):
         return expr
 
     def _visit_FunctionHeader(self, expr):
+        warnings.warn("Support for specifying types via headers will be removed in a " +
+                      "future version of Pyccel. Please use type hints. The @template " +
+                      "decorator can be used to specify multiple types", FutureWarning)
         # TODO should we return it and keep it in the AST?
         expr.clear_syntactic_user_nodes()
         expr.update_pyccel_staging()
@@ -3093,6 +3101,8 @@ class SemanticParser(BasicParser):
         return expr
 
     def _visit_Template(self, expr):
+        warnings.warn("Support for specifying templates via headers will be removed in " +
+                      "a future version of Pyccel. Please use the @template decorator", FutureWarning)
         expr.clear_syntactic_user_nodes()
         expr.update_pyccel_staging()
         self.scope.insert_template(expr)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -8,6 +8,7 @@ import os
 import re
 
 import ast
+import warnings
 
 #==============================================================================
 
@@ -646,18 +647,21 @@ class SyntaxParser(BasicParser):
         for a in arguments:
             annotated_args.append(a.annotation)
 
-        if all(not isinstance(a, Nil) for a in annotated_args):
-            if stmt.returns:
-                returns = FunctionCallArgument(self._visit(stmt.returns), keyword='results')
-                annotated_args.append(returns)
-            decorators['types'] = [FunctionCall('types', annotated_args)]
-
         for d in self._visit(stmt.decorator_list):
             tmp_var = d if isinstance(d, PyccelSymbol) else d.funcdef
             if tmp_var in decorators:
                 decorators[tmp_var] += [d]
             else:
                 decorators[tmp_var] = [d]
+
+        if 'types' in decorators:
+            warnings.warn("The @types decorator will be removed in a future version of Pyccel. Please use type hints. The @template decorator can be used to specify multiple types", FutureWarning)
+
+        if all(not isinstance(a, Nil) for a in annotated_args):
+            if stmt.returns:
+                returns = FunctionCallArgument(self._visit(stmt.returns), keyword='results')
+                annotated_args.append(returns)
+            decorators.setdefault('types', []).append(FunctionCall('types', annotated_args))
 
         if 'bypass' in decorators:
             return EmptyNode()


### PR DESCRIPTION
Phase 1 of issue #1487 . `FutureWarning`s are added to the code to warn users to adapt their code before future breaking changes.

Should be merged after #1470