### PR TITLE
Fix Windows runner

### DIFF
--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -16,25 +16,16 @@ runs:
     - name: Add DLL paths
       run: |
         # Add DLL paths for program execution
-        echo $CC
-        which gcc
-        ls C:\
-        ls C:\ProgramData
-        ls C:\ProgramData\chocolatey
-        ls C:\ProgramData\chocolatey\lib
-        ls C:\mingw64
-        ls C:\mingw64\bin
-        ls C:\mingw64\lib
-        $BIN_DIR="C:\mingw64\bin"
-        $LIBRARY_DIR="C:\mingw64\lib"
+        $BIN_DIR = Split-Path -Parent $CC # Find folder containing c compiler
+        $MINGW_DIR = Split-Path -Parent $BIN_DIR # Find the enclosing mingw directory
+        $LIBRARY_DIR="$MINGW_DIR/lib"
         echo $LIBRARY_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "LIBRARY_DIR=${LIBRARY_DIR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
         # Add DLL paths for python imports
         $PYTHON_PREFIX=(python -c "import sys; print(sys.prefix)")
         $PYTHON_SITE_PATH="$PYTHON_PREFIX\lib\site-packages"
-        echo "import os; os.add_dll_directory('$LIBRARY_DIR'); os.add_dll_directory('$BIN_DIR')"
-        echo "import os; os.add_dll_directory('$LIBRARY_DIR'); os.add_dll_directory('$BIN_DIR')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
+        echo "import os; os.add_dll_directory(r'$LIBRARY_DIR'); os.add_dll_directory(r'$BIN_DIR')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
       shell: powershell
     - name: Install Lapack
       run: |

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -16,7 +16,8 @@ runs:
     - name: Add DLL paths
       run: |
         # Add DLL paths for program execution
-        $EXE=(which gcc)
+        $EXE=(Get-Command cmd).Path
+        echo $EXE
         $BIN_DIR=(Split-Path -Parent ${EXE}) # Find folder containing c compiler
         $MINGW_DIR=(Split-Path -Parent ${BIN_DIR}) # Find the enclosing mingw directory
         $LIBRARY_DIR="$MINGW_DIR/lib"

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Add DLL paths
       run: |
         # Add DLL paths for program execution
-        $EXE=(Get-Command cmd).Path
+        $EXE=(Get-Command gcc).Path
         echo $EXE
         $BIN_DIR=(Split-Path -Parent ${EXE}) # Find folder containing c compiler
         $MINGW_DIR=(Split-Path -Parent ${BIN_DIR}) # Find the enclosing mingw directory

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -23,16 +23,18 @@ runs:
         ls C:\ProgramData\chocolatey
         ls C:\ProgramData\chocolatey\lib
         ls C:\mingw64
-        $BIN_DIR="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
-        $LIBRARY_DIR="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\lib"
-        echo $BIN_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        ls C:\mingw64\bin
+        ls C:\mingw64\lib
+        $BIN_DIR="C:\mingw64\bin"
+        $LIBRARY_DIR="C:\mingw64\lib"
         echo $LIBRARY_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "LIBRARY_DIR=${LIBRARY_DIR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
         # Add DLL paths for python imports
         $PYTHON_PREFIX=(python -c "import sys; print(sys.prefix)")
         $PYTHON_SITE_PATH="$PYTHON_PREFIX\lib\site-packages"
-        echo "import os; os.add_dll_directory('C://ProgramData/chocolatey/lib/mingw/tools/install/mingw64/lib'); os.add_dll_directory('C://ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
+        echo "import os; os.add_dll_directory('$LIBRARY_DIR'); os.add_dll_directory('$BIN_DIR')"
+        echo "import os; os.add_dll_directory('$LIBRARY_DIR'); os.add_dll_directory('$BIN_DIR')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
       shell: powershell
     - name: Install Lapack
       run: |

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -16,8 +16,8 @@ runs:
     - name: Add DLL paths
       run: |
         # Add DLL paths for program execution
-        $BIN_DIR = Split-Path -Parent $CC # Find folder containing c compiler
-        $MINGW_DIR = Split-Path -Parent $BIN_DIR # Find the enclosing mingw directory
+        $BIN_DIR=(Split-Path -Parent $CC) # Find folder containing c compiler
+        $MINGW_DIR=(Split-Path -Parent $BIN_DIR) # Find the enclosing mingw directory
         $LIBRARY_DIR="$MINGW_DIR/lib"
         echo $LIBRARY_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "LIBRARY_DIR=${LIBRARY_DIR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Add DLL paths
       run: |
         # Add DLL paths for program execution
-        $BIN_DIR=(Split-Path -Parent $CC) # Find folder containing c compiler
+        $BIN_DIR=(Split-Path -Parent gcc) # Find folder containing c compiler
         $MINGW_DIR=(Split-Path -Parent $BIN_DIR) # Find the enclosing mingw directory
         $LIBRARY_DIR="$MINGW_DIR/lib"
         echo $LIBRARY_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -16,14 +16,13 @@ runs:
     - name: Add DLL paths
       run: |
         # Add DLL paths for program execution
+        echo $CC
+        which gcc
         ls C:\
         ls C:\ProgramData
         ls C:\ProgramData\chocolatey
         ls C:\ProgramData\chocolatey\lib
         ls C:\ProgramData\chocolatey\lib\mingw
-        ls C:\ProgramData\chocolatey\lib\mingw\tools
-        ls C:\ProgramData\chocolatey\lib\mingw\tools\install
-        ls C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\
         $BIN_DIR="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
         $LIBRARY_DIR="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\lib"
         echo $BIN_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -22,7 +22,7 @@ runs:
         ls C:\ProgramData
         ls C:\ProgramData\chocolatey
         ls C:\ProgramData\chocolatey\lib
-        ls C:\ProgramData\chocolatey\lib\mingw
+        ls C:\mingw64
         $BIN_DIR="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
         $LIBRARY_DIR="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\lib"
         echo $BIN_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -16,6 +16,14 @@ runs:
     - name: Add DLL paths
       run: |
         # Add DLL paths for program execution
+        ls C:\
+        ls C:\ProgramData
+        ls C:\ProgramData\chocolatey
+        ls C:\ProgramData\chocolatey\lib
+        ls C:\ProgramData\chocolatey\lib\mingw
+        ls C:\ProgramData\chocolatey\lib\mingw\tools
+        ls C:\ProgramData\chocolatey\lib\mingw\tools\install
+        ls C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\
         $BIN_DIR="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
         $LIBRARY_DIR="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\lib"
         echo $BIN_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -16,8 +16,9 @@ runs:
     - name: Add DLL paths
       run: |
         # Add DLL paths for program execution
-        $BIN_DIR=(Split-Path -Parent gcc) # Find folder containing c compiler
-        $MINGW_DIR=(Split-Path -Parent $BIN_DIR) # Find the enclosing mingw directory
+        $EXE=(which gcc)
+        $BIN_DIR=(Split-Path -Parent ${EXE}) # Find folder containing c compiler
+        $MINGW_DIR=(Split-Path -Parent ${BIN_DIR}) # Find the enclosing mingw directory
         $LIBRARY_DIR="$MINGW_DIR/lib"
         echo $LIBRARY_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "LIBRARY_DIR=${LIBRARY_DIR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
Fix #1572 . Use the executable `gcc` to determine the bin directory instead of using absolute paths which may move.