### PR TITLE
Get actual Homebrew directory with `brew --prefix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable changes to this project will be documented in this file.
 -   #1507 : Fix problems with name collisions in class functions.
 -   Ensure `pyccel-init` calls the related function.
 -   Stop unnecessarily importing deprecated NumPy classes `int`, `bool`, `float`, `complex` in Python translation.
--   #1713 : Get Homebrew directory on macOS with `brew --prefix`.
+-   #1712 : Fix library path and OpenMP support for recent Apple chips by getting Homebrew directory with `brew --prefix`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 -   #1507 : Fix problems with name collisions in class functions.
 -   Ensure `pyccel-init` calls the related function.
 -   Stop unnecessarily importing deprecated NumPy classes `int`, `bool`, `float`, `complex` in Python translation.
+-   #1713 : Get Homebrew directory on macOS with `brew --prefix`.
 
 ### Changed
 

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -114,11 +114,11 @@ gcc_info = {'exec' : 'gcc',
             }
 
 if sys.platform == "darwin":
-    p = subprocess.run(['brew', '--prefix'], check=True, capture_output=True)
+    p = subprocess.run([shutil.which('brew'), '--prefix'], check=True, capture_output=True)
     HOMEBREW_PREFIX = p.stdout.decode().strip()
     OMP_PATH = os.path.join(HOMEBREW_PREFIX, 'opt/libomp')
 
-    gcc_info['openmp']['flags']    = ("-Xpreprocessor",'-fopenmp')
+    gcc_info['openmp']['flags']    = ("-Xpreprocessor", '-fopenmp')
     gcc_info['openmp']['libs']     = ('omp',)
     gcc_info['openmp']['libdirs']  = (os.path.join(OMP_PATH, 'lib'),)
     gcc_info['openmp']['includes'] = (os.path.join(OMP_PATH, 'include'),)

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -8,9 +8,12 @@ import os
 import sys
 import sysconfig
 import subprocess
+import shutil
 
 from numpy import get_include as get_numpy_include
+
 from pyccel import __version__ as pyccel_version
+
 
 gfort_info = {'exec' : 'gfortran',
               'mpi_exec' : 'mpif90',
@@ -31,6 +34,7 @@ gfort_info = {'exec' : 'gfortran',
                   },
               'family': 'GNU',
               }
+
 if sys.platform == "win32":
     gfort_info['mpi_exec'] = 'gfortran'
     gfort_info['mpi']['flags']    = ('-D','USE_MPI_MODULE')

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -111,10 +111,11 @@ gcc_info = {'exec' : 'gcc',
             'family': 'GNU',
             }
 if sys.platform == "darwin":
-    gcc_info['openmp']['flags'] = ("-Xpreprocessor",'-fopenmp')
-    gcc_info['openmp']['libs'] = ('omp',)
-    gcc_info['openmp']['libdirs'] = ('/usr/local/opt/libomp/lib',)
-    gcc_info['openmp']['includes'] = ('/usr/local/opt/libomp/include',)
+    OMP_PATH = os.path.join(os.environ['HOMEBREW_PREFIX'], 'opt/libomp')
+    gcc_info['openmp']['flags']    = ("-Xpreprocessor",'-fopenmp')
+    gcc_info['openmp']['libs']     = ('omp',)
+    gcc_info['openmp']['libdirs']  = (os.path.join(OMP_PATH, 'lib'),)
+    gcc_info['openmp']['includes'] = (os.path.join(OMP_PATH, 'include'),)
 elif sys.platform == "win32":
     gcc_info['mpi_exec'] = 'gcc'
     gcc_info['mpi']['flags']    = ('-D','USE_MPI_MODULE')

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -7,6 +7,8 @@ import glob
 import os
 import sys
 import sysconfig
+import subprocess
+
 from numpy import get_include as get_numpy_include
 from pyccel import __version__ as pyccel_version
 
@@ -110,13 +112,19 @@ gcc_info = {'exec' : 'gcc',
                 },
             'family': 'GNU',
             }
+
 if sys.platform == "darwin":
-    OMP_PATH = os.path.join(os.environ['HOMEBREW_PREFIX'], 'opt/libomp')
+    p = subprocess.run(['brew', '--prefix'], check=True, capture_output=True)
+    HOMEBREW_PREFIX = p.stdout.decode().strip()
+    OMP_PATH = os.path.join(HOMEBREW_PREFIX, 'opt/libomp')
+
     gcc_info['openmp']['flags']    = ("-Xpreprocessor",'-fopenmp')
     gcc_info['openmp']['libs']     = ('omp',)
     gcc_info['openmp']['libdirs']  = (os.path.join(OMP_PATH, 'lib'),)
     gcc_info['openmp']['includes'] = (os.path.join(OMP_PATH, 'include'),)
+
 elif sys.platform == "win32":
+
     gcc_info['mpi_exec'] = 'gcc'
     gcc_info['mpi']['flags']    = ('-D','USE_MPI_MODULE')
     gcc_info['mpi']['libs']     = ('msmpi',)


### PR DESCRIPTION
Do not hardcode Homebrew installation directory when using Pyccel on macOS platforms. Instead, use command `brew --prefix`. This fixes #1712.