### PR TITLE
Fix Variable.clone function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 -   #1484 : Use scope for classes to avoid name clashes.
 -   Stop raising warning for unrecognised functions imported via intermediate modules.
 -   Set status of header variables to 'unallocated'.
+-   #1536 : Fix allocation of arrays in classes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ All notable changes to this project will be documented in this file.
 -   #1484 : Use scope for classes to avoid name clashes.
 -   Stop raising warning for unrecognised functions imported via intermediate modules.
 -   Set status of header variables to 'unallocated'.
--   #1536 : Fix allocation of arrays in classes.
 
 ### Changed
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -515,6 +515,7 @@ class Variable(PyccelAstNode):
                             if '_'+k in dir(self)}
         new_kwargs.update(kwargs)
         new_kwargs['name'] = name
+        new_kwargs['shape'] = self.alloc_shape
 
         return cls(**new_kwargs)
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -489,19 +489,27 @@ class Variable(PyccelAstNode):
 
     def clone(self, name, new_class = None, **kwargs):
         """
+        Create a clone of the current variable.
+
         Create a new Variable object of the chosen class
-        with the provided name and options
+        with the provided name and options. All non-specified
+        options will match the current instance.
 
         Parameters
-        ==========
-        name      : str
-                    The name of the new Variable
-        new_class : type
-                    The class of the new Variable
-                    The default is the same class
-        kwargs    : dict
-                    Dictionary containing any keyword-value
-                    pairs which are valid constructor keywords
+        ----------
+        name : str
+            The name of the new Variable.
+        new_class : type, optional
+            The class type of the new Variable (e.g. DottedVariable).
+            The default is the same class type.
+        **kwargs : dict
+            Dictionary containing any keyword-value
+            pairs which are valid constructor keywords.
+
+        Returns
+        -------
+        Variable
+            The cloned variable.
         """
 
         if (new_class is None):


### PR DESCRIPTION
Fix the `Variable.clone` function. This fixes the problem described in #1536. This problem is recent so it does not need to go into the CHANGELOG. The changes will be covered by the descriptions in #1508.

A test cannot be added due to #1538 .