### PR TITLE
Remove HomogeneousTupleVariable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 -   #1576 : Correct destructor invocation for proper cleanup.
 -   #1576 : Remove inline class method definition.
 -   Ensure an error is raised when if conditions are used in comprehension statements.
+-   #1582 : Allow homogeneous tuples in classes.
 
 ### Changed
 
@@ -22,6 +23,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] #1593 : Use a setter instead of a method to update `PyccelAstNode.ast`.
 -   \[INTERNALS\] #1593 : Rename `BasicParser._current_fst_node` to the `BasicParser._current_ast_node`.
 -   \[INTERNALS\] #1390 : Remove dead code handling a `CodeBlock` in an assignment.
+-   \[INTERNALS\] #1582 : Remove the `HomogeneousTupleVariable` type.
 
 ### Deprecated
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -23,7 +23,7 @@ from .builtins       import (PythonInt, PythonBool, PythonFloat, PythonTuple,
 
 from .core           import Module, Import, PyccelFunctionDef, FunctionCall
 
-from .datatypes      import (dtype_and_precision_registry as dtype_registry,
+from .datatypes      import (dtype_and_precision_registry as dtype_registry, NativeHomogeneousTuple,
                              default_precision, NativeInteger, DataType, NativeNumericTypes,
                              NativeFloat, NativeComplex, NativeBool, NativeNumeric)
 
@@ -35,7 +35,7 @@ from .literals       import LiteralTrue, LiteralFalse
 from .literals       import Nil
 from .mathext        import MathCeil
 from .operators      import broadcast, PyccelMinus, PyccelDiv, PyccelMul, PyccelAdd
-from .variable       import Variable, Constant, HomogeneousTupleVariable
+from .variable       import Variable, Constant
 
 errors = Errors()
 pyccel_stage = PyccelStage()
@@ -650,7 +650,7 @@ class NumpyArray(NumpyNewArray):
         if not isinstance(arg, (PythonTuple, PythonList, Variable)):
             raise TypeError('Unknown type of  %s.' % type(arg))
 
-        is_homogeneous_tuple = isinstance(arg, (PythonTuple, HomogeneousTupleVariable)) and arg.is_homogeneous
+        is_homogeneous_tuple = isinstance(arg.class_type, NativeHomogeneousTuple)
         is_array = isinstance(arg, Variable) and arg.is_ndarray
 
         # TODO: treat inhomogenous lists and tuples when they have mixed ordering
@@ -1245,7 +1245,7 @@ class NumpyFull(NumpyNewArray):
     shape : TypedAstNode
         Shape of the new array, e.g., ``(2, 3)`` or ``2``.
         For a 1D array this is either a `LiteralInteger` or an expression.
-        For a ND array this is a `PythonTuple` or a `HomogeneousTupleVariable`.
+        For a ND array this is a `TypedAstNode` with the class type NativeHomogeneousTuple.
 
     fill_value : TypedAstNode
         Fill value.
@@ -1405,7 +1405,7 @@ class NumpyFullLike(PyccelInternalFunction):
     shape : PythonTuple of TypedAstNode
         Overrides the shape of the array.
         For a 1D array this is either a `LiteralInteger` or an expression.
-        For a ND array this is a `PythonTuple` or a `HomogeneousTupleVariable`.
+        For a ND array this is a `TypedAstNode` with the class type NativeHomogeneousTuple.
 
     See Also
     --------
@@ -1449,7 +1449,7 @@ class NumpyEmptyLike(PyccelInternalFunction):
     shape : PythonTuple of TypedAstNode
         Overrides the shape of the array.
         For a 1D array this is either a `LiteralInteger` or an expression.
-        For a ND array this is a `PythonTuple` or a `HomogeneousTupleVariable`.
+        For a ND array this is a `TypedAstNode` with the class type NativeHomogeneousTuple.
 
     See Also
     --------
@@ -1495,7 +1495,7 @@ class NumpyOnesLike(PyccelInternalFunction):
     shape : PythonTuple of TypedAstNode
         Overrides the shape of the array.
         For a 1D array this is either a `LiteralInteger` or an expression.
-        For a ND array this is a `PythonTuple` or a `HomogeneousTupleVariable`.
+        For a ND array this is a `TypedAstNode` with the class type NativeHomogeneousTuple.
 
     See Also
     --------
@@ -1540,7 +1540,7 @@ class NumpyZerosLike(PyccelInternalFunction):
     shape : PythonTuple of TypedAstNode
         Overrides the shape of the array.
         For a 1D array this is either a `LiteralInteger` or an expression.
-        For a ND array this is a `PythonTuple` or a `HomogeneousTupleVariable`.
+        For a ND array this is a `TypedAstNode` with the class type NativeHomogeneousTuple.
 
     See Also
     --------

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -2092,7 +2092,7 @@ class NumpyNonZeroElement(NumpyNewArray):
         """
         return self._dim
 
-class NumpyNonZero(NumpyNewArray):
+class NumpyNonZero(PyccelInternalFunction):
     """
     Class representing a call to the function `numpy.nonzero`.
 
@@ -2117,6 +2117,8 @@ class NumpyNonZero(NumpyNewArray):
     _precision = 8
     _rank  = 2
     _order = 'C'
+    _class_type = NativeHomogeneousTuple()
+
     def __init__(self, a):
         if (a.rank > 1):
             raise NotImplementedError("Non-Zero function is only implemented for 1D arrays")

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -654,12 +654,18 @@ def insert_fors(blocks, indices, scope, level = 0):
 #==============================================================================
 def expand_inhomog_tuple_assignments(block, language_has_vectors = False):
     """
-    Simplify expressions in a CodeBlock by unravelling tuple assignments into multiple lines
+    Simplify expressions in a CodeBlock by unravelling tuple assignments into multiple lines.
+
+    Simplify expressions in a CodeBlock by unravelling tuple assignments into multiple lines.
+    These changes are carried out in-place.
 
     Parameters
-    ==========
-    block      : CodeBlock
-                The expression to be modified
+    ----------
+    block : CodeBlock
+        The expression to be modified.
+
+    language_has_vectors : bool, default=False
+        Indicates whether the target language has built-in support for vector operations.
 
     Examples
     --------

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -29,7 +29,6 @@ __all__ = (
     'Constant',
     'DottedName',
     'DottedVariable',
-    'HomogeneousTupleVariable',
     'IndexedElement',
     'InhomogeneousTupleVariable',
     'TupleVariable',
@@ -595,6 +594,10 @@ class Variable(TypedAstNode):
 
         return IndexedElement(self, *args)
 
+    def __iter__(self):
+        assert isinstance(self.shape[0], LiteralInteger)
+        return (self[i] for i in range(self.shape[0]))
+
     def invalidate_node(self):
         # Don't invalidate Variables
         pass
@@ -664,74 +667,7 @@ class DottedName(PyccelAstNode):
     def __hash__(self):
         return hash(str(self))
 
-class TupleVariable(Variable):
-
-    """Represents a tuple variable in the code.
-
-    Parameters
-    ----------
-    arg_vars: Iterable
-        Multiple variables contained within the tuple
-
-    Examples
-    --------
-    >>> from pyccel.ast.core import TupleVariable, Variable
-    >>> v1 = Variable('int','v1')
-    >>> v2 = Variable('bool','v2')
-    >>> n  = TupleVariable([v1, v2],'n')
-    >>> n
-    n
-    """
-    __slots__ = ()
-
-    @property
-    def is_ndarray(self):
-        return False
-
-class HomogeneousTupleVariable(TupleVariable):
-    """
-    Represents a homogeneous tuple variable in the code.
-
-    Represents a homogeneous tuple variable in the code.
-
-    Parameters
-    ----------
-    dtype : DataType
-        The data type of the elements of the tuple.
-    *args : tuple
-        See Variable.
-    **kwargs : dict
-        See Variable.
-
-    Examples
-    --------
-    >>> from pyccel.ast.core import TupleVariable, Variable
-    >>> v1 = Variable('int','v1')
-    >>> v2 = Variable('bool','v2')
-    >>> n  = TupleVariable([v1, v2],'n')
-    >>> n
-    n
-    """
-    __slots__ = ()
-    is_homogeneous = True
-
-    def __init__(self, dtype, *args, **kwargs):
-        super().__init__(dtype, *args, **kwargs)
-
-    def shape_can_change(self, i):
-        """
-        Indicates if the shape can change in the i-th dimension
-        """
-        return self.is_alias and i == (self.rank-1)
-
-    def __len__(self):
-        return self.shape[0]
-
-    def __iter__(self):
-        assert isinstance(self.shape[0], LiteralInteger)
-        return (self[i] for i in range(self.shape[0]))
-
-class InhomogeneousTupleVariable(TupleVariable):
+class InhomogeneousTupleVariable(Variable):
     """
     Represents an inhomogeneous tuple variable in the code.
 
@@ -838,6 +774,10 @@ class InhomogeneousTupleVariable(TupleVariable):
         for var in self._vars:
             if var.rank > 0:
                 var.is_target = is_target
+
+    @property
+    def is_ndarray(self):
+        return False
 
 class Constant(Variable):
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -779,6 +779,11 @@ class InhomogeneousTupleVariable(Variable):
 
     @property
     def is_ndarray(self):
+        """
+        Helper function to determine whether the variable is a NumPy array.
+
+        Helper function to determine whether the variable is a NumPy array.
+        """
         return False
 
 class Constant(Variable):

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -586,6 +586,9 @@ class Variable(TypedAstNode):
 
     def __getitem__(self, *args):
 
+        if self.rank < len(args):
+            raise IndexError('Rank mismatch.')
+
         if len(args) == 1:
             arg0 = args[0]
             if isinstance(arg0, (tuple, list)):
@@ -594,9 +597,6 @@ class Variable(TypedAstNode):
                 self_len = self.shape[0]
                 if isinstance(self_len, LiteralInteger) and arg0 >= int(self_len):
                     raise StopIteration
-
-        if self.rank < len(args):
-            raise IndexError('Rank mismatch.')
 
         return IndexedElement(self, *args)
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -586,17 +586,19 @@ class Variable(TypedAstNode):
 
     def __getitem__(self, *args):
 
-        if len(args) == 1 and isinstance(args[0], (tuple, list)):
-            args = args[0]
+        if len(args) == 1:
+            arg0 = args[0]
+            if isinstance(arg0, (tuple, list)):
+                args = arg0
+            elif isinstance(arg0, int):
+                self_len = self.shape[0]
+                if isinstance(self_len, LiteralInteger) and arg0 >= int(self_len):
+                    raise StopIteration
 
         if self.rank < len(args):
             raise IndexError('Rank mismatch.')
 
         return IndexedElement(self, *args)
-
-    def __iter__(self):
-        assert isinstance(self.shape[0], LiteralInteger)
-        return (self[i] for i in range(self.shape[0]))
 
     def invalidate_node(self):
         # Don't invalidate Variables

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -27,7 +27,7 @@ from pyccel.ast.operators import PyccelUnarySub, IfTernaryOperator
 
 from pyccel.ast.datatypes import NativeInteger, NativeBool, NativeComplex, NativeVoid
 from pyccel.ast.datatypes import NativeFloat, NativeTuple, datatype, default_precision
-from pyccel.ast.datatypes import CustomDataType, NativeString
+from pyccel.ast.datatypes import CustomDataType, NativeString, NativeHomogeneousTuple
 
 from pyccel.ast.internals import Slice, PrecomputedCode, get_final_precision, PyccelArrayShapeElement
 
@@ -46,7 +46,7 @@ from pyccel.ast.variable import IndexedElement
 from pyccel.ast.variable import Variable
 from pyccel.ast.variable import DottedName
 from pyccel.ast.variable import DottedVariable
-from pyccel.ast.variable import InhomogeneousTupleVariable, HomogeneousTupleVariable
+from pyccel.ast.variable import InhomogeneousTupleVariable
 
 from pyccel.ast.c_concepts import ObjectAddress, CMacro, CStringExpression
 
@@ -1209,7 +1209,7 @@ class CCodePrinter(CodePrinter):
         rank  = expr.rank
 
         if rank > 0:
-            if expr.is_ndarray or isinstance(expr, HomogeneousTupleVariable):
+            if expr.is_ndarray or isinstance(expr.class_type, NativeHomogeneousTuple):
                 if expr.rank > 15:
                     errors.report(UNSUPPORTED_ARRAY_RANK, symbol=expr, severity='fatal')
                 self.add_import(c_imports['ndarrays'])
@@ -1350,7 +1350,7 @@ class CCodePrinter(CodePrinter):
         #set dtype to the C struct types
         dtype = self.find_in_ndarray_type_registry(expr.dtype, expr.precision)
         base_name = self._print(base)
-        if getattr(base, 'is_ndarray', False) or isinstance(base, HomogeneousTupleVariable):
+        if getattr(base, 'is_ndarray', False) or isinstance(base.class_type, NativeHomogeneousTuple):
             if expr.rank > 0:
                 #managing the Slice input
                 for i , ind in enumerate(inds):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -10,13 +10,14 @@ from pyccel.decorators import __all__ as pyccel_decorators
 from pyccel.ast.builtins   import PythonMin, PythonMax, PythonType
 from pyccel.ast.core       import CodeBlock, Import, Assign, FunctionCall, For, AsName, FunctionAddress
 from pyccel.ast.core       import IfSection, FunctionDef, Module, DottedFunctionCall, PyccelFunctionDef
+from pyccel.ast.datatypes  import NativeHomogeneousTuple
 from pyccel.ast.functionalexpr import FunctionalFor
 from pyccel.ast.literals   import LiteralTrue, LiteralString
 from pyccel.ast.literals   import LiteralInteger, LiteralFloat, LiteralComplex
 from pyccel.ast.numpyext   import numpy_target_swap
 from pyccel.ast.numpyext   import NumpyArray, NumpyNonZero, NumpyResultType
 from pyccel.ast.numpyext   import DtypePrecisionToCastFunction
-from pyccel.ast.variable   import DottedName, HomogeneousTupleVariable, Variable
+from pyccel.ast.variable   import DottedName, Variable
 from pyccel.ast.utilities  import builtin_import_registry as pyccel_builtin_import_registry
 from pyccel.ast.utilities  import decorators_mod
 
@@ -290,7 +291,7 @@ class PythonCodePrinter(CodePrinter):
                 indices = indices[0]
 
             indices = [self._print(i) for i in indices]
-            if isinstance(expr.base, HomogeneousTupleVariable):
+            if isinstance(expr.base.class_type, NativeHomogeneousTuple):
                 indices = ']['.join(i for i in indices)
             else:
                 indices = ','.join(i for i in indices)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3025,7 +3025,8 @@ class SemanticParser(BasicParser):
             for l,r in zip(lhs, rhs):
                 # Split assign (e.g. for a,b = 1,c)
                 if isinstance(l, (PythonTuple, InhomogeneousTupleVariable)) \
-                        and isinstance(r.class_type,(NativeTuple, NativeHomogeneousList)):
+                        and isinstance(r.class_type,(NativeTuple, NativeHomogeneousList)) \
+                        and not isinstance(r, FunctionCall):
                     new_lhs.extend(l)
                     new_rhs.extend(r)
                     # Repeat step to handle tuples of tuples of etc.

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3805,7 +3805,7 @@ class SemanticParser(BasicParser):
                 # create a new attribute to check allocation
                 deallocater_rhs = Variable(NativeBool(), self.scope.get_new_name('is_freed'))
                 deallocater_lhs = Variable(cls.name, 'self', cls_base = cls, is_argument=True)
-                deallocater = DottedVariable(*deallocater_rhs, lhs = deallocater_lhs, name = deallocater_rhs.name, dtype = deallocater_rhs.dtype)
+                deallocater = DottedVariable(lhs = deallocater_lhs, name = deallocater_rhs.name, dtype = deallocater_rhs.dtype)
                 cls.add_new_attribute(deallocater)
                 deallocater_assign = Assign(deallocater, LiteralFalse())
                 cls.methods[i].body.insert2body(deallocater_assign, back=False)


### PR DESCRIPTION
Remove the class `HomogeneousTupleVariable`. This is no longer needed now that we have `TypedAstNode.class_type`. Removing this class allows us to store homogeneous tuples in classes. Fixes #1582 .