### PR TITLE
Remove dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] #1593 : Rename `PyccelAstNode.fst` to the `PyccelAstNode.ast`.
 -   \[INTERNALS\] #1593 : Use a setter instead of a method to update `PyccelAstNode.ast`.
 -   \[INTERNALS\] #1593 : Rename `BasicParser._current_fst_node` to the `BasicParser._current_ast_node`.
+-   \[INTERNALS\] #1390 : Remove dead code handling a `CodeBlock` in an assignment.
 
 ### Deprecated
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2909,32 +2909,6 @@ class SemanticParser(BasicParser):
                 i.set_current_ast(python_ast)
             return rhs
 
-        elif isinstance(rhs, CodeBlock):
-            if len(rhs.body)>1 and isinstance(rhs.body[1], FunctionalFor):
-                return rhs
-
-            # case of complex stmt
-            # that needs to be splitted
-            # into a list of stmts
-            stmts = rhs.body
-            stmt  = stmts[-1]
-            lhs   = expr.lhs
-            if isinstance(lhs, PyccelSymbol):
-                name = lhs
-                if self.check_for_variable(name) is None:
-                    d_var = self._infer_type(stmt)
-                    dtype = d_var.pop('datatype')
-                    lhs = Variable(dtype, name , **d_var, is_temp = lhs.is_temp)
-                    self.scope.insert_variable(lhs)
-
-            if isinstance(expr, Assign):
-                stmt = Assign(lhs, stmt)
-            elif isinstance(expr, AugAssign):
-                stmt = AugAssign(lhs, expr.op, stmt)
-            stmt.set_current_ast(python_ast)
-            stmts[-1] = stmt
-            return CodeBlock(stmts)
-
         elif isinstance(rhs, FunctionCall):
             func = rhs.funcdef
             results = func.results

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2909,6 +2909,9 @@ class SemanticParser(BasicParser):
                 i.set_current_ast(python_ast)
             return rhs
 
+        elif isinstance(rhs, CodeBlock) and len(rhs.body)>1 and isinstance(rhs.body[1], FunctionalFor):
+            return rhs
+
         elif isinstance(rhs, FunctionCall):
             func = rhs.funcdef
             results = func.results


### PR DESCRIPTION
After investigating the code flagged in issues #1390 and #1594 it seems it is dead code. It is therefore removed in this PR. Fixes #1390. Fixes #1594.

The original code was designed to handle `CodeBlock`s but this has been superseded by `SemanticParser._additional_exprs`