### PR TITLE
Fix returns in for loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## \[UNRELEASED\]
-
-### Added
+## \[1.11.1\] - 2024-02-13
 
 ### Fixed
 
 -   #1724 : Fix returns in for loops
-
-### Changed
-
-### Deprecated
 
 ## \[1.11.0\] - 2024-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+### Fixed
+
+-   #1724 : Fix returns in for loops
+
+### Changed
+
+### Deprecated
+
+## \[1.11.0\] - 2024-02-12
+
+### Added
+
 -   #1645 : Handle deprecated `ast` classes.
 -   #1649 : Add support for `np.min` in C code.
 -   #1621 : Add support for `np.max` in C code.

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -651,7 +651,7 @@ class SemanticParser(BasicParser):
 
         if self._current_function:
             func_name = self._current_function.name[-1] if isinstance(self._current_function, DottedName) else self._current_function
-            current_func = self.scope.functions[func_name]
+            current_func = self.scope.find(func_name, 'functions')
             arg_vars = {a.var:a for a in current_func.arguments}
 
             for p, t_list in self._pointer_targets[-1].items():

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.11.0"
+__version__ = "1.11.1"

--- a/tests/epyccel/modules/loops.py
+++ b/tests/epyccel/modules/loops.py
@@ -248,3 +248,10 @@ def temp_array_in_loop(a : 'int[:]', b : 'int[:]'):
         d2[:] = np.abs(b - a)
     return d1, d2
 
+def less_than_100(n : int):
+    for i in range(100):
+        if i > n:
+            return True
+    return False
+
+

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -229,6 +229,12 @@ def test_temp_array_in_loop(language):
     assert np.array_equal(c_py, c_ep)
     assert np.array_equal(d_py, d_ep)
 
+def test_less_than_100(language):
+    f1 = loops.less_than_100
+    f2 = epyccel( f1, language = language )
+
+    assert f1(10) == f2(10)
+    assert f1(101) == f2(101)
 
 ##==============================================================================
 ## CLEAN UP GENERATED FILES AFTER RUNNING TESTS


### PR DESCRIPTION
As described in #1723 the scope is searched incorrectly when handling pointers and targets. This PR fixes #1723