### PR TITLE
Fix: handle paths with dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 -   #1712 : Fix library path and OpenMP support for recent Apple chips by getting Homebrew directory with `brew --prefix`.
 -   #1687 : Pointers in tuples are deallocated.
 -   #1586 : Raise an error for targets of class instances which go out of scope too early.
+-   #1717 : Fix a bug when handling paths with dots.
 
 ### Changed
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -125,7 +125,7 @@ def get_filename_from_import(module, input_folder=''):
         return filename_py
 
     errors = Errors()
-    errors.report(PYCCEL_UNFOUND_IMPORTED_MODULE, symbol=module,
+    raise errors.report(PYCCEL_UNFOUND_IMPORTED_MODULE, symbol=module,
                   severity='fatal')
 
 #==============================================================================

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -71,15 +71,13 @@ def get_filename_from_import(module,input_folder=''):
 
     filename_pyh = '{}.pyh'.format(filename)
     filename_py  = '{}.py'.format(filename)
-    folders = input_folder.split(""".""")
-    for i in range(len(folders)):
-        poss_dirname      = os.path.join( *folders[:i+1] )
-        poss_filename_pyh = os.path.join( poss_dirname, filename_pyh )
-        poss_filename_py  = os.path.join( poss_dirname, filename_py  )
-        if is_valid_filename_pyh(poss_filename_pyh):
-            return os.path.abspath(poss_filename_pyh)
-        if is_valid_filename_py(poss_filename_py):
-            return os.path.abspath(poss_filename_py)
+
+    poss_filename_pyh = os.path.join( input_folder, filename_pyh )
+    poss_filename_py  = os.path.join( input_folder, filename_py  )
+    if is_valid_filename_pyh(poss_filename_pyh):
+        return os.path.abspath(poss_filename_pyh)
+    if is_valid_filename_py(poss_filename_py):
+        return os.path.abspath(poss_filename_py)
 
     source = module
     if len(module.split(""".""")) > 1:

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -38,6 +38,7 @@ from pyccel.errors.messages import PYCCEL_UNFOUND_IMPORTED_MODULE
 
 errors = Errors()
 error_mode = ErrorsMode()
+
 #==============================================================================
 
 strip_ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]|[\n\t\r]')
@@ -46,14 +47,33 @@ strip_ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]|[\n\t\r]')
 # Useful for very coarse version differentiation.
 
 #==============================================================================
+def get_filename_from_import(module, input_folder=''):
+    """
+    Get the absolute path of a module, searching in a given folder.
 
-
-def get_filename_from_import(module,input_folder=''):
-    """Returns a valid filename with absolute path, that corresponds to the
+    Return a valid filename with an absolute path, that corresponds to the
     definition of module.
     The priority order is:
         - header files (extension == pyh)
         - python files (extension == py)
+
+    Parameters
+    ----------
+    module : str | AsName
+        Name of the module of interest.
+
+    input_folder : str
+        Relative path of the folder which should be searched for the module.
+
+    Returns
+    -------
+    str
+        Absolute path of the given module.
+
+    Raises
+    ------
+    PyccelError
+        Error raised when the module cannot be found.
     """
 
     if (isinstance(module, AsName)):
@@ -108,10 +128,7 @@ def get_filename_from_import(module,input_folder=''):
     errors.report(PYCCEL_UNFOUND_IMPORTED_MODULE, symbol=module,
                   severity='fatal')
 
-
-
 #==============================================================================
-
 class BasicParser(object):
     """
     Class for a basic parser.
@@ -276,7 +293,6 @@ class BasicParser(object):
     @property
     def blocking(self):
         return self._blocking
-
 
     def insert_function(self, func):
         """."""
@@ -536,9 +552,8 @@ class BasicParser(object):
         self._syntax_done   = parser.syntax_done
         self._semantic_done = parser.semantic_done
 
+
 #==============================================================================
-
-
 if __name__ == '__main__':
     import sys
 


### PR DESCRIPTION
Description:
This PR addresses an issue #1716 encountered in `pyccel/parser/base.py`, where paths containing dots `.` were incorrectly split, leading to errors. The problem specifically arises due to the use of `input_folder.split(".")` at line `74`, which does not account for legitimate dots in directory names or usernames (e.g., `some/pa.th`).

Fix:
The `input_folder` is created by using `dirname` method there is no need to parse the dots in it.