### PR TITLE
Fix fork PR commit check

### DIFF
--- a/.github/actions/add_remote/action.yml
+++ b/.github/actions/add_remote/action.yml
@@ -1,0 +1,32 @@
+name: 'Add a remote and fetch if it is a fork'
+inputs:
+  pr_id:
+    description: "The number of the pull request"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Get repo information"
+      run: |
+        REPO_INFO=$(gh pr view ${{ inputs.pr_id }} --json=headRepositoryOwner,headRepository)
+        echo "REPO_INFO=${REPO_INFO}" >> $GITHUB_ENV
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+    - name: "Get repo identifier"
+      run: |
+        import json
+        import os
+        j=json.loads(os.environ['REPO_INFO'])
+        headRepo = j['headRepository']['name']
+        headOwner = j['headRepositoryOwner']['login']
+        repo_name = f'{headOwner}/{headRepo}'
+        with open(os.environ['GITHUB_ENV'], 'a') as f:
+            print(f"repo_name={repo_name}", file=f)
+      shell: python
+    - name: Add remote
+      if: env.repo_name != 'pyccel/pyccel'
+      run: |
+        git remote add -f --no-tags fork https://github.com/${repo_name}
+      shell: bash

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -12,6 +12,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/add_remote
+        with:
+          pr_id: ${{ github.event.issue.number }}
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/prepare_review_stage.yml
+++ b/.github/workflows/prepare_review_stage.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/add_remote
+        with:
+          pr_id: ${{ github.event.number }}
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/ci_tools/bot_comment_react.py
+++ b/ci_tools/bot_comment_react.py
@@ -64,14 +64,14 @@ if __name__ == '__main__':
 
     elif command_words[0] == 'run':
         if bot.is_user_trusted(event['comment']['user']['login']):
-            bot.run_tests(get_unique_test_list(command_words[1:]), force_run = bot.is_pr_fork())
+            bot.run_tests(get_unique_test_list(command_words[1:]))
         else:
             bot.warn_untrusted()
 
     elif command_words[0] == 'try':
         if bot.is_user_trusted(event['comment']['user']['login']):
             print(command_words, get_unique_test_list(command_words[2:]), command_words[1])
-            bot.run_tests(get_unique_test_list(command_words[2:]), command_words[1], force_run = bot.is_pr_fork())
+            bot.run_tests(get_unique_test_list(command_words[2:]), command_words[1])
         else:
             bot.warn_untrusted()
 

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -537,7 +537,7 @@ class Bot:
             self.mark_as_draft()
             return False
 
-        states = self.run_tests(pr_test_keys, force_run = self.is_pr_fork())
+        states = self.run_tests(pr_test_keys)
 
         if 'failure' in states:
             self.draft_due_to_failure()


### PR DESCRIPTION
Add an action `add_remote` to add a remote to the checked out branch. This is designed to add a fork as a remote. In this way git can see the commits on the fork which allows it to investigate them when trying to avoid running unnecessary tests