### PR TITLE
Remove unnecessary dtype property from Declare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ All notable changes to this project will be documented in this file.
 
 ### Deprecated
 
--   \[INTERNALS\] Remove unnecessary `dtype` parameter from `Declare`.
--   \[INTERNALS\] Remove unnecessary `passed_from_dotted` parameter from `Declare`.
+-   \[INTERNALS\] Remove unnecessary `dtype` parameter from `ast.core.Declare` class.
+-   \[INTERNALS\] Remove unnecessary `passed_from_dotted` parameter from `ast.core.Declare` class.
 -   \[INTERNALS\] Remove unused `ast.core.Block` class.
 
 ## \[1.11.1\] - 2024-02-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 
 -   \[INTERNALS\] Remove unnecessary `dtype` parameter from `Declare`.
+-   \[INTERNALS\] Remove unnecessary `passed_from_dotted` parameter from `Declare`.
 -   \[INTERNALS\] Remove unused `ast.core.Block` class.
 
 ## \[1.11.1\] - 2024-02-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Deprecated
 
+-   \[INTERNALS\] Remove unnecessary `dtype` parameter from `Declare`.
+
 ## \[1.11.1\] - 2024-02-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 
 -   \[INTERNALS\] Remove unnecessary `dtype` parameter from `Declare`.
+-   \[INTERNALS\] Remove unused `ast.core.Block` class.
 
 ## \[1.11.1\] - 2024-02-13
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3904,8 +3904,6 @@ class Declare(PyccelAstNode):
         ):
         if not isinstance(variable, Variable):
             raise TypeError('var must be of type Variable, given {0}'.format(variable))
-        if variable.dtype != dtype:
-            raise ValueError('All variables must have the same dtype')
 
         if intent:
             if not intent in ['in', 'out', 'inout']:

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1075,7 +1075,7 @@ class Block(ScopedAstNode):
 
     @property
     def declarations(self):
-        return [Declare(i.dtype, i) for i in self.variables]
+        return [Declare(i) for i in self.variables]
 
 
 
@@ -1307,7 +1307,7 @@ class Module(ScopedAstNode):
     def declarations(self):
         """ Returns the declarations of the variables
         """
-        return [Declare(i.dtype, i, value=v, module_variable=True) \
+        return [Declare(i, value=v, module_variable=True) \
                 for i,v in zip(self.variables, self._variable_inits)]
 
     @property
@@ -3865,8 +3865,6 @@ class Declare(PyccelAstNode):
 
     Parameters
     ----------
-    dtype : DataType
-        The type for the declaration.
     variable(s)
         A single variable or an iterable of Variables. If iterable, all
         Variables must be of the same type.
@@ -3884,10 +3882,10 @@ class Declare(PyccelAstNode):
     Examples
     --------
     >>> from pyccel.ast.core import Declare, Variable
-    >>> Declare('int', Variable('int', 'n'))
-    Declare(NativeInteger(), (n,), None)
-    >>> Declare('float', Variable('float', 'x'), intent='out')
-    Declare(NativeFloat(), (x,), out)
+    >>> Declare(Variable('int', 'n'))
+    Declare((n,), None)
+    >>> Declare(Variable('float', 'x'), intent='out')
+    Declare((x,), out)
     """
     __slots__ = ('_dtype','_variable','_intent','_value',
                  '_static','_passed_from_dotted', '_external',
@@ -3896,7 +3894,6 @@ class Declare(PyccelAstNode):
 
     def __init__(
         self,
-        dtype,
         variable,
         intent=None,
         value=None,
@@ -3905,11 +3902,6 @@ class Declare(PyccelAstNode):
         external = False,
         module_variable = False
         ):
-        if isinstance(dtype, str):
-            dtype = datatype(dtype)
-        elif not isinstance(dtype, DataType):
-            raise TypeError('datatype must be an instance of DataType.')
-
         if not isinstance(variable, Variable):
             raise TypeError('var must be of type Variable, given {0}'.format(variable))
         if variable.dtype != dtype:
@@ -3931,7 +3923,6 @@ class Declare(PyccelAstNode):
         if not isinstance(module_variable, bool):
             raise TypeError('Expecting a boolean for module_variable attribute')
 
-        self._dtype = dtype
         self._variable = variable
         self._intent = intent
         self._value = value
@@ -3940,10 +3931,6 @@ class Declare(PyccelAstNode):
         self._external = external
         self._module_variable = module_variable
         super().__init__()
-
-    @property
-    def dtype(self):
-        return self._dtype
 
     @property
     def variable(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3883,9 +3883,9 @@ class Declare(PyccelAstNode):
     --------
     >>> from pyccel.ast.core import Declare, Variable
     >>> Declare(Variable('int', 'n'))
-    Declare((n,), None)
+    Declare(n, None)
     >>> Declare(Variable('float', 'x'), intent='out')
-    Declare((x,), out)
+    Declare(x, out)
     """
     __slots__ = ('_variable','_intent','_value',
                  '_static','_passed_from_dotted', '_external',

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -1207,7 +1207,10 @@ class Module(ScopedAstNode):
 
     @property
     def declarations(self):
-        """ Returns the declarations of the variables
+        """
+        Get the declarations of all variables in the module.
+
+        Get the declarations of all variables in the module.
         """
         return [Declare(i, value=v, module_variable=True) \
                 for i,v in zip(self.variables, self._variable_inits)]
@@ -3762,24 +3765,25 @@ class FuncAddressDeclare(PyccelAstNode):
 
 # ARA : issue-999 add is_external for external function exported through header files
 class Declare(PyccelAstNode):
+    """
+    Represents a variable declaration in the code.
 
-    """Represents a variable declaration in the code.
+    Represents a variable declaration in the translated code.
 
     Parameters
     ----------
-    variable(s)
-        A single variable or an iterable of Variables. If iterable, all
-        Variables must be of the same type.
-    intent: None, str
-        one among {'in', 'out', 'inout'}
-    value: TypedAstNode
-        variable value
-    static: bool
+    variable : Variable
+        A single variable which should be declared.
+    intent : str, optional
+        One among {'in', 'out', 'inout'}.
+    value : TypedAstNode, optional
+        The initialisation value of the variable.
+    static : bool, default=False
         True for a static declaration of an array.
-    external: bool
-        True for a function declared through a header
-    module_variable : bool
-        True for a variable which belongs to a module
+    external : bool, default=False
+        True for a function declared through a header.
+    module_variable : bool, default=False
+        True for a variable which belongs to a module.
 
     Examples
     --------

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3794,7 +3794,7 @@ class Declare(PyccelAstNode):
     Declare(x, out)
     """
     __slots__ = ('_variable','_intent','_value',
-                 '_static','_passed_from_dotted', '_external',
+                 '_static', '_external',
                  '_module_variable')
     _attribute_nodes = ('_variable', '_value')
 
@@ -3804,7 +3804,6 @@ class Declare(PyccelAstNode):
         intent=None,
         value=None,
         static=False,
-        passed_from_dotted = False,
         external = False,
         module_variable = False
         ):
@@ -3818,9 +3817,6 @@ class Declare(PyccelAstNode):
         if not isinstance(static, bool):
             raise TypeError('Expecting a boolean for static attribute')
 
-        if not isinstance(passed_from_dotted, bool):
-            raise TypeError('Expecting a boolean for passed_from_dotted attribute')
-
         if not isinstance(external, bool):
             raise TypeError('Expecting a boolean for external attribute')
 
@@ -3831,7 +3827,6 @@ class Declare(PyccelAstNode):
         self._intent = intent
         self._value = value
         self._static = static
-        self._passed_from_dotted = passed_from_dotted
         self._external = external
         self._module_variable = module_variable
         super().__init__()
@@ -3851,12 +3846,6 @@ class Declare(PyccelAstNode):
     @property
     def static(self):
         return self._static
-
-    @property
-    def passed_from_dotted(self):
-        """ Argument is the lhs of a DottedFunction
-        """
-        return self._passed_from_dotted
 
     @property
     def external(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3887,7 +3887,7 @@ class Declare(PyccelAstNode):
     >>> Declare(Variable('float', 'x'), intent='out')
     Declare((x,), out)
     """
-    __slots__ = ('_dtype','_variable','_intent','_value',
+    __slots__ = ('_variable','_intent','_value',
                  '_static','_passed_from_dotted', '_external',
                  '_module_variable')
     _attribute_nodes = ('_variable', '_value')

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -46,7 +46,6 @@ __all__ = (
     'Assert',
     'Assign',
     'AugAssign',
-    'Block',
     'Break',
     'ClassDef',
     'CodeBlock',
@@ -980,103 +979,6 @@ class With(ScopedAstNode):
     @property
     def body(self):
         return self._body
-
-    @property
-    def block(self):
-        """
-        Get the code block for the with block.
-
-        Get the code block created by calling the enter method followed by
-        the code in the with block and finally the exit method.
-
-        Returns
-        -------
-        Block
-            The code block.
-        """
-        methods = self.test.cls_base.methods
-        for i in methods:
-            if str(i.name) == '__enter__':
-                start = i
-            elif str(i.name) == '__exit__':
-                end   = i
-        start = FunctionCall(start,[])
-        end   = FunctionCall(end  ,[])
-
-        # TODO check if enter is empty or not first
-
-        body = start.body.body
-        body += self.body.body
-        body +=  end.body.body
-        return Block('with', [], body, scope=self.scope)
-
-
-# TODO add a name to a block?
-
-class Block(ScopedAstNode):
-
-    """Represents a block in the code. A block consists of the following inputs
-
-    Parameters
-    ----------
-    variables: list
-        list of the variables that appear in the block.
-
-    declarations: list
-        list of declarations of the variables that appear in the block.
-
-    body: list
-        a list of statements
-
-    Examples
-    --------
-    >>> from pyccel.ast.core import Variable, Assign, Block
-    >>> n = Variable('int', 'n')
-    >>> x = Variable('int', 'x')
-    >>> Block([n, x], [Assign(x,2.*n + 1.), Assign(n, n + 1)])
-    Block([n, x], [x := 1.0 + 2.0*n, n := 1 + n])
-    """
-    __slots__ = ('_name','_variables','_body')
-    _attribute_nodes = ('_variables','_body')
-
-    def __init__(
-        self,
-        name,
-        variables,
-        body,
-        scope = None):
-        if not isinstance(name, str):
-            raise TypeError('name must be of type str')
-        if not iterable(variables):
-            raise TypeError('variables must be an iterable')
-        for var in variables:
-            if not isinstance(var, Variable):
-                raise TypeError('Only a Variable instance is allowed.')
-        if iterable(body):
-            body = CodeBlock(body)
-        elif not isinstance(body, CodeBlock):
-            raise TypeError('body must be an iterable or a CodeBlock')
-        self._name = name
-        self._variables = variables
-        self._body = body
-        super().__init__(scope)
-
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def variables(self):
-        return self._variables
-
-    @property
-    def body(self):
-        return self._body
-
-    @property
-    def declarations(self):
-        return [Declare(i) for i in self.variables]
-
 
 
 class Module(ScopedAstNode):

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -944,7 +944,7 @@ class PyModInitFunc(FunctionDef):
 
         Returns the declarations of the variables.
         """
-        return [Declare(v.dtype, v, static=(v in self._static_vars)) \
+        return [Declare(v, static=(v in self._static_vars)) \
                 for v in self.scope.variables.values()]
 
 #-------------------------------------------------------------------

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -756,7 +756,7 @@ class CCodePrinter(CodePrinter):
             if classDef.docstring is not None:
                 classes += self._print(classDef.docstring)
             classes += f"struct {classDef.name} {{\n"
-            classes += ''.join(self._print(Declare(var.dtype,var)) for var in classDef.attributes)
+            classes += ''.join(self._print(Declare(var)) for var in classDef.attributes)
             class_scope = classDef.scope
             for method in classDef.methods:
                 if not method.is_inline:
@@ -1256,7 +1256,7 @@ class CCodePrinter(CodePrinter):
 
     def _print_Declare(self, expr):
         if isinstance(expr.variable, InhomogeneousTupleVariable):
-            return ''.join(self._print_Declare(Declare(v.dtype,v,intent=expr.intent, static=expr.static)) for v in expr.variable)
+            return ''.join(self._print_Declare(Declare(v,intent=expr.intent, static=expr.static)) for v in expr.variable)
 
         declaration_type = self.get_declare_type(expr.variable)
         variable = self._print(expr.variable.name)
@@ -1838,15 +1838,15 @@ class CCodePrinter(CodePrinter):
             self._additional_args.append(results)
 
         body  = self._print(expr.body)
-        decs  = [Declare(i.dtype, i) if isinstance(i, Variable) else FuncAddressDeclare(i) for i in expr.local_vars]
+        decs  = [Declare(i) if isinstance(i, Variable) else FuncAddressDeclare(i) for i in expr.local_vars]
 
         if len(results) == 1 :
             res = results[0]
             if isinstance(res, Variable) and not res.is_temp:
-                decs += [Declare(res.dtype, res)]
+                decs += [Declare(res)]
             elif not isinstance(res, Variable):
                 raise NotImplementedError(f"Can't return {type(res)} from a function")
-        decs += [Declare(v.dtype,v) for v in self.scope.variables.values() \
+        decs += [Declare(v) for v in self.scope.variables.values() \
                 if v not in chain(expr.local_vars, results, arguments)]
         decs  = ''.join(self._print(i) for i in decs)
 
@@ -2370,7 +2370,7 @@ class CCodePrinter(CodePrinter):
         self.set_scope(expr.scope)
         body  = self._print(expr.body)
         variables = self.scope.variables.values()
-        decs = ''.join(self._print(Declare(v.dtype, v)) for v in variables)
+        decs = ''.join(self._print(Declare(v)) for v in variables)
 
         imports = [*expr.imports, *self._additional_imports.values()]
         imports = ''.join(self._print(i) for i in imports)

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -277,7 +277,7 @@ class CWrapperCodePrinter(CCodePrinter):
         for i,c in enumerate(mod.classes):
             struct_name = c.struct_name
             type_name = c.type_name
-            attributes = ''.join(self._print(Declare(a.dtype, a)) for a in c.attributes)
+            attributes = ''.join(self._print(Declare(a)) for a in c.attributes)
             classes.append(f"struct {struct_name} {{\n"
                     "    PyObject_HEAD\n"
                     + attributes +
@@ -290,7 +290,7 @@ class CWrapperCodePrinter(CCodePrinter):
 
         class_code = '\n'.join(classes)
 
-        static_import_decs = self._print(Declare(API_var.dtype, API_var, static=True))
+        static_import_decs = self._print(Declare(API_var, static=True))
         import_func = self._print(mod.import_func)
 
         header_id = f'{name.upper()}_WRAPPER'

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1866,26 +1866,6 @@ class FCodePrinter(CodePrinter):
   #      self.exit_scope()
   #      return ''
 
-    def _print_Block(self, expr):
-        self.set_scope(expr.scope)
-
-        decs=[Declare(v) for v in expr.variables]
-        body = expr.body
-
-        body_code = self._print(body)
-        prelude   = ''.join(self._print(i) for i in decs)
-
-        self.exit_scope()
-
-        #case of no local variables
-        if len(decs) == 0:
-            return body_code
-
-        return ('{name} : Block\n'
-                '{prelude}\n'
-                 '{body}\n'
-                'end Block {name}\n').format(name=expr.name, prelude=prelude, body=body_code)
-
     def _print_FunctionAddress(self, expr):
         return expr.name
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -490,10 +490,10 @@ class FCodePrinter(CodePrinter):
         decs += '\n'.join(c[0] for c in class_decs_and_methods)
         # ...
 
-        decs += ''.join(self._print(i) for i in expr.declarations)
+        declarations = list(expr.declarations)
         # look for external functions and declare their result type
-        external_decs = self._get_external_declarations()
-        decs += ''.join(self._print(i) for i in external_decs.values())
+        self._get_external_declarations(declarations)
+        decs += ''.join(self._print(d) for d in declarations)
 
         # ... TODO add other elements
         private_funcs = [f.name for f in expr.funcs if f.is_private]

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1926,12 +1926,9 @@ class FCodePrinter(CodePrinter):
             arg_var = arg.var
             if isinstance(arg_var, Variable):
                 if isinstance(arg, BindCFunctionDefArgument) and arg.original_function_argument_variable.rank!=0:
-                    for b_arg,inout in zip(arg.get_all_function_def_arguments(), arg.inout):
+                    for b_arg in arg.get_all_function_def_arguments():
                         v = b_arg.var
-                        if inout:
-                            dec = Declare(v, intent='inout')
-                        else:
-                            dec = Declare(v, intent='in')
+                        dec = Declare(v, intent='in')
                         args_decs[v] = dec
                 else:
                     if i == 0 and expr.cls_name:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1411,7 +1411,9 @@ class FCodePrinter(CodePrinter):
 
     def _print_Declare(self, expr):
         # ... ignored declarations
-        if isinstance(expr.dtype, NativeSymbol):
+        var = expr.variable
+        expr_dtype      = var.dtype
+        if isinstance(expr_dtype, NativeSymbol):
             return ''
 
         # meta-variables
@@ -1425,8 +1427,6 @@ class FCodePrinter(CodePrinter):
 
         # ... TODO improve
         # Group the variables by intent
-        var = expr.variable
-        expr_dtype      = var.dtype
         rank            = var.rank
         shape           = var.alloc_shape
         is_const        = var.is_const
@@ -1446,7 +1446,7 @@ class FCodePrinter(CodePrinter):
         # ...
 
         # ... print datatype
-        if isinstance(expr.dtype, CustomDataType):
+        if isinstance(expr_dtype, CustomDataType):
             name   = expr_dtype.__class__.__name__
             prefix = expr_dtype.prefix
             alias  = expr_dtype.alias
@@ -1935,7 +1935,7 @@ class FCodePrinter(CodePrinter):
                         args_decs[v] = dec
                 else:
                     if i == 0 and expr.cls_name:
-                        dec = Declare(arg_var, intent='inout', passed_from_dotted = True)
+                        dec = Declare(arg_var, intent='inout')
                     elif arg.inout:
                         dec = Declare(arg_var, intent='inout')
                     else:

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1084,7 +1084,7 @@ class CToPythonWrapper(Wrapper):
         pymod = self._wrap_Module(expr)
 
         # Add declarations for C-compatible variables
-        decs = [Declare(v.dtype, v.clone(v.name.lower()), module_variable=True, external = True) \
+        decs = [Declare(v.clone(v.name.lower()), module_variable=True, external = True) \
                                     for v in expr.variables if not v.is_private and isinstance(v, BindCVariable)]
         pymod.declarations = decs
 

--- a/tests/warnings/test_warnings.py
+++ b/tests/warnings/test_warnings.py
@@ -82,7 +82,8 @@ def test_cwrapper_warnings(f, language):
         epyccel(f, language='c')
 
 @pytest.mark.parametrize("f", [HIGH_ORDER_FUNCTIONS_IN_CLASS_FUNCS])
-def test_bind_c_warnings(f, language):
+@pytest.mark.fortran
+def test_bind_c_warnings(f):
     with pytest.warns(UserWarning):
         epyccel(f, language='fortran')
 


### PR DESCRIPTION
Currently the class `Declare` takes a `dtype`. In the C translation this value is ignored. In the Fortran translation it is used but other typing details are collected from the variable. Whenever the `Declare` instance is created the dtype parameter passed is always collected from the Variable. This is quite repetitive and unnecessary. This PR removes this redundancy and duplication. This will remove an unnecessary complexity when modifying datatype handling (see #1722).

**Commit Summary**
- Remove unnecessary `ast.core.Declare.dtype` parameter
- Remove unnecessary `ast.core.Declare.passed_from_dotted` parameter
- Remove the unused class `ast.core.Block`
- Simplify storage of declarations in Fortran printer to avoid using dictionary (without using keys)
- Remove dead code