### PR TITLE
Clarify developer docs

### DIFF
--- a/developer_docs/codegen_stage.md
+++ b/developer_docs/codegen_stage.md
@@ -21,7 +21,7 @@ def _print_ClassName(self, stmt):
 ```
 where `Y` must be a string.
 Each of these `_print_X` functions should internally call the `_print` function on each of the `PyccelAstNode` elements of the object to obtain strings which can be combined to create a string describing the current object in the target language.
-It can be tempting to skip some of these `_print` calls, especially for basic types such as literals.
+It can be tempting to skip some of these `_print` calls, especially for basic types such as `Literal`s.
 However it is very important to use these functions as much as possible, for several reasons:
 1.  It ensures that the same conventions are used throughout the generated code
 2.  It ensures that code details are not forgotten

--- a/developer_docs/codegen_stage.md
+++ b/developer_docs/codegen_stage.md
@@ -20,7 +20,7 @@ def _print_ClassName(self, stmt):
     return Y
 ```
 where `Y` must be a string.
-Each of these `_print_X` functions should internally call the `_print` function on each of the elements of the object to obtain strings which can be combined to create a string describing the current object in the target language.
+Each of these `_print_X` functions should internally call the `_print` function on each of the `PyccelAstNode` elements of the object to obtain strings which can be combined to create a string describing the current object in the target language.
 It can be tempting to skip some of these `_print` calls, especially for basic types such as literals.
 However it is very important to use these functions as much as possible, for several reasons:
 1.  It ensures that the same conventions are used throughout the generated code

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -239,7 +239,7 @@ class PythonCodePrinter(CodePrinter):
         return 'complex'
 
     def _print_Variable(self, expr):
-        return self._print(expr.name)
+        return expr.name
 
     def _print_DottedVariable(self, expr):
         rhs_code = self._print_Variable(expr)


### PR DESCRIPTION
As remarked in PR #1764 , the documentation is clear on when `_print` should be used, but not where it is not necessary. For example it is not necessary to call `_print` on an object which is known to be a string as this is not a `PyccelAstNode` so the 3 points used to justify the need to call `_print` do not apply:
1.  It ensures that the same conventions are used throughout the generated code (a string does not have enough context to apply conventions)
2.  It ensures that code details are not forgotten (there are no details available)
3.  It makes refactoring much simpler (a string is so fundamental that it will not be refactored via the `_print` implementation.