### PR TITLE
Make `PythonComplex` a subclass of `PyccelInternalFunction`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Contributors
 * Soukaina Hikma
 * Mudit Loya
 * Priyabrata Mondal
+* Farouk ECH-CHAREF

--- a/AUTHORS
+++ b/AUTHORS
@@ -28,4 +28,4 @@ Contributors
 * Soukaina Hikma
 * Mudit Loya
 * Priyabrata Mondal
-* Farouk ECH-CHAREF
+* Farouk Ech-Charef

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -236,7 +236,7 @@ class PythonBool(PyccelInternalFunction):
         return f'Bool({self.arg})'
 
 #==============================================================================
-class PythonComplex(TypedAstNode):
+class PythonComplex(PyccelInternalFunction):
     """
     Represents a call to Python's native `complex()` function.
 
@@ -251,6 +251,7 @@ class PythonComplex(TypedAstNode):
     arg1 : TypedAstNode, default=0
         The second argument passed to the function (the imaginary part).
     """
+    
     __slots__ = ('_real_part', '_imag_part', '_internal_var', '_is_cast')
     name = 'complex'
 

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -251,7 +251,6 @@ class PythonComplex(PyccelInternalFunction):
     arg1 : TypedAstNode, default=0
         The second argument passed to the function (the imaginary part).
     """
-    
     __slots__ = ('_real_part', '_imag_part', '_internal_var', '_is_cast')
     name = 'complex'
 


### PR DESCRIPTION
Change the base class of `PythonComplex` from `TypedAstNode` to `PyccelInternalFunction`. This fixes #1703.