### PR TITLE
Fix Pyccel checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## \[UNRELEASED\]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Deprecated
+
 ## \[1.11.1\] - 2024-02-13
 
 ### Fixed

--- a/ci_tools/check_slots.py
+++ b/ci_tools/check_slots.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
 
     # Get ast modules
     ast_folder = os.path.dirname(ast.__file__)
-    ast_modules = [mod[:-3] for mod in os.listdir(ast_folder) if mod != '__init__.py' and mod.endswith('.py')]
+    ast_modules = ['.'.join(f.parts)[:-3] for f in folder.rglob('*.py') if f.parts[-1] != '__init__.py']
 
     # Prepare error collection
     missing_all = []

--- a/ci_tools/check_slots.py
+++ b/ci_tools/check_slots.py
@@ -4,6 +4,7 @@ import argparse
 import importlib
 import inspect
 import os
+import pathlib
 import sys
 import json
 from pyccel import ast

--- a/ci_tools/check_slots.py
+++ b/ci_tools/check_slots.py
@@ -92,8 +92,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Get ast modules
-    ast_folder = pathlib.Path(ast.__file__)
-    ast_modules = ['.'.join(f.parts)[:-3] for f in ast_folder.rglob('*.py') if f.parts[-1] != '__init__.py']
+    ast_folder = pathlib.Path(ast.__file__).parent
+    ast_modules = ['.'.join(f.relative_to(ast_folder).parts)[:-3] for f in ast_folder.rglob('*.py') if f.parts[-1] != '__init__.py']
 
     # Prepare error collection
     missing_all = []

--- a/ci_tools/check_slots.py
+++ b/ci_tools/check_slots.py
@@ -3,7 +3,6 @@
 import argparse
 import importlib
 import inspect
-import os
 import pathlib
 import sys
 import json
@@ -93,8 +92,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Get ast modules
-    ast_folder = os.path.dirname(ast.__file__)
-    ast_modules = ['.'.join(f.parts)[:-3] for f in folder.rglob('*.py') if f.parts[-1] != '__init__.py']
+    ast_folder = pathlib.Path(ast.__file__)
+    ast_modules = ['.'.join(f.parts)[:-3] for f in ast_folder.rglob('*.py') if f.parts[-1] != '__init__.py']
 
     # Prepare error collection
     missing_all = []


### PR DESCRIPTION
The PR test which checks that all AST nodes are following the expected conventions (`__slots__` and `_attribute_nodes` defined) is not running on subfolders. As new PRs are introducing subfolders this needs fixing ASAP. This PR fixes that