### PR TITLE
Manage Pylint errors via bot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,6 +90,7 @@ jobs:
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
           python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
+          export PYTHONPATH=compare/ci_tools
           while read line; do
             echo "python -m numpydoc --validate $line"
             python -m numpydoc --validate $line 2>&1 | tee -a report.txt || true 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,7 +90,7 @@ jobs:
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
           python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
-          export PYTHONPATH=compare/ci_tools
+          export PYTHONPATH=ci_tools
           while read line; do
             echo "python -m numpydoc --validate $line"
             python -m numpydoc --validate $line 2>&1 | tee -a report.txt || true 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pylint
+          python -m pip install defusedxml
         shell: bash
       - name: Pylint
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -57,14 +57,12 @@ jobs:
         shell: bash
       - name: Reference Pylint
         run: |
-          python_files=$(find -name "*.py")
-          python -m pylint --rcfile=.pylintrc ${python_files} 2>&1 | tee pylint_results.txt || true
+          python -m pylint --rcfile=.pylintrc --recursive=true . 2>&1 | tee pylint_results.txt || true
         working-directory: base
         shell: bash
       - name: New Pylint
         run: |
-          python_files=$(find -name "*.py")
-          python -m pylint --rcfile=.pylintrc ${python_files} 2>&1 | tee pylint_results.txt || true
+          python -m pylint --rcfile=.pylintrc --recursive=true . 2>&1 | tee pylint_results.txt || true
         working-directory: compare
         shell: bash
       - name: Pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -34,13 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.base }}
-          path: base
-      - uses: actions/checkout@v3
-        with:
           path: compare
           ref: ${{ env.COMMIT }}
           repository: ${{ env.PR_REPO }}
+          fetch-depth: 0
       - name: Set up Python ${{ inputs.python_version }}
         uses: actions/setup-python@v4
         with:
@@ -59,12 +56,10 @@ jobs:
         run: |
           check_files=$(git diff ${{ inputs.base }}..HEAD --name-only --diff-filter=AM | grep "\.py$")
           python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
-        working-directory: compare
         shell: bash
       - name: Pylint
         id: pylint
         run: |
-          cd compare
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
           python ci_tools/parse_pylint_output.py pylint_results.txt pull_diff.txt $GITHUB_STEP_SUMMARY
         shell: bash

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -58,13 +58,13 @@ jobs:
       - name: Reference Pylint
         run: |
           python_files=$(find -name "*.py")
-          python -m pylint --rcfile=.pylintrc ${python_files} > pylint_results.txt || true
+          python -m pylint --rcfile=.pylintrc ${python_files} 2>&1 | tee pylint_results.txt || true
         working-directory: base
         shell: bash
       - name: New Pylint
         run: |
           python_files=$(find -name "*.py")
-          python -m pylint --rcfile=.pylintrc ${python_files} > pylint_results.txt || true
+          python -m pylint --rcfile=.pylintrc ${python_files} 2>&1 | tee pylint_results.txt || true
         working-directory: compare
         shell: bash
       - name: Pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -57,18 +57,22 @@ jobs:
         shell: bash
       - name: Reference Pylint
         run: |
-          python -m pylint --rcfile=.pylintrc --recursive=true . 2>&1 | tee pylint_results.txt || true
+          check_files=$(git diff ${{ inputs.ref }}..HEAD --name-only --diff-filter=DM | grep "\.py$")
+          python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
         working-directory: base
         shell: bash
       - name: New Pylint
         run: |
-          python -m pylint --rcfile=.pylintrc --recursive=true . 2>&1 | tee pylint_results.txt || true
+          check_files=$(git diff ${{ inputs.base }}..HEAD --name-only --diff-filter=AM | grep "\.py$")
+          python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
         working-directory: compare
         shell: bash
       - name: Pylint
         id: pylint
         run: |
-          python compare/ci_tools/parse_pylint_output.py base/pylint_results.txt compare/pylint_results.txt $GITHUB_STEP_SUMMARY
+          cd compare
+          git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
+          python ci_tools/parse_pylint_output.py ../base/pylint_results.txt pylint_results.txt pull_diff.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
         if: always()

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: compare
           ref: ${{ env.COMMIT }}
           repository: ${{ env.PR_REPO }}
           fetch-depth: 0
@@ -46,7 +45,7 @@ jobs:
         id: token
         run: |
           pip install jwt requests
-          python base/ci_tools/setup_check_run.py pylint
+          python ci_tools/setup_check_run.py pylint
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -66,4 +65,4 @@ jobs:
       - name: "Post completed"
         if: always()
         run:
-          python base/ci_tools/complete_check_run.py ${{ steps.pylint.outcome }}
+          python ci_tools/complete_check_run.py ${{ steps.pylint.outcome }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,6 +9,9 @@ on:
       ref:
         required: false
         type: string
+      base:
+        required: true
+        type: string
       check_run_id:
         required: false
         type: string
@@ -31,6 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.base }}
+          path: base
+      - uses: actions/checkout@v3
+        with:
+          path: compare
           ref: ${{ env.COMMIT }}
           repository: ${{ env.PR_REPO }}
       - name: Set up Python ${{ inputs.python_version }}
@@ -41,27 +49,30 @@ jobs:
         id: token
         run: |
           pip install jwt requests
-          python ci_tools/setup_check_run.py pylint
-      - name: Check branch
-        run: |
-          git branch
-          git status
+          python base/ci_tools/setup_check_run.py pylint
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install pylint
         shell: bash
+      - name: Reference Pylint
+        run: |
+          python_files=$(find -name "*.py")
+          python -m pylint --rcfile=.pylintrc ${python_files} > pylint_results.txt || true
+        working-directory: base
+        shell: bash
+      - name: New Pylint
+        run: |
+          python_files=$(find -name "*.py")
+          python -m pylint --rcfile=.pylintrc ${python_files} > pylint_results.txt || true
+        working-directory: compare
+        shell: bash
       - name: Pylint
         id: pylint
         run: |
-          echo $GITHUB_WORKFLOW_SHA
-          ast_files="basic.py bind_c.py bitwise_operators.py builtin_imports.py builtins.py c_concepts.py class_defs.py cmathext.py itertoolsext.py omp.py operators.py scipyext.py sympy_helper.py sysext.py type_annotations.py"
-          pylintable_files="pyccel/parser/semantic.py"
-          for f in $ast_files; do pylintable_files="$pylintable_files pyccel/ast/$f"; done
-          python -m pylint --rcfile=.pylintrc $pylintable_files | tee pylint_output.out || true
-          python ci_tools/parse_pylint_output.py pylint_output.out $GITHUB_STEP_SUMMARY
+          python compare/ci_tools/parse_pylint_output.py base/pylint_results.txt compare/pylint_results.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
         if: always()
         run:
-          python ci_tools/complete_check_run.py ${{ steps.pylint.outcome }}
+          python base/ci_tools/complete_check_run.py ${{ steps.pylint.outcome }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -52,12 +52,12 @@ jobs:
           python -m pip install pylint
           python -m pip install defusedxml
         shell: bash
-      - name: Pylint
+      - name: Run Pylint
         run: |
           check_files=$(git diff ${{ inputs.base }}..HEAD --name-only --diff-filter=AM | grep "\.py$")
           python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
         shell: bash
-      - name: Pylint
+      - name: Filter Pylint output
         id: pylint
         run: |
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -55,13 +55,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pylint
         shell: bash
-      - name: Reference Pylint
-        run: |
-          check_files=$(git diff ${{ inputs.ref }}..HEAD --name-only --diff-filter=DM | grep "\.py$")
-          python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
-        working-directory: base
-        shell: bash
-      - name: New Pylint
+      - name: Pylint
         run: |
           check_files=$(git diff ${{ inputs.base }}..HEAD --name-only --diff-filter=AM | grep "\.py$")
           python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
@@ -72,7 +66,7 @@ jobs:
         run: |
           cd compare
           git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
-          python ci_tools/parse_pylint_output.py ../base/pylint_results.txt pylint_results.txt pull_diff.txt $GITHUB_STEP_SUMMARY
+          python ci_tools/parse_pylint_output.py pylint_results.txt pull_diff.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
         if: always()

--- a/.pylintrc
+++ b/.pylintrc
@@ -100,6 +100,7 @@ disable=invalid-name,
         abstract-method, # Raised when a method contains raise NotImplementedError
         redundant-keyword-arg,
         duplicate-code,
+        cyclic-import, # Output not consistent between pylint calls. This should be reactivated if cyclic dependencies can be fixed.
         unused-wildcard-import, # Raised by everything not used in pyccel.errors.messages when using 'from pyccel.errors.messages import *'
         isinstance-second-argument-not-valid-type # prevents doing isinstance(a, acceptable_iterable_types)
         

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -45,7 +45,7 @@ test_names = {
 
 test_dependencies = {'coverage':['linux']}
 
-tests_with_base = ('coverage', 'docs', 'pyccel_lint')
+tests_with_base = ('coverage', 'docs', 'pyccel_lint', 'pylint')
 
 pr_test_keys = ('linux', 'windows', 'macosx', 'coverage', 'docs', 'pylint',
                 'pyccel_lint', 'spelling')
@@ -425,7 +425,7 @@ class Bot:
             has_relevant_change = lambda diff: any(f.startswith('pyccel/') and f.endswith('.py') #pylint: disable=unnecessary-lambda-assignment
                                                     and f != 'pyccel/version.py' for f in diff)
         elif key in ('pylint'):
-            has_relevant_change = lambda diff: any(f == 'pyccel/parser/semantic.py' for f in diff) #pylint: disable=unnecessary-lambda-assignment
+            has_relevant_change = lambda diff: any(f.endswith('.py') for f in diff) #pylint: disable=unnecessary-lambda-assignment
         elif key in ('docs'):
             has_relevant_change = lambda diff: any(f.endswith('.py') and f != 'pyccel/version.py' #pylint: disable=unnecessary-lambda-assignment
                                                     for f in diff)

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -38,7 +38,7 @@ def get_pylint_results(filename):
             _, key = line.split(' Module ')
             pylint_results[key] = []
         else:
-            file, line, start, code, message = line.split(':')
+            file, line, start, code, message = line.split(':', 4)
             pylint_results[key].append(PylintMessage(file, line, start, message.strip()))
         idx += 1
         line = pylint_output[idx]

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -38,7 +38,7 @@ def get_pylint_results(filename):
     line = pylint_output[idx]
     while not all(c=='-' for c in line):
         if not line.startswith('***'):
-            file, line, start, code, message = line.split(':', 4)
+            file, line, start, _, message = line.split(':', 4)
             pylint_results.setdefault(file, []).append(PylintMessage(file, line, start, message.strip()))
         idx += 1
         line = pylint_output[idx]

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -64,13 +64,13 @@ def filter_pylint_results(pylint_results, diff):
     dict
         A dictionary containing only the pylint errors caused by this branch.
     """
-    lines = {k: [vi.line for vi in v] for k,v in pylint_results.items()}
+    lines = {k: [int(vi.line) for vi in v] for k,v in pylint_results.items()}
     filtered_lines = cov.compare_coverage_to_diff(lines, diff)
 
     filtered_pylint_results = {}
     for k,lines in filtered_lines.items():
         orig_errors = pylint_results[k]
-        filtered_pylint_results[k] = [v for v in orig_errors if v.line in lines]
+        filtered_pylint_results[k] = [v for v in orig_errors if int(v.line) in lines]
 
     return filtered_pylint_results
 

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -30,13 +30,13 @@ def get_pylint_results(filename):
 
     pylint_output = [l.strip() for l in pylint_output]
 
-    pylint_results_by_mod = {}
+    pylint_results = {}
     idx = 0
     line = pylint_output[idx]
     while not all(c=='-' for c in line):
         if not line.startswith('***'):
             file, line, start, code, message = line.split(':', 4)
-            pylint_results_by_mod.get(file, []).append(PylintMessage(file, line, start, message.strip()))
+            pylint_results.get(file, []).append(PylintMessage(file, line, start, message.strip()))
         idx += 1
         line = pylint_output[idx]
 

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -35,18 +35,12 @@ def get_pylint_results(filename):
     line = pylint_output[idx]
     while not all(c=='-' for c in line):
         if line.startswith('***'):
-            _, key = line.split(' Module ')
-            pylint_results_by_mod[key] = []
+            continue
         else:
             file, line, start, code, message = line.split(':', 4)
-            pylint_results_by_mod[key].append(PylintMessage(file, line, start, message.strip()))
+            pylint_results_by_mod.get(file, []).append(PylintMessage(file, line, start, message.strip()))
         idx += 1
         line = pylint_output[idx]
-
-    # Use file as key as module output is not consistent
-    pylint_results = {}
-    for v in pylint_results_by_mod.values():
-        pylint_results[v[0].file] = v
 
     return pylint_results
 

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -36,7 +36,7 @@ def get_pylint_results(filename):
     while not all(c=='-' for c in line):
         if not line.startswith('***'):
             file, line, start, code, message = line.split(':', 4)
-            pylint_results.get(file, []).append(PylintMessage(file, line, start, message.strip()))
+            pylint_results.setdefault(file, []).append(PylintMessage(file, line, start, message.strip()))
         idx += 1
         line = pylint_output[idx]
 

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -64,11 +64,11 @@ def filter_pylint_results(pylint_results, diff):
     dict
         A dictionary containing only the pylint errors caused by this branch.
     """
-    lines = {k: [vi.line for vi in v] for k,v in pylint_results}
+    lines = {k: [vi.line for vi in v] for k,v in pylint_results.items()}
     filtered_lines = cov.compare_coverage_to_diff(lines, diff)
 
     filtered_pylint_results = {}
-    for k,lines in filtered_lines:
+    for k,lines in filtered_lines.items():
         orig_errors = pylint_results[k]
         filtered_pylint_results[k] = [v for v in orig_errors if v.line in lines]
 

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -35,7 +35,7 @@ def get_pylint_results(filename):
     line = pylint_output[idx]
     while not all(c=='-' for c in line):
         if not line.startswith('***'):
-            file, line, start, code, message = line.split(':', 4)
+            file, line, start, _, message = line.split(':', 4)
             pylint_results.setdefault(file, []).append(PylintMessage(file, line, start, message.strip()))
         idx += 1
         line = pylint_output[idx]

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -99,6 +99,7 @@ if __name__ == '__main__':
         json.dump(json_data, json_file)
     with open(args.output, mode='a', encoding="utf-8") as md_file:
         md_file.write(output)
+    print(output)
 
     if annotations:
         sys.exit(1)

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -30,18 +30,23 @@ def get_pylint_results(filename):
 
     pylint_output = [l.strip() for l in pylint_output]
 
-    pylint_results = {}
+    pylint_results_by_mod = {}
     idx = 0
     line = pylint_output[idx]
     while not all(c=='-' for c in line):
         if line.startswith('***'):
             _, key = line.split(' Module ')
-            pylint_results[key] = []
+            pylint_results_by_mod[key] = []
         else:
             file, line, start, code, message = line.split(':', 4)
-            pylint_results[key].append(PylintMessage(file, line, start, message.strip()))
+            pylint_results_by_mod[key].append(PylintMessage(file, line, start, message.strip()))
         idx += 1
         line = pylint_output[idx]
+
+    # Use file as key as module output is not consistent
+    pylint_results = {}
+    for v in pylint_results_by_mod.values():
+        pylint_results[v[0].file] = v
 
     return pylint_results
 

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -38,7 +38,7 @@ def get_pylint_results(filename):
     line = pylint_output[idx]
     while not all(c=='-' for c in line):
         if not line.startswith('***'):
-            file, line, start, _, message = line.split(':', 4)
+            file, line, start, code, message = line.split(':', 4)
             pylint_results.setdefault(file, []).append(PylintMessage(file, line, start, message.strip()))
         idx += 1
         line = pylint_output[idx]

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -34,9 +34,7 @@ def get_pylint_results(filename):
     idx = 0
     line = pylint_output[idx]
     while not all(c=='-' for c in line):
-        if line.startswith('***'):
-            continue
-        else:
+        if not line.startswith('***'):
             file, line, start, code, message = line.split(':', 4)
             pylint_results_by_mod.get(file, []).append(PylintMessage(file, line, start, message.strip()))
         idx += 1

--- a/developer_docs/review_process.md
+++ b/developer_docs/review_process.md
@@ -10,7 +10,7 @@ Once the pull request is opened 9 tests should be triggered they are:
 -   **MacOS** : Runs the suite of tests on a macOS machine
 -   **Windows** : Runs the suite of tests on a windows machine
 -   **Codacy** : Runs a static compiler via the [codacy](https://app.codacy.com/gh/pyccel/pyccel/dashboard) platform
--   **Python Linting** : Does the same job as Codacy for certain files which are too large for Codacy to handle.
+-   **Python Linting** : Runs pylint on all Python files and reports any errors introduced by the pull request.
 -   **Pyccel Linting** : Runs a small static compiler to ensure that Pyccel coding guidelines are followed
 -   **Spellcheck** : Checks whether there are any spelling mistakes in the documentation (if a word is incorrectly flagged as a typo it should be added to the file [.dict_custom.txt](../.dict_custom.txt))
 -   **Coverage Checker** : Checks that the code which has been added is used in at least one test. Occasionally this test is overenthusiastic, it may therefore be disabled if an issue is created to find the problem at a later date.

--- a/developer_docs/review_process.md
+++ b/developer_docs/review_process.md
@@ -10,7 +10,7 @@ Once the pull request is opened 9 tests should be triggered they are:
 -   **MacOS** : Runs the suite of tests on a macOS machine
 -   **Windows** : Runs the suite of tests on a windows machine
 -   **Codacy** : Runs a static compiler via the [codacy](https://app.codacy.com/gh/pyccel/pyccel/dashboard) platform
--   **Python Linting** : Runs pylint on all Python files and reports any errors introduced by the pull request.
+-   **Python Linting** : Runs Pylint on all Python files and reports any errors introduced by the pull request.
 -   **Pyccel Linting** : Runs a small static compiler to ensure that Pyccel coding guidelines are followed
 -   **Spellcheck** : Checks whether there are any spelling mistakes in the documentation (if a word is incorrectly flagged as a typo it should be added to the file [.dict_custom.txt](../.dict_custom.txt))
 -   **Coverage Checker** : Checks that the code which has been added is used in at least one test. Occasionally this test is overenthusiastic, it may therefore be disabled if an issue is created to find the problem at a later date.

--- a/tests/epyccel/modules/bitwise.py
+++ b/tests/epyccel/modules/bitwise.py
@@ -49,10 +49,10 @@ def bit_and_b_b(a : 'bool', b : 'bool'):
     return a & b
 
 def bit_and_i_i_i(a : 'int', b : 'int', c : 'int'):
-        return a & b & c
+    return a & b & c
 
 def bit_and_b_b_i(a : 'bool', b : 'bool', c : 'int'):
-        return a & b & c
+    return a & b & c
 
 def invert_b(a : 'bool'):
     return ~a

--- a/tests/epyccel/modules/bitwise.py
+++ b/tests/epyccel/modules/bitwise.py
@@ -19,34 +19,34 @@ def left_shift_b_b(a : 'bool', b : 'bool'):
     return a >> b
 
 def bit_xor_b_b(a : 'bool', b : 'bool'):
-   return a ^ b
+    return a ^ b
 
 def bit_xor_b_b_b(a : 'bool', b : 'bool', c : 'bool'):
     return a ^ b ^ c
 
 def bit_xor_i_i(a : 'int', b : 'int'):
-   return a ^ b
+    return a ^ b
 
 def bit_xor_b_i(a : 'bool', b : 'int'):
-   return a ^ b
+    return a ^ b
 
 def bit_or_i_b(a : 'int', b : 'bool'):
-   return a | b
+    return a | b
 
 def bit_or_i_i(a : 'int', b : 'int'):
-   return a | b
+    return a | b
 
 def bit_or_b_b(a : 'bool', b : 'bool'):
-   return a | b
+    return a | b
 
 def bit_and_i_b(a : 'int', b : 'bool'):
-   return a & b
+    return a & b
 
 def bit_and_i_i(a : 'int', b : 'int'):
-   return a & b
+    return a & b
 
 def bit_and_b_b(a : 'bool', b : 'bool'):
-   return a & b
+    return a & b
 
 def bit_and_i_i_i(a : 'int', b : 'int', c : 'int'):
         return a & b & c
@@ -55,10 +55,10 @@ def bit_and_b_b_i(a : 'bool', b : 'bool', c : 'int'):
         return a & b & c
 
 def invert_b(a : 'bool'):
-   return ~a
+    return ~a
 
 def invert_i(a : 'int'):
-   return ~a
+    return ~a
 
 def or_ints(n : int):
     if n & 1 or n < 128:


### PR DESCRIPTION
Modify the pylint test. Pylint is now run on all files with a Python extension. The git diff is used to filter the results to avoid an extreme number of errors. Errors are only reported on lines that were changed. This means new unused-imports will not be reported for now. This mostly removes the necessity for Codacy for Python files (although it may still be useful for some corner cases) and fixes #1648 . Errors are not reported for cyclic-imports as they seem to be reported on lines unrelated to the error.

Additionally some pylint errors are fixed and the ci_tools folder is added to the PYTHONPATH for the docs test to prevent import issues causing failing tests