### PR TITLE
Class simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] #1584 : Remove unused functions from `pyccel.ast.datatypes` : `is_iterable_datatype`, `is_with_construct_datatype`, `is_pyccel_datatype`.
 -   \[INTERNALS\] #1584 : Remove unused class from `pyccel.ast.core`: `ForIterator`.
 -   \[INTERNALS\] #1584 : Remove unused method from `pyccel.ast.core`: `ClassDef.get_attribute`.
+-   \[INTERNALS\] #1676 : Remove `DottedFunctionCall` from `pyccel.ast.core` (use `bound_argument` instead).
 
 ## \[1.10.0\] - 2023-10-23
 

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -27,7 +27,7 @@ __all__ = ('BooleanClass',
 
 #=======================================================================================
 
-ComplexClass = ClassDef('complex',
+ComplexClass = ClassDef('complex', class_type = NativeComplex(),
         methods=[
             PyccelFunctionDef('imag', func_class = PythonImag,
                 decorators={'property':'property', 'numpy_wrapper':'numpy_wrapper'}),
@@ -39,7 +39,7 @@ ComplexClass = ClassDef('complex',
 
 #=======================================================================================
 
-FloatClass = ClassDef('float',
+FloatClass = ClassDef('float', class_type = NativeFloat(),
         methods=[
             PyccelFunctionDef('imag', func_class = PythonImag,
                 decorators={'property':'property', 'numpy_wrapper': 'numpy_wrapper'}),
@@ -55,7 +55,7 @@ FloatClass = ClassDef('float',
 
 #=======================================================================================
 
-IntegerClass = ClassDef('integer',
+IntegerClass = ClassDef('integer', class_type = NativeInteger(),
         methods=[
             PyccelFunctionDef('imag', func_class = PythonImag,
                 decorators={'property':'property', 'numpy_wrapper': 'numpy_wrapper'}),
@@ -73,12 +73,12 @@ IntegerClass = ClassDef('integer',
 
 #=======================================================================================
 
-BooleanClass = ClassDef('boolean',
+BooleanClass = ClassDef('boolean', class_type = NativeBool(),
         superclasses=(IntegerClass,))
 
 #=======================================================================================
 
-StringClass = ClassDef('string',
+StringClass = ClassDef('string', class_type = NativeString(),
         methods=[
                 #capitalize
                 #casefold
@@ -129,7 +129,7 @@ StringClass = ClassDef('string',
 
 #=======================================================================================
 
-TupleClass = ClassDef('tuple',
+TupleClass = ClassDef('tuple', class_type = NativeTuple(),
         methods=[
             #index
             #count
@@ -137,7 +137,7 @@ TupleClass = ClassDef('tuple',
 
 #=======================================================================================
 
-NumpyArrayClass = ClassDef('numpy.ndarray',
+NumpyArrayClass = ClassDef('numpy.ndarray', class_type = NumpyNDArrayType(),
         methods=[
             PyccelFunctionDef('shape', func_class = NumpyShape,
                 decorators = {'property': 'property', 'numpy_wrapper': 'numpy_wrapper'}),

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1833,6 +1833,11 @@ class FunctionDefArgument(TypedAstNode):
     annotation : str
         The type annotation describing the argument.
 
+    bound_argument : bool
+        Indicates if the argument is bound to the function call. This is
+        the case if the argument is the first argument of a method of a
+        class.
+
     See Also
     --------
     FunctionDef : The class where these objects will be stored.
@@ -1844,10 +1849,10 @@ class FunctionDefArgument(TypedAstNode):
     >>> n
     n
     """
-    __slots__ = ('_name','_var','_kwonly','_annotation','_value','_inout')
+    __slots__ = ('_name','_var','_kwonly','_annotation','_value','_inout', '_bound_argument')
     _attribute_nodes = ('_value','_var')
 
-    def __init__(self, name, *, value = None, kwonly=False, annotation=None):
+    def __init__(self, name, *, value = None, kwonly=False, annotation=None, bound_argument = False):
         if isinstance(name, (Variable, FunctionAddress)):
             self._var  = name
             self._name = name.name
@@ -1862,6 +1867,7 @@ class FunctionDefArgument(TypedAstNode):
         self._value      = value
         self._kwonly     = kwonly
         self._annotation = annotation
+        self._bound_argument = bound_argument
 
         if isinstance(name, Variable):
             name.declare_as_argument()
@@ -1939,6 +1945,21 @@ class FunctionDefArgument(TypedAstNode):
         modifying the inout flag.
         """
         self._inout = False
+
+    @property
+    def bound_argument(self):
+        """
+        Indicate if the argument is bound to the function call.
+
+        Indicate if the argument is bound to the function call. This is
+        the case if the argument is the first argument of a method of a
+        class.
+        """
+        return self._bound_argument
+
+    @bound_argument.setter
+    def bound_argument(self, bound):
+        self._bound_argument = bound
 
     def __str__(self):
         if self.has_default:
@@ -3501,6 +3522,7 @@ class ClassDef(ScopedAstNode):
         if not isinstance(method, FunctionDef):
             raise TypeError("Method must be FunctionDef")
         method.set_current_user_node(self)
+        method.arguments[0].bound_argument = True
         self._methods += (method,)
 
     def add_new_interface(self, interface):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3319,7 +3319,7 @@ class ClassDef(ScopedAstNode):
     >>> ClassDef('Point', attributes, methods)
     ClassDef(Point, (x, y), (FunctionDef(translate, (x, y, a, b), (z, t), [y := a + x], [], [], None, False, function),), [public])
     """
-    __slots__ = ('_name','_attributes','_methods','_options',
+    __slots__ = ('_name','_attributes','_methods','_options', '_class_type',
                  '_imports','_superclasses','_interfaces', '_docstring')
     _attribute_nodes = ('_attributes', '_methods', '_imports', '_interfaces', '_docstring')
 
@@ -3333,7 +3333,8 @@ class ClassDef(ScopedAstNode):
         superclasses=(),
         interfaces=(),
         docstring = None,
-        scope = None
+        scope = None,
+        class_type = None
         ):
 
         # name
@@ -3370,6 +3371,9 @@ class ClassDef(ScopedAstNode):
             for s in superclasses:
                 if not isinstance(s, ClassDef):
                     raise TypeError('superclass item must be a ClassDef')
+
+            if not isinstance(class_type, DataType):
+                raise TypeError("class_type must be a DataType")
 
         if not iterable(interfaces):
             raise TypeError('interfaces must be iterable')
@@ -3418,12 +3422,17 @@ class ClassDef(ScopedAstNode):
         self._superclasses  = superclasses
         self._interfaces = interfaces
         self._docstring = docstring
+        self._class_type = class_type
 
         super().__init__(scope = scope)
 
     @property
     def name(self):
         return self._name
+
+    @property
+    def class_type(self):
+        return self._class_type
 
     @property
     def attributes(self):
@@ -3522,7 +3531,6 @@ class ClassDef(ScopedAstNode):
         if not isinstance(method, FunctionDef):
             raise TypeError("Method must be FunctionDef")
         method.set_current_user_node(self)
-        method.arguments[0].bound_argument = True
         self._methods += (method,)
 
     def add_new_interface(self, interface):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1960,8 +1960,8 @@ class FunctionDefArgument(TypedAstNode):
 
     @bound_argument.setter
     def bound_argument(self, bound):
-        if not isinstance(bound_argument, bool):
-            raise TypeError("bound_argument must be a boolean")
+        if not isinstance(bound, bool):
+            raise TypeError("bound must be a boolean")
         self._bound_argument = bound
 
     def __str__(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -59,7 +59,6 @@ __all__ = (
     'Declare',
     'Decorator',
     'Del',
-    'DottedFunctionCall',
     'Duplicate',
     'DoConcurrent',
     'EmptyNode',
@@ -2219,46 +2218,7 @@ class FunctionCall(TypedAstNode):
         """
         return c is None or isinstance(c, (FunctionDef, *cls._ignored_types))
 
-class DottedFunctionCall(FunctionCall):
-    """
-    Represents a function call in the code where
-    the function is defined in another object
-    (e.g. module/class)
-
-    a.f()
-
-    Parameters
-    ==========
-    func             : FunctionDef
-                       The definition of the function being called
-    args             : tuple
-                       The arguments being passed to the function
-    prefix           : TypedAstNode
-                       The object in which the function is defined
-                       E.g. for a.f()
-                       prefix will contain a
-    current_function : str
-                        The function from which this call occurs
-                        (This is required in order to recognise
-                        recursive functions)
-    """
-    __slots__ = ('_prefix',)
-    _attribute_nodes = (*FunctionCall._attribute_nodes, '_prefix')
-
-    def __init__(self, func, args, prefix, current_function=None):
-        self._prefix = prefix
-        super().__init__(func, args, current_function)
-        self._func_name = DottedName(prefix, self._func_name)
-        if self._interface:
-            self._interface_name = DottedName(prefix, self._interface_name)
-
-    @property
-    def prefix(self):
-        """ The object in which the function is defined
-        """
-        return self._prefix
-
-class ConstructorCall(DottedFunctionCall):
+class ConstructorCall(FunctionCall):
 
     """
     Represents a Constructor call in the code.
@@ -2274,7 +2234,7 @@ class ConstructorCall(DottedFunctionCall):
     arguments : list, tuple, None
         A list of arguments.
 
-    cls_variable : CustomDataType, optional
+    cls_variable : Variable
         The variable on the left-hand side of an assignment,
         where the right-hand side is a constructor call.
         Used to store data inside the class, set during object creation.
@@ -2288,7 +2248,7 @@ class ConstructorCall(DottedFunctionCall):
         self,
         func,
         arguments,
-        cls_variable=None,
+        cls_variable
         ):
         if not isinstance(func, (FunctionDef, Interface, str)):
             raise TypeError('Expecting func to be a FunctionDef or str')

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3391,10 +3391,20 @@ class ClassDef(ScopedAstNode):
 
     @property
     def name(self):
+        """
+        The name of the class.
+
+        The name of the class.
+        """
         return self._name
 
     @property
     def class_type(self):
+        """
+        The DataType of an object of the described class.
+
+        The DataType of an object of the described class.
+        """
         return self._class_type
 
     @property
@@ -3592,6 +3602,13 @@ class ClassDef(ScopedAstNode):
 
     @property
     def is_unused(self):
+        """
+        Indicates whether the class has any users.
+
+        This function always returns False as a class definition
+        shouldn't be invalidated and deleted due to a lack of
+        users.
+        """
         return False
 
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1863,6 +1863,8 @@ class FunctionDefArgument(TypedAstNode):
             self._name = name.name
         else:
             raise TypeError("Name must be a PyccelSymbol, Variable or FunctionAddress")
+        if not isinstance(bound_argument, bool):
+            raise TypeError("bound_argument must be a boolean")
         self._value      = value
         self._kwonly     = kwonly
         self._annotation = annotation
@@ -1958,6 +1960,8 @@ class FunctionDefArgument(TypedAstNode):
 
     @bound_argument.setter
     def bound_argument(self, bound):
+        if not isinstance(bound_argument, bool):
+            raise TypeError("bound_argument must be a boolean")
         self._bound_argument = bound
 
     def __str__(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2384,7 +2384,7 @@ class FunctionDef(ScopedAstNode):
         Variables which will not be passed into the function.
 
     cls_name : str
-        Class name if the function is a method of cls_name.
+        The alternative name of the function required for classes.
 
     is_static : bool
         True for static functions. Needed for iso_c_binding interface.
@@ -2524,7 +2524,6 @@ class FunctionDef(ScopedAstNode):
         elif not isinstance(body,CodeBlock):
             raise TypeError('body must be an iterable or a CodeBlock')
 
-#        body = tuple(i for i in body)
         # results
 
         if not iterable(results):
@@ -2532,15 +2531,10 @@ class FunctionDef(ScopedAstNode):
         if not all(isinstance(r, FunctionDefResult) for r in results):
             raise TypeError('results must be all be FunctionDefResults')
 
-        # if method
-
         if cls_name:
 
             if not isinstance(cls_name, str):
                 raise TypeError('cls_name must be a string')
-
-            # if not cls_variable:
-             #   raise TypeError('Expecting a instance of {0}'.format(cls_name))
 
         if not isinstance(is_static, bool):
             raise TypeError('Expecting a boolean for is_static attribute')
@@ -2649,8 +2643,14 @@ class FunctionDef(ScopedAstNode):
 
     @property
     def cls_name(self):
-        """ String containing the name of the class to which the method belongs.
-        If the function is not a class procedure then this returns None """
+        """
+        String containing an alternative name for the function if it is a class method.
+
+        If a function is a class method then in some languages an alternative name is
+        required. For example in Fortran a name is required for the definition of the
+        class in the module. This name is different from the name of the method which
+        is used when calling the function via the class variable.
+        """
         return self._cls_name
 
     @cls_name.setter
@@ -3301,6 +3301,9 @@ class ClassDef(ScopedAstNode):
 
     scope : Scope
         The scope for the class contents.
+
+    class_type : DataType
+        The data type associated with this class.
 
     Examples
     --------

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -756,14 +756,15 @@ class CCodePrinter(CodePrinter):
                 classes += self._print(classDef.docstring)
             classes += f"struct {classDef.name} {{\n"
             classes += ''.join(self._print(Declare(var.dtype,var)) for var in classDef.attributes)
+            class_scope = classDef.scope
             for method in classDef.methods:
                 if not method.is_inline:
-                    method.rename(classDef.name + ("__" + method.name if not method.name.startswith("__") else method.name))
+                    class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
                     funcs += f"{self.function_signature(method)};\n"
             for interface in classDef.interfaces:
                 for func in interface.functions:
                     if not func.is_inline:
-                        func.rename(classDef.name + ("__" + func.name if not func.name.startswith("__") else func.name))
+                        class_scope.rename_function(func, f"{classDef.name}__{func.name.lstrip('__')}")
                         funcs += f"{self.function_signature(func)};\n"
             classes += "};\n"
         funcs += '\n'.join(f"{self.function_signature(f)};" for f in expr.module.funcs)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -442,7 +442,12 @@ class FCodePrinter(CodePrinter):
         Calculate the class names of the functions in a class.
 
         Calculate the names that will be referenced from the class
-        for each function in a class.
+        for each function in a class. Also rename magic methods.
+
+        Parameters
+        ----------
+        expr : ClassDef
+            The class whose functions should be renamed.
         """
         scope = expr.scope
         name = expr.name

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -1087,8 +1087,8 @@ class PythonCodePrinter(CodePrinter):
         return classDef
 
     def _print_ConstructorCall(self, expr):
-        cls_name = expr.funcdef.cls_name
         cls_variable = expr.cls_variable
+        cls_name = cls_variable.cls_base.name
         args = ', '.join(self._print(arg) for arg in expr.args[1:])
         return f"{cls_variable} = {cls_name}({args})\n"
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -9,7 +9,7 @@ from pyccel.decorators import __all__ as pyccel_decorators
 
 from pyccel.ast.builtins   import PythonMin, PythonMax, PythonType
 from pyccel.ast.core       import CodeBlock, Import, Assign, FunctionCall, For, AsName, FunctionAddress
-from pyccel.ast.core       import IfSection, FunctionDef, Module, DottedFunctionCall, PyccelFunctionDef
+from pyccel.ast.core       import IfSection, FunctionDef, Module, PyccelFunctionDef
 from pyccel.ast.datatypes  import NativeHomogeneousTuple
 from pyccel.ast.functionalexpr import FunctionalFor
 from pyccel.ast.literals   import LiteralTrue, LiteralString
@@ -547,14 +547,16 @@ class PythonCodePrinter(CodePrinter):
         return '.'.join(self._print(n) for n in expr.name)
 
     def _print_FunctionCall(self, expr):
-        if expr.funcdef in self._ignore_funcs:
+        func = expr.funcdef
+        if func in self._ignore_funcs:
             return ''
         if expr.interface:
             func_name = expr.interface_name
         else:
             func_name = expr.func_name
         args = expr.args
-        if isinstance(expr, DottedFunctionCall):
+        if func.arguments and func.arguments[0].bound_argument:
+            func_name = f'{self._print(args[0])}.{func_name}'
             args = args[1:]
         args_str = ', '.join(self._print(i) for i in args)
         code = f'{func_name}({args_str})'

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1215,14 +1215,14 @@ class CToPythonWrapper(Wrapper):
         """
         name = expr.name
         struct_name = self.scope.get_new_name(f'Py{name}Object')
+        dtype = DataTypeFactory(struct_name, BaseClass=WrapperCustomDataType)()
 
         type_name = self.scope.get_new_name(f'Py{name}Type')
         docstring = expr.docstring
-        wrapped_class = PyClassDef(expr, struct_name, type_name, Scope(), docstring = docstring)
+        wrapped_class = PyClassDef(expr, struct_name, type_name, Scope(), docstring = docstring, class_type = dtype)
 
         self._python_object_map[expr] = wrapped_class
-        self._python_object_map[expr.scope.parent_scope.cls_constructs[name]] = \
-                DataTypeFactory(struct_name, BaseClass=WrapperCustomDataType)()
+        self._python_object_map[expr.scope.parent_scope.cls_constructs[name]] = dtype
 
         self.scope.insert_class(wrapped_class, name)
 

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -474,4 +474,4 @@ class FortranToCWrapper(Wrapper):
         BindCClassDef
             The wrapped class.
         """
-        return BindCClassDef(expr, docstring = expr.docstring)
+        return BindCClassDef(expr, docstring = expr.docstring, class_type = expr.class_type)

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -736,3 +736,24 @@ class Scope(object):
         """ Get map of new names to original python names
         """
         return self._original_symbol
+
+    def rename_function(self, o, name):
+        """
+        Rename a function that exists in the scope.
+
+        Rename a function that exists in the scope. This is done by
+        finding a new collisionless name, renaming the FunctionDef
+        instance, and updating the dictionary of symbols.
+
+        Parameters
+        ----------
+        o : FunctionDef
+            The object that should be renamed.
+
+        name : str
+            The suggested name for the new function.
+        """
+        newname = self.get_new_name(name)
+        python_name = self._original_symbol.pop(o.name)
+        o.rename(newname)
+        self._original_symbol[newname] = python_name

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2065,7 +2065,7 @@ class SemanticParser(BasicParser):
                                         value = value, kwonly = kwonly, annotation = expr.annotation))
             else:
                 args.append(FunctionDefArgument(v.clone(v.name, is_optional = is_optional,
-                                is_kwonly = kwonly, is_argument = True, bound_argument = bound_argument),
+                                is_kwonly = kwonly, is_argument = True), bound_argument = bound_argument,
                                 value = value, kwonly = kwonly, annotation = expr.annotation))
         return args
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -38,7 +38,6 @@ from pyccel.ast.core import AugAssign, CodeBlock
 from pyccel.ast.core import Return, FunctionDefArgument, FunctionDefResult
 from pyccel.ast.core import ConstructorCall, InlineFunctionDef
 from pyccel.ast.core import FunctionDef, Interface, FunctionAddress, FunctionCall, FunctionCallArgument
-from pyccel.ast.core import DottedFunctionCall
 from pyccel.ast.core import ClassDef
 from pyccel.ast.core import For
 from pyccel.ast.core import Module
@@ -992,7 +991,7 @@ class SemanticParser(BasicParser):
                The arguments passed to the function.
 
         is_method : bool
-                Indicates if the function is a method (and should return a DottedFunctionCall).
+                Indicates if the function is a class method.
 
         Returns
         -------
@@ -1054,10 +1053,7 @@ class SemanticParser(BasicParser):
 
             args = input_args
 
-            if is_method:
-                new_expr = DottedFunctionCall(func, args, current_function = self._current_function, prefix = args[0].value)
-            else:
-                new_expr = FunctionCall(func, args, self._current_function)
+            new_expr = FunctionCall(func, args, self._current_function)
 
             if None in new_expr.args:
                 errors.report("Too few arguments passed in function call",
@@ -3880,7 +3876,7 @@ class SemanticParser(BasicParser):
             self._visit(i)
 
         if not any(method.name == '__del__' for method in methods):
-            argument = FunctionDefArgument(Variable(cls.name, 'self', cls_base = cls))
+            argument = FunctionDefArgument(Variable(cls.name, 'self', cls_base = cls), bound_argument = True)
             self.scope.insert_symbol('__del__')
             scope = self.create_new_function_scope('__del__')
             del_method = FunctionDef('__del__', [argument], (), [Pass()], scope=scope)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3570,7 +3570,7 @@ class SemanticParser(BasicParser):
         is_inline       = expr.is_inline
         docstring      = self._visit(expr.docstring) if expr.docstring else expr.docstring
 
-        current_class = expr.get_user_nodes(ClassDef, excluded_nodes = (FunctionCall,))
+        current_class = expr.get_direct_user_nodes(lambda u: isinstance(u, ClassDef))
         cls_name = current_class[0].name if current_class else None
         if cls_name:
             bound_class = self.scope.find(cls_name, 'classes')

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2053,6 +2053,7 @@ class SemanticParser(BasicParser):
         value = None if expr.value is None else self._visit(expr.value)
         kwonly = expr.is_kwonly
         is_optional = isinstance(value, Nil)
+        bound_argument = expr.bound_argument
 
         args = []
         for v in arg:
@@ -2064,11 +2065,11 @@ class SemanticParser(BasicParser):
                         value.precision != prec:
                     value = convert_to_literal(value.python_value, dtype, prec)
                 clone_var = v.clone(v.name, is_optional = is_optional, is_argument = True)
-                args.append(FunctionDefArgument(clone_var,
+                args.append(FunctionDefArgument(clone_var, bound_argument = bound_argument,
                                         value = value, kwonly = kwonly, annotation = expr.annotation))
             else:
                 args.append(FunctionDefArgument(v.clone(v.name, is_optional = is_optional,
-                                is_kwonly = kwonly, is_argument = True),
+                                is_kwonly = kwonly, is_argument = True, bound_argument = bound_argument),
                                 value = value, kwonly = kwonly, annotation = expr.annotation))
         return args
 
@@ -2737,8 +2738,8 @@ class SemanticParser(BasicParser):
                 errors.report(UNDEFINED_INIT_METHOD, symbol=name,
                     bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
                     severity='error')
-            cls_def = self.scope.find(method.cls_name, 'classes')
-            d_var = {'datatype': self.get_class_construct(method.cls_name),
+            cls_def = method.arguments[0].var.cls_base
+            d_var = {'datatype': method.arguments[0].var.class_type,
                     'memory_handling':'stack',
                     'shape' : None,
                     'rank' : 0,
@@ -2749,7 +2750,7 @@ class SemanticParser(BasicParser):
             lhs = expr.get_user_nodes(Assign)[0].lhs
             if isinstance(lhs, AnnotatedPyccelSymbol):
                 annotation = self._visit(lhs.annotation)
-                if len(annotation.type_list) != 1 or annotation.type_list[0].class_type.name != method.cls_name:
+                if len(annotation.type_list) != 1 or annotation.type_list[0].class_type != method.arguments[0].var.class_type:
                     errors.report(f"Unexpected type annotation in creation of {cls_def.name}",
                             symbol=annotation, severity='error')
                 lhs = lhs.name
@@ -3563,7 +3564,6 @@ class SemanticParser(BasicParser):
 
     def _visit_FunctionDef(self, expr):
         name            = self.scope.get_expected_name(expr.name)
-        cls_name        = expr.cls_name
         decorators      = expr.decorators
         funcs           = []
         sub_funcs       = []
@@ -3573,6 +3573,11 @@ class SemanticParser(BasicParser):
         is_private      = expr.is_private
         is_inline       = expr.is_inline
         docstring      = self._visit(expr.docstring) if expr.docstring else expr.docstring
+
+        current_class = expr.get_user_nodes(ClassDef, excluded_nodes = (FunctionCall,))
+        cls_name = current_class[0].name if current_class else None
+        if cls_name:
+            bound_class = self.scope.find(cls_name, 'classes')
 
         not_used = [d for d in decorators if d not in def_decorators.__all__]
         if len(not_used) >= 1:
@@ -3600,6 +3605,7 @@ class SemanticParser(BasicParser):
 
         # this for the case of a function without arguments => no headers
         interface_name = name
+        interface_counter = 0
 
         for tmpl_idx in range(n_templates):
             # Change to syntactic FunctionDef scope to ensure get_expected_name is available
@@ -3624,12 +3630,12 @@ class SemanticParser(BasicParser):
                 arg_dict = {a.name:a.var for a in arguments}
 
                 if is_interface:
-                    name = interface_name + '_' + str(tmpl_idx*n_interface_funcs + i).zfill(2)
+                    name, interface_counter = self.scope.get_new_incremented_symbol(interface_name, interface_counter)
                 scope = self.create_new_function_scope(name, decorators = decorators,
                         used_symbols = expr.scope.local_used_symbols.copy(),
                         original_symbols = expr.scope.python_names.copy())
 
-                if cls_name:
+                if len(arguments)>0 and arguments[0].bound_argument:
                     if arguments[0].var.cls_base.name != cls_name:
                         errors.report('Class method self argument does not have the expected type',
                                 severity='error', symbol=arguments[0])
@@ -3732,7 +3738,6 @@ class SemanticParser(BasicParser):
 
                 func_kwargs = {
                         'global_vars':global_vars,
-                        'cls_name':cls_name,
                         'is_pure':is_pure,
                         'is_elemental':is_elemental,
                         'is_private':is_private,
@@ -3760,11 +3765,9 @@ class SemanticParser(BasicParser):
                     recursive_func_obj.invalidate_node()
 
                 if cls_name:
-                    cls = self.scope.find(cls_name, 'classes')
-
                     # update the class methods
                     if expr.name == func.name:
-                        cls.add_new_method(func)
+                        bound_class.add_new_method(func)
 
                 funcs += [func]
 
@@ -3778,21 +3781,8 @@ class SemanticParser(BasicParser):
 
             funcs = Interface(interface_name, funcs)
             if cls_name:
-                cls = self.scope.find(cls_name, 'classes')
-                cls.add_new_interface(funcs)
+                bound_class.add_new_interface(funcs)
             self.insert_function(funcs)
-#        TODO move this to codegen
-#        if vec_func:
-#           self._visit_FunctionDef(vec_func)
-#           vec_func = self.scope.functions.pop(vec_name)
-#           if isinstance(funcs, Interface):
-#               funcs = list(funcs.funcs)+[vec_func]
-#           else:
-#               self.scope.sons_scopes['sc_'+ name] = self.scope.sons_scopes[name]
-#               funcs = funcs.rename('sc_'+ name)
-#               funcs = [funcs, vec_func]
-#           funcs = Interface(name, funcs)
-#           self.insert_function(funcs)
         return EmptyNode()
 
     def _visit_PythonPrint(self, expr):
@@ -3856,7 +3846,7 @@ class SemanticParser(BasicParser):
         docstring = self._visit(expr.docstring) if expr.docstring else expr.docstring
 
         cls = ClassDef(name, attributes, [], superclasses=parent, scope=scope,
-                docstring = docstring)
+                docstring = docstring, class_type = dtype())
         self.scope.parent_scope.insert_class(cls)
 
         methods = list(expr.methods)
@@ -3891,8 +3881,9 @@ class SemanticParser(BasicParser):
 
         if not any(method.name == '__del__' for method in methods):
             argument = FunctionDefArgument(Variable(cls.name, 'self', cls_base = cls))
+            self.scope.insert_symbol('__del__')
             scope = self.create_new_function_scope('__del__')
-            del_method = FunctionDef('__del__', [argument], (), [Pass()], cls_name=cls.name, scope=scope)
+            del_method = FunctionDef('__del__', [argument], (), [Pass()], scope=scope)
             self.exit_function_scope()
             self.insert_function(del_method)
             cls.add_new_method(del_method)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1028,6 +1028,7 @@ class SyntaxParser(BasicParser):
             visited_i = self._visit(i)
             if isinstance(visited_i, FunctionDef):
                 methods.append(visited_i)
+                visited_i.arguments[0].bound_argument = True
             elif isinstance(visited_i, Pass):
                 return errors.report(UNSUPPORTED_FEATURE_OOP_EMPTY_CLASS, symbol = stmt, severity='error')
             elif isinstance(visited_i, AnnotatedPyccelSymbol):
@@ -1037,8 +1038,6 @@ class SyntaxParser(BasicParser):
             else:
                 errors.report(f"{type(visited_i)} not currently supported in classes",
                         severity='error', symbol=visited_i)
-        for i in methods:
-            i.cls_name = name
         parent = [p for p in (self._visit(i) for i in stmt.bases) if p != 'object']
         self.exit_class_scope()
         expr = ClassDef(name=name, attributes=attributes,


### PR DESCRIPTION
This PR simplifies the handling of classes in a few locations. This will notably be useful for #1607 .

**Commit summary**
- Add a `bound_argument` property to `FunctionDefArgument` to identify class arguments that are bound to the calling function
- Add a `class_type` property to `ClassDef` to store the associated `DataType`
- Remove `DottedFunctionCall`. A separate concept is not needed for this.
- Use `FunctionDef.cls_name` to save the alternative name of a class method.
- Rename `FunctionDef` objects which are printed with alternative names to ensure that these names are collisionless and can be accessed elsewhere in Pyccel (e.g. in the wrapper)
- Remove dead code