### PR TITLE
added numpy functions for `isnan`, `isinf`,`isfinite` 

### DIFF
--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -114,6 +114,9 @@ __all__ = (
     'NumpyZeros',
     'NumpyZerosLike',
     'NumpyShape',
+    'NumpyIsInfinte'
+    'NumpyIsFinite'
+    'NumpyIsNan'
 )
 
 #=======================================================================================
@@ -2087,6 +2090,33 @@ class NumpySize(PyccelInternalFunction):
 
         return PyccelArrayShapeElement(a, axis)
 
+class NumpyIsNan(PyccelInternalFunction):
+    """ Represents a call to numpy.isnan() function.
+    """
+    __slots__ = ('_arg',)
+    name = 'isnan'
+
+    def __init__(self, arg):
+        self._arg = arg
+
+class NumpyIsInf(PyccelInternalFunction):
+    """ Represents a call to numpy.isinf() function.
+    """
+    __slots__ = ('_arg',)
+    name = 'isinf'
+
+    def __init__(self, arg):
+        self._arg = arg
+
+class NumpyIsFinite(PyccelInternalFunction):
+    """ Represents a call to numpy.isfinite() function.
+    """
+    __slots__ = ('_arg',)
+    name = 'isfinite'
+
+    def __init__(self, arg):
+        self._arg = arg
+
 #==============================================================================
 # TODO split numpy_functions into multiple dictionaries following
 # https://docs.scipy.org/doc/numpy-1.15.0/reference/routines.array-creation.html
@@ -2149,6 +2179,9 @@ numpy_funcs = {
     'linspace'  : PyccelFunctionDef('linspace'  , NumpyLinspace),
     'where'     : PyccelFunctionDef('where'     , NumpyWhere),
     # ---
+    'isnan'     : PyccelFunctionDef('isnan'     ,NumpyIsNan),
+    'isinf'     : PyccelFunctionDef('isinf'     ,NumpyIsInf),
+    'isfinite'  : PyccelFunctionDef('isfinite'  ,NumpyIsFinite),
     'sign'      : PyccelFunctionDef('sign'      , NumpySign),
     'abs'       : PyccelFunctionDef('abs'       , NumpyAbs),
     'floor'     : PyccelFunctionDef('floor'     , NumpyFloor),

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -89,6 +89,9 @@ numpy_ufunc_to_c_float = {
     'NumpyArcsinh': 'asinh',
     'NumpyArccosh': 'acosh',
     'NumpyArctanh': 'atanh',
+    'NumpyIsInfinte':'isinf',
+    'NumpyIsFinite':'isfinite',
+    'NumpyIsNan':'isnan',
 }
 
 numpy_ufunc_to_c_complex = {

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -107,6 +107,9 @@ numpy_ufunc_to_fortran = {
     'NumpyArcsinh': 'asinh',
     'NumpyArccosh': 'acosh',
     'NumpyArctanh': 'atanh',
+    'NumpyIsInfinte':'ieee_is_inf',
+    'NumpyIsFinite':'ieee_is_finite',
+    'NumpyIsNan':'ieee_is_nan',
 }
 
 math_function_to_fortran = {


### PR DESCRIPTION
fixes issue #1425
@EmilyBourne 
- [x]Create classes in numpyext.py for each of the three functions
- [x]Add the functions to the [list of numpy functions
- [x]Add print functions in C ensuring that the necessary header is imported
- [x]Add print functions in Fortran ensuring that the necessary module is imported
