### PR TITLE
Use Python 3.10 with new Intel compiler

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - if: github.event_name == 'push'
       run: |
-        echo "version=3.9" >> $GITHUB_ENV
+        echo "version=3.10" >> $GITHUB_ENV
       shell: bash
     - id: dispatch-matrix
       if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
       - name: Run Pylint
         run: |
-          check_files=$(git diff ${{ inputs.base }}..HEAD --name-only --diff-filter=AM | grep "\.py$")
+          check_files=$(git diff ${{ inputs.base }}..HEAD --name-only --diff-filter=AM | grep "\.py$" || true)
           python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
         shell: bash
       - name: Filter Pylint output

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -55,7 +55,12 @@ jobs:
       - name: Run Pylint
         run: |
           check_files=$(git diff ${{ inputs.base }}..HEAD --name-only --diff-filter=AM | grep "\.py$" || true)
-          python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
+          if [ -z ${check_files} ]
+          then
+            touch pylint_results.txt
+          else
+            python -m pylint --rcfile=.pylintrc ${check_files} 2>&1 | tee pylint_results.txt || true
+          fi
         shell: bash
       - name: Filter Pylint output
         id: pylint

--- a/ci_tools/parse_pylint_output.py
+++ b/ci_tools/parse_pylint_output.py
@@ -34,6 +34,9 @@ def get_pylint_results(filename):
     pylint_output = [l.strip() for l in pylint_output]
 
     pylint_results = {}
+    if not pylint_output:
+        return pylint_results
+
     idx = 0
     line = pylint_output[idx]
     while not all(c=='-' for c in line):


### PR DESCRIPTION
When running tests with the Intel compiler on Linux in the `devel` branch, use Python 3.10 to avoid the workflow to hang. 

With Python 3.9 the workflow was hanging as shown here: https://github.com/pyccel/pyccel/actions/runs/7494351871.

See PR #1672, where the same modification was applied to the `run intel` bot command.

Fix a minor bug with the pylint test by handling the case where there are no Python files modified in a PR.