### PR TITLE
Set Support : add method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 -   #1690 : Add Python support for list method `pop()`
 -   #1575 : Add support for homogeneous tuple type annotations on variables.
 -   #1691 : Add Python support for list method `clear()`
+-   #1738 : Add Python support for set method `add()`
 
 ### Fixed
 

--- a/developer_docs/overview.md
+++ b/developer_docs/overview.md
@@ -9,7 +9,7 @@ Pyccel's development is split into 4 main stages:
 -   [Syntactic Stage](#Syntactic-stage) (for more details see [syntactic stage](syntactic_stage.md))
 -   [Semantic Stage](#Semantic-stage) (for more details see [semantic stage](semantic_stage.md))
 -   [Code Generation Stage](#Code-generation-stage) (for more details see [codegen stage](codegen_stage.md))
--   [Wrapping Stage](#Wrapping-stage) (for more details see [wrapping stage](wrapper_stage.md))
+-   [Wrapping Stage](#Wrapping-stage) (for more details see [wrapping stage](wrapping_stage.md))
 -   [Compilation Stage](#Compilation-stage)
 
 ### Syntactic Stage

--- a/developer_docs/overview.md
+++ b/developer_docs/overview.md
@@ -9,7 +9,7 @@ Pyccel's development is split into 4 main stages:
 -   [Syntactic Stage](#Syntactic-stage) (for more details see [syntactic stage](syntactic_stage.md))
 -   [Semantic Stage](#Semantic-stage) (for more details see [semantic stage](semantic_stage.md))
 -   [Code Generation Stage](#Code-generation-stage) (for more details see [codegen stage](codegen_stage.md))
--   [Wrapping Stage](#Wrapping-stage) (for more details see [wrapping stage](wrapping_stage.md))
+-   [Wrapping Stage](#Wrapping-stage) (for more details see [wrapping stage](wrapper_stage.md))
 -   [Compilation Stage](#Compilation-stage)
 
 ### Syntactic Stage

--- a/pyccel/ast/builtin_methods/set_methods.py
+++ b/pyccel/ast/builtin_methods/set_methods.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/master/LICENSE for full license details.     #
+#------------------------------------------------------------------------------------------#
+"""
+The Set container has a number of built-in methods that are 
+always available.
+
+This module contains objects which describe these methods within Pyccel's AST.
+"""
+from pyccel.ast.datatypes import NativeVoid, NativeGeneric, NativeHomogeneousSet
+from pyccel.ast.internals import PyccelInternalFunction
+from pyccel.ast.builtins import PythonTuple
+
+__all__ = ('SetAdd',)
+
+class SetAdd(PyccelInternalFunction) :
+    """
+    Represents a call to the .add() method.
+    
+    Represents a call to the .add() method which add an element
+    to the set if it's not already present.
+    If the element is already in the set, the set remains unchanged.
+    Parameters
+    ----------
+    set_variable : TypedAstNode
+        The name of the set.
+
+    index_element : TypedAstNode
+        The current index value for the element to be add.
+    """
+    __slots__ = ("_set_variable", "_add_arg")
+    _attribute_nodes = ("_set_variable", "_add_arg")
+    _dtype = NativeVoid()
+    _shape = None
+    _order = None
+    _rank = 0
+    _precision = None
+    _class_type = NativeVoid()
+    name = 'add'
+
+    def __init__(self, set_variable, new_elem) -> None:
+        if (new_elem.rank > 0 and not isinstance(new_elem, PythonTuple)) :
+                raise TypeError(f"Can't add an unhashable type")
+        is_homogeneous = (
+            new_elem.dtype is not NativeGeneric() and
+            set_variable.dtype is not NativeGeneric() and
+            set_variable.dtype == new_elem.dtype and
+            set_variable.precision == new_elem.precision and
+            set_variable.rank - 1 == new_elem.rank
+        )
+        if not is_homogeneous:
+            raise TypeError("Expecting an argument of the same type as the elements of the set")
+        self._set_variable = set_variable
+        self._add_arg = new_elem
+        super().__init__()
+
+    @property
+    def set_variable(self):
+        """
+        Get the variable representing the set.
+
+        Get the variable representing the set.
+        """
+        return self._set_variable
+
+    @property
+    def add_argument(self):
+        """
+        Get the argument which is passed to add().
+
+        Get the argument which is passed to add().
+        """
+        return self._add_arg

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -7,6 +7,7 @@ This module contains all types which define a python class which is automaticall
 """
 
 from pyccel.ast.builtin_methods.list_methods import ListAppend, ListPop, ListClear
+from pyccel.ast.builtin_methods.set_methods import SetAdd
 
 
 from .builtins  import PythonImag, PythonReal, PythonConjugate
@@ -14,7 +15,7 @@ from .core      import ClassDef, PyccelFunctionDef
 from .c_concepts import CStackArray
 from .datatypes import (NativeBool, NativeInteger, NativeFloat,
                         NativeComplex, NativeString, NativeNumericTypes,
-                        NativeTuple, CustomDataType, NativeHomogeneousList)
+                        NativeTuple, CustomDataType, NativeHomogeneousList, NativeHomogeneousSet)
 from .numpyext  import (NumpyShape, NumpySum, NumpyAmin, NumpyAmax,
                         NumpyImag, NumpyReal, NumpyTranspose,
                         NumpyConjugate, NumpySize, NumpyResultType,
@@ -24,6 +25,7 @@ __all__ = ('BooleanClass',
         'IntegerClass',
         'FloatClass',
         'ComplexClass',
+        'SetClass',
         'StringClass',
         'NumpyArrayClass',
         'TupleClass',
@@ -147,6 +149,14 @@ ListClass = ClassDef('list', class_type = NativeHomogeneousList(),
 
 #=======================================================================================
 
+SetClass = ClassDef('set', class_type=NativeHomogeneousSet(),
+        methods=[
+            PyccelFunctionDef('add', func_class = SetAdd,
+                decorators = {}),
+        ])
+
+#=======================================================================================
+
 TupleClass = ClassDef('tuple', class_type = NativeTuple(),
         methods=[
             #index
@@ -240,6 +250,8 @@ def get_cls_base(dtype, precision, container_type):
         return TupleClass
     elif isinstance(container_type, NativeHomogeneousList):
         return ListClass
+    elif isinstance(container_type, NativeHomogeneousSet):
+        return SetClass
     else:
         if container_type:
             type_name = str(container_type)

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -331,6 +331,23 @@ class NativeHomogeneousList(DataType, metaclass = Singleton):
         else:
             return NotImplemented
 
+class NativeHomogeneousSet(DataType, metaclass = Singleton):
+    """
+    Class representing the homogeneous Set type.
+
+    Class representing the type of a homogeneous Set. This
+    is a container type and should be used as the class_type.
+    """
+    __slots__ = ()
+    _name = 'Set'
+
+    @lru_cache
+    def __add__(self, other):
+        if isinstance(other, NativeHomogeneousSet):
+            return self
+        else:
+            return NotImplemented
+
 class NativeSymbol(DataType, metaclass=Singleton):
     """
     Class representing a symbol datatype.

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -442,6 +442,10 @@ class PythonCodePrinter(CodePrinter):
         args = ', '.join(self._print(i) for i in expr.args)
         return '['+args+']'
 
+    def _print_PythonSet(self, expr):
+        args = ', '.join(self._print(i) for i in expr.args)
+        return '{'+args+'}'
+
     def _print_PythonBool(self, expr):
         return 'bool({})'.format(self._print(expr.arg))
 
@@ -869,6 +873,11 @@ class PythonCodePrinter(CodePrinter):
                 start = start,
                 stop  = stop,
                 step  = step)
+    
+    def _print_SetAdd(self, expr):
+        name = self._print(expr.set_variable)
+        args = self._print(expr.add_argument)
+        return f"{name}.add({args})\n"
 
     def _print_Nil(self, expr):
         return 'None'

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -111,6 +111,7 @@ PYCCEL_RESTRICTION_LIST_COMPREHENSION_ASSIGN = "The result of a list comprehensi
 PYCCEL_RESTRICTION_LIST_COMPREHENSION_SIZE = 'Could not deduce the size of this list comprehension. If you believe this expression is simple then please create an issue at https://github.com/pyccel/pyccel/issues and provide a small example of your problem.'
 PYCCEL_RESTRICTION_LIST_COMPREHENSION_LIMITS = 'Pyccel cannot handle this list comprehension. This is because there are occasions where the upper bound is smaller than the lower bound for variable {}'
 PYCCEL_RESTRICTION_INHOMOG_LIST = 'Inhomogeneous lists are not supported by Pyccel. Please use a tuple'
+PYCCEL_RESTRICTION_INHOMOG_SET = 'Inhomogeneous Sets are not supported by Pyccel. Please use a tuple'
 
 # Fortran limitation
 FORTRAN_ALLOCATABLE_IN_EXPRESSION = 'An allocatable function cannot be used in an expression'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -26,7 +26,7 @@ from pyccel.ast.basic import PyccelAstNode, TypedAstNode, ScopedAstNode
 from pyccel.ast.builtins import PythonPrint, PythonTupleFunction
 from pyccel.ast.builtins import PythonComplex
 from pyccel.ast.builtins import builtin_functions_dict, PythonImag, PythonReal
-from pyccel.ast.builtins import PythonList, PythonConjugate
+from pyccel.ast.builtins import PythonList, PythonConjugate , PythonSet
 from pyccel.ast.builtins import (PythonRange, PythonZip, PythonEnumerate,
                                  PythonTuple, Lambda, PythonMap)
 
@@ -133,7 +133,7 @@ from pyccel.errors.messages import (PYCCEL_RESTRICTION_TODO, UNDERSCORE_NOT_A_TH
         PYCCEL_RESTRICTION_LIST_COMPREHENSION_LIMITS, PYCCEL_RESTRICTION_LIST_COMPREHENSION_SIZE,
         UNUSED_DECORATORS, UNSUPPORTED_POINTER_RETURN_VALUE, PYCCEL_RESTRICTION_OPTIONAL_NONE,
         PYCCEL_RESTRICTION_PRIMITIVE_IMMUTABLE, PYCCEL_RESTRICTION_IS_ISNOT,
-        FOUND_DUPLICATED_IMPORT, UNDEFINED_WITH_ACCESS, MACRO_MISSING_HEADER_OR_FUNC,)
+        FOUND_DUPLICATED_IMPORT, UNDEFINED_WITH_ACCESS, MACRO_MISSING_HEADER_OR_FUNC, PYCCEL_RESTRICTION_INHOMOG_SET)
 
 from pyccel.parser.base      import BasicParser
 from pyccel.parser.syntactic import SyntaxParser
@@ -2195,6 +2195,18 @@ class SemanticParser(BasicParser):
             expr = PythonList(*ls)
         except TypeError:
             errors.report(PYCCEL_RESTRICTION_INHOMOG_LIST, symbol=expr,
+                severity='fatal')
+        return expr
+
+    def _visit_PythonSet(self, expr):
+        ls = [self._visit(i) for i in expr]
+        try:
+            expr = PythonSet(*ls)
+        except TypeError as e:
+            message = str(e)
+            if not message :
+                message = PYCCEL_RESTRICTION_INHOMOG_SET
+            errors.report(message, symbol=expr,
                 severity='fatal')
         return expr
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -51,7 +51,7 @@ from pyccel.ast.operators import PyccelIs, PyccelIsNot
 from pyccel.ast.operators import IfTernaryOperator
 from pyccel.ast.numpyext  import NumpyMatmul
 
-from pyccel.ast.builtins import PythonTuple, PythonList
+from pyccel.ast.builtins import PythonTuple, PythonList, PythonSet
 from pyccel.ast.builtins import PythonPrint, Lambda
 from pyccel.ast.headers  import MetaVariable, FunctionHeader, MethodHeader
 from pyccel.ast.literals import LiteralInteger, LiteralFloat, LiteralComplex
@@ -362,6 +362,9 @@ class SyntaxParser(BasicParser):
 
     def _visit_List(self, stmt):
         return PythonList(*self._treat_iterable(stmt.elts))
+
+    def _visit_Set(self, stmt):
+        return PythonSet(*self._treat_iterable(stmt.elts))
 
     def _visit_tuple(self, stmt):
         return tuple(self._treat_iterable(stmt))

--- a/tests/epyccel/test_epyccel_sets.py
+++ b/tests/epyccel/test_epyccel_sets.py
@@ -1,0 +1,48 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+import pytest
+from  pyccel.epyccel import epyccel
+
+@pytest.fixture( params=[
+        pytest.param("fortran", marks = [
+            pytest.mark.skip(reason="list methods not implemented in fortran"),
+            pytest.mark.fortran]),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="list methods not implemented in c"),
+            pytest.mark.c]),
+        pytest.param("python", marks = pytest.mark.python)
+    ],
+    scope = "module"
+)
+def language(request):
+    return request.param
+
+def test_add_1(language) :
+    def add_int():
+        a = {1,3,45}
+        a.add(4)
+        return a
+    epyc_add_element = epyccel(add_int, language = language)
+    pyccel_result = epyc_add_element()
+    python_result = add_int()
+    assert python_result == pyccel_result
+
+def test_add_element2(language) :
+    def add_complex():
+        a = {6j,7j,8j}
+        a.add(9j)
+        return a
+    epyc_add_element = epyccel(add_complex, language = language)
+    pyccel_result = epyc_add_element()
+    python_result = add_complex()
+    assert python_result == pyccel_result
+
+def test_add_element_3(language):
+    def add_element_range():
+        a = {1, 2, 3}
+        for i in range(50, 100):
+            a.add(i)
+        return a
+    epyc_add_element = epyccel(add_element_range, language = language)
+    pyccel_result = epyc_add_element()
+    python_result = add_element_range()
+    assert python_result == pyccel_result

--- a/tests/errors/semantic/blocking/ADD_SET_INCOMPATIBLE_TYPES.py
+++ b/tests/errors/semantic/blocking/ADD_SET_INCOMPATIBLE_TYPES.py
@@ -1,0 +1,6 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+a = {1,2,3}
+b = 5j
+a.add(b)
+

--- a/tests/errors/semantic/blocking/ADD_SET_UNHASHABLE_TYPE.py
+++ b/tests/errors/semantic/blocking/ADD_SET_UNHASHABLE_TYPE.py
@@ -1,0 +1,6 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+a = {1,2,3}
+b = [4,5]
+a.add(b)
+


### PR DESCRIPTION
Add support for the add() method of Python sets to the semantic stage. 
Add handling of that method to the Python printer. This fixes  #1738 

**Commit Summary**

- Add a class named `NativeHomogeneousSet` to represent the homogenous set type in `pyccel.ast.datatypes`.
- Add a `PythonSet` class to represent a call to Python's {,} in `pyccel.ast.builtins`.
- In `pyccel.parser.syntactic`, add _visit_Set that calls the `pythonSet` class.
- Add `_visit_PythonSet` in `pyccel.parser.semantic` and `_print_PythonSet` to the Python printer for generating appropriate Python code.
- Create a file named set_methods in `pyccel.ast.builtin_methods`.
- Add a class representing the `add()` method, inheriting from `PyccelInternalFunction`.
- Create a ClassDef class representing a `NativeHomogeneousSet`. This class will include an `add()` method implemented by the `SetAdd` class.
- Update the condition in the `get_cls_base()` function to properly check the class type of the containers.
- Add the `_print_Setadd()` method to the Python printer for generating the appropriate Python code for the `add()` method.
- Add tests for the `add()` method involving various scenarios where the function could be used.