### PR TITLE
Correct wrapper stage link in documentation

### DIFF
--- a/developer_docs/overview.md
+++ b/developer_docs/overview.md
@@ -9,7 +9,7 @@ Pyccel's development is split into 4 main stages:
 -   [Syntactic Stage](#Syntactic-stage) (for more details see [syntactic stage](syntactic_stage.md))
 -   [Semantic Stage](#Semantic-stage) (for more details see [semantic stage](semantic_stage.md))
 -   [Code Generation Stage](#Code-generation-stage) (for more details see [codegen stage](codegen_stage.md))
--   [Wrapping Stage](#Wrapping-stage) (for more details see [wrapping stage](wrapping_stage.md))
+-   [Wrapping Stage](#Wrapping-stage) (for more details see [wrapping stage](wrapper_stage.md))
 -   [Compilation Stage](#Compilation-stage)
 
 ### Syntactic Stage


### PR DESCRIPTION
Fix project documentation: correct wrapper stage link in `overview.md`.