### PR TITLE
Integration of BLAS and LAPACK for Optimized ndarray Operations: A Proof of Concept with GEMM

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -37,7 +37,7 @@ from pyccel.ast.literals  import Nil
 
 from pyccel.ast.mathext  import math_constants
 
-from pyccel.ast.numpyext import NumpyFull, NumpyArray
+from pyccel.ast.numpyext import NumpyFull, NumpyArray, NumpyMatmul
 from pyccel.ast.numpyext import NumpyReal, NumpyImag, NumpyFloat, NumpySize
 
 from pyccel.ast.utilities import expand_to_loops
@@ -1736,6 +1736,11 @@ class CCodePrinter(CodePrinter):
             return f'numpy_sum_bool({name})'
         raise NotImplementedError('Sum not implemented for argument')
 
+    def _print_NumpyMatmul(self, expr, lhs):
+        if all(x.dtype == NativeFloat() for x in expr.args) and all(len(x.shape) == 2 for x in expr.args):
+            a, b = expr.args
+            return f'cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,{a.shape[0]}, {b.shape[1]}, {a.shape[1]}, 1.0f, {self._print(a)}.nd_float, {a.shape[1]}, {self._print(b)}.nd_float, {b.shape[1]}, 0.0f, {self._print(lhs)}.nd_float, {b.shape[1]});\n'
+
     def _print_NumpyLinspace(self, expr):
         template = '({start} + {index}*{step})'
         if not isinstance(expr.endpoint, LiteralFalse):
@@ -2005,6 +2010,8 @@ class CCodePrinter(CodePrinter):
             return prefix_code+self.copy_NumpyArray_Data(expr)
         if isinstance(rhs, (NumpyFull)):
             return prefix_code+self.arrayFill(expr)
+        if isinstance(rhs, (NumpyMatmul)):
+            return prefix_code+self._print_NumpyMatmul(rhs, lhs)
         lhs = self._print(expr.lhs)
         rhs = self._print(expr.rhs)
         return prefix_code+'{} = {};\n'.format(lhs, rhs)

--- a/pyccel/stdlib/ndarrays/ndarrays.h
+++ b/pyccel/stdlib/ndarrays/ndarrays.h
@@ -9,6 +9,7 @@
 # include <complex.h>
 # include <stdbool.h>
 # include <stdint.h>
+# include <cblas.h>
 
 /* mapping the function array_fill to the correct type */
 # define array_fill(c, arr) _Generic((c), int64_t : _array_fill_int64,\


### PR DESCRIPTION
## Overview

This pull request represents a significant step forward in enhancing Pyccel's performance capabilities. Currently, Pyccel's ndarray functions rely on naive implementations, which, when functional, do not leverage the computational efficiency and speed optimizations provided by advanced libraries like BLAS and LAPACK. These libraries are cornerstones in scientific computing for their unparalleled optimizations in linear algebra operations.

## Motivation

The motivation for this pull request is twofold:

1. **Performance Boost**: The existing naive implementation of ndarray functions in Pyccel results in suboptimal performance, particularly evident in large-scale computations. Integrating BLAS and LAPACK will enable Pyccel to achieve a substantial speed-up, aligning it with the performance of native implementations in more lower-level languages.

2. **Application of the DRY concept**: The integration of widely recognized and utilized libraries like BLAS and LAPACK brings Pyccel in line with numpy methods, enhancing its appeal and utility in the scientific computing community.

## Proof of Concept: GEMM for Float Arrays

As a proof of concept, this pull request introduces the integration of the GEMM (General Matrix Multiply) operation from BLAS for float arrays. This implementation showcases the potential performance improvements Pyccel can achieve by utilizing these optimized libraries.

Input:
```
import numpy as np

if __name__ == "__main__":
    a = np.array([[1,2,4],[4,5,3]], dtype=np.float32)
    b = np.array([[1,2],[4,5], [3,4]], dtype=np.float32)
    c = np.matmul(a,b)
    print(c)
    
```
Command:
```
pyccel --language c test.py --libs=openblas
```

Result:
```
#include "test.h"
#include <stdlib.h>
#include "ndarrays.h"
#include <stdint.h>
#include <string.h>
#include <stdio.h>
#include <inttypes.h>
int main()
{
    t_ndarray a = {.shape = NULL};
    t_ndarray b = {.shape = NULL};
    t_ndarray c = {.shape = NULL};
    int64_t i;
    int64_t i_0001;
    int64_t i_0002;
    a = array_create(2, (int64_t[]){INT64_C(2), INT64_C(3)}, nd_float, false, order_c);
    float Dummy_0000[] = {INT64_C(1), INT64_C(2), INT64_C(4), INT64_C(4), INT64_C(5), INT64_C(3)};
    memcpy(&a.nd_float[INT64_C(0)], Dummy_0000, 6 * a.type_size);
    b = array_create(2, (int64_t[]){INT64_C(3), INT64_C(2)}, nd_float, false, order_c);
    float Dummy_0001[] = {INT64_C(1), INT64_C(2), INT64_C(4), INT64_C(5), INT64_C(3), INT64_C(4)};
    memcpy(&b.nd_float[INT64_C(0)], Dummy_0001, 6 * b.type_size);
    c = array_create(2, (int64_t[]){INT64_C(2), INT64_C(2)}, nd_float, false, order_c);
    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,2, 2, 3, 1.0f, a.nd_float, 3, b.nd_float, 2, 0.0f, c.nd_float, 2);
    printf("%s", "[");
    for (i = INT64_C(0); i < INT64_C(1); i += INT64_C(1))
    {
        printf("%s", "[");
        for (i_0001 = INT64_C(0); i_0001 < INT64_C(1); i_0001 += INT64_C(1))
        {
            printf("%.12f ", GET_ELEMENT(c, nd_float, (int64_t)i, (int64_t)i_0001));
        }
        printf("%.12f]\n", GET_ELEMENT(c, nd_float, (int64_t)i, (int64_t)INT64_C(1)));
    }
    printf("%s", "[");
    for (i_0002 = INT64_C(0); i_0002 < INT64_C(1); i_0002 += INT64_C(1))
    {
        printf("%.12f ", GET_ELEMENT(c, nd_float, (int64_t)INT64_C(1), (int64_t)i_0002));
    }
    printf("%.12f]]\n", GET_ELEMENT(c, nd_float, (int64_t)INT64_C(1), (int64_t)INT64_C(1)));
    free_array(&a);
    free_array(&b);
    free_array(&c);
    return 0;
}
```

## Discussion: Roadmap for Full Integration

This proof of concept is just the beginning of fully harnessing BLAS and LAPACK in Pyccel. The complete integration of these libraries necessitates a comprehensive discussion on several key points:

- **Scope and Extent**: Identifying the most essential functions from BLAS and LAPACK for early integration, based on Pyccel's common use-cases.

- **Integration Strategy**: Developing a systematic approach for incorporating these functions, with considerations for ease of use, maintainability, and compatibility with the existing Pyccel codebase.

- **Discrepency mitigation**: For gemm for example, there is no implementation for int types, however numpy does support this. Discussion is needed in such scenario or when there is no equivalent function in blas/lapack.

- **Performance Benchmarks**: Establishing a benchmarking framework to quantitatively evaluate the performance gains from this integration.

## Conclusion

This pull request not only aims to improve the performance of Pyccel but also seeks to align it with the best practices in scientific computing. Your feedback and contributions are crucial as we set out to enhance Pyccel's efficiency and utility through the integration of BLAS and LAPACK.
