### PR TITLE
Remove dead code

### DIFF
--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -653,6 +653,7 @@ class PythonLen(PyccelInternalFunction):
     arg : TypedAstNode
         The argument whose length is being examined.
     """
+    __slots__ = ()
     def __new__(cls, arg):
         return arg.shape[0]
 

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -653,35 +653,8 @@ class PythonLen(PyccelInternalFunction):
     arg : TypedAstNode
         The argument whose length is being examined.
     """
-    __slots__ = ()
-    name      = 'len'
-    _dtype     = NativeInteger()
-    _precision = -1
-    _rank      = 0
-    _shape     = None
-    _order     = None
-    _class_type = NativeInteger()
-
     def __new__(cls, arg):
-        if not getattr(arg, 'is_homogeneous', False):
-            return arg.shape[0]
-        else:
-            return super().__new__(cls)
-
-    def __init__(self, arg):
-        super().__init__(arg)
-
-    @property
-    def arg(self):
-        """
-        Get the argument which was passed to the function.
-
-        Get the argument which was passed to the function.
-        """
-        return self._args[0]
-
-    def __str__(self):
-        return f'len({self.arg})'
+        return arg.shape[0]
 
 #==============================================================================
 class PythonList(TypedAstNode):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -734,15 +734,6 @@ class CCodePrinter(CodePrinter):
         self.add_import(c_imports['complex'])
         return '_Complex_I'
 
-    def _print_PythonLen(self, expr):
-        var = expr.arg
-        if var.rank > 0:
-            return self._print(var.shape[0])
-        else:
-            return errors.report("PythonLen not implemented for type {}\n".format(type(expr.arg)) +
-                    PYCCEL_RESTRICTION_TODO,
-                    symbol = expr, severity='fatal')
-
     def _print_Header(self, expr):
         return ''
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -920,19 +920,6 @@ class FCodePrinter(CodePrinter):
     def _print_Lambda(self, expr):
         return '"{args} -> {expr}"'.format(args=expr.variables, expr=expr.expr)
 
-    def _print_PythonLen(self, expr):
-        var = expr.arg
-        idx = 1 if var.order == 'F' else var.rank
-        prec = self.print_kind(expr)
-
-        dtype = var.dtype
-        if dtype is NativeString():
-            return 'len({})'.format(self._print(var))
-        elif var.rank == 1:
-            return 'size({}, kind={})'.format(self._print(var), prec)
-        else:
-            return 'size({},{},{})'.format(self._print(var), self._print(idx), prec)
-
     def _print_PythonSum(self, expr):
         args = [self._print(arg) for arg in expr.args]
         return "sum({})".format(", ".join(args))

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -357,3 +357,15 @@ def test_len_tuple(language):
     epyc_f = epyccel(f, language=language)
 
     assert epyc_f() == f()
+
+
+def test_len_inhomog_tuple(language):
+    def f():
+        a = (3,True)
+        b = (4j,False,5)
+        c = b
+        return len(a), len(b), len(c), len((1.5,2))
+
+    epyc_f = epyccel(f, language=language)
+
+    assert epyc_f() == f()

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -333,3 +333,27 @@ def test_sum_expr(language):
 
     assert epyc_f(*int_args) == f(*int_args)
     assert np.allclose(epyc_f(*float_args), f(*float_args), rtol=RTOL, atol=ATOL)
+
+def test_len_numpy(language):
+    def f():
+        from numpy import ones
+        a = ones((3,4))
+        b = ones((4,3,5))
+        c = ones(4)
+        return len(a), len(b), len(c)
+
+    epyc_f = epyccel(f, language=language)
+
+    assert epyc_f() == f()
+
+
+def test_len_tuple(language):
+    def f():
+        a = (3,4)
+        b = (4,3,5)
+        c = b
+        return len(a), len(b), len(c), len((1,2))
+
+    epyc_f = epyccel(f, language=language)
+
+    assert epyc_f() == f()


### PR DESCRIPTION
The `len` function is handled through the `__new__` function for all examples except homogeneous tuple literals. This does not need to be a special case. The unnecessary code is removed and tests are added.