### PR TITLE
Fix array to slice assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 -   #1792 : Fix array unpacking.
 -   #1795 : Fix bug when returning slices in C.
 -   #1732 : Fix multidimensional list indexing in Python.
+-   #1218 : Fix bug when assigning an array to a slice in Fortran.
 
 ### Changed
 -   #1720 : functions with the `@inline` decorator are no longer exposed to Python in the shared library.

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -244,7 +244,6 @@ def compatible_operation(*args, language_has_vectors = True):
         shapes = [a.shape[::-1] if a.order == 'F' else a.shape for a in args if a.rank != 0]
         shapes = set(tuple(d if d == LiteralInteger(1) else -1 for d in s) for s in shapes)
         order  = set(a.order for a in args if a.order is not None)
-        print(shapes)
         return len(shapes) <= 1 and len(order) <= 1
     else:
         return all(a.rank == 0 for a in args)

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -564,7 +564,7 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
                 for index in range(lhs.rank-rhs.rank):
                     # If an index exists at the same depth, reuse it if not create one
                     if index >= len(indices):
-                        indices.append(new_index('int','i'))
+                        indices.append(new_index(PythonNativeInt(),'i'))
                     index_var = indices[index]
                     lhs = insert_index(lhs, index, index_var)
                 collect_loops([Assign(lhs,rhs)], indices, new_index, language_has_vectors, result = result)

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -494,14 +494,14 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
             # Loop over indexes, inserting until the expression can be evaluated
             # in the desired language
             new_level = 0
-            for index in range(-rank,0):
+            for index_depth in range(-rank,0):
                 new_level += 1
                 # If an index exists at the same depth, reuse it if not create one
-                if rank+index >= len(indices):
+                if rank+index_depth >= len(indices):
                     indices.append(new_index(PythonNativeInt(),'i'))
-                index_var = indices[rank+index]
-                new_vars = [insert_index(v, index, index_var) for v in new_vars]
-                handled_funcs = [insert_index(v, index, index_var) for v in handled_funcs]
+                index = indices[rank+index_depth]
+                new_vars = [insert_index(v, index_depth, index) for v in new_vars]
+                handled_funcs = [insert_index(v, index_depth, index) for v in handled_funcs]
                 if compatible_operation(*new_vars, *handled_funcs, language_has_vectors = language_has_vectors):
                     break
 
@@ -545,12 +545,12 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
             lhs = line.lhs
             rhs = line.rhs
             if lhs.rank > rhs.rank:
-                for index in range(lhs.rank-rhs.rank):
+                for index_depth in range(lhs.rank-rhs.rank):
                     # If an index exists at the same depth, reuse it if not create one
-                    if index >= len(indices):
+                    if index_depth >= len(indices):
                         indices.append(new_index(PythonNativeInt(), 'i'))
-                    index_var = indices[index]
-                    lhs = insert_index(lhs, index, index_var)
+                    index = indices[index_depth]
+                    lhs = insert_index(lhs, index_depth, index)
                 collect_loops([Assign(lhs, rhs)], indices, new_index, language_has_vectors, result = result)
 
             elif not language_has_vectors:

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -494,11 +494,11 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
             # Loop over indexes, inserting until the expression can be evaluated
             # in the desired language
             new_level = 0
-            for index_depth in range(-rank,0):
+            for index_depth in range(-rank, 0):
                 new_level += 1
                 # If an index exists at the same depth, reuse it if not create one
                 if rank+index_depth >= len(indices):
-                    indices.append(new_index(PythonNativeInt(),'i'))
+                    indices.append(new_index(PythonNativeInt(), 'i'))
                 index = indices[rank+index_depth]
                 new_vars = [insert_index(v, index_depth, index) for v in new_vars]
                 handled_funcs = [insert_index(v, index_depth, index) for v in handled_funcs]

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -548,10 +548,10 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
                 for index in range(lhs.rank-rhs.rank):
                     # If an index exists at the same depth, reuse it if not create one
                     if index >= len(indices):
-                        indices.append(new_index(PythonNativeInt(),'i'))
+                        indices.append(new_index(PythonNativeInt(), 'i'))
                     index_var = indices[index]
                     lhs = insert_index(lhs, index, index_var)
-                collect_loops([Assign(lhs,rhs)], indices, new_index, language_has_vectors, result = result)
+                collect_loops([Assign(lhs, rhs)], indices, new_index, language_has_vectors, result = result)
 
             elif not language_has_vectors:
                 if isinstance(rhs, NumpyArray):

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -557,9 +557,7 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
                 and isinstance(line.rhs, (PythonTuple, NumpyArray)):
             lhs = line.lhs
             rhs = line.rhs
-            modified = False
             if lhs.rank > rhs.rank:
-                modified = True
                 for index in range(lhs.rank-rhs.rank):
                     # If an index exists at the same depth, reuse it if not create one
                     if index >= len(indices):

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -1582,6 +1582,29 @@ def array_2d_C_slice_stride_23(a : 'int[:,:]'):
     return np.sum(b), b[0][0], b[-1][-1], len(b), len(b[0])
 
 #==============================================================================
+# Slice assignment
+#==============================================================================
+
+def copy_to_slice_issue_1218(n : int):
+    from numpy import zeros, array
+    x = 1
+    arr = zeros((2, n))
+    arr[0:x,0:6:2] = array([2,5,6])
+    return arr
+
+def copy_to_slice_1(a : 'float[:]', b : 'float[:]'):
+    a[1:-1] = b
+
+def copy_to_slice_2(a : 'float[:,:]', b : 'float[:]'):
+    a[:,1:-1] = b
+
+def copy_to_slice_3(a : 'float[:,:]', b : 'float[:]'):
+    a[:,0] = b
+
+def copy_to_slice_4(a : 'float[:]', b : 'float[:]'):
+    a[::2] = b
+
+#==============================================================================
 # ARITHMETIC OPERATIONS
 #==============================================================================
 

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -1589,17 +1589,17 @@ def copy_to_slice_issue_1218(n : int):
     from numpy import zeros, array
     x = 1
     arr = zeros((2, n))
-    arr[0:x,0:6:2] = array([2,5,6])
+    arr[0:x, 0:6:2] = array([2, 5, 6])
     return arr
 
 def copy_to_slice_1(a : 'float[:]', b : 'float[:]'):
     a[1:-1] = b
 
 def copy_to_slice_2(a : 'float[:,:]', b : 'float[:]'):
-    a[:,1:-1] = b
+    a[:, 1:-1] = b
 
 def copy_to_slice_3(a : 'float[:,:]', b : 'float[:]'):
-    a[:,0] = b
+    a[:, 0] = b
 
 def copy_to_slice_4(a : 'float[:]', b : 'float[:]'):
     a[::2] = b

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -3506,7 +3506,7 @@ def test_copy_to_slice_1(language):
 
     pyth_a = np.arange(10, dtype=float)
     epyc_a = pyth_a.copy()
-    b = np.arange(20,28, dtype=float)
+    b = np.arange(20, 28, dtype=float)
     pyth_f(pyth_a, b)
     epyc_f(epyc_a, b)
     check_array_equal(pyth_a, epyc_a)
@@ -3515,9 +3515,9 @@ def test_copy_to_slice_2(language):
     pyth_f = arrays.copy_to_slice_2
     epyc_f = epyccel(pyth_f, language = language)
 
-    pyth_a = np.arange(20, dtype=float).reshape(2,10)
+    pyth_a = np.arange(20, dtype=float).reshape(2, 10)
     epyc_a = pyth_a.copy()
-    b = np.arange(20,28, dtype=float)
+    b = np.arange(20, 28, dtype=float)
     pyth_f(pyth_a, b)
     epyc_f(epyc_a, b)
     check_array_equal(pyth_a, epyc_a)
@@ -3526,9 +3526,9 @@ def test_copy_to_slice_3(language):
     pyth_f = arrays.copy_to_slice_3
     epyc_f = epyccel(pyth_f, language = language)
 
-    pyth_a = np.arange(20, dtype=float).reshape(4,5)
+    pyth_a = np.arange(20, dtype=float).reshape(4, 5)
     epyc_a = pyth_a.copy()
-    b = np.arange(20,24, dtype=float)
+    b = np.arange(20, 24, dtype=float)
     pyth_f(pyth_a, b)
     epyc_f(epyc_a, b)
     check_array_equal(pyth_a, epyc_a)
@@ -3539,7 +3539,7 @@ def test_copy_to_slice_4(language):
 
     pyth_a = np.arange(10, dtype=float)
     epyc_a = pyth_a.copy()
-    b = np.arange(20,25, dtype=float)
+    b = np.arange(20, 25, dtype=float)
     pyth_f(pyth_a, b)
     epyc_f(epyc_a, b)
     check_array_equal(pyth_a, epyc_a)

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -3489,6 +3489,62 @@ def test_array_2d_C_slice_stride_23(language):
     assert f1(a) == f2(a)
 
 #==============================================================================
+# TEST : Slice assignment
+#==============================================================================
+def test_copy_to_slice_issue_1218(language):
+    pyth_f = arrays.copy_to_slice_issue_1218
+    epyc_f = epyccel(pyth_f, language = language)
+
+    n = 10
+    pyth_arr = pyth_f(n)
+    epyc_arr = epyc_f(n)
+    check_array_equal(pyth_arr, epyc_arr)
+
+def test_copy_to_slice_1(language):
+    pyth_f = arrays.copy_to_slice_1
+    epyc_f = epyccel(pyth_f, language = language)
+
+    pyth_a = np.arange(10, dtype=float)
+    epyc_a = pyth_a.copy()
+    b = np.arange(20,28, dtype=float)
+    pyth_f(pyth_a, b)
+    epyc_f(epyc_a, b)
+    check_array_equal(pyth_a, epyc_a)
+
+def test_copy_to_slice_2(language):
+    pyth_f = arrays.copy_to_slice_2
+    epyc_f = epyccel(pyth_f, language = language)
+
+    pyth_a = np.arange(20, dtype=float).reshape(2,10)
+    epyc_a = pyth_a.copy()
+    b = np.arange(20,28, dtype=float)
+    pyth_f(pyth_a, b)
+    epyc_f(epyc_a, b)
+    check_array_equal(pyth_a, epyc_a)
+
+def test_copy_to_slice_3(language):
+    pyth_f = arrays.copy_to_slice_3
+    epyc_f = epyccel(pyth_f, language = language)
+
+    pyth_a = np.arange(20, dtype=float).reshape(4,5)
+    epyc_a = pyth_a.copy()
+    b = np.arange(20,24, dtype=float)
+    pyth_f(pyth_a, b)
+    epyc_f(epyc_a, b)
+    check_array_equal(pyth_a, epyc_a)
+
+def test_copy_to_slice_4(language):
+    pyth_f = arrays.copy_to_slice_4
+    epyc_f = epyccel(pyth_f, language = language)
+
+    pyth_a = np.arange(10, dtype=float)
+    epyc_a = pyth_a.copy()
+    b = np.arange(20,25, dtype=float)
+    pyth_f(pyth_a, b)
+    epyc_f(epyc_a, b)
+    check_array_equal(pyth_a, epyc_a)
+
+#==============================================================================
 # TEST : arithmetic operations
 #==============================================================================
 


### PR DESCRIPTION
Fix assigning an array to a slice and add tests. Fixes #1218

This is achieved by fixing the indexing in the case where the variable on the left-hand side of the assignment has a higher rank than the variable on the right hand side.