### PR TITLE
Allow printing of parameters in Fortran

### DIFF
--- a/pyccel/ast/cmathext.py
+++ b/pyccel/ast/cmathext.py
@@ -12,7 +12,7 @@ from pyccel.ast.core      import PyccelFunctionDef, Module
 from pyccel.ast.datatypes import PythonNativeBool, PythonNativeFloat, PythonNativeComplex
 from pyccel.ast.datatypes import PrimitiveComplexType
 from pyccel.ast.internals import PyccelInternalFunction
-from pyccel.ast.literals  import LiteralInteger
+from pyccel.ast.literals  import LiteralInteger, LiteralComplex
 from pyccel.ast.operators import PyccelAnd, PyccelOr
 from pyccel.ast.variable  import Constant
 
@@ -475,8 +475,8 @@ cmath_functions = [PyccelFunctionDef(v.name, v) for v in
             CmathPolar, CmathRect, CmathSin, CmathSinh, CmathSqrt, CmathTan, CmathTanh)]
 
 cmath_constants = { **math_constants,
-    'infj': Constant(PythonNativeComplex(), 'infj', value=cmath.infj),
-    'nanj': Constant(PythonNativeComplex(), 'nanj', value=cmath.nanj),
+    'infj': Constant(PythonNativeComplex(), 'infj', value=LiteralComplex(0.0, cmath.infj.imag)),
+    'nanj': Constant(PythonNativeComplex(), 'nanj', value=LiteralComplex(0.0, cmath.nanj.imag)),
     }
 
 cmath_mod = Module('cmath',

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -30,7 +30,7 @@ from .literals  import NilArgument, LiteralTrue
 from .operators import PyccelAdd, PyccelMinus, PyccelMul, PyccelDiv, PyccelMod
 from .operators import PyccelOperator, PyccelAssociativeParenthesis, PyccelIs
 
-from .variable import DottedName, IndexedElement
+from .variable import DottedName, IndexedElement, Constant
 from .variable import Variable, AnnotatedPyccelSymbol
 
 errors = Errors()
@@ -4001,6 +4001,8 @@ class Declare(PyccelAstNode):
         self._static = static
         self._external = external
         self._module_variable = module_variable
+        if isinstance(variable, Constant):
+            self._value = variable.value
         super().__init__()
 
     @property

--- a/pyccel/ast/mathext.py
+++ b/pyccel/ast/mathext.py
@@ -10,6 +10,7 @@ import math
 from pyccel.ast.core      import PyccelFunctionDef, Module
 from pyccel.ast.datatypes import PythonNativeInt, PythonNativeBool, PythonNativeFloat
 from pyccel.ast.internals import PyccelInternalFunction
+from pyccel.ast.literals  import LiteralFloat
 from pyccel.ast.variable  import Constant
 
 __all__ = (
@@ -943,11 +944,11 @@ math_functions = [PyccelFunctionDef(v.name, v) for k, v in globals().copy().item
 # Constants
 #==============================================================================
 math_constants = {
-    'e'  : Constant(PythonNativeFloat(), 'e'  , value=math.e  ),
-    'pi' : Constant(PythonNativeFloat(), 'pi' , value=math.pi ),
-    'inf': Constant(PythonNativeFloat(), 'inf', value=math.inf),
-    'nan': Constant(PythonNativeFloat(), 'nan', value=math.nan),
-    'tau': Constant(PythonNativeFloat(), 'tau', value=2.*math.pi),
+    'e'  : Constant(PythonNativeFloat(), 'e'  , value=LiteralFloat(math.e)  ),
+    'pi' : Constant(PythonNativeFloat(), 'pi' , value=LiteralFloat(math.pi) ),
+    'inf': Constant(PythonNativeFloat(), 'inf', value=LiteralFloat(math.inf)),
+    'nan': Constant(PythonNativeFloat(), 'nan', value=LiteralFloat(math.nan)),
+    'tau': Constant(PythonNativeFloat(), 'tau', value=LiteralFloat(2.*math.pi)),
 }
 
 math_mod = Module('math',

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -2573,7 +2573,7 @@ numpy_random_mod = Module('random', (),
      PyccelFunctionDef('randint', NumpyRandint)])
 
 numpy_constants = {
-        'pi': Constant(PythonNativeFloat(), 'pi', value=numpy.pi),
+        'pi': Constant(PythonNativeFloat(), 'pi', value=LiteralFloat(numpy.pi)),
     }
 
 numpy_funcs = {

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -383,6 +383,9 @@ class PyccelUnarySub(PyccelUnary):
     def __repr__(self):
         return f'-{repr(self.args[0])}'
 
+    def __index__(self):
+        return -self.args[0]
+
 #==============================================================================
 
 class PyccelNot(PyccelUnaryOperator):

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -384,7 +384,7 @@ class PyccelUnarySub(PyccelUnary):
         return f'-{repr(self.args[0])}'
 
     def __index__(self):
-        return -self.args[0]
+        return -int(self.args[0])
 
 #==============================================================================
 

--- a/pyccel/ast/scipyext.py
+++ b/pyccel/ast/scipyext.py
@@ -9,11 +9,12 @@
 from numpy import pi
 from .core import Module, Import
 from .datatypes import PythonNativeFloat
+from .literals import LiteralFloat
 from .variable import Constant
 
 __all__ = ('scipy_mod', 'scipy_pi_const')
 
-scipy_pi_const = Constant(PythonNativeFloat(), 'pi', value=pi)
+scipy_pi_const = Constant(PythonNativeFloat(), 'pi', value=LiteralFloat(pi))
 
 scipy_mod = Module('scipy',
         variables = (scipy_pi_const,),

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -19,10 +19,11 @@ from .core          import (AsName, Import, FunctionDef, FunctionCall,
 from .builtins      import (builtin_functions_dict,
                             PythonRange, PythonList, PythonTuple)
 from .cmathext      import cmath_mod
-from .datatypes     import HomogeneousTupleType, PythonNativeInt
+from .datatypes     import HomogeneousTupleType, PythonNativeInt, PrimitiveIntegerType
 from .internals     import PyccelInternalFunction, Slice
 from .itertoolsext  import itertools_mod
 from .literals      import LiteralInteger, LiteralEllipsis, Nil
+from .operators     import PyccelUnarySub
 from .mathext       import math_mod
 from .sysext        import sys_mod
 
@@ -31,7 +32,7 @@ from .numpyext      import (NumpyEmpty, NumpyArray, numpy_mod,
 from .operators     import PyccelAdd, PyccelMul, PyccelIs, PyccelArithmeticOperator
 from .scipyext      import scipy_mod
 from .typingext     import typing_mod
-from .variable      import (Variable, IndexedElement, InhomogeneousTupleVariable )
+from .variable      import Variable, IndexedElement, InhomogeneousTupleVariable, Constant
 
 from .c_concepts import ObjectAddress
 
@@ -755,3 +756,26 @@ def expand_to_loops(block, new_index, scope, language_has_vectors = False):
     body = [bi for b in body for bi in b]
 
     return body
+
+#==============================================================================
+def is_literal_integer(expr):
+    """
+    Determine whether the expression is a literal integer.
+
+    Determine whether the expression is a literal integer. A literal integer
+    can be described by a LiteralInteger, a PyccelUnarySub(LiteralInteger) or
+    a Constant.
+
+    Parameters
+    ----------
+    expr : object
+        Any Python object which should be analysed to determine whether it is an integer.
+
+    Returns
+    -------
+    bool
+        True if the object represents a literal integer, false otherwise.
+    """
+    return isinstance(a, (int, LiteralInteger)) or \
+        (isinstance(a, PyccelUnarySub) and isinstance(a.args[0], (int, LiteralInteger))) or \
+        (isinstance(a, Constant) and isinstance(a.dtype.primitive_type, PrimitiveIntegerType))

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -12,25 +12,23 @@ from collections import namedtuple
 import pyccel.decorators as pyccel_decorators
 from pyccel.errors.errors import Errors, PyccelError
 
+from .builtins      import (builtin_functions_dict, PythonLen, PythonAbs,
+                            PythonRange, PythonList, PythonTuple)
 from .core          import (AsName, Import, FunctionDef, FunctionCall,
                             Allocate, Duplicate, Assign, For, CodeBlock,
                             Concatenate, Module, PyccelFunctionDef)
-
-from .builtins      import (builtin_functions_dict, PythonLen, PythonAbs,
-                            PythonRange, PythonList, PythonTuple)
 from .cmathext      import cmath_mod
 from .datatypes     import HomogeneousTupleType, PythonNativeInt, PrimitiveIntegerType
 from .internals     import PyccelInternalFunction, Slice, PyccelArrayShapeElement
 from .itertoolsext  import itertools_mod
 from .literals      import LiteralInteger, LiteralEllipsis, Nil
-from .operators     import PyccelUnarySub
 from .mathext       import math_mod
-from .sysext        import sys_mod
-
 from .numpyext      import (NumpyEmpty, NumpyArray, numpy_mod, NumpyAbs,
                             NumpyTranspose, NumpyLinspace)
 from .operators     import PyccelAdd, PyccelMul, PyccelIs, PyccelArithmeticOperator
+from .operators     import PyccelUnarySub, PyccelMinus
 from .scipyext      import scipy_mod
+from .sysext        import sys_mod
 from .typingext     import typing_mod
 from .variable      import Variable, IndexedElement, InhomogeneousTupleVariable, Constant
 
@@ -791,12 +789,13 @@ def get_expression_sign(expr):
     is 1. If the expression is known to be negative then the return value is -1.
     If nothing is known about the sign of the expression the return value is None.
     """
+    positive_types = (PyccelArrayShapeElement, PythonLen, NumpyAbs, PythonAbs)
     try:
         sign = int(expr)
     except TypeError:
-        if isinstance(expr, (PyccelArrayShapeElement, PythonLen, NumpyAbs, PythonAbs)):
+        if isinstance(expr, positive_types):
             sign = 1
-        elif isinstance(expr, UnarySub) and isinstance(expr.args[0], positive_types):
+        elif isinstance(expr, PyccelUnarySub) and isinstance(expr.args[0], positive_types):
             sign = -1
         else:
             sign = None

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -792,6 +792,8 @@ class Constant(Variable):
         value = str(self.value)
         return '{0}={1}'.format(name, value)
 
+    def __index__(self):
+        return self.value.__index__()
 
 
 class IndexedElement(TypedAstNode):

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -16,7 +16,7 @@ from .basic     import PyccelAstNode, TypedAstNode
 from .datatypes import PyccelType
 from .internals import PyccelArrayShapeElement, Slice, PyccelSymbol
 from .internals import apply_pickle
-from .literals  import LiteralInteger, Nil, LiteralEllipsis
+from .literals  import LiteralInteger, LiteralEllipsis, Literal
 from .operators import (PyccelMinus, PyccelDiv, PyccelMul,
                         PyccelUnarySub, PyccelAdd)
 from .numpytypes import NumpyNDArrayType
@@ -758,7 +758,7 @@ class Constant(Variable):
     *args : tuple
         See pyccel.ast.variable.Variable.
 
-    value : bool|int|float|complex
+    value : Literal
         The value that the constant represents.
 
     **kwargs : dict
@@ -777,6 +777,7 @@ class Constant(Variable):
     _attribute_nodes = ()
 
     def __init__(self, *args, value, **kwargs):
+        assert isinstance(value, Literal)
         self._value = value
         super().__init__(*args, **kwargs)
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -795,6 +795,9 @@ class Constant(Variable):
     def __index__(self):
         return self.value.__index__()
 
+    def __eq__(self, other):
+        return self.value == other
+
 
 class IndexedElement(TypedAstNode):
     """

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -776,7 +776,7 @@ class Constant(Variable):
     # The value of a constant is not a translated object
     _attribute_nodes = ()
 
-    def __init__(self, *args, value = Nil(), **kwargs):
+    def __init__(self, *args, value, **kwargs):
         self._value = value
         super().__init__(*args, **kwargs)
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -798,6 +798,9 @@ class Constant(Variable):
     def __eq__(self, other):
         return self.value == other
 
+    def __hash__(self):
+        return hash((type(self).__name__, self._name))
+
 
 class IndexedElement(TypedAstNode):
     """

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1062,7 +1062,7 @@ class FCodePrinter(CodePrinter):
         else:
             v = self._print(expr.stop)
 
-        if not isinstance(expr.endpoint, LiteralFalse):
+        if expr.endpoint != LiteralFalse():
             lhs = expr.get_user_nodes(Assign)[0].lhs
 
 
@@ -1077,7 +1077,7 @@ class FCodePrinter(CodePrinter):
                                                  PyccelMinus(expr.num, LiteralInteger(1),
                                                  simplify = True)))
 
-            if isinstance(expr.endpoint, LiteralTrue):
+            if expr.endpoint == LiteralTrue():
                 cond_template = lhs + ' = {stop}'
             else:
                 cond_template = lhs + ' = merge({stop}, {lhs}, ({cond}))'
@@ -1096,9 +1096,9 @@ class FCodePrinter(CodePrinter):
             end   = self._print(PyccelMinus(expr.num, LiteralInteger(1), simplify = True)),
         )
 
-        if isinstance(expr.endpoint, LiteralFalse):
+        if expr.endpoint == LiteralFalse():
             code = init_value
-        elif isinstance(expr.endpoint, LiteralTrue):
+        elif expr.endpoint == LiteralTrue():
             code = init_value + '\n' + cond_template.format(stop=v)
         else:
             code = init_value + '\n' + cond_template.format(stop=v, lhs=lhs, cond=self._print(expr.endpoint))

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -534,6 +534,8 @@ class FCodePrinter(CodePrinter):
         # ...
 
         declarations = list(expr.declarations)
+        builtin_constants = set(c for c in expr.get_attribute_nodes(Constant) if c not in declarations)
+        declarations += [Declare(c) for c in builtin_constants if c in expr.scope.imports['variables'].values()]
         # look for external functions and declare their result type
         self._get_external_declarations(declarations)
         decs += ''.join(self._print(d) for d in declarations)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -66,6 +66,7 @@ from pyccel.ast.utilities import builtin_import_registry as pyccel_builtin_impor
 from pyccel.ast.utilities import expand_to_loops
 
 from pyccel.ast.variable import Variable, IndexedElement, InhomogeneousTupleVariable, DottedName
+from pyccel.ast.variable import Constant
 
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import *
@@ -961,10 +962,6 @@ class FCodePrinter(CodePrinter):
         else:
             return '{}'.format(self._print(expr.value))
 
-    def _print_Constant(self, expr):
-        val = LiteralFloat(expr.value)
-        return self._print(val)
-
     def _print_DottedVariable(self, expr):
         if isinstance(expr.lhs, FunctionCall):
             base = expr.lhs.funcdef.results[0].var
@@ -1541,6 +1538,7 @@ class FCodePrinter(CodePrinter):
         privatestr     = ''
         rankstr        = ''
         externalstr    = ''
+        parameterstr   = ''
 
         # Compute intent string
         if intent:
@@ -1576,6 +1574,9 @@ class FCodePrinter(CodePrinter):
         if is_external:
             externalstr = ', external'
 
+        if isinstance(var, Constant):
+            parameterstr = ', parameter'
+
         # Compute rank string
         # TODO: improve
         if ((rank == 1) and (isinstance(shape, (int, TypedAstNode))) and (is_static or on_stack)):
@@ -1607,7 +1608,7 @@ class FCodePrinter(CodePrinter):
             mod_str = ', bind(c)'
 
         # Construct declaration
-        left  = dtype + allocatablestr + optionalstr + privatestr + externalstr + mod_str + intentstr
+        left  = dtype + allocatablestr + optionalstr + privatestr + externalstr + mod_str + intentstr + parameterstr
         right = vstr + rankstr + code_value
         return '{} :: {}\n'.format(left, right)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3300,7 +3300,7 @@ class SemanticParser(BasicParser):
             self._ensure_inferred_type_matches_existing(d_var.pop('class_type'), d_var, semantic_lhs_var, False, new_expressions, rhs)
 
             if semantic_lhs_var.is_const and isinstance(rhs, Literal):
-                lhs = semantic_lhs_var.clone(lhs.name, new_class = Constant, value=rhs.python_value)
+                lhs = semantic_lhs_var.clone(lhs.name, new_class = Constant, value=rhs)
 
             if isinstance(lhs, DottedVariable):
                 cls_def = lhs.lhs.cls_base
@@ -3312,6 +3312,9 @@ class SemanticParser(BasicParser):
                 insert_scope.insert_variable(lhs)
             except RuntimeError as e:
                 errors.report(e, symbol=expr, severity='error')
+
+            if isinstance(lhs, Constant):
+                return EmptyNode()
 
         elif isinstance(lhs, (PyccelSymbol, DottedName)):
             lhs = self._assign_lhs_variable(lhs, d_var, rhs, new_expressions, isinstance(expr, AugAssign))


### PR DESCRIPTION
Allow the printing of constants as `parameter` in Fortran. Use this improvement to avoid unnecessary sign checks when using negative indices.

_Blocked by #1120_