### PR TITLE
Minor bot fixes

### DIFF
--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -289,7 +289,9 @@ class Bot:
             return []
         else:
             check_runs = self._GAI.get_check_runs(self._ref)['check_runs']
-            already_triggered = [c["name"] for c in check_runs if c['status'] in ('completed', 'in_progress') and c['conclusion'] != 'cancelled']
+            already_triggered = [c["name"] for c in check_runs if c['status'] in ('completed', 'in_progress') and \
+                                                                  c['conclusion'] != 'cancelled' and \
+                                                                  c['name'] not in ('coverage',)]
             already_triggered_names = [self.get_name_key(t) for t in already_triggered]
             already_programmed = {c["name"]:c for c in check_runs if c['status'] == 'queued'}
             success_names = [self.get_name_key(c["name"]) for c in check_runs if c['status'] == 'completed' and c['conclusion'] == 'success']
@@ -417,7 +419,7 @@ class Bot:
             True if the test should be run, False otherwise.
         """
         print("Checking : ", name)
-        if key in ('linux', 'windows', 'macosx', 'anaconda_linux', 'anaconda_windows', 'coverage', 'intel'):
+        if key in ('linux', 'windows', 'macosx', 'anaconda_linux', 'anaconda_windows', 'intel'):
             has_relevant_change = lambda diff: any((f.startswith('pyccel/') or f.startswith('tests/'))  #pylint: disable=unnecessary-lambda-assignment
                                                     and f.endswith('.py') and f != 'pyccel/version.py'
                                                     for f in diff)
@@ -436,6 +438,8 @@ class Bot:
                                                     and f != 'pyccel/version.py') or f == 'pyproject.toml'
                                                     or f.startswith('install_scripts/')
                                                     for f in diff)
+        elif key in ('coverage',):
+            has_relevant_change = lambda diff: True
         else:
             raise NotImplementedError(f"Please update for new has_relevant_change : {key}")
 

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -121,7 +121,7 @@ class Bot:
         if commit:
             self._ref = commit
             if '/' in self._ref:
-                _, _, branch = self._ref.split('/')
+                _, _, branch = self._ref.split('/',2)
                 branch_info = self._GAI.get_branch_details(branch)
                 self._ref = branch_info['commit']['sha']
         else:
@@ -294,7 +294,7 @@ class Bot:
             already_programmed = {c["name"]:c for c in check_runs if c['status'] == 'queued'}
             success_names = [self.get_name_key(c["name"]) for c in check_runs if c['status'] == 'completed' and c['conclusion'] == 'success']
             print(already_triggered)
-            states = []
+            states = [c['conclusion'] for c in check_runs if c['status'] == 'completed']
 
             if not force_run:
                 # Get a list of all commits on this branch

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -418,20 +418,17 @@ class Bot:
         bool
             True if the test should be run, False otherwise.
         """
-        print("Checking : ", name)
+        print("Checking : ", name, key)
         if key in ('linux', 'windows', 'macosx', 'anaconda_linux', 'anaconda_windows', 'intel'):
-            has_relevant_change = lambda diff: any((f.startswith('pyccel/') or f.startswith('tests/'))  #pylint: disable=unnecessary-lambda-assignment
+            has_relevant_change = lambda diff: any((f.startswith('pyccel/') or f.startswith('tests/')) #pylint: disable=unnecessary-lambda-assignment
                                                     and f.endswith('.py') and f != 'pyccel/version.py'
                                                     for f in diff)
-        elif key in ('pyccel_lint'):
-            has_relevant_change = lambda diff: any(f.startswith('pyccel/') and f.endswith('.py') #pylint: disable=unnecessary-lambda-assignment
-                                                    and f != 'pyccel/version.py' for f in diff)
-        elif key in ('pylint'):
+        elif key in ('pylint',):
             has_relevant_change = lambda diff: any(f.endswith('.py') for f in diff) #pylint: disable=unnecessary-lambda-assignment
-        elif key in ('docs'):
+        elif key in ('pyccel_lint','docs'):
             has_relevant_change = lambda diff: any(f.endswith('.py') and f != 'pyccel/version.py' #pylint: disable=unnecessary-lambda-assignment
                                                     for f in diff)
-        elif key in ('spelling'):
+        elif key in ('spelling',):
             has_relevant_change = lambda diff: any(f.endswith('.md') or f == '.dict_custom.txt' for f in diff) #pylint: disable=unnecessary-lambda-assignment
         elif key in ('pickle', 'pickle_wheel', 'editable_pickle'):
             has_relevant_change = lambda diff: any((f.startswith('pyccel/') and f.endswith('.py') #pylint: disable=unnecessary-lambda-assignment
@@ -439,12 +436,13 @@ class Bot:
                                                     or f.startswith('install_scripts/')
                                                     for f in diff)
         elif key in ('coverage',):
-            has_relevant_change = lambda diff: True
+            has_relevant_change = lambda diff: True #pylint: disable=unnecessary-lambda-assignment
         else:
             raise NotImplementedError(f"Please update for new has_relevant_change : {key}")
 
         for c in commit_log:
             diff = self.get_diff(c)
+            print("Diff found : ", diff)
             if has_relevant_change(diff):
                 print("Contains relevant change : ", c)
                 return True
@@ -857,7 +855,7 @@ class Bot:
             base_commit = self._base
         assert bool(base_commit)
         cmd = [git, 'diff', f"{base_commit}..{self._ref}"]
-        print(cmd)
+        print(''.join(cmd))
         with subprocess.Popen(cmd + ['--name-only'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True) as p:
             out, _ = p.communicate()
         diff = {f: None for f in out.strip().split('\n')}


### PR DESCRIPTION
Allow for branches with slashes in the name. Ensure old tests are considered when calculating ready for review success. Allow the coverage to be retriggered without checking any conditions.