### PR TITLE
Use new class `ast.Constant` to avoid deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   #1645 : Handle deprecated ast classes.
+-   #1645 : Handle deprecated `ast` classes.
 -   #1649 : Add support for `np.min` in C code.
 -   #1621 : Add support for `np.max` in C code.
 -   #1571 : Add support for the function `tuple`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## \[UNRELEASED\]
 
 ### Added
-
+-   #1645 : Handle deprecated ast classes.
 -   #1649 : Add support for `np.min` in C code.
 -   #1621 : Add support for `np.max` in C code.
 -   #1571 : Add support for the function `tuple`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## \[UNRELEASED\]
 
 ### Added
+
 -   #1645 : Handle deprecated ast classes.
 -   #1649 : Add support for `np.min` in C code.
 -   #1621 : Add support for `np.max` in C code.

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -395,24 +395,6 @@ class SyntaxParser(BasicParser):
 
         return stmt
 
-    def _visit_Str(self, stmt):
-        val =  stmt.s
-        if isinstance(self._context[-2], ast.Expr):
-            return CommentBlock(val)
-        return LiteralString(val)
-
-    def _visit_Num(self, stmt):
-        val = stmt.n
-
-        if isinstance(val, int):
-            return LiteralInteger(val)
-        elif isinstance(val, float):
-            return LiteralFloat(val)
-        elif isinstance(val, complex):
-            return LiteralComplex(val.real, val.imag)
-        else:
-            raise NotImplementedError('Num type {} not recognised'.format(type(val)))
-
     def _visit_Assign(self, stmt):
 
         self._in_lhs_assign = True
@@ -538,7 +520,9 @@ class SyntaxParser(BasicParser):
             return LiteralComplex(stmt.value.real, stmt.value.imag)
 
         elif isinstance(stmt.value, str):
-            return self._visit_Str(stmt)
+            if isinstance(self._context[-2], ast.Expr):
+                return CommentBlock(stmt.s)
+            return LiteralString(stmt.s)
 
         else:
             raise NotImplementedError('Constant type {} not recognised'.format(type(stmt.value)))

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -521,8 +521,8 @@ class SyntaxParser(BasicParser):
 
         elif isinstance(stmt.value, str):
             if isinstance(self._context[-2], ast.Expr):
-                return CommentBlock(stmt.s)
-            return LiteralString(stmt.s)
+                return CommentBlock(stmt.value)
+            return LiteralString(stmt.value)
 
         else:
             raise NotImplementedError('Constant type {} not recognised'.format(type(stmt.value)))

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -527,20 +527,6 @@ class SyntaxParser(BasicParser):
         else:
             raise NotImplementedError('Constant type {} not recognised'.format(type(stmt.value)))
 
-    def _visit_NameConstant(self, stmt):
-        if stmt.value is None:
-            return Nil()
-
-        elif stmt.value is True:
-            return LiteralTrue()
-
-        elif stmt.value is False:
-            return LiteralFalse()
-
-        else:
-            raise NotImplementedError("Unknown NameConstant : {}".format(stmt.value))
-
-
     def _visit_Name(self, stmt):
         name = PyccelSymbol(stmt.id)
         if self._in_lhs_assign:


### PR DESCRIPTION
Fix issue #1645: Use the new Python `ast` class `Constant` (introduced with Python 3.8) instead of the obsolete `NamedConstant`, `Num` and `Str` (deprecated since Python 3.12, to be removed in Python 3.14).
