### PR TITLE
Fix none_dealloc bug

### DIFF
--- a/.dict_custom.txt
+++ b/.dict_custom.txt
@@ -13,6 +13,7 @@ pyccelised
 pyccelising
 allocatable
 deallocate
+deallocation
 conda
 PyPI
 CentOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+### Fixed
+
+### Changed
+
+### Deprecated
+
+## \[1.9.1\] - 2023-08-31
+
+### Added
+
 -   #1497 : Add support for NumPy `copy` method: `a.copy`.
 -   #1497 : Add support for NumPy function `copy`.
 
@@ -14,10 +24,7 @@ All notable changes to this project will be documented in this file.
 -   #1241 : Missing transpose when converting from a C-ordered array to F-ordered array.
 -   #1241 : Incorrect transpose when copying an F-ordered array.
 -   #1241 : Fix infinite loop when passing an array as the only argument to `np.array`.
-
-### Changed
-
-### Deprecated
+-   #1506 : Increment `Py_None` reference count to avoid unexpected deallocation.
 
 ## \[1.9.0\] - 2023-08-22
 

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -51,7 +51,6 @@ __all__ = (
     'Py_ReturnNone',
     'flags_registry',
 #----- C / PYTHON FUNCTIONS ---
-    'Py_INCREF',
     'Py_DECREF',
 )
 

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -48,8 +48,10 @@ __all__ = (
     'Py_True',
     'Py_False',
     'Py_None',
+    'Py_ReturnNone',
     'flags_registry',
 #----- C / PYTHON FUNCTIONS ---
+    'Py_INCREF',
     'Py_DECREF',
 )
 
@@ -492,6 +494,9 @@ Py_False = Variable(PyccelPyObject(), 'Py_False', memory_handling='alias')
 
 # Python.h object representing None
 Py_None = Variable(PyccelPyObject(), 'Py_None', memory_handling='alias')
+
+# Python.h macro for returning None. See https://docs.python.org/3/c-api/none.html#c.Py_RETURN_NONE
+Py_ReturnNone = Variable(PyccelPyObject(), 'Py_RETURN_NONE', memory_handling='alias')
 
 # https://docs.python.org/3/c-api/refcounting.html#c.Py_DECREF
 Py_DECREF = FunctionDef(name = 'Py_DECREF',

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -48,9 +48,9 @@ __all__ = (
     'Py_True',
     'Py_False',
     'Py_None',
-    'Py_ReturnNone',
     'flags_registry',
 #----- C / PYTHON FUNCTIONS ---
+    'Py_INCREF',
     'Py_DECREF',
 )
 
@@ -494,8 +494,11 @@ Py_False = Variable(PyccelPyObject(), 'Py_False', memory_handling='alias')
 # Python.h object representing None
 Py_None = Variable(PyccelPyObject(), 'Py_None', memory_handling='alias')
 
-# Python.h macro for returning None. See https://docs.python.org/3/c-api/none.html#c.Py_RETURN_NONE
-Py_ReturnNone = Variable(PyccelPyObject(), 'Py_RETURN_NONE', memory_handling='alias')
+# https://docs.python.org/3/c-api/refcounting.html#c.Py_INCREF
+Py_INCREF = FunctionDef(name = 'Py_INCREF',
+                        body = [],
+                        arguments = [FunctionDefArgument(Variable(dtype=PyccelPyObject(), name='o', memory_handling='alias'))],
+                        results = [])
 
 # https://docs.python.org/3/c-api/refcounting.html#c.Py_DECREF
 Py_DECREF = FunctionDef(name = 'Py_DECREF',

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -22,6 +22,7 @@ from pyccel.ast.cwrapper      import py_to_c_registry, check_type_registry, PyBu
 from pyccel.ast.cwrapper      import PyErr_SetString, PyTypeError, PyNotImplementedError
 from pyccel.ast.cwrapper      import C_to_Python, PyFunctionDef, PyInterface
 from pyccel.ast.cwrapper      import PyModule_AddObject, Py_DECREF
+from pyccel.ast.cwrapper      import Py_ReturnNone
 from pyccel.ast.c_concepts    import ObjectAddress
 from pyccel.ast.datatypes     import NativeVoid, NativeInteger
 from pyccel.ast.internals     import get_final_precision
@@ -753,7 +754,7 @@ class CToPythonWrapper(Wrapper):
         # Pack the Python compatible results of the function into one argument.
         n_py_results = len(python_result_variables)
         if n_py_results == 0:
-            res = Py_None
+            res = Py_ReturnNone
             func_results = [FunctionDefResult(self.get_new_PyObject("result", is_temp=True))]
         elif n_py_results == 1:
             res = python_result_variables[0]

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -22,7 +22,7 @@ from pyccel.ast.cwrapper      import py_to_c_registry, check_type_registry, PyBu
 from pyccel.ast.cwrapper      import PyErr_SetString, PyTypeError, PyNotImplementedError
 from pyccel.ast.cwrapper      import C_to_Python, PyFunctionDef, PyInterface
 from pyccel.ast.cwrapper      import PyModule_AddObject, Py_DECREF
-from pyccel.ast.cwrapper      import Py_ReturnNone
+from pyccel.ast.cwrapper      import Py_INCREF
 from pyccel.ast.c_concepts    import ObjectAddress
 from pyccel.ast.datatypes     import NativeVoid, NativeInteger
 from pyccel.ast.internals     import get_final_precision
@@ -754,8 +754,9 @@ class CToPythonWrapper(Wrapper):
         # Pack the Python compatible results of the function into one argument.
         n_py_results = len(python_result_variables)
         if n_py_results == 0:
-            res = Py_ReturnNone
+            res = Py_None
             func_results = [FunctionDefResult(self.get_new_PyObject("result", is_temp=True))]
+            body.append(FunctionCall(Py_INCREF, [res]))
         elif n_py_results == 1:
             res = python_result_variables[0]
             func_results = [FunctionDefResult(res)]

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.9.0"
+__version__ = "1.9.1"


### PR DESCRIPTION
Increment the counter on `Py_None` before returning `None` from functions which return nothing. This avoids unexpected deallocation, which would result in a fatal Python error.

cc: @pyccel/psydac-dev 