### PR TITLE
Bot bug fixes for collaborators on forks

### DIFF
--- a/ci_tools/bot_comment_react.py
+++ b/ci_tools/bot_comment_react.py
@@ -2,7 +2,7 @@
 """
 import json
 import os
-from bot_tools.bot_funcs import Bot, pr_test_keys
+from bot_tools.bot_funcs import Bot, pr_test_keys, trust_givers
 
 def get_unique_test_list(keys):
     """
@@ -61,7 +61,7 @@ if __name__ == '__main__':
 
     elif command_words[0] == 'run':
         if bot.is_user_trusted(event['comment']['user']['login']):
-            bot.run_tests(get_unique_test_list(command_words[1:]))
+            bot.run_tests(get_unique_test_list(command_words[1:]), force_run = bot.is_pr_fork())
         else:
             bot.warn_untrusted()
 
@@ -78,7 +78,7 @@ if __name__ == '__main__':
         else:
             bot.warn_untrusted()
 
-    elif command_words[:2] == ['trust', 'user'] and len(command_words)==3 and event['comment']['user']['login'] in Bot.trust_givers:
+    elif command_words[:2] == ['trust', 'user'] and len(command_words)==3 and event['comment']['user']['login'] in trust_givers:
 
         bot.indicate_trust(command_words[2])
 

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -909,6 +909,19 @@ class Bot:
         """
         return self._pr_details['draft']
 
+    def is_pr_fork(self):
+        """
+        Indicate whether the pull request is created from a fork.
+
+        Indicate whether the pull request is created from a fork.
+
+        Returns
+        -------
+        bool
+            True if fork, False otherwise.
+        """
+        return self._pr_details['isCrossRepository']
+
     def leave_comment(self, comment):
         """
         Leave a comment on the pull request.

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -654,7 +654,7 @@ class Bot:
         """
         print("Trusted?")
         in_team = self._GAI.check_for_user_in_team(user, 'pyccel-dev')
-        if in_team["message"] != "Not found":
+        if in_team["message"] != "Not Found":
             print("In team")
             return True
         print("User not in team")

--- a/ci_tools/bot_tools/github_api_interactions.py
+++ b/ci_tools/bot_tools/github_api_interactions.py
@@ -513,7 +513,7 @@ class GitHubAPIInteractions:
         dict
             A dictionary describing the result.
         """
-        url = f'https://api.github.com/orgs/{self._org}/teams/{team}/membersips/{user}'
+        url = f'https://api.github.com/orgs/{self._org}/teams/{team}/memberships/{user}'
         return self._post_request("GET", url).json()
 
     def get_prs(self, state='open'):


### PR DESCRIPTION
Don't try to examine commits from forks to ensure that tests are not rerun as the bot doesn't pull these commits (and shouldn't do for security reasons). Correct use of trust_givers