### PR TITLE
Update docs wrong path

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -224,8 +224,8 @@ If the folder where Pyccel is saved is read only, it may be necessary to run an 
 sudo pyccel-init
 ```
 
-This step is necessary in order to [pickle header files](./tutorial/header-files.md#Pickling-header-files).
-If this command is not run then Pyccel will still run correctly but may be slower when using [OpenMP](./tutorial/openmp.md) or other supported external packages.
+This step is necessary in order to [pickle header files](./header-files.md#Pickling-header-files).
+If this command is not run then Pyccel will still run correctly but may be slower when using [OpenMP](./openmp.md) or other supported external packages.
 A warning, reminding the user to execute this command, will be printed to the screen when pyccelising files which rely on these packages if the pickling step has not been executed.
 
 ## Additional packages


### PR DESCRIPTION
Fix wrong path in `docs/installation.md` due to the removal of the `docs/tutorial/` subfolder.