### PR TITLE
Cleanup some datatype handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   #1484 : Use scope for classes to avoid name clashes.
+-   Stop raising warning for unrecognised functions imported via intermediate modules.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 
 -   #1513 : Stop printing `@types` decorators in generated Python code.
+-   \[INTERNALS\] Remove `dtype_registry` in favour of `dtype_and_precision_registry`.
+-   \[INTERNALS\] Prefer DataType keys over string keys which describe data types.
 
 ## \[1.9.1\] - 2023-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 
 -   #1513 : Stop printing `@types` decorators in generated Python code.
 -   \[INTERNALS\] Remove `dtype_registry` in favour of `dtype_and_precision_registry`.
--   \[INTERNALS\] Prefer DataType keys over string keys which describe data types.
+-   \[INTERNALS\] Prefer `DataType` keys over string keys which describe data types.
 
 ## \[1.9.1\] - 2023-08-31
 

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -17,7 +17,7 @@ from pyccel.utilities.stage import PyccelStage
 from .basic     import Basic, PyccelAstNode
 from .datatypes import (NativeInteger, NativeBool, NativeFloat,
                         NativeComplex, NativeString, str_dtype,
-                        NativeGeneric, default_precision)
+                        NativeGeneric)
 from .internals import PyccelInternalFunction, max_precision, Slice
 from .literals  import LiteralInteger, LiteralFloat, LiteralComplex, Nil
 from .literals  import Literal, LiteralImaginaryUnit, get_default_literal_value

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -575,7 +575,7 @@ def C_to_Python(c_object):
 # Functions definitions are defined in pyccel/stdlib/cwrapper/cwrapper.c
 c_to_py_registry = {
     (NativeBool(), -1)     : 'Bool_to_PyBool',
-    (NativeInteger(), -1)  : 'Int'+str(default_precision['int']*8)+'_to_PyLong',
+    (NativeInteger(), -1)  : 'Int'+str(default_precision[NativeInteger()]*8)+'_to_PyLong',
     (NativeInteger(), 1)   : 'Int8_to_NumpyLong',
     (NativeInteger(), 2)   : 'Int16_to_NumpyLong',
     (NativeInteger(), 4)   : 'Int32_to_NumpyLong',

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -57,7 +57,6 @@ __all__ = (
 #    '_Symbol',
     'default_precision',
     'dtype_and_precision_registry',
-    'dtype_registry'
 )
 
 #==============================================================================
@@ -93,39 +92,6 @@ iso_c_binding_shortcut_mapping = {
     'C_LONG_DOUBLE_COMPLEX' : 'c128',
     'C_BOOL'                : 'b1'
 }
-default_precision = {'float': 8,
-                    'int': numpy.dtype(int).alignment,
-                    'integer': numpy.dtype(int).alignment,
-                    'complex': 8,
-                    'bool':-1}
-dtype_and_precision_registry = { 'float':('float', -1),
-                                 'double':('float', -1),
-                                 'real':('float', -1),
-                                 'pythonfloat':('float', -1), # built-in float
-                                 'float32':('float',4),
-                                 'float64':('float',8),
-                                 'f4':('float',4),
-                                 'f8':('float',8),
-                                 'pythoncomplex':('complex', -1),
-                                 'complex':('complex', -1),  # to create numpy array with dtype='complex'
-                                 'complex64':('complex',4),
-                                 'complex128':('complex',8),
-                                 'c8':('complex',4),
-                                 'c16':('complex',8),
-                                 'int8' :('int',1),
-                                 'int16':('int',2),
-                                 'int32':('int',4),
-                                 'int64':('int',8),
-                                 'i1' :('int',1),
-                                 'i2':('int',2),
-                                 'i4':('int',4),
-                                 'i8':('int',8),
-                                 'int'  :('int', -1),
-                                 'pythonint'  :('int', -1),
-                                 'integer':('int',-1),
-                                 'bool' :('bool',-1),
-                                 'b1' :('bool',-1),
-                                 'pythonbool' :('bool',-1)}
 
 
 class DataType(metaclass=Singleton):
@@ -218,17 +184,41 @@ String         = NativeString()
 _Symbol        = NativeSymbol()
 Generic        = NativeGeneric()
 
-dtype_registry = {'bool': Bool,
-                  'int': Int,
-                  'integer': Int,
-                  'float'   : Float,
-                  'complex': Cmplx,
-                  'void': Void,
-                  'nil': Nil,
-                  'symbol': _Symbol,
-                  '*': Generic,
-                  'str': String}
+dtype_and_precision_registry = { 'float' : (Float, -1),
+                                 'double' : (Float, -1),
+                                 'real' : (Float, -1),
+                                 'float32' : (Float,4),
+                                 'float64' : (Float,8),
+                                 'f4' : (Float,4),
+                                 'f8' : (Float,8),
+                                 'complex' : (Cmplx, -1),
+                                 'complex64' : (Cmplx,4),
+                                 'complex128' : (Cmplx,8),
+                                 'c8' : (Cmplx,4),
+                                 'c16' : (Cmplx,8),
+                                 'int8' :(Int,1),
+                                 'int16' : (Int,2),
+                                 'int32' : (Int,4),
+                                 'int64' : (Int,8),
+                                 'i1' :(Int,1),
+                                 'i2' : (Int,2),
+                                 'i4' : (Int,4),
+                                 'i8' : (Int,8),
+                                 'int'  :(Int, -1),
+                                 'integer' : (Int,-1),
+                                 'bool' :(Bool,-1),
+                                 'b1' :(Bool,-1),
+                                 'void' : (Void, 0),
+                                 'nil' : (Nil, 0),
+                                 'symbol' : (_Symbol, 0),
+                                 '*' : (Generic, 0),
+                                 'str' : (String, 0),
+                                 }
 
+default_precision = {Float : 8,
+                     Int : numpy.dtype(int).alignment,
+                     Cmplx : 8,
+                     Bool : -1}
 
 class UnionType:
     """ Class representing multiple different possible
@@ -296,7 +286,7 @@ def DataTypeFactory(name, argnames=["_name"],
                      "prefix": prefix,
                      "alias": name})
 
-    dtype_registry[name] = newclass()
+    dtype_and_precision_registry[name] = (newclass(), 0)
     return newclass
 
 def is_pyccel_datatype(expr):
@@ -335,13 +325,13 @@ def datatype(arg):
 
     """
 
+    if isinstance(arg, DataType):
+        arg = arg.name.lower()
 
     if isinstance(arg, str):
-        if arg not in dtype_registry:
+        if arg not in dtype_and_precision_registry:
             raise ValueError("Unrecognized datatype " + arg)
-        return dtype_registry[arg]
-    if isinstance(arg, DataType):
-        return dtype_registry[arg.name.lower()]
+        return dtype_and_precision_registry[arg][0]
     else:
         raise TypeError('Expecting a DataType')
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -96,12 +96,21 @@ iso_c_binding_shortcut_mapping = {
 #==============================================================================
 
 class DataType(metaclass=Singleton):
-    """Base class representing native datatypes"""
+    """
+    Base class representing native datatypes.
+
+    The base class from which all data types must inherit.
+    """
     __slots__ = ()
     _name = '__UNDEFINED__'
 
     @property
     def name(self):
+        """
+        Get the name of the datatype.
+
+        Get the name of the datatype.
+        """
         return self._name
 
     def __str__(self):

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -93,6 +93,7 @@ iso_c_binding_shortcut_mapping = {
     'C_BOOL'                : 'b1'
 }
 
+#==============================================================================
 
 class DataType(metaclass=Singleton):
     """Base class representing native datatypes"""
@@ -108,6 +109,21 @@ class DataType(metaclass=Singleton):
 
     def __repr__(self):
         return str(self.__class__.__name__)+'()'
+
+    def __reduce__(self):
+        """
+        Function called during pickling.
+
+        For more details see : https://docs.python.org/3/library/pickle.html#object.__reduce__.
+
+        Returns
+        -------
+        callable
+            A callable to create the object.
+        args
+            A tuple containing any arguments to be passed to the callable.
+        """
+        return (self.__class__, ())
 
 class NativeBool(DataType):
     """Class representing boolean datatype"""

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -310,24 +310,23 @@ def is_with_construct_datatype(dtype):
     else:
         return False
 
-# TODO check the use of Floats
 def datatype(arg):
-    """Returns the datatype singleton for the given dtype.
-
-    arg : str or pyccel expression
-        If a str ('bool', 'int', 'float','complex', or 'void'), return the
-        singleton for the corresponding dtype. If a pyccel expression, return
-        the datatype that best fits the expression. This is determined from the
-        assumption system. For more control, use the `DataType` class directly.
-
-    Returns:
-        DataType
-
     """
+    Get the datatype indicated by a string.
 
-    if isinstance(arg, DataType):
-        arg = arg.name.lower()
+    Return the datatype singleton for the dtype described
+    by the argument.
 
+    Parameters
+    ----------
+    arg : str
+        Return the singleton for the corresponding dtype.
+
+    Returns
+    -------
+    DataType
+        The data type described by the string.
+    """
     if isinstance(arg, str):
         if arg not in dtype_and_precision_registry:
             raise ValueError("Unrecognized datatype " + arg)

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -115,6 +115,7 @@ class DataType(metaclass=Singleton):
         Function called during pickling.
 
         For more details see : https://docs.python.org/3/library/pickle.html#object.__reduce__.
+        This function is necessary to ensure that DataTypes remain singletons.
 
         Returns
         -------

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -335,18 +335,19 @@ class FunctionHeader(Header):
             shape = None
             annotation = None
 
-            if rank and precision == -1:
-                precision = default_precision[dtype]
-
-            if rank >1:
-                order = dc['order']
-
             if isinstance(dtype, str):
                 annotation = dtype
                 try:
                     dtype = datatype(dtype)
                 except ValueError:
                     dtype = DataTypeFactory(str(dtype), ("_name"))()
+
+            if rank and precision == -1:
+                precision = default_precision[dtype]
+
+            if rank >1:
+                order = dc['order']
+
             var = Variable(dtype, var_name,
                            memory_handling=memory_handling, is_const=is_const,
                            rank=rank, shape=shape ,order=order, precision=precision,

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -390,7 +390,7 @@ def max_precision(objs : list, dtype = None, allow_native = True):
     if allow_native and all(o.precision == -1 for o in objs):
         return -1
     elif dtype:
-        def_prec = default_precision[str(dtype)]
+        def_prec = default_precision[dtype]
         return max(def_prec if o.precision == -1 \
                 else o.precision for o in objs if o.dtype is dtype)
     else:
@@ -408,4 +408,4 @@ def get_final_precision(obj):
     If the precision is set to the default then the value of the default
     precision is returned, otherwise the provided precision is returned
     """
-    return default_precision[str(obj.dtype)] if obj.precision == -1 else obj.precision
+    return default_precision[obj.dtype] if obj.precision == -1 else obj.precision

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -376,9 +376,9 @@ def symbols(names):
 
 def max_precision(objs : list, dtype = None, allow_native = True):
     """
-    Returns the largest precision of an object in the list.
+    Returns the largest precision amongst the object in the list.
 
-    Returns the largest precision of an object in the list.
+    Returns the largest precision amongst the object in the list.
 
     Parameters
     ----------

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -376,9 +376,9 @@ def symbols(names):
 
 def max_precision(objs : list, dtype = None, allow_native = True):
     """
-    Returns the largest precision amongst the object in the list.
+    Return the largest precision amongst the object in the list.
 
-    Returns the largest precision amongst the object in the list.
+    Return the largest precision amongst the object in the list.
 
     Parameters
     ----------
@@ -424,5 +424,10 @@ def get_final_precision(obj):
     ----------
     obj : PyccelAstNode
         The object whose precision we want to investigate.
+
+    Returns
+    -------
+    int
+        The precision of the object to be used in the code.
     """
     return default_precision[obj.dtype] if obj.precision == -1 else obj.precision

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -374,7 +374,7 @@ def symbols(names):
     return tuple(symbols)
 
 
-def max_precision(objs : list, dtype = None, allow_native = True):
+def max_precision(objs : list, allow_native = True):
     """
     Return the largest precision amongst the object in the list.
 

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -376,16 +376,26 @@ def symbols(names):
 
 def max_precision(objs : list, dtype = None, allow_native = True):
     """
-    Returns the largest precision of an object in the list
+    Returns the largest precision of an object in the list.
+
+    Returns the largest precision of an object in the list.
 
     Parameters
     ----------
     objs : list
-           A list of PyccelAstNodes
-    dtype : Dtype class
-            If this argument is provided then only the
-            precision of objects with this dtype are
-            considered
+       A list of PyccelAstNodes.
+
+    dtype : DataType, optional
+        If this argument is provided then only the precision
+        of objects with this dtype are considered.
+
+    allow_native : bool, default=True
+        Allow the final result to be a native precision (i.e. -1).
+
+    Returns
+    -------
+    int
+        The largest precision found.
     """
     if allow_native and all(o.precision == -1 for o in objs):
         return -1

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -19,8 +19,8 @@ pyccel_stage = PyccelStage()
 
 __all__ = (
     'PrecomputedCode',
-    'PyccelArraySize',
     'PyccelArrayShapeElement',
+    'PyccelArraySize',
     'PyccelInternalFunction',
     'PyccelSymbol',
     'Slice',
@@ -374,11 +374,11 @@ def symbols(names):
     return tuple(symbols)
 
 
-def max_precision(objs : list, allow_native = True):
+def max_precision(objs : list, allow_native : bool = True):
     """
-    Return the largest precision amongst the object in the list.
+    Return the largest precision amongst the objects in the list.
 
-    Return the largest precision amongst the object in the list.
+    Return the largest precision amongst the objects in the list.
 
     Parameters
     ----------
@@ -404,10 +404,10 @@ def max_precision(objs : list, allow_native = True):
 
 def get_final_precision(obj):
     """
-    Get the the usable precision of an object.
+    Get the usable precision of an object.
 
-    Get the the usable precision of an object. Ie. the precision that you
-    can use to print, eg 8 instead of -1 for a default precision float.
+    Get the usable precision of an object. I.e. the precision that you
+    can use to print, e.g. 8 instead of -1 for a default precision float.
 
     If the precision is set to the default then the value of the default
     precision is returned, otherwise the provided precision is returned.

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -385,10 +385,6 @@ def max_precision(objs : list, dtype = None, allow_native = True):
     objs : list
        A list of PyccelAstNodes.
 
-    dtype : DataType, optional
-        If this argument is provided then only the precision
-        of objects with this dtype are considered.
-
     allow_native : bool, default=True
         Allow the final result to be a native precision (i.e. -1).
 
@@ -399,10 +395,6 @@ def max_precision(objs : list, dtype = None, allow_native = True):
     """
     if allow_native and all(o.precision == -1 for o in objs):
         return -1
-    elif dtype:
-        def_prec = default_precision[dtype]
-        return max(def_prec if o.precision == -1 \
-                else o.precision for o in objs if o.dtype is dtype)
     else:
         ndarray_list = [o for o in objs if getattr(o, 'is_ndarray', False)]
         if ndarray_list:

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -412,10 +412,17 @@ def max_precision(objs : list, dtype = None, allow_native = True):
 
 def get_final_precision(obj):
     """
+    Get the the usable precision of an object.
+
     Get the the usable precision of an object. Ie. the precision that you
-    can use to print, eg 8 instead of -1 for a default precision float
+    can use to print, eg 8 instead of -1 for a default precision float.
 
     If the precision is set to the default then the value of the default
-    precision is returned, otherwise the provided precision is returned
+    precision is returned, otherwise the provided precision is returned.
+
+    Parameters
+    ----------
+    obj : PyccelAstNode
+        The object whose precision we want to investigate.
     """
     return default_precision[obj.dtype] if obj.precision == -1 else obj.precision

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -390,7 +390,7 @@ class NumpyResultType(PyccelInternalFunction):
             self._precision = max(dtype_array_precisions)
         else:
             if -1 in precisions:
-                precisions.append(default_precision[str(self.dtype)])
+                precisions.append(default_precision[self.dtype])
             self._precision = max(precisions)
 
         super().__init__(*arrays_and_dtypes)
@@ -684,7 +684,7 @@ class NumpySum(PyccelInternalFunction):
             self._dtype = NativeInteger()
         else:
             self._dtype = arg.dtype
-        self._precision = max(arg.precision, default_precision[str(self._dtype)])
+        self._precision = max(arg.precision, default_precision[self._dtype])
 
     @property
     def arg(self):
@@ -708,7 +708,7 @@ class NumpyProduct(PyccelInternalFunction):
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
         self._arg = NumpyInt(self._arg) if (isinstance(arg.dtype, NativeBool) or \
-                    (isinstance(arg.dtype, NativeInteger) and get_final_precision(self._arg) < default_precision['int']))\
+                    (isinstance(arg.dtype, NativeInteger) and get_final_precision(self._arg) < default_precision[NativeInteger()]))\
                     else self._arg
         self._dtype = self._arg.dtype
         self._precision = get_final_precision(self._arg)
@@ -864,7 +864,7 @@ class NumpyLinspace(NumpyNewArray):
             type_info = NumpyResultType(*args)
             if type_info.dtype is NativeInteger():
                 self._dtype     = NativeFloat()
-                self._precision = default_precision['float']
+                self._precision = default_precision[self._dtype]
             else:
                 self._dtype = type_info.dtype
                 self._precision = type_info.precision
@@ -1035,7 +1035,7 @@ class NumpyRand(PyccelInternalFunction):
     __slots__ = ('_shape','_rank','_order')
     name = 'rand'
     _dtype = NativeFloat()
-    _precision = default_precision['float']
+    _precision = default_precision[NativeFloat()]
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -1167,7 +1167,7 @@ class NumpyEmpty(NumpyAutoFill):
 
     def __init__(self, shape, dtype='float', order='C'):
         if dtype in NativeNumeric:
-            precision = default_precision[str_dtype(dtype)]
+            precision = default_precision[dtype]
             dtype = DtypePrecisionToCastFunction[dtype.name][precision]
         super().__init__(shape, dtype, order)
     @property
@@ -1472,7 +1472,7 @@ class NumpyUfuncUnary(NumpyUfuncBase):
 
     def _set_dtype_precision(self, x):
         self._dtype      = x.dtype if x.dtype is NativeComplex() else NativeFloat()
-        self._precision  = default_precision[str_dtype(self._dtype)]
+        self._precision  = default_precision[self._dtype]
 
     def _set_order(self, x):
         self._order      = x.order
@@ -1495,7 +1495,7 @@ class NumpyUfuncBinary(NumpyUfuncBase):
 
     def _set_dtype_precision(self, x1, x2):
         self._dtype     = NativeFloat()
-        self._precision = default_precision['float']
+        self._precision = default_precision[self._dtype]
 
     def _set_order(self, x1, x2):
         if x1.order == x2.order:
@@ -1617,7 +1617,7 @@ class NumpyFloor(NumpyUfuncUnary):
     name = 'floor'
     def _set_dtype_precision(self, x):
         self._dtype     = NativeFloat()
-        self._precision = default_precision[str_dtype(self._dtype)]
+        self._precision = default_precision[self._dtype]
 
 class NumpyMod(NumpyUfuncBinary):
     """

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -1515,6 +1515,16 @@ class NumpyUfuncUnary(NumpyUfuncBase):
         self._rank       = x.rank
 
     def _set_dtype_precision(self, x):
+        """
+        Use the argument to calculate the dtype and precision of the result.
+
+        Use the argument to calculate the dtype and precision of the result.
+
+        Parameters
+        ----------
+        x : PyccelAstNode
+            The argument passed to the function.
+        """
         self._dtype      = x.dtype if x.dtype is NativeComplex() else NativeFloat()
         self._precision  = default_precision[self._dtype]
 
@@ -1553,6 +1563,16 @@ class NumpyUfuncBinary(NumpyUfuncBase):
         self._rank  = 0 if self._shape is None else len(self._shape)
 
     def _set_dtype_precision(self, x1, x2):
+        """
+        Use the argument to calculate the dtype and precision of the result.
+
+        Use the argument to calculate the dtype and precision of the result.
+
+        Parameters
+        ----------
+        x : PyccelAstNode
+            The argument passed to the function.
+        """
         self._dtype     = NativeFloat()
         self._precision = default_precision[self._dtype]
 
@@ -1671,10 +1691,30 @@ class NumpyAbs(NumpyUfuncUnary):
         self._precision = get_final_precision(x)
 
 class NumpyFloor(NumpyUfuncUnary):
-    """Represent a call to the floor function in the Numpy library"""
+    """
+    Represent a call to the floor function in the Numpy library.
+
+    Represent a call to the floor function in the Numpy library.
+
+    Parameters
+    ----------
+    x : PyccelAstNode
+        The argument passed to the function.
+    """
     __slots__ = ()
     name = 'floor'
+
     def _set_dtype_precision(self, x):
+        """
+        Use the argument to calculate the dtype and precision of the result.
+
+        Use the argument to calculate the dtype and precision of the result.
+
+        Parameters
+        ----------
+        x : PyccelAstNode
+            The argument passed to the function.
+        """
         self._dtype     = NativeFloat()
         self._precision = default_precision[self._dtype]
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -665,9 +665,15 @@ class NumpyArange(NumpyNewArray):
 
 #==============================================================================
 class NumpySum(PyccelInternalFunction):
-    """Represents a call to  numpy.sum for code generation.
+    """
+    Represents a call to  numpy.sum for code generation.
 
+    Represents a call to  numpy.sum for code generation.
+
+    Parameters
+    ----------
     arg : list , tuple , PythonTuple, PythonList, Variable
+        The argument passed to the sum function.
     """
     __slots__ = ('_dtype','_precision')
     name = 'sum'
@@ -691,9 +697,15 @@ class NumpySum(PyccelInternalFunction):
 
 #==============================================================================
 class NumpyProduct(PyccelInternalFunction):
-    """Represents a call to  numpy.prod for code generation.
+    """
+    Represents a call to numpy.prod for code generation.
 
+    Represents a call to numpy.prod for code generation.
+
+    Parameters
+    ----------
     arg : list , tuple , PythonTuple, PythonList, Variable
+        The argument passed to the prod function.
     """
     __slots__ = ('_arg','_dtype','_precision')
     name = 'product'
@@ -1026,10 +1038,15 @@ class NumpyWhere(PyccelInternalFunction):
 
 #==============================================================================
 class NumpyRand(PyccelInternalFunction):
-
     """
-      Represents a call to  numpy.random.random or numpy.random.rand for code generation.
+    Represents a call to  numpy.random.random or numpy.random.rand for code generation.
 
+    Represents a call to  numpy.random.random or numpy.random.rand for code generation.
+
+    Parameters
+    ----------
+    *args : tuple of PyccelAstNode
+        The arguments passed to the function.
     """
     __slots__ = ('_shape','_rank','_order')
     name = 'rand'
@@ -1159,7 +1176,21 @@ class NumpyAutoFill(NumpyFull):
 
 #==============================================================================
 class NumpyEmpty(NumpyAutoFill):
-    """ Represents a call to numpy.empty for code generation.
+    """
+    Represents a call to numpy.empty for code generation.
+
+    Represents a call to numpy.empty for code generation.
+
+    Parameters
+    ----------
+    shape : PyccelAstNode
+        The shape of the array to be created.
+
+    dtype : PythonType, PyccelFunctionDef, LiteralString, str
+        The actual dtype passed to the NumPy function.
+
+    order : str, LiteralString
+        The order passed to the function.
     """
     __slots__ = ()
     name = 'empty'
@@ -1456,7 +1487,21 @@ class NumpyUfuncBase(PyccelInternalFunction):
 
 #------------------------------------------------------------------------------
 class NumpyUfuncUnary(NumpyUfuncBase):
-    """Numpy's universal function with one argument.
+    """
+    Class representing Numpy's universal function with one argument.
+
+    Class representing Numpy's universal function. All classes which
+    inherit from this class have one argument and operate on it
+    elementally. In other words it should be equivalent to write:
+    >>> for i in iterable: NumpyUfuncUnary(i)
+    
+    or
+    >>> NumpyUfuncUnary(iterable)
+
+    Parameters
+    ----------
+    x : PyccelAstNode
+        The argument passed to the function.
     """
     __slots__ = ()
     def __init__(self, x):
@@ -1478,10 +1523,25 @@ class NumpyUfuncUnary(NumpyUfuncBase):
 
 #------------------------------------------------------------------------------
 class NumpyUfuncBinary(NumpyUfuncBase):
-    """Numpy's universal function with two arguments.
+    """
+    Class representing Numpy's universal function with two arguments.
+
+    Class representing Numpy's universal function. All classes which
+    inherit from this class have two arguments and operate on them
+    in lockstep. In other words it should be equivalent to write:
+    >>> for i,_ in enumerate(iterable1): NumpyUfuncUnary(iterable1(i), iterable2(i))
+    
+    or
+    >>> NumpyUfuncUnary(iterable1, iterable2)
+
+    Parameters
+    ----------
+    x1 : PyccelAstNode
+        The first argument passed to the function.
+    x2 : PyccelAstNode
+        The second argument passed to the function.
     """
     __slots__ = ()
-    # TODO: apply Numpy's broadcasting rules to get shape/rank of output
     def __init__(self, x1, x2):
         super().__init__(x1, x2)
         self._set_dtype_precision(x1, x2)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -1570,8 +1570,10 @@ class NumpyUfuncBinary(NumpyUfuncBase):
 
         Parameters
         ----------
-        x : PyccelAstNode
-            The argument passed to the function.
+        x1 : PyccelAstNode
+            The first argument passed to the function.
+        x2 : PyccelAstNode
+            The second argument passed to the function.
         """
         self._dtype     = NativeFloat()
         self._precision = default_precision[self._dtype]

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -453,7 +453,6 @@ def process_dtype(dtype):
     dtype, precision = dtype_registry[dtype]
     if precision == -1:
         precision = default_precision[dtype]
-    dtype = datatype(dtype)
 
     return dtype, precision
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -1494,7 +1494,7 @@ class NumpyUfuncUnary(NumpyUfuncBase):
     inherit from this class have one argument and operate on it
     elementally. In other words it should be equivalent to write:
     >>> for i in iterable: NumpyUfuncUnary(i)
-    
+
     or
     >>> NumpyUfuncUnary(iterable)
 
@@ -1530,7 +1530,7 @@ class NumpyUfuncBinary(NumpyUfuncBase):
     inherit from this class have two arguments and operate on them
     in lockstep. In other words it should be equivalent to write:
     >>> for i,_ in enumerate(iterable1): NumpyUfuncUnary(iterable1(i), iterable2(i))
-    
+
     or
     >>> NumpyUfuncUnary(iterable1, iterable2)
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -183,7 +183,7 @@ class Variable(PyccelAstNode):
         # ------------ PyccelAstNode Properties ---------------
         if isinstance(dtype, str) or str(dtype) == '*':
 
-            dtype = datatype(str(dtype))
+            dtype = datatype(dtype)
         elif not isinstance(dtype, DataType):
             raise TypeError('datatype must be an instance of DataType.')
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -503,14 +503,14 @@ class CCodePrinter(CodePrinter):
         Parameters
         ----------
         expr : PyccelAstNode
-            The Assign Node used to get the lhs and rhs
+            The Assign Node used to get the lhs and rhs.
 
         Returns
         -------
         buffer_array : str
-            String initialising the stack (C) array which stores the data
+            String initialising the stack (C) array which stores the data.
         array_init   : str
-            String containing the rhs of the initialization of a stack array
+            String containing the rhs of the initialization of a stack array.
         """
         var = expr
         dtype = self.find_in_dtype_registry(var.dtype, var.precision)
@@ -1374,7 +1374,7 @@ class CCodePrinter(CodePrinter):
         to the specified dtype and precision. If the dtype and precision already
         match then the format string will simply print the expression.
 
-        parameters
+        Parameters
         ----------
         expr : PyccelAstNode
             The expression to be cast.

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1381,7 +1381,7 @@ class CCodePrinter(CodePrinter):
         dtype : Datatype
             The target type of the cast.
         precision : int
-            The target precision of the of the cast.
+            The target precision of the cast.
 
         Returns
         -------

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -467,16 +467,20 @@ class CCodePrinter(CodePrinter):
         return operations
 
     def arrayFill(self, expr):
-        """ print the assignment of a NdArray
+        """
+        Print the assignment of a NdArray.
 
-        parameters
+        Print the code necessary to create and fill an ndarray.
+
+        Parameters
         ----------
-            expr : PyccelAstNode
-                The Assign Node used to get the lhs and rhs
-        Return
-        ------
-            String
-                Return a str that contains a call to the C function array_fill,
+        expr : PyccelAstNode
+            The Assign Node used to get the lhs and rhs.
+
+        Returns
+        -------
+        str
+            Return a str that contains a call to the C function array_fill.
         """
         rhs = expr.rhs
         lhs = expr.lhs
@@ -491,18 +495,22 @@ class CCodePrinter(CodePrinter):
         return code_init
 
     def _init_stack_array(self, expr):
-        """ return a string which handles the assignment of a stack ndarray
+        """
+        Return a string which handles the assignment of a stack ndarray.
+
+        Print the code necessary to initialise a ndarray on the stack.
 
         Parameters
         ----------
-            expr : PyccelAstNode
-                The Assign Node used to get the lhs and rhs
+        expr : PyccelAstNode
+            The Assign Node used to get the lhs and rhs
+
         Returns
         -------
-            buffer_array : str
-                String initialising the stack (C) array which stores the data
-            array_init   : str
-                String containing the rhs of the initialization of a stack array
+        buffer_array : str
+            String initialising the stack (C) array which stores the data
+        array_init   : str
+            String containing the rhs of the initialization of a stack array
         """
         var = expr
         dtype = self.find_in_dtype_registry(var.dtype, var.precision)
@@ -955,6 +963,26 @@ class CCodePrinter(CodePrinter):
         return '"{}"'.format(format_str)
 
     def get_print_format_and_arg(self, var):
+        """
+        Get the C print format string for the object var.
+
+        Get the C print format string which will allow the generated code
+        to print the variable passed as argument.
+
+        Parameters
+        ----------
+        var : PyccelAstNode
+            The object which will be printed.
+
+        Returns
+        -------
+        arg_format : str
+            The format which should be printed in the format string of the
+            generated print expression.
+        arg : str
+            The code which should be printed in the arguments of the generated
+            print expression to print the object.
+        """
         try:
             arg_format = self.type_to_format[(var.dtype, get_final_precision(var))]
         except KeyError:
@@ -1082,7 +1110,7 @@ class CCodePrinter(CodePrinter):
         dtype : DataType
             The data type of the expression.
 
-        prec  : int
+        prec : int
             The precision of the expression.
 
         Returns
@@ -1120,7 +1148,7 @@ class CCodePrinter(CodePrinter):
         dtype : DataType
             The data type of the expression.
 
-        prec  : int
+        prec : int
             The precision of the expression.
 
         Returns
@@ -1339,21 +1367,28 @@ class CCodePrinter(CodePrinter):
 
 
     def _cast_to(self, expr, dtype, precision):
-        """ add cast to an expression when needed
+        """
+        Add a cast to an expression when needed.
+
+        Get a format string which provides the code to cast the object `expr`
+        to the specified dtype and precision. If the dtype and precision already
+        match then the format string will simply print the expression.
+
         parameters
         ----------
-            expr      : PyccelAstNode
-                the expression to be cast
-            dtype     : Datatype
-                base type of the cast
-            precision : integer
-                precision of the base type of the cast
+        expr : PyccelAstNode
+            The expression to be cast.
+        dtype : Datatype
+            The target type of the cast.
+        precision : int
+            The target precision of the of the cast.
 
-        Return
-        ------
-            String
-                Return format string that contains the desired cast type
-                NB: You should insert the expression to be cast in the string after using this function.
+        Returns
+        -------
+        str
+            A format string that contains the desired cast type.
+            NB: You should insert the expression to be cast in the string
+            after using this function.
         """
         if (expr.dtype != dtype or expr.precision != precision):
             cast=self.find_in_dtype_registry(dtype, precision)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1106,7 +1106,7 @@ class CCodePrinter(CodePrinter):
         Raise PYCCEL_RESTRICTION_TODO if not found.
 
         Parameters
-        -----------
+        ----------
         dtype : DataType
             The data type of the expression.
 
@@ -1144,7 +1144,7 @@ class CCodePrinter(CodePrinter):
         Raise PYCCEL_RESTRICTION_TODO if not found.
 
         Parameters
-        -----------
+        ----------
         dtype : DataType
             The data type of the expression.
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1656,7 +1656,7 @@ class CCodePrinter(CodePrinter):
                              expr.arg.precision,
                              self._print(expr.arg))
         if prec == -1:
-            prec = default_precision[self._print(dtype)]
+            prec = default_precision[dtype]
 
         if isinstance(dtype, NativeInteger):
             return f'numpy_sum_int{prec * 8}({name})'

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -6,32 +6,28 @@
 
 from pyccel.codegen.printing.ccode import CCodePrinter
 
-from pyccel.ast.bind_c   import BindCPointer
-from pyccel.ast.bind_c   import BindCModule, BindCFunctionDef
-
-from pyccel.ast.core import FunctionAddress, SeparatorComment
-from pyccel.ast.core import Import, Module
-
-from pyccel.ast.cwrapper    import PyBuildValueNode
-from pyccel.ast.cwrapper    import Py_None
-from pyccel.ast.cwrapper    import PyccelPyObject
-
-from pyccel.ast.literals  import LiteralString, Nil
-
+from pyccel.ast.bind_c     import BindCPointer
+from pyccel.ast.bind_c     import BindCModule, BindCFunctionDef
+from pyccel.ast.core       import FunctionAddress, SeparatorComment
+from pyccel.ast.core       import Import, Module
+from pyccel.ast.cwrapper   import PyBuildValueNode
+from pyccel.ast.cwrapper   import Py_None
+from pyccel.ast.cwrapper   import PyccelPyObject
+from pyccel.ast.literals   import LiteralString, Nil
 from pyccel.ast.c_concepts import ObjectAddress
 
-from pyccel.errors.errors   import Errors
+from pyccel.errors.errors  import Errors
+
+__all__ = ("CWrapperCodePrinter", "cwrappercode")
 
 errors = Errors()
 
-__all__ = ["CWrapperCodePrinter", "cwrappercode"]
-
-
-module_imports  = [Import('numpy_version', Module('numpy_version',(),())),
+module_imports = [Import('numpy_version', Module('numpy_version',(),())),
             Import('numpy/arrayobject', Module('numpy/arrayobject',(),())),
             Import('cwrapper', Module('cwrapper',(),()))]
 
 cwrapper_ndarray_import = Import('cwrapper_ndarrays', Module('cwrapper_ndarrays', (), ()))
+
 
 class CWrapperCodePrinter(CCodePrinter):
     """
@@ -52,8 +48,6 @@ class CWrapperCodePrinter(CCodePrinter):
     **settings : dict
             Any additional arguments which are necessary for CCodePrinter.
     """
-
-
     dtype_registry = {**CCodePrinter.dtype_registry,
                       (PyccelPyObject() , 0) : 'PyObject',
                       (BindCPointer()   , 0) : 'void'}
@@ -64,7 +58,6 @@ class CWrapperCodePrinter(CCodePrinter):
         self._to_free_PyObject_list = []
         self._function_wrapper_names = dict()
         self._module_name = None
-
 
     # --------------------------------------------------------------------
     #                       Helper functions

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -16,8 +16,6 @@ from pyccel.ast.cwrapper    import PyBuildValueNode
 from pyccel.ast.cwrapper    import Py_None
 from pyccel.ast.cwrapper    import PyccelPyObject
 
-from pyccel.ast.datatypes import NativeVoid
-
 from pyccel.ast.literals  import LiteralString, Nil
 
 from pyccel.ast.c_concepts import ObjectAddress

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -28,8 +28,6 @@ errors = Errors()
 
 __all__ = ["CWrapperCodePrinter", "cwrappercode"]
 
-dtype_registry = {(PyccelPyObject() , 0) : 'PyObject',
-                  (BindCPointer()   , 0) : 'void'}
 
 module_imports  = [Import('numpy_version', Module('numpy_version',(),())),
             Import('numpy/arrayobject', Module('numpy/arrayobject',(),())),
@@ -56,6 +54,12 @@ class CWrapperCodePrinter(CCodePrinter):
     **settings : dict
             Any additional arguments which are necessary for CCodePrinter.
     """
+
+
+    dtype_registry = {**CCodePrinter.dtype_registry,
+                      (PyccelPyObject() , 0) : 'PyObject',
+                      (BindCPointer()   , 0) : 'void'}
+
     def __init__(self, filename, target_language, **settings):
         CCodePrinter.__init__(self, filename, **settings)
         self._target_language = target_language
@@ -162,28 +166,6 @@ class CWrapperCodePrinter(CCodePrinter):
         if expr.dtype is BindCPointer():
             return 'void*'
         return CCodePrinter.get_declare_type(self, expr)
-
-    def find_in_dtype_registry(self, dtype, prec):
-        """
-        Find the corresponding C dtype in the dtype_registry
-        raise PYCCEL_RESTRICTION_TODO if not found
-
-        Parameters
-        -----------
-        dtype : String
-            expression data type
-
-        prec  : Integer
-            expression precision
-
-        Returns
-        -------
-        dtype : String
-        """
-        try :
-            return dtype_registry[(dtype, prec)]
-        except KeyError:
-            return CCodePrinter.find_in_dtype_registry(self, dtype, prec)
 
     def _handle_is_operator(self, Op, expr):
         """

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -161,17 +161,7 @@ class CWrapperCodePrinter(CCodePrinter):
         """
         if expr.dtype is BindCPointer():
             return 'void*'
-        dtype = self._print(expr.dtype)
-        prec  = expr.precision
-        if dtype != "pyarrayobject":
-            return CCodePrinter.get_declare_type(self, expr)
-        else :
-            dtype = self.find_in_dtype_registry(dtype, prec)
-
-        if self.is_c_pointer(expr):
-            return f'{dtype}*'
-        else:
-            return dtype
+        return CCodePrinter.get_declare_type(self, expr)
 
     def find_in_dtype_registry(self, dtype, prec):
         """
@@ -191,7 +181,7 @@ class CWrapperCodePrinter(CCodePrinter):
         dtype : String
         """
         try :
-            return dtype_registry[(dtype, prec)]
+            return dtype_registry[(self._print(dtype), prec)]
         except KeyError:
             return CCodePrinter.find_in_dtype_registry(self, dtype, prec)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -15,35 +15,25 @@ from collections import OrderedDict
 import functools
 
 from pyccel.ast.basic import PyccelAstNode
+
 from pyccel.ast.bind_c import BindCPointer, BindCFunctionDef, BindCFunctionDefArgument, BindCModule
+
+from pyccel.ast.builtins import PythonInt, PythonType,PythonPrint, PythonRange
+from pyccel.ast.builtins import PythonFloat, PythonTuple
+from pyccel.ast.builtins import PythonComplex, PythonBool, PythonAbs
+from pyccel.ast.builtins import python_builtin_datatypes_dict as python_builtin_datatypes
+
 from pyccel.ast.core import get_iterable_ranges
 from pyccel.ast.core import FunctionDef, InlineFunctionDef
 from pyccel.ast.core import SeparatorComment, Comment
 from pyccel.ast.core import ConstructorCall
 from pyccel.ast.core import FunctionCallArgument
 from pyccel.ast.core import ErrorExit, FunctionAddress
-from pyccel.ast.core import Return, Module
-from pyccel.ast.core import Import
-from pyccel.ast.itertoolsext import Product
-from pyccel.ast.core import (Assign, AliasAssign, Declare,
-                             CodeBlock, AsName, EmptyNode,
-                             If, IfSection, For, Deallocate)
+from pyccel.ast.core import Return, Module, If, IfSection, For
+from pyccel.ast.core import Import, CodeBlock, AsName, EmptyNode
+from pyccel.ast.core import Assign, AliasAssign, Declare, Deallocate
+from pyccel.ast.core import FunctionCall, DottedFunctionCall, PyccelFunctionDef
 
-from pyccel.ast.variable  import (Variable,
-                             IndexedElement,
-                             InhomogeneousTupleVariable,
-                             DottedName, )
-
-from pyccel.ast.operators      import PyccelAdd, PyccelMul, PyccelMinus
-from pyccel.ast.operators      import PyccelMod
-from pyccel.ast.operators      import PyccelUnarySub, PyccelLt, PyccelGt, IfTernaryOperator
-
-from pyccel.ast.core      import FunctionCall, DottedFunctionCall, PyccelFunctionDef
-
-from pyccel.ast.builtins  import (PythonInt, PythonType,
-                                  PythonPrint, PythonRange,
-                                  PythonFloat, PythonTuple)
-from pyccel.ast.builtins  import PythonComplex, PythonBool, PythonAbs
 from pyccel.ast.datatypes import is_pyccel_datatype
 from pyccel.ast.datatypes import is_iterable_datatype, is_with_construct_datatype
 from pyccel.ast.datatypes import NativeSymbol, NativeString, str_dtype
@@ -55,6 +45,8 @@ from pyccel.ast.datatypes import CustomDataType
 
 from pyccel.ast.internals import Slice, PrecomputedCode, PyccelArrayShapeElement
 from pyccel.ast.internals import PyccelInternalFunction, get_final_precision
+
+from pyccel.ast.itertoolsext import Product
 
 from pyccel.ast.literals  import LiteralInteger, LiteralFloat, Literal
 from pyccel.ast.literals  import LiteralTrue, LiteralFalse, LiteralString
@@ -71,8 +63,14 @@ from pyccel.ast.numpyext import NumpyNonZero
 from pyccel.ast.numpyext import NumpySign
 from pyccel.ast.numpyext import DtypePrecisionToCastFunction
 
+from pyccel.ast.operators import PyccelAdd, PyccelMul, PyccelMinus
+from pyccel.ast.operators import PyccelMod
+from pyccel.ast.operators import PyccelUnarySub, PyccelLt, PyccelGt, IfTernaryOperator
+
 from pyccel.ast.utilities import builtin_import_registry as pyccel_builtin_import_registry
 from pyccel.ast.utilities import expand_to_loops
+
+from pyccel.ast.variable import Variable, IndexedElement, InhomogeneousTupleVariable, DottedName
 
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import *
@@ -177,13 +175,6 @@ INF = math_constants['inf']
 _default_methods = {
     '__init__': 'create',
     '__del__' : 'free',
-}
-
-python_builtin_datatypes = {
-    'integer' : PythonInt,
-    'float'   : PythonFloat,
-    'bool'    : PythonBool,
-    'complex' : PythonComplex
 }
 
 type_to_print_format = {

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -215,7 +215,7 @@ class PythonCodePrinter(CodePrinter):
         else:
             dtype = self._print(expr.dtype)
             if expr.precision != -1:
-                dtype = self._get_numpy_name(DtypePrecisionToCastFunction[datatype(dtype).name][expr.precision])
+                dtype = self._get_numpy_name(DtypePrecisionToCastFunction[expr.dtype.name][expr.precision])
         return f"dtype = {dtype}"
 
     def _print_Header(self, expr):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -10,7 +10,7 @@ from pyccel.decorators import __all__ as pyccel_decorators
 from pyccel.ast.builtins   import PythonMin, PythonMax, PythonType
 from pyccel.ast.core       import CodeBlock, Import, Assign, FunctionCall, For, AsName, FunctionAddress
 from pyccel.ast.core       import IfSection, FunctionDef, Module, DottedFunctionCall, PyccelFunctionDef
-from pyccel.ast.datatypes  import default_precision, datatype
+from pyccel.ast.datatypes  import datatype
 from pyccel.ast.functionalexpr import FunctionalFor
 from pyccel.ast.literals   import LiteralTrue, LiteralString
 from pyccel.ast.literals   import LiteralInteger, LiteralFloat, LiteralComplex

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1301,7 +1301,7 @@ class SemanticParser(BasicParser):
                 If is_augassign is False, this value is not used
         """
         precision = d_var.get('precision',None)
-        internal_precision = default_precision[str(dtype)] if precision == -1 else precision
+        internal_precision = default_precision[dtype] if precision == -1 else precision
 
         # TODO improve check type compatibility
         if not hasattr(var, 'dtype'):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3739,8 +3739,13 @@ class SemanticParser(BasicParser):
             if expr.target:
                 targets = {i.target if isinstance(i,AsName) else i:None for i in expr.target}
                 names = [i.name if isinstance(i,AsName) else i for i in expr.target]
-                for entry in ['variables', 'classes', 'functions']:
-                    d_son = getattr(p.scope, entry)
+
+                p_scope = p.scope
+                p_imports = p_scope.imports
+                entries = ['variables', 'classes', 'functions']
+                direct_sons = ((e,getattr(p.scope, e)) for e in entries)
+                import_sons = ((e,p_imports[e]) for e in entries)
+                for entry, d_son in chain(direct_sons, import_sons):
                     for t,n in zip(targets.keys(),names):
                         if n in d_son:
                             e = d_son[n]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1278,6 +1278,8 @@ class SemanticParser(BasicParser):
 
     def _ensure_inferred_type_matches_existing(self, dtype, d_var, var, is_augassign, new_expressions, rhs):
         """
+        Ensure that the inferred type matches the existing variable.
+
         Ensure that the inferred type of the new variable, matches the existing variable (which has the
         same name). If this is not the case then errors are raised preventing pyccel reaching the codegen
         stage.
@@ -1287,18 +1289,18 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         dtype : DataType
-                The inferred DataType
+            The inferred DataType.
         d_var : dict
-                The inferred information about the variable. Usually created by the _infer_type function
-        var   : Variable
-                The existing variable
+            The inferred information about the variable. Usually created by the _infer_type function.
+        var : Variable
+            The existing variable.
         is_augassign : bool
-                A boolean indicating if the assign statement is an augassign (tests are less strict)
+            A boolean indicating if the assign statement is an augassign (tests are less strict).
         new_expressions : list
-                A list to which any new expressions created are appended
-        rhs   : PyccelAstNode
-                The right hand side of the expression : lhs=rhs
-                If is_augassign is False, this value is not used
+            A list to which any new expressions created are appended.
+        rhs : PyccelAstNode
+            The right hand side of the expression : lhs=rhs.
+            If is_augassign is False, this value is not used.
         """
         precision = d_var.get('precision',None)
         internal_precision = default_precision[dtype] if precision == -1 else precision

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -16,6 +16,7 @@ from pyccel.ast.headers   import construct_macro, MacroFunction, MacroVariable
 from pyccel.ast.core      import FunctionDefArgument, EmptyNode
 from pyccel.ast.variable  import DottedName
 from pyccel.ast.datatypes import dtype_and_precision_registry as dtype_registry, default_precision
+from pyccel.ast.datatypes import NativeNumeric
 from pyccel.ast.literals  import LiteralString, LiteralInteger, LiteralFloat
 from pyccel.ast.literals  import LiteralTrue, LiteralFalse
 from pyccel.ast.internals import PyccelSymbol
@@ -151,7 +152,7 @@ class Type(BasicStmt):
         d_var['is_func'] = False
         d_var['is_const'] = False
         if not(precision):
-            if dtype in ['double' ,'float','complex', 'int']:
+            if dtype in NativeNumeric:
                 d_var['precision'] = default_precision[dtype]
 
         if d_var['rank']>1:

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -114,23 +114,38 @@ class ListType(BasicStmt):
         return d_var
 
 class Type(BasicStmt):
-    """Base class representing a header type in the grammar."""
+    """
+    Base class representing a header type in the grammar.
 
-    def __init__(self, **kwargs):
-        """
-        Constructor for a Type.
+    Base class representing a header type in the grammar.
 
-        dtype: str
-            variable type
-        """
-        self.dtype   = kwargs.pop('dtype')
-        self.prec    = kwargs.pop('prec')
-        self.trailer = kwargs.pop('trailer', [])
+    Parameters
+    ----------
+    dtype : str
+        The variable type.
+
+    prec : int
+        The precision of the object.
+
+    trailer : TrailerSubscriptList
+        An object created by textx describing the trailing decorators of the
+        type. These describe the rank and order.
+    """
+
+    def __init__(self, dtype, prec, trailer = (), **kwargs):
+        self.dtype   = dtype
+        self.prec    = prec
+        self.trailer = trailer
 
         super(Type, self).__init__(**kwargs)
 
     @property
     def expr(self):
+        """
+        Get the dictionary describing the type.
+
+        Get the dictionary describing the type.
+        """
         dtype = self.dtype
         precision = self.prec
         if dtype in dtype_registry.keys():

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -130,6 +130,9 @@ class Type(BasicStmt):
     trailer : TrailerSubscriptList
         An object created by textx describing the trailing decorators of the
         type. These describe the rank and order.
+
+    **kwargs : dict
+        The textx arguments.
     """
 
     def __init__(self, dtype, prec, trailer = (), **kwargs):

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -127,9 +127,10 @@ class Type(BasicStmt):
     prec : int
         The precision of the object.
 
-    trailer : TrailerSubscriptList
+    trailer : iterable, TrailerSubscriptsList
         An object created by textx describing the trailing decorators of the
-        type. These describe the rank and order.
+        type. The number of elements is equal to the rank. The order is also
+        described when the iterable is non-empty.
 
     **kwargs : dict
         The textx arguments.


### PR DESCRIPTION
The code contains both a `dtype_registry` and a `dtype_and_precision_registry` (which is often imported and renamed to `dtype_registry`. This overlap is confusing and unnecessary when working with type handling (e.g.#1487). This PR simplifies the code by retaining only `dtype_and_precision_registry`. Datatypes are used as keys rather than strings (which may be different depending on whether they are obtained via `dtype.name`, `str(dtype)` or `_print(dtype)`).
In order to make this change a `__reduce__` method was implemented for DataTypes. This means that either devs should delete all .pyccel files in their stdlib folder, or we should update the version number.

Additionally there is a minor bug fix. The lapack tests were raising an import warning. It was caused by trying to import functions from the internals via the externals. This change removes the warning by also searching for imported objects in the imports of the imported file.