### PR TITLE
Wrap class variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable changes to this project will be documented in this file.
 -   #1495 : Add support for functions with class instance arguments.
 -   #1684 : Add support for classes without `__init__` functions.
 -   #1685 : Add support for `type()` function with class instance argument.
--   #1605 : Add support for class methods and interfaces (including `__init__` and `__del__`).
+-   #1605 : Add support for methods and interfaces in classes (including `__init__` and `__del__`).
+-   #1618 : Add support for class instance attributes.
 
 ### Fixed
 

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -2,7 +2,7 @@
 
 Pyccel strives to provide robust support for object-oriented programming concepts commonly used by developers. In Pyccel, classes are a fundamental building block for creating structured and reusable code. This documentation outlines key features and considerations when working with classes in Pyccel.
 
-:warning: Pyccel's class support is currently limited to translations only. The implementation of the wrapper which will make the class accessible from Python is in progress.
+:warning: Pyccel's class support is currently limited to single file translations.
 
 ## Constructor Method
 

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -2,8 +2,6 @@
 
 Pyccel strives to provide robust support for object-oriented programming concepts commonly used by developers. In Pyccel, classes are a fundamental building block for creating structured and reusable code. This documentation outlines key features and considerations when working with classes in Pyccel.
 
-:warning: Pyccel's class support is currently limited to single file translations.
-
 ## Constructor Method
 
 -   The Constructor Method, `__init__`, is used to initialise the object's attributes.

--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -18,6 +18,7 @@ from pyccel.ast.variable import Variable
 __all__ = (
     'BindCArrayVariable',
     'BindCClassDef',
+    'BindCClassProperty',
     'BindCFunctionDef',
     'BindCFunctionDefArgument',
     'BindCFunctionDefResult',

--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -574,6 +574,24 @@ class BindCArrayVariable(Variable):
 
 class BindCClassProperty(PyccelAstNode):
     """
+    A class which wraps a class attribute.
+
+    A class which wraps a class attribute to make it accessible
+    from C. In the future this class will also be used to handle properties of
+    classes (i.e. functions marked with the `@property` decorator).
+
+    Parameters
+    ----------
+    python_name : str
+        The name of the attribute/property in the original Python code.
+    getter : FunctionDef
+        The function which collects the value of the class attribute.
+    setter : FunctionDef
+        The function which modifies the value of the class attribute.
+    class_type : Variable
+        The type of the class to which the attribute belongs.
+    docstring : LiteralString, optional
+        The docstring of the property.
     """
     __slots__ = ('_getter', '_setter', '_python_name', '_docstring', '_class_var')
     _attribute_nodes = ('_getter', '_setter')
@@ -611,15 +629,30 @@ class BindCClassProperty(PyccelAstNode):
 
     @property
     def class_var(self):
+        """
+        The type of the class to which the attribute belongs.
+
+        The type of the class to which the attribute belongs.
+        """
         return self._class_var
 
     @property
     def python_name(self):
+        """
+        The name of the attribute/property in the original Python code.
+
+        The name of the attribute/property in the original Python code.
+        """
         return self._python_name
 
     @property
     def docstring(self):
-        self._docstring
+        """
+        The docstring of the property being wrapped.
+
+        The docstring of the property being wrapped.
+        """
+        return self._docstring
 
 # =======================================================================================
 

--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -572,6 +572,30 @@ class BindCArrayVariable(Variable):
 
 # =======================================================================================
 
+class BindCClassProperty(PyccelAstNode):
+    __slots__ = ('_getter', '_setter', '_python_name', '_docstring')
+    _attribute_nodes = ('_getter', '_setter')
+    def __init__(self, python_name, getter, setter, docstring = None):
+        if not isinstance(getter, BindCFunctionDef):
+            raise TypeError("Getter should be a BindCFunctionDef")
+        if not isinstance(setter, BindCFunctionDef):
+            raise TypeError("Setter should be a BindCFunctionDef")
+        self._python_name = python_name
+        self._getter = getter
+        self._setter = setter
+        self_docstring = docstring
+        super().__init__()
+
+    @property
+    def getter(self):
+        return self._getter
+
+    @property
+    def setter(self):
+        return self._setter
+
+# =======================================================================================
+
 class BindCClassDef(ClassDef):
     """
     Represents a class which is compatible with C.

--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -573,6 +573,8 @@ class BindCArrayVariable(Variable):
 # =======================================================================================
 
 class BindCClassProperty(PyccelAstNode):
+    """
+    """
     __slots__ = ('_getter', '_setter', '_python_name', '_docstring', '_class_var')
     _attribute_nodes = ('_getter', '_setter')
     def __init__(self, python_name, getter, setter, class_var, docstring = None):
@@ -584,15 +586,27 @@ class BindCClassProperty(PyccelAstNode):
         self._getter = getter
         self._setter = setter
         self._class_var = class_var
-        self_docstring = docstring
+        self._docstring = docstring
         super().__init__()
 
     @property
     def getter(self):
+        """
+        The BindCFunctionDef describing the getter function.
+
+        The BindCFunctionDef describing the function which allows the user to collect
+        the value of the property.
+        """
         return self._getter
 
     @property
     def setter(self):
+        """
+        The BindCFunctionDef describing the setter function.
+
+        The BindCFunctionDef describing the function which allows the user to modify
+        the value of the property.
+        """
         return self._setter
 
     @property
@@ -602,6 +616,10 @@ class BindCClassProperty(PyccelAstNode):
     @property
     def python_name(self):
         return self._python_name
+
+    @property
+    def docstring(self):
+        self._docstring
 
 # =======================================================================================
 

--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -573,9 +573,9 @@ class BindCArrayVariable(Variable):
 # =======================================================================================
 
 class BindCClassProperty(PyccelAstNode):
-    __slots__ = ('_getter', '_setter', '_python_name', '_docstring')
+    __slots__ = ('_getter', '_setter', '_python_name', '_docstring', '_class_var')
     _attribute_nodes = ('_getter', '_setter')
-    def __init__(self, python_name, getter, setter, docstring = None):
+    def __init__(self, python_name, getter, setter, class_var, docstring = None):
         if not isinstance(getter, BindCFunctionDef):
             raise TypeError("Getter should be a BindCFunctionDef")
         if not isinstance(setter, BindCFunctionDef):
@@ -583,6 +583,7 @@ class BindCClassProperty(PyccelAstNode):
         self._python_name = python_name
         self._getter = getter
         self._setter = setter
+        self._class_var = class_var
         self_docstring = docstring
         super().__init__()
 
@@ -593,6 +594,14 @@ class BindCClassProperty(PyccelAstNode):
     @property
     def setter(self):
         return self._setter
+
+    @property
+    def class_var(self):
+        return self._class_var
+
+    @property
+    def python_name(self):
+        return self._python_name
 
 # =======================================================================================
 

--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -593,9 +593,9 @@ class BindCClassProperty(PyccelAstNode):
     docstring : LiteralString, optional
         The docstring of the property.
     """
-    __slots__ = ('_getter', '_setter', '_python_name', '_docstring', '_class_var')
+    __slots__ = ('_getter', '_setter', '_python_name', '_docstring', '_class_type')
     _attribute_nodes = ('_getter', '_setter')
-    def __init__(self, python_name, getter, setter, class_var, docstring = None):
+    def __init__(self, python_name, getter, setter, class_type, docstring = None):
         if not isinstance(getter, BindCFunctionDef):
             raise TypeError("Getter should be a BindCFunctionDef")
         if not isinstance(setter, BindCFunctionDef):
@@ -603,7 +603,7 @@ class BindCClassProperty(PyccelAstNode):
         self._python_name = python_name
         self._getter = getter
         self._setter = setter
-        self._class_var = class_var
+        self._class_type = class_type
         self._docstring = docstring
         super().__init__()
 
@@ -628,13 +628,13 @@ class BindCClassProperty(PyccelAstNode):
         return self._setter
 
     @property
-    def class_var(self):
+    def class_type(self):
         """
         The type of the class to which the attribute belongs.
 
         The type of the class to which the attribute belongs.
         """
-        return self._class_var
+        return self._class_type
 
     @property
     def python_name(self):

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -644,16 +644,44 @@ class PyClassDef(ClassDef):
         return self._new_func
 
     def add_property(self, p):
+        """
+        Add a class property which has been wrapped.
+
+        Add a class property which has been wrapped.
+        """
         p.set_current_user_node(self)
         self._properties += (p,)
 
     @property
     def properties(self):
+        """
+        Get all wrapped class properties.
+
+        Get all wrapped class properties.
+        """
         return self._properties
 
 #-------------------------------------------------------------------
 
 class PyGetSetDefElement(PyccelAstNode):
+    """
+    A class representing a PyGetSetDef object.
+
+    A class representing an element of the list of PyGetSetDef objects
+    which are used to add attributes/properties to classes.
+    See <https://docs.python.org/3/c-api/structures.html#c.PyGetSetDef>.
+
+    Properties
+    ----------
+    python_name : str
+        The name of the attribute/property in the original Python code.
+    getter : FunctionDef
+        The function which collects the value of the class attribute.
+    setter : FunctionDef
+        The function which modifies the value of the class attribute.
+    docstring : LiteralString
+        The docstring of the property.
+    """
     _attribute_nodes = ('_getter', '_setter', '_docstring')
     __slots__ = ('_python_name', '_getter', '_setter', '_docstring')
     def __init__(self, python_name, getter, setter, docstring):
@@ -669,6 +697,11 @@ class PyGetSetDefElement(PyccelAstNode):
 
     @property
     def python_name(self):
+        """
+        The name of the attribute/property in the original Python code.
+
+        The name of the attribute/property in the original Python code.
+        """
         return self._python_name
 
     @property
@@ -693,6 +726,11 @@ class PyGetSetDefElement(PyccelAstNode):
 
     @property
     def docstring(self):
+        """
+        The docstring of the property being wrapped.
+
+        The docstring of the property being wrapped.
+        """
         return self._docstring
 
 #-------------------------------------------------------------------

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -55,10 +55,14 @@ __all__ = (
     'Py_False',
     'Py_None',
     'flags_registry',
+    'PyNotImplementedError',
+    'PyTypeError',
+    'PyAttributeError',
 #----- C / PYTHON FUNCTIONS ---
     'Py_INCREF',
     'Py_DECREF',
     'PyObject_TypeCheck',
+    'PyErr_SetString',
 )
 
 #-------------------------------------------------------------------
@@ -805,6 +809,7 @@ PyErr_SetString = FunctionDef(name = 'PyErr_SetString',
 
 PyNotImplementedError = Variable(PyccelPyObject(), name = 'PyExc_NotImplementedError')
 PyTypeError = Variable(PyccelPyObject(), name = 'PyExc_TypeError')
+PyAttributeError = Variable(PyccelPyObject(), name = 'PyExc_AttributeError')
 
 PyObject_TypeCheck = FunctionDef(name = 'PyObject_TypeCheck',
             arguments = [FunctionDefArgument(Variable(PyccelPyObject(), 'o', memory_handling = 'alias')), FunctionDefArgument(Variable(PyccelPyClassType(), 'c_type', memory_handling='alias'))],

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -671,10 +671,22 @@ class PyGetSetDefElement(PyccelAstNode):
 
     @property
     def getter(self):
+        """
+        The BindCFunctionDef describing the getter function.
+
+        The BindCFunctionDef describing the function which allows the user to collect
+        the value of the property.
+        """
         return self._getter
 
     @property
     def setter(self):
+        """
+        The BindCFunctionDef describing the setter function.
+
+        The BindCFunctionDef describing the function which allows the user to modify
+        the value of the property.
+        """
         return self._setter
 
     @property

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -725,7 +725,7 @@ def C_to_Python(c_object):
 
     cast_func = FunctionDef(name = cast_function,
                        body      = [],
-                       arguments = [FunctionDefArgument(c_object.clone('v', is_argument = True, memory_handling=memory_handling))],
+                       arguments = [FunctionDefArgument(c_object.clone('v', is_argument = True, memory_handling=memory_handling, new_class = Variable))],
                        results   = [FunctionDefResult(Variable(dtype=PyccelPyObject(), name = 'o', memory_handling='alias'))])
 
     return cast_func

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -49,6 +49,7 @@ __all__ = (
     'PyArgKeywords',
     'PyArg_ParseTupleNode',
     'PyBuildValueNode',
+    'PyGetSetDefElement',
     'PyModule_AddObject',
 #--------- CONSTANTS ----------
     'Py_True',

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -648,6 +648,11 @@ class PyClassDef(ClassDef):
         Add a class property which has been wrapped.
 
         Add a class property which has been wrapped.
+
+        Parameters
+        ----------
+        p : PyccelAstNode
+            The new wrapped property which is added to the class.
         """
         p.set_current_user_node(self)
         self._properties += (p,)
@@ -671,7 +676,7 @@ class PyGetSetDefElement(PyccelAstNode):
     which are used to add attributes/properties to classes.
     See <https://docs.python.org/3/c-api/structures.html#c.PyGetSetDef>.
 
-    Properties
+    Parameters
     ----------
     python_name : str
         The name of the attribute/property in the original Python code.

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -60,7 +60,6 @@ __all__ = (
     'Py_True',
     'Py_False',
     'Py_None',
-    'flags_registry',
 #----- C / PYTHON FUNCTIONS ---
     'Py_INCREF',
     'Py_DECREF',

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -46,17 +46,7 @@ __all__ = (
     'PyArray_SetBaseObject',
     #-------OTHERS--------
     'get_numpy_max_acceptable_version_file',
-    'PyccelPyArrayObject'
 )
-class PyccelPyArrayObject(DataType, metaclass=Singleton):
-    """
-    Datatype representing a `PyArrayObject`.
-
-    Datatype representing a `PyArrayObject` which is the
-    class used to hold NumPy array objects in Python.
-    """
-    __slots__ = ()
-    _name = 'PyArrayObject'
 
 class PyccelPyArrayObject(DataType, metaclass=Singleton):
     """

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -9,8 +9,10 @@ Handling the transitions between Python code and C code using (Numpy/C Api).
 
 import numpy as np
 
+from pyccel.utilities.metaclasses import Singleton
+
 from .datatypes         import (NativeInteger, NativeFloat, NativeComplex,
-                                NativeBool, NativeGeneric, NativeVoid)
+                                NativeBool, NativeGeneric, NativeVoid, DataType)
 
 from .cwrapper          import PyccelPyObject
 
@@ -42,6 +44,15 @@ __all__ = (
     #-------OTHERS--------
     'get_numpy_max_acceptable_version_file'
 )
+class PyccelPyArrayObject(DataType, metaclass=Singleton):
+    """
+    Datatype representing a `PyArrayObject`.
+
+    Datatype representing a `PyArrayObject` which is the
+    class used to hold NumPy array objects in Python.
+    """
+    __slots__ = ()
+    _name = 'PyArrayObject'
 
 #-------------------------------------------------------------------
 #                      Numpy functions
@@ -124,6 +135,12 @@ array_get_data  = FunctionDef(name   = 'nd_data',
                            body      = [],
                            arguments = [FunctionDefArgument(Variable(dtype=NativeVoid(), name = 'o', is_optional=True))],
                            results   = [FunctionDefResult(Variable(dtype=NativeVoid(), name = 'v', memory_handling='alias', rank = 1, class_type = NativeVoid()))])
+
+PyArray_SetBaseObject = FunctionDef(name   = 'PyArray_SetBaseObject',
+                            body      = [],
+                            arguments = [FunctionDefArgument(Variable(dtype=PyccelPyArrayObject(), name = 'arr', memory_handling='alias')),
+                                         FunctionDefArgument(Variable(dtype=PyccelPyObject(), name = 'obj', memory_handling='alias'))],
+                            results   = [FunctionDefResult(Variable(dtype=NativeInteger(), name = 'd'))])
 
 # Basic Array Flags
 # https://numpy.org/doc/stable/reference/c-api/array.html#c.NPY_ARRAY_OWNDATA

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -42,7 +42,8 @@ __all__ = (
     'array_get_c_step',
     'array_get_f_step',
     #-------OTHERS--------
-    'get_numpy_max_acceptable_version_file'
+    'get_numpy_max_acceptable_version_file',
+    'PyccelPyArrayObject'
 )
 class PyccelPyArrayObject(DataType, metaclass=Singleton):
     """

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -14,6 +14,7 @@ from pyccel.ast.cwrapper   import PyBuildValueNode
 from pyccel.ast.cwrapper   import Py_None, WrapperCustomDataType
 from pyccel.ast.cwrapper   import PyccelPyObject, PyccelPyTypeObject
 from pyccel.ast.literals   import LiteralString, Nil
+from pyccel.ast.numpy_wrapper import PyccelPyArrayObject
 from pyccel.ast.c_concepts import ObjectAddress
 
 from pyccel.errors.errors  import Errors
@@ -50,6 +51,7 @@ class CWrapperCodePrinter(CCodePrinter):
     """
     dtype_registry = {**CCodePrinter.dtype_registry,
                       (PyccelPyObject() , 0) : 'PyObject',
+                      (PyccelPyArrayObject() , 0) : 'PyArrayObject',
                       (PyccelPyTypeObject() , 0) : 'PyTypeObject',
                       (BindCPointer()   , 0) : 'void'}
 

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -283,7 +283,8 @@ class CWrapperCodePrinter(CCodePrinter):
                     + attributes +
                     "};\n")
             sig_methods = c.methods + (c.new_func,) + tuple(f for i in c.interfaces for f in i.functions) + \
-                          tuple(i.interface_func for i in c.interfaces)
+                          tuple(i.interface_func for i in c.interfaces) + \
+                          tuple(getset for p in c.properties for getset in (p.getter, p.setter))
             function_signatures += '\n'+''.join(self.function_signature(f)+';\n' for f in sig_methods)
             macro_defs += f'#define {type_name} (*(PyTypeObject*){API_var.name}[{i}])\n'
 

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -453,7 +453,7 @@ class CWrapperCodePrinter(CCodePrinter):
                 f"    .tp_getset = {property_def_name},\n"
                 "};\n")
 
-        return method_def + '\n' + type_code + '\n' + functions
+        return '\n'.join((method_def, property_def, type_code, functions))
 
     def _print_PyModInitFunc(self, expr):
         decs = ''.join(self._print(d) for d in expr.declarations)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3232,7 +3232,8 @@ class FCodePrinter(CodePrinter):
         return self._print(expr.wrapper_function)
 
     def _print_BindCClassDef(self, expr):
-        funcs = [expr.new_func, *expr.methods, *[f for i in expr.interfaces for f in i.functions]]
+        funcs = [expr.new_func, *expr.methods, *[f for i in expr.interfaces for f in i.functions],
+                 *[a.getter for a in expr.attributes], *[a.setter for a in expr.attributes]]
         sep = f'\n{self._print(SeparatorComment(40))}\n'
         return '', sep.join(self._print(f) for f in funcs)
 

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1876,6 +1876,7 @@ class CToPythonWrapper(Wrapper):
                                                                                      new_class = DottedVariable,
                                                                                     lhs = setter_args[0]),
                                                               cast_type = lhs)),
+                           *self._incref_return_pointer(setter_args[1], setter_args[0], expr.lhs),
                            update,
                            Return((LiteralInteger(0, precision=-2),))]
         else:

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1596,8 +1596,13 @@ class CToPythonWrapper(Wrapper):
                         for r in expr.getter.results]
         c_results = [ObjectAddress(r) if r.dtype is BindCPointer() else r for r in res_vars]
 
+        if len(c_results) == 1:
+            call = Assign(c_results[0], FunctionCall(expr.getter, (class_obj,)))
+        else:
+            call = Assign(c_results, FunctionCall(expr.getter, (class_obj,)))
+
         getter_body = [*arg_code,
-                       Assign(c_results, FunctionCall(expr.getter, (class_obj,))),
+                       call,
                        *res_wrapper,
                        Return((getter_result,))]
         self.exit_scope()

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1534,6 +1534,23 @@ class CToPythonWrapper(Wrapper):
 
     def _wrap_DottedVariable(self, expr):
         """
+        Create all objects necessary to expose a class attribute to C.
+
+        Create the getter and setter functions which expose the class attribute
+        to C. Return these objects in a PyGetSetDefElement.
+        See <https://docs.python.org/3/extending/newtypes_tutorial.html#providing-finer-control-over-data-attributes>
+        for more information about the necessary prototypes.
+
+        Parameters
+        ----------
+        expr : DottedVariable
+            The class attribute.
+
+        Returns
+        -------
+        PyGetSetDefElement
+            An object which contains the new getter and setter functions that should be
+            described in the array of PyGetSetDef objects.
         """
         lhs = expr.lhs
         class_type = lhs.cls_base
@@ -1634,6 +1651,24 @@ class CToPythonWrapper(Wrapper):
 
     def _wrap_BindCClassProperty(self, expr):
         """
+        Create a PyGetSetDefElement to expose a class attribute/property to Python.
+
+        Create getter and setter functions which are compatible with the expected prototype for
+        `PyGetSetDef` and which call the getter and setter functions contained in the
+        BindCClassProperty. The result is returned in a PyGetSetDefElement.
+        See <https://docs.python.org/3/extending/newtypes_tutorial.html#providing-finer-control-over-data-attributes>
+        for more information about the necessary prototypes.
+
+        Parameters
+        ----------
+        expr : BindCClassProperty
+            The object containing the getter and setter functions to be wrapped.
+
+        Returns
+        -------
+        PyGetSetDefElement
+            An object which contains the new getter and setter functions that should be
+            described in the array of PyGetSetDef objects.
         """
         class_type = expr.class_type
         name = expr.python_name

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1538,13 +1538,19 @@ class CToPythonWrapper(Wrapper):
         attrib = expr.clone(expr.name, lhs = class_obj)
         arg_wrapper = self._wrap(new_set_val_arg)
         new_set_val = self.scope.find(expr.name, category='variables', raise_if_missing = True)
+
+        if expr.memory_handling == 'alias':
+            update = AliasAssign(attrib, new_set_val)
+        else:
+            update = Assign(attrib, new_set_val)
+
         # Cast the C variable into a Python variable
         setter_body = [*arg_wrapper,
                        AliasAssign(class_obj, PointerCast(class_ptr_attrib.clone(class_ptr_attrib.name,
                                                                                  new_class = DottedVariable,
                                                                                 lhs = getter_args[0]),
                                                           cast_type = lhs)),
-                       Assign(attrib, new_set_val),
+                       update,
                        Return((LiteralInteger(0, precision=-2),))]
         self.exit_scope()
 

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -22,6 +22,7 @@ from pyccel.ast.cwrapper      import PyModule, PyccelPyObject, PyArgKeywords, Py
 from pyccel.ast.cwrapper      import PyArg_ParseTupleNode, Py_None, PyClassDef, PyModInitFunc
 from pyccel.ast.cwrapper      import py_to_c_registry, check_type_registry, PyBuildValueNode
 from pyccel.ast.cwrapper      import PyErr_SetString, PyTypeError, PyNotImplementedError
+from pyccel.ast.cwrapper      import PyAttributeError
 from pyccel.ast.cwrapper      import C_to_Python, PyFunctionDef, PyInterface
 from pyccel.ast.cwrapper      import PyModule_AddObject, Py_DECREF, PyObject_TypeCheck
 from pyccel.ast.cwrapper      import Py_INCREF, PyType_Ready, WrapperCustomDataType
@@ -1880,7 +1881,7 @@ class CToPythonWrapper(Wrapper):
                            update,
                            Return((LiteralInteger(0, precision=-2),))]
         else:
-            setter_body = [FunctionCall(PyErr_SetString, [PyTypeError,
+            setter_body = [FunctionCall(PyErr_SetString, [PyAttributeError,
                                         LiteralString("Can't reallocate memory via Python interface.")]),
                         Return([self._error_exit_code])]
         self.exit_scope()
@@ -2008,7 +2009,7 @@ class CToPythonWrapper(Wrapper):
                            *self._save_referenced_objects(expr.setter, setter_args),
                            Return((LiteralInteger(0, precision=-2),))]
         else:
-            setter_body = [FunctionCall(PyErr_SetString, [PyTypeError,
+            setter_body = [FunctionCall(PyErr_SetString, [PyAttributeError,
                                         LiteralString("Can't reallocate memory via Python interface.")]),
                         Return([self._error_exit_code])]
         self.exit_scope()

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1634,7 +1634,7 @@ class CToPythonWrapper(Wrapper):
         else:
             body = [Assign(new_res_val, attrib), *res_wrapper]
 
-        body.extend(self._return_self_reference(getter_args[0], getter_result.var, expr))
+        body.extend(self._return_self_reference(getter_args[0], getter_result, expr))
 
         getter_body = [AliasAssign(class_obj, PointerCast(class_ptr_attrib.clone(class_ptr_attrib.name,
                                                                                  new_class = DottedVariable,

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1632,7 +1632,7 @@ class CToPythonWrapper(Wrapper):
         setter_body = [*arg_wrapper,
                        AliasAssign(class_obj, PointerCast(class_ptr_attrib.clone(class_ptr_attrib.name,
                                                                                  new_class = DottedVariable,
-                                                                                lhs = getter_args[0]),
+                                                                                lhs = setter_args[0]),
                                                           cast_type = lhs)),
                        update,
                        Return((LiteralInteger(0, precision=-2),))]
@@ -1750,6 +1750,7 @@ class CToPythonWrapper(Wrapper):
 
         setter_body = [*arg_code,
                        FunctionCall(expr.setter, func_call_args),
+                       *self._save_referenced_objects(expr.setter, setter_args)
                        Return((LiteralInteger(0, precision=-2),))]
         self.exit_scope()
 

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1827,7 +1827,7 @@ class CToPythonWrapper(Wrapper):
         else:
             body = [Assign(new_res_val, attrib), *res_wrapper]
 
-        body.extend(self._return_self_reference(getter_args[0], getter_result, expr))
+        body.extend(self._incref_return_pointer(getter_args[0], getter_result, expr))
 
         getter_body = [AliasAssign(class_obj, PointerCast(class_ptr_attrib.clone(class_ptr_attrib.name,
                                                                                  new_class = DottedVariable,
@@ -1959,7 +1959,7 @@ class CToPythonWrapper(Wrapper):
             arg_code.append(Allocate(getter_result, shape=(), order=None, status='unallocated'))
 
         wrapped_var = expr.getter.original_function
-        res_wrapper.extend(self._return_self_reference(getter_args[0], getter_result, wrapped_var))
+        res_wrapper.extend(self._incref_return_pointer(getter_args[0], getter_result, wrapped_var))
 
         getter_body = [*arg_code,
                        call,

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -517,7 +517,7 @@ class CToPythonWrapper(Wrapper):
         list[PyccelAstNode]
             Any nodes which must be printed to increase reference counts.
         """
-        if orig_var.rank == 0 and orig_var.dtype in NativeNumeric:
+        if not orig_var.is_alias:
             return []
         elif isinstance(orig_var.class_type, NumpyNDArrayType):
             save_ref_call = FunctionCall(PyArray_SetBaseObject,
@@ -531,7 +531,7 @@ class CToPythonWrapper(Wrapper):
             raise NotImplementedError("Unsure how to preserve references for attribute of type {type(expr.class_type)}")
 
         return [FunctionCall(Py_INCREF, (self_obj,)),
-                If(IfSection(PyccelLt(save_ref_call,LiteralInteger(0)),
+                If(IfSection(PyccelLt(save_ref_call,LiteralInteger(0, precision=-2)),
                                   [Return([self._error_exit_code])]))]
 
     def _build_module_exec_function(self, expr):

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1575,6 +1575,7 @@ class CToPythonWrapper(Wrapper):
         docstring = expr.docstring
         wrapped_class = PyClassDef(expr, struct_name, type_name, self.scope.new_child_scope(expr.name),
                                    docstring = docstring, class_type = dtype)
+        bound_class = isinstance(expr, BindCClassDef)
 
         orig_cls_dtype = expr.scope.parent_scope.cls_constructs[name]
 
@@ -1600,13 +1601,13 @@ class CToPythonWrapper(Wrapper):
                 self._wrap(f)
             wrapped_class.add_new_interface(self._wrap(i))
 
-        if isinstance(expr, BindCClassDef):
+        if bound_class:
             wrapped_class.add_alloc_method(self._get_class_allocator(orig_cls_dtype, expr.new_func))
         else:
             wrapped_class.add_alloc_method(self._get_class_allocator(orig_cls_dtype))
 
         for a in expr.attributes:
-            if not a.is_private:
+            if bound_class or not a.is_private:
                 wrapped_class.add_property(self._wrap(a))
 
         return wrapped_class

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -24,7 +24,7 @@ from pyccel.ast.cwrapper      import PyErr_SetString, PyTypeError, PyNotImplemen
 from pyccel.ast.cwrapper      import C_to_Python, PyFunctionDef, PyInterface
 from pyccel.ast.cwrapper      import PyModule_AddObject, Py_DECREF, PyObject_TypeCheck
 from pyccel.ast.cwrapper      import Py_INCREF, PyType_Ready, WrapperCustomDataType
-from pyccel.ast.cwrapper      import PyccelPyTypeObject
+from pyccel.ast.cwrapper      import PyccelPyTypeObject, PyGetSetDefElement
 from pyccel.ast.c_concepts    import ObjectAddress, PointerCast
 from pyccel.ast.datatypes     import NativeVoid, NativeInteger, CustomDataType, DataTypeFactory
 from pyccel.ast.datatypes     import NativeNumeric
@@ -1547,7 +1547,9 @@ class CToPythonWrapper(Wrapper):
         self._python_object_map.pop(new_set_val_arg)
         # ----------------------------------------------------------------------------------
 
-        return getter
+        python_name = class_type.scope.get_python_name(expr.name)
+        return PyGetSetDefElement(python_name, getter, setter,
+                                LiteralString(f"The attribute {python_name}"))
 
     def _wrap_ClassDef(self, expr):
         """
@@ -1605,6 +1607,6 @@ class CToPythonWrapper(Wrapper):
 
         for a in expr.attributes:
             if not a.is_private:
-                wrapped_class.add_new_method(self._wrap(a))
+                wrapped_class.add_property(self._wrap(a))
 
         return wrapped_class

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1635,8 +1635,7 @@ class CToPythonWrapper(Wrapper):
     def _wrap_BindCClassProperty(self, expr):
         """
         """
-        class_var = expr.class_var
-        class_type = class_var.dtype
+        class_type = expr.class_type
         name = expr.python_name
         # ----------------------------------------------------------------------------------
         #                        Create getter

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -618,7 +618,11 @@ class FortranToCWrapper(Wrapper):
             for f in i.functions:
                 self._wrap(f)
         interfaces = [self._wrap(i) for i in expr.interfaces]
-        properties = [self._wrap(v) for v in expr.attributes if not v.is_private]
+
+        # Pseudo-self variable is useful for pre-defined attributes which are not DottedVariables
+        pseudo_self = Variable(expr.class_type, 'self', cls_base = expr)
+        properties = [self._wrap(v if isinstance(v, DottedVariable) else v.clone(v.name, new_class = DottedVariable, lhs=pseudo_self)) \
+                        for v in expr.attributes if not v.is_private]
         return BindCClassDef(expr, new_func = new_method, methods = methods,
                              interfaces = interfaces, attributes = properties,
                              docstring = expr.docstring, class_type = expr.class_type)

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -546,7 +546,7 @@ class FortranToCWrapper(Wrapper):
         setter = BindCFunctionDef(setter_name, setter_args, (), setter_body,
                                 original_function = expr, scope = setter_scope)
         return BindCClassProperty(lhs.cls_base.scope.get_python_name(expr.name),
-                                  getter, setter, lhs)
+                                  getter, setter, lhs.dtype)
 
     def _wrap_ClassDef(self, expr):
         """

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -481,6 +481,7 @@ class FortranToCWrapper(Wrapper):
                                 original_variable = expr)
 
     def _wrap_DottedVariable(self, expr):
+        assert expr.memory_handling != 'alias'
         lhs = expr.lhs
         class_dtype = lhs.dtype
         # ----------------------------------------------------------------------------------

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -481,6 +481,23 @@ class FortranToCWrapper(Wrapper):
                                 original_variable = expr)
 
     def _wrap_DottedVariable(self, expr):
+        """
+        Create all objects necessary to expose a class attribute to C.
+
+        Create the getter and setter functions which expose the class attribute
+        to C. Return these objects in a BindCClassProperty.
+
+        Parameters
+        ----------
+        expr : DottedVariable
+            The class attribute.
+
+        Returns
+        -------
+        BindCClassProperty
+            An object containing the getter and setter functions which expose
+            the class attribute to C.
+        """
         lhs = expr.lhs
         class_dtype = lhs.dtype
         # ----------------------------------------------------------------------------------

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -382,10 +382,7 @@ class FortranToCWrapper(Wrapper):
         scope.insert_symbol(name)
         wrap_dotted = isinstance(var, DottedVariable)
         stored_in_c_ptr = var.rank or isinstance(var.dtype, CustomDataType)
-        if stored_in_c_ptr:
-            memory_handling = 'alias' if wrap_dotted else 'heap'
-        else:
-            memory_handling = 'stack'
+        memory_handling = 'alias' if wrap_dotted and stored_in_c_ptr else var.memory_handling
         local_var = var.clone(scope.get_expected_name(name), new_class = Variable,
                             memory_handling = memory_handling)
 
@@ -407,7 +404,6 @@ class FortranToCWrapper(Wrapper):
             if wrap_dotted:
                 ptr_var = local_var
             else:
-                print(wrap_dotted, var)
                 # Create an array variable which can be passed to CLocFunc
                 ptr_var = var.clone(scope.get_new_name(name+'_ptr'),
                                     memory_handling='alias', new_class = Variable)

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -382,7 +382,10 @@ class FortranToCWrapper(Wrapper):
         scope.insert_symbol(name)
         wrap_dotted = isinstance(var, DottedVariable)
         stored_in_c_ptr = var.rank or isinstance(var.dtype, CustomDataType)
-        memory_handling = 'alias' if wrap_dotted and stored_in_c_ptr else 'heap'
+        if stored_in_c_ptr:
+            memory_handling = 'alias' if wrap_dotted else 'heap'
+        else:
+            memory_handling = 'stack'
         local_var = var.clone(scope.get_expected_name(name), new_class = Variable,
                             memory_handling = memory_handling)
 

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -481,7 +481,6 @@ class FortranToCWrapper(Wrapper):
                                 original_variable = expr)
 
     def _wrap_DottedVariable(self, expr):
-        assert expr.memory_handling != 'alias'
         lhs = expr.lhs
         class_dtype = lhs.dtype
         # ----------------------------------------------------------------------------------
@@ -537,7 +536,10 @@ class FortranToCWrapper(Wrapper):
 
         attrib = expr.clone(expr.name, lhs = self_obj)
         # Cast the C variable into a Python variable
-        setter_body.append(Assign(attrib, set_val))
+        if expr.memory_handling == 'alias':
+            setter_body.append(AliasAssign(attrib, set_val))
+        else:
+            setter_body.append(Assign(attrib, set_val))
         self.exit_scope()
 
         setter = BindCFunctionDef(setter_name, setter_args, (), setter_body,

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -528,11 +528,12 @@ class FortranToCWrapper(Wrapper):
 
         if isinstance(set_val.dtype, CustomDataType):
             setter_body.append(C_F_Pointer(setter_args[1].var, set_val))
-        elif isinstance(set_val.rank, IndexedElement):
-            size = set_val.shape[::-1] if expr.order == 'C' else set_val.shape
-            stride = set_val.strides[::-1] if expr.order == 'C' else set_val.strides
+        elif isinstance(set_val, IndexedElement):
+            func_arg = setter_args[1]
+            size = func_arg.shape[::-1] if expr.order == 'C' else func_arg.shape
+            stride = func_arg.strides[::-1] if expr.order == 'C' else func_arg.strides
             orig_size = [PyccelMul(sz,st) for sz,st in zip(size, stride)]
-            setter_body.append(C_F_Pointer(setter_args[1].var, set_val, orig_size))
+            setter_body.append(C_F_Pointer(func_arg.var, set_val.base, orig_size))
 
         attrib = expr.clone(expr.name, lhs = self_obj)
         # Cast the C variable into a Python variable

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -538,6 +538,9 @@ class FortranToCWrapper(Wrapper):
 
         setter_args = (self._wrap(FunctionDefArgument(lhs, bound_argument = True)),
                        self._wrap(FunctionDefArgument(expr)))
+        if expr.is_alias:
+            setter_args[1].persistent_target = True
+
         self_obj = self._get_call_argument(setter_args[0])
         set_val = self._get_call_argument(setter_args[1])
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3871,9 +3871,9 @@ class SemanticParser(BasicParser):
                 methods.pop(i)
 
                 # create a new attribute to check allocation
-                deallocater_rhs = Variable(NativeBool(), self.scope.get_new_name('is_freed'))
                 deallocater_lhs = Variable(cls.name, 'self', cls_base = cls, is_argument=True)
-                deallocater = DottedVariable(lhs = deallocater_lhs, name = deallocater_rhs.name, dtype = deallocater_rhs.dtype)
+                deallocater = DottedVariable(lhs = deallocater_lhs, name = self.scope.get_new_name('is_freed'),
+                                             dtype = NativeBool(), is_private=True)
                 cls.add_new_attribute(deallocater)
                 deallocater_assign = Assign(deallocater, LiteralFalse())
                 init_func.body.insert2body(deallocater_assign, back=False)

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/tests/epyccel/classes/array_attribute.py
+++ b/tests/epyccel/classes/array_attribute.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring, missing-class-docstring
 import numpy as np
 
 class A:

--- a/tests/epyccel/classes/array_attribute.py
+++ b/tests/epyccel/classes/array_attribute.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+class A:
+    def __init__(self, n : int):
+        self.x = np.ones(n)
+
+    def get_x(self):
+        return self.x

--- a/tests/epyccel/classes/ptr_in_class.py
+++ b/tests/epyccel/classes/ptr_in_class.py
@@ -1,0 +1,4 @@
+
+class A:
+    def __init__(self, x : 'float[:]'):
+        self.x = x

--- a/tests/epyccel/classes/ptr_in_class.py
+++ b/tests/epyccel/classes/ptr_in_class.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring, missing-class-docstring
 
 class A:
     def __init__(self, x : 'float[:]'):

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -275,7 +275,7 @@ def test_class_out(language):
 
     if language != 'python':
         with pytest.raises(AttributeError):
-            p_l.x[:] = np.ones(6)
+            p_l.x = np.ones(6)
 
 def test_ptr_in_class(language):
     import classes.ptr_in_class as mod

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -288,3 +288,27 @@ def test_class_out(language):
     if language != 'python':
         with pytest.raises(AttributeError):
             p_l.x[:] = np.ones(6)
+
+def test_ptr_in_class(language):
+    import classes.ptr_in_class as mod
+    modnew = epyccel(mod, language = language)
+
+    x = np.ones(4)
+    a_py = mod.A(x)
+    a_l = modnew.A(x)
+
+    assert np.array_equal(a_py.x, a_l.x)
+
+    x[2] = 3
+
+    assert np.array_equal(a_py.x, a_l.x)
+
+    y = np.zeros(3)
+    a_py.x = y
+    a_l.x = y
+
+    assert np.array_equal(a_py.x, a_l.x)
+
+    y[0] = -3
+
+    assert np.array_equal(a_py.x, a_l.x)

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -259,6 +259,18 @@ def test_classes(language):
     assert p_py.x == p_l.x
     assert p_py.y == p_l.y
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [
+            pytest.mark.xfail(reason="Can't return a pointer. Fixed in #1686"),
+            pytest.mark.fortran]
+        ),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="Can't return a pointer. Fixed in #1686"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_class_out(language):
     import classes.array_attribute as mod
     modnew = epyccel(mod, language = language)

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -150,6 +150,19 @@ def test_classes_3(language):
 
     assert p_py.get_coordinates() == p_l.get_coordinates()
 
+    assert p_py.x == p_l.x
+    assert p_py.X == p_l.X
+    assert isinstance(p_py.x, type(p_l.x))
+    assert isinstance(p_py.X, type(p_l.X))
+
+    p_py.x = -1.2
+    p_py.X = -10.2
+
+    p_l.x = -1.2
+    p_l.X = -10.2
+
+    assert p_py.get_coordinates() == p_l.get_coordinates()
+
 def test_classes_4(language):
     import classes.classes_4 as mod
     modnew = epyccel(mod, language = language)
@@ -208,3 +221,58 @@ def test_generic_methods(language):
 
     assert p_py.get_x() == p_l.get_x()
     assert p_py.get_y() == p_l.get_y()
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("python", marks = [
+            pytest.mark.skip(reason="Attribute renamed. See #1705"),
+            pytest.mark.python]
+        )
+    )
+)
+def test_classes(language):
+    import classes.classes as mod
+    modnew = epyccel(mod, language = language)
+
+    p_py = mod.Point(0.0, 0.0)
+    p_l  = modnew.Point(0.0, 0.0)
+
+    assert p_py.x == p_l.x
+    assert isinstance(p_py.x, type(p_l.x))
+
+    assert p_py.y == p_l.y
+    assert isinstance(p_py.y, type(p_l.y))
+
+    p_py.x = 2.0
+    p_l.x = 2.0
+
+    if language != 'python':
+        with pytest.raises(TypeError):
+            p_l.y = 1j
+
+    assert p_py.x == p_l.x
+
+    p_py.translate(1.0, 2.0)
+    p_l.translate(1.0, 2.0)
+
+    assert p_py.x == p_l.x
+    assert p_py.y == p_l.y
+
+def test_class_out(language):
+    import classes.array_attribute as mod
+    modnew = epyccel(mod, language = language)
+
+    p_py = mod.A(5)
+    p_l  = modnew.A(5)
+
+    assert np.array_equal(p_py.x, p_l.x)
+    assert np.array_equal(p_py.get_x(), p_l.get_x())
+    assert np.array_equal(p_py.x, p_py.get_x())
+
+    p_py.x[:] = 4
+    p_l.x[:] = 4
+
+    if language != 'python':
+        with pytest.raises(AttributeError):
+            p_l.x[:] = np.ones(6)

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -247,18 +247,6 @@ def test_classes(language):
     assert p_py.x == p_l.x
     assert p_py.y == p_l.y
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [
-            pytest.mark.xfail(reason="Can't return a pointer. Fixed in #1686"),
-            pytest.mark.fortran]
-        ),
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="Can't return a pointer. Fixed in #1686"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_class_out(language):
     import classes.array_attribute as mod
     modnew = epyccel(mod, language = language)

--- a/tests/epyccel/test_epyccel_garbage_collection.py
+++ b/tests/epyccel/test_epyccel_garbage_collection.py
@@ -247,3 +247,27 @@ def test_return_class_array_pointer(language):
 
     # All references should now be released
     assert ref_count_x == start_ref_count_x
+
+def test_getter(language):
+    import classes.array_attribute as mod_pyt
+
+    mod = epyccel(mod_pyt, language=language)
+
+    a = mod.A(10)
+
+    b = a.x
+
+    if language != 'python':
+        assert b.base is a
+
+    del a
+
+    gc.collect()
+
+    a_x_elem = b[0]
+
+    if language != 'python':
+        c = b.base.x
+
+        np.array_equiv(b, c)
+

--- a/tests/epyccel/test_epyccel_garbage_collection.py
+++ b/tests/epyccel/test_epyccel_garbage_collection.py
@@ -271,6 +271,8 @@ def test_getter(language):
 
     a_x_elem = b[0]
 
+    assert a_x_elem == 1
+
     if language != 'python':
         c = b.base.x
 

--- a/tests/epyccel/test_epyccel_garbage_collection.py
+++ b/tests/epyccel/test_epyccel_garbage_collection.py
@@ -255,10 +255,15 @@ def test_getter(language):
 
     a = mod.A(10)
 
+    start_ref_count_a = sys.getrefcount(a)
+
     b = a.x
+
+    ref_count_a = sys.getrefcount(a)
 
     if language != 'python':
         assert b.base is a
+        assert ref_count_a == start_ref_count_a+1
 
     del a
 
@@ -271,3 +276,39 @@ def test_getter(language):
 
         np.array_equiv(b, c)
 
+def test_setter(language):
+    import classes.ptr_in_class as mod_pyt
+
+    mod = epyccel(mod_pyt, language=language)
+
+    target1 = np.ones(10)
+
+    start_ref_count_target = sys.getrefcount(target1)
+
+    cls = mod.A(target1)
+
+    ref_count_target = sys.getrefcount(target1)
+
+    assert ref_count_target == start_ref_count_target + 1
+
+    target2 = np.ones(10)
+
+    cls.x = target2
+
+    ref_count_target1 = sys.getrefcount(target1)
+    ref_count_target2 = sys.getrefcount(target2)
+
+    if language == 'python':
+        assert ref_count_target1 == start_ref_count_target
+        assert ref_count_target2 == start_ref_count_target+1
+    else:
+        assert ref_count_target1 == start_ref_count_target + 1
+        assert ref_count_target2 == start_ref_count_target + 1
+
+    del cls
+
+    ref_count_target1 = sys.getrefcount(target1)
+    ref_count_target2 = sys.getrefcount(target2)
+
+    assert ref_count_target1 == start_ref_count_target
+    assert ref_count_target2 == start_ref_count_target

--- a/tests/epyccel/test_epyccel_return_arrays.py
+++ b/tests/epyccel/test_epyccel_return_arrays.py
@@ -734,15 +734,6 @@ def test_c_array_return(language):
         assert f_output.flags.c_contiguous == test_output.flags.c_contiguous
         assert f_output.flags.f_contiguous == test_output.flags.f_contiguous
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.c),
-        pytest.param("python", marks = [
-            pytest.mark.xfail(reason="Order not printed in Python. See #1260"),
-            pytest.mark.python
-        ])
-    )
-)
 def test_f_array_return(language):
     @template('T', ['int', 'int8', 'int16', 'int32', 'int64',
                     'float', 'float32', 'float64',


### PR DESCRIPTION
Add the wrapping of class variables. Getters and setters are created which can be called from Python. These getters and setters are packed into a class called `PyGetSetDefElement` to expose the property. Fixes #1618 .

**Commit Summary**
- Update documentation to remove the reference to incomplete wrapping
- Add `BindCClassProperty` to hold the getters and setters necessary to wrap a class property in Fortran and expose it to C
- Add `PyGetSetDefElement` to hold the getters and setters necessary to wrap a class property in C and expose it to Python
- Update version to 1.11.0
- Remove obsolete xfail mark