### PR TITLE
Fix name collision issue for class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 -   #1259 : Fix bug causing problems with user editable installation.
 -   #1651 : Fix name collision resolution to include parent scopes.
 -   #1156 : Raise an error for variable name collisions with non-variable objects.
+-   #1507 : Fix problems with name collisions in class functions.
 
 ### Changed
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3546,7 +3546,11 @@ class ClassDef(ScopedAstNode):
         """
         if self.scope is not None:
             # Collect translated name from scope
-            name = self.scope.get_expected_name(name)
+            try:
+                name = self.scope.get_expected_name(name)
+            except RuntimeError:
+                errors.report(f"Can't find method {name} in class {self.name}",
+                        severity='fatal', symbol=self)
 
         try:
             method = next(i for i in chain(self.methods, self.interfaces) if i.name == name)

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3544,6 +3544,10 @@ class ClassDef(ScopedAstNode):
         ValueError
             Raised if the method cannot be found.
         """
+        if self.scope is not None:
+            # Collect translated name from scope
+            name = self.scope.get_expected_name(name)
+
         try:
             method = next(i for i in chain(self.methods, self.interfaces) if i.name == name)
         except StopIteration:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3763,7 +3763,8 @@ class SemanticParser(BasicParser):
                     cls = self.scope.find(cls_name, 'classes')
 
                     # update the class methods
-                    cls.add_new_method(func)
+                    if not is_interface:
+                        cls.add_new_method(func)
 
                 funcs += [func]
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2396,7 +2396,6 @@ class SemanticParser(BasicParser):
                 errors.report("Cannot get attribute of function call with multiple returns",
                         symbol=expr, severity='fatal')
             first = results[0].var
-
         rhs_name = _get_name(rhs)
 
         # Handle case of imported module

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2396,6 +2396,7 @@ class SemanticParser(BasicParser):
                 errors.report("Cannot get attribute of function call with multiple returns",
                         symbol=expr, severity='fatal')
             first = results[0].var
+
         rhs_name = _get_name(rhs)
 
         # Handle case of imported module
@@ -3763,8 +3764,7 @@ class SemanticParser(BasicParser):
                     cls = self.scope.find(cls_name, 'classes')
 
                     # update the class methods
-                    if expr.name == func.name:
-                        cls.add_new_method(func)
+                    cls.add_new_method(func)
 
                 funcs += [func]
 

--- a/tests/pyccel/scripts/classes/classes_1.py
+++ b/tests/pyccel/scripts/classes/classes_1.py
@@ -16,6 +16,9 @@ class Point(object):
     def print_x(self : 'Point'):
         print(self._x)
 
+    def print_X(self : 'Point'):
+        print(self._X)
+
 class Line(object):
     def __init__(self : 'Line', l : Point):
         self.l = l
@@ -32,6 +35,7 @@ if __name__ == '__main__':
 
     p.translate(a)
     p.print_x()
+    p.print_X()
 
     p = Point(np.array([6.,6.,6.]))
     p.translate(a)


### PR DESCRIPTION
Fix the name collision issue for class methods by using `Scope.get_expected_name` in `ClassDef.get_method` to get the name which should be used for searching. Ensure renamed functions are also added to classes. Add a test. Fixes #1507 