### PR TITLE
Add typing.Final and simplify type inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,15 @@ All notable changes to this project will be documented in this file.
 -   #1259 : Fix bug causing problems with user editable installation.
 -   #1651 : Fix name collision resolution to include parent scopes.
 -   #1156 : Raise an error for variable name collisions with non-variable objects.
+-   Ensure `pyccel-init` calls the related function.
+-   Stop unnecessarily importing deprecated NumPy classes `int`, `bool`, `float`, `complex`.
 
 ### Changed
 
 -   #1672 : Make `icx` and `ifx` the default Intel compilers (Found in Intel oneAPI).
 -   #1644 : Stop printing the step of a range if that step is 1.
 -   #1638 : Migrate from `setuptools` to `hatch` for installation scripts.
+-   Don't raise a warning for an unnecessary specification of the order.
 -   \[INTERNALS\] #1593 : Rename `PyccelAstNode.fst` to the `PyccelAstNode.ast`.
 -   \[INTERNALS\] #1593 : Use a setter instead of a method to update `PyccelAstNode.ast`.
 -   \[INTERNALS\] #1593 : Rename `BasicParser._current_fst_node` to the `BasicParser._current_ast_node`.
@@ -54,6 +57,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] #1584 : Remove unused functions from `pyccel.ast.datatypes` : `is_iterable_datatype`, `is_with_construct_datatype`, `is_pyccel_datatype`.
 -   \[INTERNALS\] #1584 : Remove unused class from `pyccel.ast.core`: `ForIterator`.
 -   \[INTERNALS\] #1584 : Remove unused method from `pyccel.ast.core`: `ClassDef.get_attribute`.
+-   \[INTERNALS\] #1683 : Remove unused redundant class from `pyccel.ast.datatypes`: `UnionType`.
 
 ## \[1.10.0\] - 2023-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Add `class_type` attribute to `TypedAstNode`.
 -   #1494 : Add support for functions returning class instances.
 -   #1495 : Add support for functions with class instance arguments.
+-   #1680 : Add support for `typing.Final`.
 
 ### Fixed
 
@@ -44,6 +45,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] #1593 : Rename `BasicParser._current_fst_node` to the `BasicParser._current_ast_node`.
 -   \[INTERNALS\] #1390 : Remove dead code handling a `CodeBlock` in an assignment.
 -   \[INTERNALS\] #1582 : Remove the `HomogeneousTupleVariable` type.
+-   \[INTERNALS\] #1581 : Unify handling of string and Python annotations.
 
 ### Deprecated
 

--- a/ci_tools/coverage_analysis_tools.py
+++ b/ci_tools/coverage_analysis_tools.py
@@ -257,7 +257,7 @@ def get_json_summary(untested, content_lines, existing_comments, diff):
             if j < n_code_lines-1:
                 end_line = line_indices[j]-1
             else:
-                end_line = line_indices[j]
+                end_line = line_indices[n_code_lines-1]
             last_valid_line = start_line
             last_valid_line_idx = next(i for i in diff[f]['addition'] if i == last_valid_line)
             for i in diff[f]['addition'][last_valid_line_idx:]:

--- a/ci_tools/coverage_analysis_tools.py
+++ b/ci_tools/coverage_analysis_tools.py
@@ -257,7 +257,7 @@ def get_json_summary(untested, content_lines, existing_comments, diff):
             if j < n_code_lines-1:
                 end_line = line_indices[j]-1
             else:
-                end_line = line_indices[n_code_lines-1]
+                end_line = line_indices[-1]
             last_valid_line = start_line
             last_valid_line_idx = next(i for i in diff[f]['addition'] if i == last_valid_line)
             for i in diff[f]['addition'][last_valid_line_idx:]:

--- a/docs/supported-libraries.md
+++ b/docs/supported-libraries.md
@@ -11,5 +11,6 @@ We additionally have support for the specified functions from the following libr
 -   `numpy` : See [NumPy functions](./numpy-functions.md).
 -   `scipy` : `constants.pi`
 -   `sys` : `exit`
+-   `typingext` : `Final`
 
 If you need support for a library which is not mentioned here, please open a [discussion](https://github.com/pyccel/pyccel/discussions/categories/ideas) and we will investigate whether this can be added simply.

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -54,7 +54,6 @@ __all__ = (
     'PythonType',
     'PythonZip',
     'builtin_functions_dict',
-    'python_builtin_datatype',
 )
 
 #==============================================================================
@@ -1219,32 +1218,10 @@ class PythonType(PyccelAstNode):
             return LiteralString(f"<class 'numpy.{dtype}{precision}'>")
 
 #==============================================================================
-python_builtin_datatypes_dict = {
-    'bool'   : PythonBool,
-    'float'  : PythonFloat,
-    'int'    : PythonInt,
-    'complex': PythonComplex,
-    'str'    : LiteralString
-}
-
-def python_builtin_datatype(name):
-    """
-    Given a symbol name, return the corresponding datatype.
-
-    name: str
-        Datatype as written in Python.
-
-    """
-    if not isinstance(name, str):
-        raise TypeError('name must be a string')
-
-    if name in python_builtin_datatypes_dict:
-        return python_builtin_datatypes_dict[name]
-
-    return None
 
 builtin_functions_dict = {
     'abs'      : PythonAbs,
+    'bool'     : PythonBool,
     'range'    : PythonRange,
     'zip'      : PythonZip,
     'enumerate': PythonEnumerate,
@@ -1258,6 +1235,7 @@ builtin_functions_dict = {
     'min'      : PythonMin,
     'not'      : PyccelNot,
     'map'      : PythonMap,
+    'str'      : LiteralString,
     'type'     : PythonType,
     'tuple'    : PythonTupleFunction,
 }

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4060,13 +4060,15 @@ class EmptyNode(PyccelAstNode):
 
 
 class Comment(PyccelAstNode):
+    """
+    Represents a Comment in the code.
 
-    """Represents a Comment in the code.
+    Represents a Comment in the code.
 
     Parameters
     ----------
     text : str
-       the comment line
+       The comment line.
 
     Examples
     --------

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -22,7 +22,7 @@ from .datatypes import (datatype, DataType, NativeSymbol, NativeHomogeneousTuple
                         NativeBool, NativeTuple, str_dtype, NativeInhomogeneousTuple,
                         NativeVoid)
 
-from .internals import PyccelSymbol, PyccelInternalFunction, get_final_precision
+from .internals import PyccelSymbol, PyccelInternalFunction, get_final_precision, apply_pickle
 
 from .literals  import Nil, LiteralFalse, LiteralInteger
 from .literals  import NilArgument, LiteralTrue
@@ -108,7 +108,6 @@ __all__ = (
 #      - add a new Idx that uses Variable instead of Symbol
 
 #==============================================================================
-def apply(func, args, kwargs):return func(*args, **kwargs)
 
 #==============================================================================
 def create_variable(forbidden_names, prefix = None, counter = 1):
@@ -698,7 +697,7 @@ class CodeBlock(PyccelAstNode):
            and its arguments.
         """
         kwargs = dict(body = self.body)
-        return (apply, (self.__class__, (), kwargs))
+        return (apply_pickle, (self.__class__, (), kwargs))
 
     def set_current_ast(self, ast_node):
         """
@@ -2828,7 +2827,7 @@ class FunctionDef(ScopedAstNode):
            and its arguments.
         """
         args, kwargs = self.__getnewargs__()
-        out = (apply, (self.__class__, args, kwargs))
+        out = (apply_pickle, (self.__class__, args, kwargs))
         return out
 
 
@@ -4108,7 +4107,7 @@ class Comment(PyccelAstNode):
            and its arguments.
         """
         kwargs = dict(text = self.text)
-        return (apply, (self.__class__, (), kwargs))
+        return (apply_pickle, (self.__class__, (), kwargs))
 
 
 class SeparatorComment(Comment):

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -34,7 +34,6 @@ __all__ = (
     'NativeSymbol',
     'NativeTuple',
     'NativeVoid',
-    'UnionType',
     'DataTypeFactory',
 #
 # --------- FUNCTIONS -----------
@@ -413,22 +412,6 @@ default_precision = {Float : 8,
                      Int : numpy.dtype(int).alignment,
                      Cmplx : 8,
                      Bool : -1}
-
-class UnionType:
-    """ Class representing multiple different possible
-    datatypes for a function argument. If multiple
-    arguments have union types then the result is a
-    cross product of types
-    """
-    __slots__ = ('_args',)
-
-    def __init__(self, args):
-        self._args = args
-        super().__init__()
-
-    @property
-    def args(self):
-        return self._args
 
 
 def DataTypeFactory(name, argnames=["_name"],

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -8,10 +8,9 @@ from ..errors.errors    import Errors
 from .basic             import PyccelAstNode, iterable
 from .core              import Assign, FunctionCallArgument
 from .core              import FunctionCall
-from .datatypes         import UnionType
 from .internals         import PyccelSymbol, Slice
 from .macros            import Macro, MacroShape, construct_macro
-from .type_annotations  import SyntacticTypeAnnotation
+from .type_annotations  import SyntacticTypeAnnotation, UnionTypeAnnotation
 from .variable          import DottedName, DottedVariable
 from .variable          import Variable
 
@@ -304,11 +303,11 @@ class MethodHeader(FunctionHeader):
             raise TypeError("Expecting dtypes to be iterable.")
 
         for d in dtypes:
-            if not isinstance(d, (UnionType, SyntacticTypeAnnotation)):
+            if not isinstance(d, (UnionTypeAnnotation, SyntacticTypeAnnotation)):
                 raise TypeError("Wrong element in dtypes.")
 
         for d in results:
-            if not isinstance(d, (UnionType, SyntacticTypeAnnotation)):
+            if not isinstance(d, (UnionTypeAnnotation, SyntacticTypeAnnotation)):
                 raise TypeError("Wrong element in dtypes.")
 
 

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -433,3 +433,23 @@ def get_final_precision(obj):
         The precision of the object to be used in the code.
     """
     return default_precision[obj.dtype] if obj.precision == -1 else obj.precision
+
+def apply_pickle(class_type, args, kwargs):
+    """
+    Utility function which recreates a class instance for pickle.
+
+    Utility function which recreates a class instance for pickle. Pickle cannot
+    handle lambdas so this is necessary.
+
+    Parameters
+    ----------
+    class_type : type
+        The type being recreated.
+
+    args : tuple
+        The positional arguments to be passed to the constructor.
+
+    kwargs : dict
+        The keyword arguments to be passed to the constructor.
+    """
+    return class_type(*args, **kwargs)

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -451,5 +451,10 @@ def apply_pickle(class_type, args, kwargs):
 
     kwargs : dict
         The keyword arguments to be passed to the constructor.
+
+    Returns
+    -------
+    class_type
+        An object of class_type built from the args and kwargs.
     """
     return class_type(*args, **kwargs)

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -118,6 +118,12 @@ class VariableTypeAnnotation(PyccelAstNode):
         """
         return self._order
 
+    @order.setter
+    def order(self, order):
+        if order not in ('C', 'F', None):
+            raise ValueError("Order must be C, F, or None")
+        self._order = order
+
     @property
     def is_const(self):
         """
@@ -131,10 +137,6 @@ class VariableTypeAnnotation(PyccelAstNode):
     @is_const.setter
     def is_const(self, val):
         self._is_const = val
-
-    @order.setter
-    def order(self, order):
-        self._order = order
 
     def __hash__(self):
         return hash((self.datatype, self.class_type, self.precision, self.rank, self.order))

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -240,7 +240,6 @@ class UnionTypeAnnotation(PyccelAstNode):
     _attribute_nodes = ('_type_annotations',)
 
     def __init__(self, *type_annotations):
-        assert len(type_annotations) > 0
         annots = [ti for t in type_annotations for ti in (t.type_list if isinstance(t, UnionTypeAnnotation) else [t])]
         self._type_annotations = tuple(set(annots))
 

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -132,6 +132,10 @@ class VariableTypeAnnotation(PyccelAstNode):
     def is_const(self, val):
         self._is_const = val
 
+    @order.setter
+    def order(self, order):
+        self._order = order
+
     def __hash__(self):
         return hash((self.datatype, self.class_type, self.precision, self.rank, self.order))
 
@@ -297,7 +301,7 @@ class SyntacticTypeAnnotation(PyccelAstNode):
     """
     __slots__ = ('_dtype', '_order')
     _attribute_nodes = ()
-    def __init__(self, dtype, order):
+    def __init__(self, dtype, order = None):
         if not isinstance(dtype, (str, DottedName, IndexedElement)):
             raise ValueError("Syntactic datatypes should be strings")
         if not (order is None or isinstance(order, str)):
@@ -314,7 +318,7 @@ class SyntacticTypeAnnotation(PyccelAstNode):
         A list of the dtypes named in the type annotation. These dtypes are
         all strings.
         """
-        return self._dtypes
+        return self._dtype
 
     @property
     def order(self):

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -136,6 +136,8 @@ class VariableTypeAnnotation(PyccelAstNode):
 
     @is_const.setter
     def is_const(self, val):
+        if not isinstance(val, bool):
+            raise TypeError("Is const value should be a boolean")
         self._is_const = val
 
     def __hash__(self):

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -234,6 +234,8 @@ class FunctionTypeAnnotation(PyccelAstNode):
 
     @is_const.setter
     def is_const(self, val):
+        if not isinstance(val, bool):
+            raise TypeError("Is const value should be a boolean")
         self._is_const = val
 
 class UnionTypeAnnotation(PyccelAstNode):

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -128,6 +128,10 @@ class VariableTypeAnnotation(PyccelAstNode):
         """
         return self._is_const
 
+    @is_const.setter
+    def is_const(self, val):
+        self._is_const = val
+
     def __hash__(self):
         return hash((self.datatype, self.class_type, self.precision, self.rank, self.order))
 
@@ -165,10 +169,10 @@ class FunctionTypeAnnotation(PyccelAstNode):
         In the syntactic stage these objects are of type SyntacticTypeAnnotation.
         In the semantic stage these objects are of type UnionTypeAnnotation.
     """
-    __slots__ = ('_args', '_results',)
-    _attribute_nodes = ('_args', '_results')
+    __slots__ = ('_args', '_results', '_is_const')
+    _attribute_nodes = ('_args', '_results', '_is_const')
 
-    def __init__(self, args, results):
+    def __init__(self, args, results, is_const = False):
         if pyccel_stage == 'syntactic':
             self._args = [FunctionDefArgument(AnnotatedPyccelSymbol('_', a), annotation = a) \
                             for i, a in enumerate(args)]
@@ -177,6 +181,8 @@ class FunctionTypeAnnotation(PyccelAstNode):
         else:
             self._args = args
             self._results = results
+
+        self._is_const = is_const
 
         super().__init__()
 
@@ -205,6 +211,20 @@ class FunctionTypeAnnotation(PyccelAstNode):
     def __repr__(self):
         return f'func({repr(self.args)}) -> {repr(self.results)}'
 
+    @property
+    def is_const(self):
+        """
+        Indicates whether the object will remain constant.
+
+        Returns a boolean which is false if the value of the object can be
+        modified, and true otherwise.
+        """
+        return self._is_const
+
+    @is_const.setter
+    def is_const(self, val):
+        self._is_const = val
+
 class UnionTypeAnnotation(PyccelAstNode):
     """
     A class which holds multiple possible type annotations.
@@ -220,6 +240,7 @@ class UnionTypeAnnotation(PyccelAstNode):
     _attribute_nodes = ('_type_annotations',)
 
     def __init__(self, *type_annotations):
+        assert len(type_annotations) > 0
         annots = [ti for t in type_annotations for ti in (t.type_list if isinstance(t, UnionTypeAnnotation) else [t])]
         self._type_annotations = tuple(set(annots))
 

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -172,11 +172,14 @@ class FunctionTypeAnnotation(PyccelAstNode):
         The type annotations describing the results of the function address.
         In the syntactic stage these objects are of type SyntacticTypeAnnotation.
         In the semantic stage these objects are of type UnionTypeAnnotation.
+
+    is_const : bool, default=True
+        True if the function pointer cannot be modified, false otherwise.
     """
     __slots__ = ('_args', '_results', '_is_const')
     _attribute_nodes = ('_args', '_results', '_is_const')
 
-    def __init__(self, args, results, is_const = False):
+    def __init__(self, args, results, is_const = True):
         if pyccel_stage == 'syntactic':
             self._args = [FunctionDefArgument(AnnotatedPyccelSymbol('_', a), annotation = a) \
                             for i, a in enumerate(args)]
@@ -293,7 +296,7 @@ class SyntacticTypeAnnotation(PyccelAstNode):
 
     Parameters
     ----------
-    dtypes : PyccelSymbol | IndexedElement | DottedName
+    dtype : PyccelSymbol | IndexedElement | DottedName
         The dtype named in the type annotation.
 
     order : str | None

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -13,7 +13,7 @@ from .basic import PyccelAstNode
 
 from .core import FunctionDefArgument
 
-from .variable import DottedName, AnnotatedPyccelSymbol
+from .variable import DottedName, AnnotatedPyccelSymbol, IndexedElement
 
 __all__ = (
         'FunctionTypeAnnotation',
@@ -286,7 +286,7 @@ class SyntacticTypeAnnotation(PyccelAstNode):
     __slots__ = ('_dtypes', '_ranks', '_orders', '_is_const')
     _attribute_nodes = ()
     def __init__(self, dtypes, ranks, orders, is_const = None):
-        if any(not isinstance(d, (str, DottedName)) for d in dtypes):
+        if any(not isinstance(d, (str, DottedName, IndexedElement)) for d in dtypes):
             raise ValueError("Syntactic datatypes should be strings")
         if any(not isinstance(r, int) for r in ranks):
             raise ValueError("Ranks should have integer values")

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
+#------------------------------------------------------------------------------------------#
+""" Module containing objects from the typing module understood by pyccel
+"""
+
+from .core      import Module
+from .datatypes import NativeSymbol
+from .variable  import Variable
+
+__all__ = (
+    'TypingFinal',
+    'typing_mod'
+)
+
+#==============================================================================
+
+typing_constants = {
+        'Final': Variable(NativeSymbol(), 'Final'),
+    }
+
+typing_mod = Module('typing',
+    variables = typing_constants.values(),
+    funcs = (),
+    )

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -9,8 +9,6 @@
 
 from .basic     import TypedAstNode
 from .core      import Module, PyccelFunctionDef
-from .datatypes import NativeSymbol
-from .variable  import Variable
 
 __all__ = (
     'TypingFinal',

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -7,7 +7,8 @@
 """ Module containing objects from the typing module understood by pyccel
 """
 
-from .core      import Module
+from .basic     import TypedAstNode
+from .core      import Module, PyccelFunctionDef
 from .datatypes import NativeSymbol
 from .variable  import Variable
 
@@ -18,11 +19,18 @@ __all__ = (
 
 #==============================================================================
 
-typing_constants = {
-        'Final': Variable(NativeSymbol(), 'Final'),
+class TypingFinal(TypedAstNode):
+    """
+    """
+    __slots__ = ()
+
+#==============================================================================
+
+typing_funcs = {
+        'Final': PyccelFunctionDef('Final', TypingFinal),
     }
 
 typing_mod = Module('typing',
-    variables = typing_constants.values(),
-    funcs = (),
+    variables = (),
+    funcs = typing_funcs.values(),
     )

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -34,9 +34,15 @@ class TypingFinal(TypedAstNode):
 
     def __init__(self, arg):
         self._arg = arg
+        super().__init__()
 
     @property
     def arg(self):
+        """
+        Get the argument describing the type annotation for an object.
+
+        Get the argument describing the type annotation for an object.
+        """
         return self._arg
 
 #==============================================================================

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -19,8 +19,25 @@ __all__ = (
 
 class TypingFinal(TypedAstNode):
     """
+    Class representing a call to the typing.Final construct.
+
+    Class representing a call to the typing.Final construct. A "call" to this
+    object looks like an IndexedElement. This is because types are involved.
+
+    Parameters
+    ----------
+    arg : SyntacticTypeAnnotation
+        The annotation which is coerced to be constant.
     """
-    __slots__ = ()
+    __slots__ = ('_arg',)
+    _attribute_nodes = ('_arg',)
+
+    def __init__(self, arg):
+        self._arg = arg
+
+    @property
+    def arg(self):
+        return self._arg
 
 #==============================================================================
 

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -30,6 +30,7 @@ from .numpyext      import (NumpyEmpty, NumpyArray, numpy_mod,
                             NumpyTranspose, NumpyLinspace)
 from .operators     import PyccelAdd, PyccelMul, PyccelIs, PyccelArithmeticOperator
 from .scipyext      import scipy_mod
+from .typingext     import typing_mod
 from .variable      import (Variable, IndexedElement, InhomogeneousTupleVariable )
 
 from .c_concepts import ObjectAddress
@@ -87,6 +88,7 @@ builtin_import_registry = Module('__main__',
             Import('math', math_mod),
             Import('pyccel', pyccel_mod),
             Import('sys', sys_mod),
+            Import('typing', typing_mod)
             ])
 if sys.version_info < (3, 10):
     from .builtin_imports import python_builtin_libs

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -1082,3 +1082,6 @@ class AnnotatedPyccelSymbol(PyccelAstNode):
 
     def __str__(self):
         return f'{self.name} : {self.annotation}'
+
+    def __reduce_ex__(self, i):
+        return (self.__class__, (self.name, self.annotation))

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -1082,3 +1082,7 @@ class AnnotatedPyccelSymbol(PyccelAstNode):
 
     def __str__(self):
         return f'{self.name} : {self.annotation}'
+
+    def __reduce_ex__(self, i):
+        return (self.__class__, (self.name, self.annotation))
+

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -17,6 +17,7 @@ from .datatypes import (datatype, DataType,
                         NativeInteger, NativeBool, NativeFloat,
                         NativeComplex, NativeHomogeneousTuple, NativeInhomogeneousTuple)
 from .internals import PyccelArrayShapeElement, Slice, get_final_precision, PyccelSymbol
+from .internals import apply_pickle
 from .literals  import LiteralInteger, Nil
 from .operators import (PyccelMinus, PyccelDiv, PyccelMul,
                         PyccelUnarySub, PyccelAdd)
@@ -580,8 +581,7 @@ class Variable(TypedAstNode):
             'cls_base':self.cls_base,
             }
 
-        apply = lambda func, args, kwargs: func(*args, **kwargs)
-        out =  (apply, (Variable, args, kwargs))
+        out =  (apply_pickle, (self.__class__, args, kwargs))
         return out
 
     def __getitem__(self, *args):

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -1082,6 +1082,3 @@ class AnnotatedPyccelSymbol(PyccelAstNode):
 
     def __str__(self):
         return f'{self.name} : {self.annotation}'
-
-    def __reduce_ex__(self, i):
-        return (self.__class__, (self.name, self.annotation))

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -21,7 +21,6 @@ from pyccel.ast.bind_c import BindCPointer, BindCFunctionDef, BindCFunctionDefAr
 from pyccel.ast.builtins import PythonInt, PythonType, PythonPrint, PythonRange
 from pyccel.ast.builtins import PythonTuple
 from pyccel.ast.builtins import PythonBool, PythonAbs
-from pyccel.ast.builtins import python_builtin_datatypes_dict as python_builtin_datatypes
 
 from pyccel.ast.core import FunctionDef, InlineFunctionDef
 from pyccel.ast.core import SeparatorComment, Comment
@@ -2484,7 +2483,7 @@ class FCodePrinter(CodePrinter):
 
         if value_true.dtype != value_false.dtype :
             try :
-                cast_func = python_builtin_datatypes[str_dtype(expr.dtype)]
+                cast_func = DtypePrecisionToCastFunction[expr.dtype.name][expr.precision]
             except KeyError:
                 errors.report(PYCCEL_RESTRICTION_TODO, severity='fatal')
             value_true = cast_func(value_true) if value_true.dtype != expr.dtype else value_true
@@ -2757,7 +2756,7 @@ class FCodePrinter(CodePrinter):
         args = []
         for arg in expr.args:
             if arg.dtype != expr.dtype:
-                cast_func = python_builtin_datatypes[str_dtype(expr.dtype)]
+                cast_func = DtypePrecisionToCastFunction[expr.dtype.name][expr.precision]
                 args.append(self._print(cast_func(arg)))
             else:
                 args.append(self._print(arg))

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -7,7 +7,8 @@ import warnings
 
 from pyccel.decorators import __all__ as pyccel_decorators
 
-from pyccel.ast.builtins   import PythonMin, PythonMax, PythonType
+from pyccel.ast.builtins   import PythonMin, PythonMax, PythonType, PythonBool, PythonInt, PythonFloat
+from pyccel.ast.builtins   import PythonComplex
 from pyccel.ast.core       import CodeBlock, Import, Assign, FunctionCall, For, AsName, FunctionAddress
 from pyccel.ast.core       import IfSection, FunctionDef, Module, DottedFunctionCall, PyccelFunctionDef
 from pyccel.ast.datatypes  import NativeHomogeneousTuple
@@ -178,7 +179,7 @@ class PythonCodePrinter(CodePrinter):
             cls = type(expr)
         type_name = expr.name
         name = self._aliases.get(cls, type_name)
-        if name == type_name and cls.__name__.startswith('Numpy'):
+        if name == type_name and cls not in (PythonBool, PythonInt, PythonFloat, PythonComplex):
             self.insert_new_import(
                     source = 'numpy',
                     target = AsName(cls, name))

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -1121,12 +1121,9 @@ class PythonCodePrinter(CodePrinter):
         return "'" + ' | '.join(types) + "'"
 
     def _print_SyntacticTypeAnnotation(self, expr):
-        dtypes = expr.dtypes
-        ranks = [f"[{','.join(':'*r)}]" if r>0 else '' for r in expr.ranks]
-        order = [f"(order={o})" if o else '' for o in expr.orders]
-        annot = [f'{d}{r}{o}' for d,r,o in zip(dtypes, ranks, order)]
-        const = 'const ' if expr.is_const else ''
-        return "'" + const + ' | '.join(annot) + "'"
+        dtype = self._print(expr.dtype)
+        order = f"(order={expr.order})" if expr.order else ''
+        return f'{dtype}{order}'
 
     def _print_FunctionTypeAnnotation(self, expr):
         args = ', '.join(self._print(a.annotation)[1:-1] for a in expr.args)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -251,7 +251,7 @@ class PythonCodePrinter(CodePrinter):
         default = ''
 
         if expr.annotation:
-            type_annotation = self._print(expr.annotation)
+            type_annotation = f"'{self._print(expr.annotation)}'"
         else:
             var = expr.var
             def get_type_annotation(var):
@@ -292,7 +292,7 @@ class PythonCodePrinter(CodePrinter):
                 indices = indices[0]
 
             indices = [self._print(i) for i in indices]
-            if isinstance(expr.base.class_type, NativeHomogeneousTuple):
+            if expr.pyccel_staging != 'syntactic' and isinstance(expr.base.class_type, NativeHomogeneousTuple):
                 indices = ']['.join(i for i in indices)
             else:
                 indices = ','.join(i for i in indices)
@@ -1118,7 +1118,7 @@ class PythonCodePrinter(CodePrinter):
 
     def _print_UnionTypeAnnotation(self, expr):
         types = [self._print(t)[1:-1] for t in expr.type_list]
-        return "'" + ' | '.join(types) + "'"
+        return ' | '.join(types)
 
     def _print_SyntacticTypeAnnotation(self, expr):
         dtype = self._print(expr.dtype)
@@ -1128,7 +1128,7 @@ class PythonCodePrinter(CodePrinter):
     def _print_FunctionTypeAnnotation(self, expr):
         args = ', '.join(self._print(a.annotation)[1:-1] for a in expr.args)
         results = ', '.join(self._print(r.annotation)[1:-1] for r in expr.results)
-        return "'" + f"({results})({args})" + "'"
+        return f"({results})({args})"
 
 #==============================================================================
 def pycode(expr, assign_to=None, **settings):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -1130,6 +1130,10 @@ class PythonCodePrinter(CodePrinter):
         results = ', '.join(self._print(r.annotation)[1:-1] for r in expr.results)
         return f"({results})({args})"
 
+    def _print_TypingFinal(self, expr):
+        annotation = self._print(expr.arg)
+        return f'const {annotation}'
+
 #==============================================================================
 def pycode(expr, assign_to=None, **settings):
     """ Converts an expr to a string of Python code

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -178,7 +178,7 @@ class PythonCodePrinter(CodePrinter):
             cls = type(expr)
         type_name = expr.name
         name = self._aliases.get(cls, type_name)
-        if name == type_name:
+        if name == type_name and cls.__name__.startswith('Numpy'):
             self.insert_new_import(
                     source = 'numpy',
                     target = AsName(cls, name))

--- a/pyccel/commands/pyccel_init.py
+++ b/pyccel/commands/pyccel_init.py
@@ -27,3 +27,4 @@ def pyccel_init_command():
     """
     parser = ArgumentParser(description='Pickle internal pyccel files')
     parser.parse_args()
+    pyccel_init()

--- a/pyccel/commands/pyccel_init.py
+++ b/pyccel/commands/pyccel_init.py
@@ -22,8 +22,10 @@ def pyccel_init():
         parser.parse(verbose=False)
 
 def pyccel_init_command():
-    """ Wrapper around the pyccel_init function removing the need
-    for ArgumentParser
+    """
+    Wrapper around the pyccel_init function removing the need for ArgumentParser.
+
+    Wrapper around the pyccel_init function removing the need for ArgumentParser.
     """
     parser = ArgumentParser(description='Pickle internal pyccel files')
     parser.parse_args()

--- a/pyccel/parser/grammar/headers.tx
+++ b/pyccel/parser/grammar/headers.tx
@@ -1,3 +1,5 @@
+reference types
+
 Header:
   statements*=HeaderStmt
 ;
@@ -13,29 +15,17 @@ Statement:
   | InterfaceStmt
 ;
 
-TrailerSubscriptList: '[' args*=':' [','] ']'  ( '(' 'order' '=' order = ID ')' )?;
-
-DataType: ID|STAR;
-
-VariableType: dtype=DataType (trailer=TrailerSubscriptList)?;
-
-FuncType: '('(results*=TypeHeader[','])?')' '('decs*=UnionTypeStmt[',']')';
-
-TypeHeader: FuncType|VariableType;
-UnionTypeStmt: (const?=Const) dtypes+=TypeHeader['|'] ;
-Const: 'const';
-
-VariableHeaderStmt: 'variable'  name=ID ('::')? dec=UnionTypeStmt;
+VariableHeaderStmt: 'variable'  name=ID ('::')? dec=[types.UnionTypeStmt];
 
 FunctionHeaderStmt: 
-  ((name=ID '(') | ((kind=FunctionKind)? (static?=Static) name=ID '(')) decs*=UnionTypeStmt[','] ')' (results=HeaderResults)?
+  ((name=ID '(') | ((kind=FunctionKind)? (static?=Static) name=ID '(')) decs*=[types.UnionTypeStmt][','] ')' (results=HeaderResults)?
 ;
 
-TemplateStmt: 'template' name = ID '(' dtypes+=TypeHeader['|'] ')';
+TemplateStmt: 'template' name = ID '(' dtypes+=[types.TypeHeader]['|'] ')';
 
 FunctionKind: 'function' | 'method';
 Static: 'static';
-HeaderResults: 'results' '(' decs+=TypeHeader[','] ')'; 
+HeaderResults: 'results' '(' decs+=[types.TypeHeader][','] ')'; 
 
 MetavarHeaderStmt: 'metavar'  name=ID '=' value=MetavarValues;
 MetavarValues: BOOL|STRING;
@@ -78,6 +68,4 @@ FunctionMacroStmt:
 ;
 
 // ****************
-
-STAR: '*';
 

--- a/pyccel/parser/grammar/headers.tx
+++ b/pyccel/parser/grammar/headers.tx
@@ -1,5 +1,3 @@
-reference types
-
 Header:
   statements*=HeaderStmt
 ;
@@ -15,17 +13,17 @@ Statement:
   | InterfaceStmt
 ;
 
-VariableHeaderStmt: 'variable'  name=ID ('::')? dec=[types.UnionTypeStmt];
+VariableHeaderStmt: 'variable'  name=ID ('::')? dec=UnionTypeStmt;
 
 FunctionHeaderStmt: 
-  ((name=ID '(') | ((kind=FunctionKind)? (static?=Static) name=ID '(')) decs*=[types.UnionTypeStmt][','] ')' (results=HeaderResults)?
+  ((name=ID '(') | ((kind=FunctionKind)? (static?=Static) name=ID '(')) decs*=UnionTypeStmt[','] ')' (results=HeaderResults)?
 ;
 
-TemplateStmt: 'template' name = ID '(' dtypes+=[types.TypeHeader]['|'] ')';
+TemplateStmt: 'template' name = ID '(' dtypes+=TypeHeader['|'] ')';
 
 FunctionKind: 'function' | 'method';
 Static: 'static';
-HeaderResults: 'results' '(' decs+=[types.TypeHeader][','] ')'; 
+HeaderResults: 'results' '(' decs+=TypeHeader[','] ')';
 
 MetavarHeaderStmt: 'metavar'  name=ID '=' value=MetavarValues;
 MetavarValues: BOOL|STRING;

--- a/pyccel/parser/grammar/types.tx
+++ b/pyccel/parser/grammar/types.tx
@@ -3,10 +3,11 @@ UnionTypeStmt: (const ?= Const) dtypes += TypeHeader['|'];
 Const: 'const';
 TypeHeader: FuncType|Type;
 
+Slice: ':';
 Type: dtype=DataType (trailer=TrailerSubscriptList)?;
-TrailerSubscriptList: '[' args*=':' [','] ']'  ( '(' 'order' '=' order = ID ')' )?;
+TrailerSubscriptList: '[' args*=Slice [','] ']'  ( '(' 'order' '=' order = ID ')' )?;
 
-FuncType: '('(results*=TypeHeader[','])?')' '('decs*=UnionTypeStmt[',']')';
+FuncType: '('(results*=TypeHeader[','])?')' '('args*=UnionTypeStmt[',']')';
 
 DataType: ID|STAR;
 STAR: '*';

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2265,6 +2265,8 @@ class SemanticParser(BasicParser):
             var = numpy_funcs.get(name, None)
             if name == 'real':
                 var = numpy_funcs['float']
+            elif name == '*':
+                return NativeGeneric()
 
         if var is None:
             if name == '_':
@@ -2381,6 +2383,8 @@ class SemanticParser(BasicParser):
             rank = 0
             order = None
             return UnionTypeAnnotation(VariableTypeAnnotation(dtype, dtype, prec, rank, order))
+        elif isinstance(visited_dtype, DataType):
+            return UnionTypeAnnotation(VariableTypeAnnotation(visited_dtype, visited_dtype, -1, 0, None))
         else:
             raise errors.report(PYCCEL_RESTRICTION_TODO + f' Could not deduce type information',
                     severity='fatal', symbol=expr)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2386,7 +2386,7 @@ class SemanticParser(BasicParser):
         elif isinstance(visited_dtype, DataType):
             return UnionTypeAnnotation(VariableTypeAnnotation(visited_dtype, visited_dtype, -1, 0, None))
         else:
-            raise errors.report(PYCCEL_RESTRICTION_TODO + f' Could not deduce type information',
+            raise errors.report(PYCCEL_RESTRICTION_TODO + ' Could not deduce type information',
                     severity='fatal', symbol=expr)
 
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -61,7 +61,7 @@ from pyccel.ast.core import Assert
 
 from pyccel.ast.class_defs import NumpyArrayClass, TupleClass, get_cls_base
 
-from pyccel.ast.datatypes import str_dtype
+from pyccel.ast.datatypes import str_dtype, DataType
 from pyccel.ast.datatypes import NativeSymbol, DataTypeFactory, CustomDataType
 from pyccel.ast.datatypes import default_precision, dtype_and_precision_registry
 from pyccel.ast.datatypes import (NativeInteger, NativeBool, NativeHomogeneousList,
@@ -84,7 +84,7 @@ from pyccel.ast.literals import Literal, convert_to_literal
 
 from pyccel.ast.mathext  import math_constants, MathSqrt, MathAtan2, MathSin, MathCos
 
-from pyccel.ast.numpyext import NumpyMatmul
+from pyccel.ast.numpyext import NumpyMatmul, numpy_funcs
 from pyccel.ast.numpyext import NumpyWhere, NumpyArray
 from pyccel.ast.numpyext import NumpyTranspose, NumpyConjugate
 from pyccel.ast.numpyext import NumpyNewArray, NumpyNonZero, NumpyResultType
@@ -223,6 +223,8 @@ class SemanticParser(BasicParser):
         self.scope.imports['imports'] = {}
         self._module_namespace  = self.scope
         self._program_namespace = self.scope.new_child_scope('__main__')
+
+        self._in_annotation = False
 
         # used to store the local variables of a code block needed for garbage collecting
         self._allocs = []
@@ -1726,48 +1728,6 @@ class SemanticParser(BasicParser):
 
         return list(parent.values())
 
-    def _PyccelAstNode_to_TypeAnnotation(self, expr, input_rank = 0, input_order = None):
-        """
-        Convert a PyccelAstNode class type to a TypeAnnotation.
-
-        Convert a PyccelAstNode class type to a TypeAnnotation. This is done using
-        the static dtype, precision and rank stored in the class.
-
-        Parameters
-        ----------
-        expr : type deriving from PyccelAstNode
-            The object which was passed to the type annotation.
-
-        input_rank : int, default=0
-            The rank that was deduced from the annotation.
-
-        input_order : str, optional
-            The order that was deduced from the annotation.
-
-        Returns
-        -------
-        VariableTypeAnnotation
-            Object describing the type that should be created.
-        """
-        dtype = expr.static_dtype()
-        prec = expr.static_precision()
-        if input_rank != 0:
-            rank = input_rank
-            order = input_order
-        else:
-            rank = expr.static_rank()
-            if not isinstance(rank, int):
-                rank = 0
-            order = expr.static_order()
-            if order is not None and not isinstance(order, str):
-                order = None
-        if rank > 1 and order is None:
-            order = 'C'
-
-        class_type = dtype if rank == 0 else expr.static_class_type()
-
-        return VariableTypeAnnotation(dtype, class_type, prec, rank, order)
-
     def _get_indexed_type(self, base, args, expr):
         """
         Extract a type annotation from an IndexedElement.
@@ -1795,6 +1755,13 @@ class SemanticParser(BasicParser):
             for t in annotation.type_list:
                 t.is_const = True
             return annotation
+        elif isinstance(base, PyccelFunctionDef) and all(isinstance(a, Slice) for a in args):
+            dtype_cls = base.cls_name
+            dtype = dtype_cls.static_dtype()
+            prec = dtype_cls.static_precision()
+            class_type = NumpyNDArrayType()
+            rank = len(args)
+            return VariableTypeAnnotation(dtype, class_type, prec, rank)
         else:
             raise errors.report("Unrecognised type slice",
                     severity='fatal', symbol=expr)
@@ -2272,6 +2239,9 @@ class SemanticParser(BasicParser):
             if var is not None:
                 var = PyccelFunctionDef(name, var)
 
+        if var is None and self._in_annotation:
+            var = numpy_funcs.get(name, None)
+
         if var is None:
             if name == '_':
                 errors.report(UNDERSCORE_NOT_A_THROWAWAY,
@@ -2359,64 +2329,34 @@ class SemanticParser(BasicParser):
         return possible_args
 
     def _visit_SyntacticTypeAnnotation(self, expr):
-        is_const = expr.is_const is True
         types = []
 
-        for dtype_name, rank, order in zip(expr.dtypes, expr.ranks, expr.orders):
-            if rank > 1 and order is None:
-                order = 'C'
+        self._in_annotation = True
+        visited_dtype = self._visit(expr.dtype)
+        self._in_annotation = False
+        order = expr.order
 
-            if isinstance(dtype_name, (PyccelSymbol, DottedName, IndexedElement)):
-                dtype_from_scope = self._visit(dtype_name)
-            else:
-                dtype_from_scope = self.scope.find(dtype_name)
-
-            if isinstance(dtype_from_scope, type) and PyccelAstNode in dtype_from_scope.__mro__:
-                types.append(self._PyccelAstNode_to_TypeAnnotation(dtype_from_scope, rank, order))
-            elif isinstance(dtype_from_scope, PyccelFunctionDef):
-                types.append(self._PyccelAstNode_to_TypeAnnotation(dtype_from_scope.cls_name, rank, order))
-            elif isinstance(dtype_from_scope, VariableTypeAnnotation):
-                if rank == 0:
-                    types.append(dtype_from_scope)
-                else:
-                    types.append(VariableTypeAnnotation(dtype_from_scope.datatype,
-                        dtype_from_scope.class_type, dtype_from_scope.precision,
-                        rank, order, dtype_from_scope.is_const))
-            elif isinstance(dtype_from_scope, ClassDef):
-                dtype = self.get_class_construct(dtype_name)
-                prec = 0
-                rank = 0
-                order = None
-                types.append(VariableTypeAnnotation(dtype, dtype, prec, rank, order))
-            elif isinstance(dtype_from_scope, UnionTypeAnnotation):
-                types.extend(dtype_from_scope.type_list)
-            elif dtype_from_scope is not None:
-                errors.report(PYCCEL_RESTRICTION_TODO + f' Could not deduce type information from {type(dtype_from_scope)} object',
-                        severity='fatal', symbol=expr)
-            else:
-                # Find the DataType instance and the associated precision
-                try:
-                    dtype, prec = dtype_and_precision_registry[dtype_name]
-                except KeyError:
-                    errors.report(f'Could not identify type : {dtype_name}',
-                            severity='fatal', symbol=expr)
-
-                # NumPy objects cannot have default precision
-                if prec == -1 and rank > 0:
-                    prec = default_precision[dtype]
-
-                if order is not None and rank < 2:
-                    errors.report(f"Ordering is not applicable to objects with rank {rank}",
-                            symbol=expr, severity='warning')
-                    order = None
-
-                cls_type = dtype if rank == 0 else NumpyNDArrayType()
-
-                # Save the potential type
-                types.append(VariableTypeAnnotation(dtype, cls_type, prec, rank, order, is_const))
-
-        # Collect all possible types into a UnionTypeAnnotation
-        return UnionTypeAnnotation(*types)
+        if isinstance(visited_dtype, PyccelFunctionDef):
+            dtype_cls = visited_dtype.cls_name
+            dtype = dtype_cls.static_dtype()
+            prec = dtype_cls.static_precision()
+            class_type = dtype_cls.static_class_type()
+            if not isinstance(class_type, DataType):
+                class_type = dtype
+            return UnionTypeAnnotation(VariableTypeAnnotation(dtype, class_type, prec, 0, None))
+        elif isinstance(visited_dtype, VariableTypeAnnotation):
+            if visited_dtype.rank > 1:
+                visited_dtype.order = order or visited_dtype.order or 'C'
+            return UnionTypeAnnotation(visited_dtype)
+        elif isinstance(dtype_from_scope, ClassDef):
+            dtype = self.get_class_construct(dtype_name)
+            prec = 0
+            rank = 0
+            order = None
+            return UnionTypeAnnotation(VariableTypeAnnotation(dtype, dtype, prec, rank, order))
+        else:
+            raise errors.report(PYCCEL_RESTRICTION_TODO + f' Could not deduce type information',
+                    severity='fatal', symbol=expr)
 
 
     def _visit_DottedName(self, expr):
@@ -3632,7 +3572,7 @@ class SemanticParser(BasicParser):
         arg_annotations = [annot for a in templatable_args for annot in (a.type_list \
                                         if isinstance(a, UnionTypeAnnotation) else [a]) \
                                         if isinstance(annot, SyntacticTypeAnnotation)]
-        used_type_names = set(type_names for a in arg_annotations for type_names in a.dtypes)
+        used_type_names = set(a.dtype for a in arg_annotations)
         templates = {t: v for t,v in templates.items() if t in used_type_names}
 
         template_combinations = list(product(*[v.type_list for v in templates.values()]))

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2241,6 +2241,8 @@ class SemanticParser(BasicParser):
 
         if var is None and self._in_annotation:
             var = numpy_funcs.get(name, None)
+            if name == 'real':
+                var = numpy_funcs['float']
 
         if var is None:
             if name == '_':

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1751,13 +1751,13 @@ class SemanticParser(BasicParser):
             The type annotation described by this object.
         """
         if isinstance(base, PyccelFunctionDef) and base.cls_name is TypingFinal:
-                syntactic_annotation = args[0]
-                if not isinstance(syntactic_annotation, SyntacticTypeAnnotation):
-                    syntactic_annotation = SyntacticTypeAnnotation(dtype=syntactic_annotation)
-                annotation = self._visit(syntactic_annotation)
-                for t in annotation.type_list:
-                    t.is_const = True
-                return annotation
+            syntactic_annotation = args[0]
+            if not isinstance(syntactic_annotation, SyntacticTypeAnnotation):
+                syntactic_annotation = SyntacticTypeAnnotation(dtype=syntactic_annotation)
+            annotation = self._visit(syntactic_annotation)
+            for t in annotation.type_list:
+                t.is_const = True
+            return annotation
 
         if all(isinstance(a, Slice) for a in args):
             if isinstance(base, VariableTypeAnnotation):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1775,6 +1775,8 @@ class SemanticParser(BasicParser):
                 prec = dtype_cls.static_precision()
                 class_type = NumpyNDArrayType()
             rank = len(args)
+            if prec == -1:
+                prec = default_precision[dtype]
             return VariableTypeAnnotation(dtype, class_type, prec, rank)
 
         raise errors.report("Unrecognised type slice",

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2348,8 +2348,9 @@ class SemanticParser(BasicParser):
             if visited_dtype.rank > 1:
                 visited_dtype.order = order or visited_dtype.order or 'C'
             return UnionTypeAnnotation(visited_dtype)
-        elif isinstance(dtype_from_scope, ClassDef):
-            dtype = self.get_class_construct(dtype_name)
+        elif isinstance(visited_dtype, ClassDef):
+            # TODO: Improve when #1676 is merged
+            dtype = self.get_class_construct(visited_dtype.name)
             prec = 0
             rank = 0
             order = None

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -282,6 +282,8 @@ class SyntaxParser(BasicParser):
                 errors.report(f"Invalid header. {e.message}",
                         symbol = stmt, column = e.col,
                         severity='fatal')
+            annot = annotation.expr
+            print(annot, type(annot))
             annot = SyntacticTypeAnnotation.build_from_textx(annotation)
             if isinstance(stmt, PyccelAstNode):
                 annot.set_current_ast(stmt.python_ast)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -945,9 +945,6 @@ class SyntaxParser(BasicParser):
 
         local_symbols = self.scope.local_used_symbols
 
-        if result_annotation and not isinstance(result_annotation, tuple):
-            result_annotation = [result_annotation]
-
         for i,r in enumerate(zip(*returns)):
             r0 = r[0]
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -271,10 +271,8 @@ class SyntaxParser(BasicParser):
         """
         if isinstance(annotation, (tuple, list)):
             return UnionTypeAnnotation(*[self._treat_type_annotation(stmt, a) for a in annotation])
-        if isinstance(annotation, (PyccelSymbol, DottedName)):
-            return SyntacticTypeAnnotation(dtypes=[annotation], ranks=[0], orders=[None], is_const=False)
-        elif isinstance(annotation, IndexedElement):
-            return SyntacticTypeAnnotation(dtypes=[annotation], ranks=[len(annotation.indices)], orders=[None], is_const=False)
+        if isinstance(annotation, (PyccelSymbol, DottedName, IndexedElement)):
+            return SyntacticTypeAnnotation(dtype=annotation)
         elif isinstance(annotation, LiteralString):
             try:
                 annotation = types_meta.model_from_str(annotation.python_value)
@@ -283,8 +281,6 @@ class SyntaxParser(BasicParser):
                         symbol = stmt, column = e.col,
                         severity='fatal')
             annot = annotation.expr
-            print(annot, type(annot))
-            annot = SyntacticTypeAnnotation.build_from_textx(annotation)
             if isinstance(stmt, PyccelAstNode):
                 annot.set_current_ast(stmt.python_ast)
             else:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -945,6 +945,9 @@ class SyntaxParser(BasicParser):
 
         local_symbols = self.scope.local_used_symbols
 
+        if result_annotation and not isinstance(result_annotation, (tuple, list)):
+            result_annotation = [result_annotation]
+
         for i,r in enumerate(zip(*returns)):
             r0 = r[0]
 

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -113,6 +113,11 @@ class Type(BasicStmt):
         ----------
         s : str
             The argument in the trailing section.
+
+        Returns
+        -------
+        PyccelAstNode
+            The Pyccel object being described.
         """
         if s == ':':
             return Slice(None, None)

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -275,7 +275,7 @@ class UnionTypeStmt(BasicStmt):
         if len(dtypes)==1:
             return dtypes[0]
 
-        return UnionTypeAnnotation(dtypes)
+        return UnionTypeAnnotation(*dtypes)
 
 class HeaderResults(BasicStmt):
     """

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -178,7 +178,7 @@ class TemplateStmt(BasicStmt):
                         severity='error')
             return EmptyNode()
 
-        dtypes = {SyntacticTypeAnnotation.build_from_textx(t)  for t in self.dtypes}
+        dtypes = {t.expr  for t in self.dtypes}
         return Template(self.name, dtypes)
 
 class ShapedID(BasicStmt):
@@ -294,8 +294,7 @@ class HeaderResults(BasicStmt):
 
         Get the Pyccel equivalent of this object.
         """
-        decs = SyntacticTypeAnnotation.build_from_textx(self.decs)
-        return decs
+        return [d.expr for d in self.decs]
 
 
 class VariableHeaderStmt(BasicStmt):
@@ -333,7 +332,7 @@ class VariableHeaderStmt(BasicStmt):
                       "in your code. If you find it is necessary please open a discussion " +
                       "at https://github.com/pyccel/pyccel/discussions so we do not " +
                       "remove support until an alternative is in place.", FutureWarning)
-        dtype = SyntacticTypeAnnotation.build_from_textx(self.dec)
+        dtype = self.dec.expr
 
         return AnnotatedPyccelSymbol(self.name, annotation=dtype)
 
@@ -376,7 +375,7 @@ class FunctionHeaderStmt(BasicStmt):
 
         Get the Pyccel equivalent of this object.
         """
-        dtypes = SyntacticTypeAnnotation.build_from_textx(self.decs)
+        dtypes = [d.expr for d in self.decs]
 
         if self.kind is None:
             kind = 'function'

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -64,7 +64,7 @@ class TrailerSubscriptList(BasicStmt):
     """
     def __init__(self, args, order, **kwargs):
         self.args = args
-        self.order = order or None
+        self.order = order.capitalize() or None
         super().__init__(**kwargs)
 
 class Type(BasicStmt):

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -20,7 +20,7 @@ from pyccel.ast.literals  import LiteralString, LiteralInteger, LiteralFloat
 from pyccel.ast.literals  import LiteralTrue, LiteralFalse
 from pyccel.ast.internals import PyccelSymbol, Slice
 from pyccel.ast.variable  import AnnotatedPyccelSymbol, IndexedElement
-from pyccel.ast.type_annotations import SyntacticTypeAnnotation
+from pyccel.ast.type_annotations import SyntacticTypeAnnotation, FunctionTypeAnnotation, UnionTypeAnnotation
 from pyccel.ast.typingext import TypingFinal
 from pyccel.errors.errors import Errors
 from pyccel.utilities.stage import PyccelStage
@@ -104,6 +104,16 @@ class Type(BasicStmt):
         return SyntacticTypeAnnotation(dtype, order)
 
     def handle_trailer_arg(self, s):
+        """
+        Get the Pyccel object equivalent to the argument in the trailing object.
+
+        Get the Pyccel object equivalent to the argument in the trailing object.
+
+        Parameters
+        ----------
+        s : str
+            The argument in the trailing section.
+        """
         if s == ':':
             return Slice(None, None)
         else:
@@ -613,9 +623,9 @@ header_grammar = join(this_folder, '../grammar/headers.tx')
 types_meta = metamodel_from_file(types_grammar, classes=type_classes)
 register_language("types", metamodel=types_meta)
 
-with open(header_grammar, 'r') as f:
+with open(header_grammar, 'r', encoding="utf-8") as f:
     grammar = f.read()
-with open(types_grammar, 'r') as f:
+with open(types_grammar, 'r', encoding="utf-8") as f:
     grammar += f.read()
 
 meta = metamodel_from_str(grammar, classes=hdr_classes+type_classes)

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -8,7 +8,7 @@
 import warnings
 from os.path import join, dirname
 
-from textx import metamodel_from_file, register_language
+from textx import metamodel_from_file, register_language, metamodel_from_str
 
 from pyccel.parser.syntax.basic import BasicStmt
 from pyccel.ast.headers   import FunctionHeader, MethodHeader, Template
@@ -609,11 +609,17 @@ this_folder = dirname(__file__)
 
 # Get meta-model from language description
 types_grammar = join(this_folder, '../grammar/types.tx')
-grammar = join(this_folder, '../grammar/headers.tx')
+header_grammar = join(this_folder, '../grammar/headers.tx')
 
 types_meta = metamodel_from_file(types_grammar, classes=type_classes)
 register_language("types", metamodel=types_meta)
-meta = metamodel_from_file(grammar, classes=hdr_classes)
+
+with open(header_grammar, 'r') as f:
+    grammar = f.read()
+with open(types_grammar, 'r') as f:
+    grammar += f.read()
+
+meta = metamodel_from_str(grammar, classes=hdr_classes+type_classes)
 register_language("headers", metamodel=meta)
 
 def parse(filename=None, stmts=None):

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -8,7 +8,7 @@
 import warnings
 from os.path import join, dirname
 
-from textx.metamodel import metamodel_from_file
+from textx import metamodel_from_file, register_language
 
 from pyccel.parser.syntax.basic import BasicStmt
 from pyccel.ast.headers   import FunctionHeader, MethodHeader, Template
@@ -635,7 +635,8 @@ class FunctionMacroStmt(BasicStmt):
 # whenever a new rule is added in the grammar, we must update the following
 # lists.
 type_classes = [UnionTypeStmt, Type, TrailerSubscriptList, FuncType]
-hdr_classes = [Header, VariableType,
+hdr_classes = [Header,
+               VariableType,
                ShapedID,
                HeaderResults,
                FunctionHeaderStmt,
@@ -646,16 +647,18 @@ hdr_classes = [Header, VariableType,
                MacroStmt,
                MacroArg,
                MacroList,
-               FunctionMacroStmt,StringStmt]
+               FunctionMacroStmt, StringStmt]
 
 this_folder = dirname(__file__)
 
 # Get meta-model from language description
-grammar = join(this_folder, '../grammar/headers.tx')
 types_grammar = join(this_folder, '../grammar/types.tx')
+grammar = join(this_folder, '../grammar/headers.tx')
 
-meta = metamodel_from_file(grammar, classes=hdr_classes)
 types_meta = metamodel_from_file(types_grammar, classes=type_classes)
+register_language("types", metamodel=types_meta)
+meta = metamodel_from_file(grammar, classes=hdr_classes)
+register_language("headers", metamodel=meta)
 
 def parse(filename=None, stmts=None):
     """ Parse header pragmas

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -191,39 +191,6 @@ class TemplateStmt(BasicStmt):
         dtypes = {SyntacticTypeAnnotation.build_from_textx(t)  for t in self.dtypes}
         return Template(self.name, dtypes)
 
-class VariableType(BasicStmt):
-    """
-    Base class representing a header type in the grammar.
-
-    Base class representing a header type in the grammar.
-
-    Parameters
-    ----------
-    dtype : str
-        The variable type.
-
-    prec : int, optional
-        The precision of the object.
-
-    trailer : iterable, TrailerSubscriptsList
-        An object created by textx describing the trailing decorators of the
-        type. The number of elements is equal to the rank. The order is also
-        described when the iterable is non-empty.
-
-    **kwargs : dict
-        The textx arguments.
-    """
-
-    def __init__(self, dtype, prec = None, trailer = (), **kwargs):
-        self.dtype   = dtype
-        self.prec    = prec
-        if trailer:
-            self.trailer = trailer
-        else:
-            self.trailer = []
-
-        super().__init__(**kwargs)
-
 class ShapedID(BasicStmt):
     """class representing a ShapedID in the grammar.
 
@@ -636,7 +603,6 @@ class FunctionMacroStmt(BasicStmt):
 # lists.
 type_classes = [UnionTypeStmt, Type, TrailerSubscriptList, FuncType]
 hdr_classes = [Header,
-               VariableType,
                ShapedID,
                HeaderResults,
                FunctionHeaderStmt,

--- a/tests/epyccel/test_array_as_func_args.py
+++ b/tests/epyccel/test_array_as_func_args.py
@@ -41,9 +41,9 @@ def test_array_real_1d_scalar_add(language):
 
     for t in float_types:
         size = randint(1, 30)
-        x1 = uniform(np.finfo(t).max / 2, size=size)
+        x1 = uniform(np.finfo(t).max / 2, size=size).astype(t)
         x2 = np.copy(x1)
-        a = uniform(np.finfo(t).max / 2)
+        a = uniform(np.finfo(t).max / 2, size=1).astype(t)[0]
 
         f1(x1, a, size)
         f2(x2, a, size)
@@ -104,9 +104,9 @@ def test_array_real_2d_scalar_add(language):
     for t in float_types:
         d1 = randint(1, 15)
         d2 = randint(1, 15)
-        x1 = uniform(np.finfo(t).max / 2, size=(d1, d2))
+        x1 = uniform(np.finfo(t).max / 2, size=(d1, d2)).astype(t)
         x2 = np.copy(x1)
-        a = uniform(np.finfo(t).max / 2)
+        a = uniform(np.finfo(t).max / 2, size=1).astype(t)[0]
 
         f1(x1, a, d1, d2)
         f2(x2, a, d1, d2)

--- a/tests/epyccel/test_epyccel_headers.py
+++ b/tests/epyccel/test_epyccel_headers.py
@@ -39,11 +39,7 @@ def test_allow_negative_index_annotation(language):
         j = -3
         return array[j]
 
-    errors = Errors()
-    errors.reset()
     epyc_allow_negative_index_annotation = epyccel(allow_negative_index_annotation, language=language)
-    assert errors.num_messages() == 1
-    errors.reset()
 
     assert epyc_allow_negative_index_annotation() == allow_negative_index_annotation()
     assert isinstance(epyc_allow_negative_index_annotation(), type(allow_negative_index_annotation()))

--- a/tests/epyccel/test_epyccel_variable_annotations.py
+++ b/tests/epyccel/test_epyccel_variable_annotations.py
@@ -39,11 +39,7 @@ def test_allow_negative_index_annotation(language):
         j = -3
         return array[j]
 
-    errors = Errors()
-    errors.reset()
     epyc_allow_negative_index_annotation = epyccel(allow_negative_index_annotation, language=language)
-    assert errors.num_messages() == 1
-    errors.reset()
 
     assert epyc_allow_negative_index_annotation() == allow_negative_index_annotation()
     assert isinstance(epyc_allow_negative_index_annotation(), type(allow_negative_index_annotation()))
@@ -97,12 +93,7 @@ def test_allow_negative_index_annotation_2(language):
         j = -3
         return array[j]
 
-    errors = Errors()
-    errors.reset()
     epyc_allow_negative_index_annotation = epyccel(allow_negative_index_annotation, language=language)
-    print(errors.check())
-    assert errors.num_messages() == 1
-    errors.reset()
 
     assert epyc_allow_negative_index_annotation() == allow_negative_index_annotation()
     assert isinstance(epyc_allow_negative_index_annotation(), type(allow_negative_index_annotation()))

--- a/tests/epyccel/test_epyccel_variable_annotations.py
+++ b/tests/epyccel/test_epyccel_variable_annotations.py
@@ -116,6 +116,7 @@ def test_final_annotation(language):
         from typing import Final
         a : Final[int] = 3
         a = 4
+        return a
 
     with pytest.raises(PyccelSemanticError):
         epyccel(final_annotation, language=language)

--- a/tests/epyccel/test_epyccel_variable_annotations.py
+++ b/tests/epyccel/test_epyccel_variable_annotations.py
@@ -110,3 +110,12 @@ def test_stack_array_annotation_2(language):
 
     assert epyc_stack_array_annotation() == stack_array_annotation()
     assert isinstance(epyc_stack_array_annotation(), type(stack_array_annotation()))
+
+def test_final_annotation(language):
+    def final_annotation():
+        from typing import Final
+        a : Final[int] = 3
+        a = 4
+
+    with pytest.raises(PyccelSemanticError):
+        epyccel(final_annotation, language=language)


### PR DESCRIPTION
Add support for `typing.Final`. Fixes #1680 . This means that the AST can describe everything that textx parses in type string annotations. Therefore the type annotation methods are simplified and unified to reduce code duplication. Fixes #1581. This should make it simpler to add support for tuple/list/set type annotations

**Commit Summary**
- Fix pickling of `Variable` and `AnnotatedPyccelSymbol` (lambda expressions can't be pickled) by moving `ast.core.apply`->`ast.core.apply_pickle`
- Remove unused redundant class `UnionType`
- Simplify `SyntacticTypeAnnotation` to only handle one type (instead of all textx output).
- Add support for `typing.Final` (represents `is_const` concept)
- Remove `python_builtin_datatypes` and simply use  `_visit_PyccelSymbol` to collect type.
  It is not useful to differentiate between datatypes and functions. The two dictionaries point at the same objects and Python itself doesn't differentiate between the two. Anything that was missing was moved into buitin_functions.
- Fix unnecessary import of deprecated types from NumPy in generated Python code.
- Stop duplicating textx logic.
- Add `_get_indexed_type` function to handle `IndexedElement` objects which describe a type.
- Use textx class descriptors to generate Pyccel AST elements that can be parsed in the semantic stage.
- Fix bug in test where `float`s were passed instead of NumPy floats.
- Stop raising a warning when the order is provided unnecessarily.
- Fix minor bot bug when whole file is new code.
- Add `is_const` setter to type annotations.
- Fix pyccel-init script which was not calling the related function.