### PR TITLE
Mark the failing Intel test

### DIFF
--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -281,6 +281,7 @@ def test_numpy_isinf(language):
     assert matching_types(obtained, expected_output)
 
 #------------------------------ isfinite function ----------------------------#
+@pytest.mark.xfail(os.environ.get('PYCCEL_DEFAULT_COMPILER', None) == 'intel', reason='Different inf representation.')
 def test_numpy_isfinite(language):
     def numpy_isfinite_test(x : 'float'):
         from numpy import isfinite


### PR DESCRIPTION
This is a small PR to mark the failing Intel test `test_numpy_isfinite`, which fails when passing `np.inf`. It seems likely that this could be due to a difference in how the Intel and GNU compilers handle infinity. Flagging this test as `xfail` will ensure that the other tests are still run so other errors can be detected.