### PR TITLE
Fix passing temporary arrays to functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 -   #682 : Wrong data layout when copying a slice of an array.
 -   #1453 : Fix error-level developer mode output.
+-   #1499 : Fix passing temporary arrays to functions.
 -   \[INTERNALS\] Fix string base class selection.
 
 ### Changed

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -96,7 +96,7 @@ from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Con
                             OMP_TaskLoop_Construct, OMP_Sections_Construct, Omp_End_Clause,
                             OMP_Single_Construct)
 
-from pyccel.ast.operators import PyccelArithmeticOperator, PyccelIs, PyccelIsNot, IfTernaryOperator, PyccelUnarySub
+from pyccel.ast.operators import PyccelIs, PyccelIsNot, IfTernaryOperator, PyccelUnarySub
 from pyccel.ast.operators import PyccelNot, PyccelEq, PyccelAdd, PyccelMul, PyccelPow
 from pyccel.ast.operators import PyccelAssociativeParenthesis, PyccelDiv
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1826,7 +1826,7 @@ class SemanticParser(BasicParser):
     def _visit_FunctionCallArgument(self, expr):
         value = self._visit(expr.value)
         a = FunctionCallArgument(value, expr.keyword)
-        if isinstance(a.value, PyccelArithmeticOperator) and a.value.rank:
+        if value.rank and not isinstance(value, Variable):
             tmp_var = self.scope.get_new_name()
             assign = self._visit(Assign(tmp_var, expr.value, fst = expr.value.fst))
             self._additional_exprs[-1].append(assign)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -96,7 +96,7 @@ from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Con
                             OMP_TaskLoop_Construct, OMP_Sections_Construct, Omp_End_Clause,
                             OMP_Single_Construct)
 
-from pyccel.ast.operators import PyccelIs, PyccelIsNot, IfTernaryOperator, PyccelUnarySub
+from pyccel.ast.operators import PyccelArithmeticOperator, PyccelIs, PyccelIsNot, IfTernaryOperator, PyccelUnarySub
 from pyccel.ast.operators import PyccelNot, PyccelEq, PyccelAdd, PyccelMul, PyccelPow
 from pyccel.ast.operators import PyccelAssociativeParenthesis, PyccelDiv
 
@@ -1826,7 +1826,7 @@ class SemanticParser(BasicParser):
     def _visit_FunctionCallArgument(self, expr):
         value = self._visit(expr.value)
         a = FunctionCallArgument(value, expr.keyword)
-        if value.rank and not isinstance(value, Variable):
+        if isinstance(value, (PyccelArithmeticOperator, PyccelInternalFunction)) and value.rank:
             tmp_var = self.scope.get_new_name()
             assign = self._visit(Assign(tmp_var, expr.value, fst = expr.value.fst))
             self._additional_exprs[-1].append(assign)

--- a/tests/pyccel/scripts/functions.py
+++ b/tests/pyccel/scripts/functions.py
@@ -1,9 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 
-#$ header function incr_(int)
-def incr_(x):
-    #$ header function decr_(int)
-    def decr_(y):
+def incr_(x : int):
+    def decr_(y : int):
         y = y-1
         return y
     x = x + 1
@@ -12,45 +10,42 @@ def incr_(x):
 def helloworld():
     print('hello world')
 
-#$ header function incr(int)
-def incr(x):
+def incr(x : int):
     x = x + 1
     return x
 
-#$ header function decr(int) results(int)
-def decr(x):
+def decr(x : int) -> int:
     y = x - 1
     return y
 
-#$ header function incr_array(int [:])
-def incr_array(x):
+def incr_array(x : 'int[:]'):
     x[:] = x + 1
 
 y_=[1,2,3]
 
-# #$ header function decr_array([int]) results([int])
-# def decr_array(x):
+# def decr_array(x : int) -> int:
 #     y_[1] = 6
 #     z = y_
 #     t = y_+x
 #     return t
 
-#$ header function decr_array(int [:])
-def decr_array(x):
+def decr_array(x : 'int[:]'):
     x[:] = x - 1
 
-#$ header function f1(int, int, int) results(int)
-def f1(x, n=2, m=3):
+def f1(x : int, n : int = 2, m : int = 3) -> int:
     y = x - n*m
     return y
 
-#$ header function f2(int, int) results(int)
-def f2(x, m=None):
+def f2(x : int, m : int = None):
     if m is None:
         y = x + 1
     else:
         y = x - 1
     return y
+
+def my_print(a : 'int[:]'):
+    print(a)
+
 
 y = decr(2)
 z = f1(1)
@@ -69,3 +64,4 @@ if __name__ == '__main__':
     print(z)
     print(z1)
     print(z2)
+    my_print([1,2,3])

--- a/tests/pyccel/scripts/functions.py
+++ b/tests/pyccel/scripts/functions.py
@@ -1,11 +1,8 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
+import numpy as np
 
 def incr_(x : int):
-    def decr_(y : int):
-        y = y-1
-        return y
     x = x + 2
-    x = decr_(x)
     return x
 
 def helloworld():
@@ -22,7 +19,7 @@ def decr(x : int) -> int:
 def incr_array(x : 'int[:]'):
     x[:] = x + 1
 
-y_=[1,2,3]
+y_ = np.array([1,2,3])
 
 # def decr_array(x : int) -> int:
 #     y_[1] = 6
@@ -65,4 +62,4 @@ if __name__ == '__main__':
     print(z)
     print(z1)
     print(z2)
-    my_print([1,2,3])
+    my_print(np.array([1,2,3]))

--- a/tests/pyccel/scripts/functions.py
+++ b/tests/pyccel/scripts/functions.py
@@ -4,7 +4,8 @@ def incr_(x : int):
     def decr_(y : int):
         y = y-1
         return y
-    x = x + 1
+    x = x + 2
+    x = decr_(x)
     return x
 
 def helloworld():

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -975,7 +975,7 @@ def test_function_aliasing():
 
 def test_function(language):
     pyccel_test("scripts/functions.py",
-            language = language, output_dtype=[str]+[int]*7 )
+            language = language, output_dtype=[str]+[int]*8 )
 
 #------------------------------------------------------------------------------
 @pytest.mark.xdist_incompatible


### PR DESCRIPTION
Fix problems when passing temporary arrays to functions by widening the applicability of the `if` block which results in temporary variables being created for arrays. Fixes #1126 