### PR TITLE
Deprecate 'real' and 'integer' type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 
 ### Deprecated
 
+-   #1786 : Remove support for `real` and `integer` as type annotations.
 -   \[INTERNALS\] Remove property `ast.basic.TypedAstNode.precision`.
 -   \[INTERNALS\] Remove class `ast.datatypes.DataType` (replaced by `ast.datatypes.PrimitiveType` and `ast.datatypes.PyccelType`).
 -   \[INTERNALS\] Remove unused properties `prefix` and `alias` from `CustomDataType`.

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -339,10 +339,8 @@ class SyntacticTypeAnnotation(PyccelAstNode):
 
 typenames_to_dtypes = { 'float'   : PythonNativeFloat(),
                         'double'  : PythonNativeFloat(),
-                        'real'    : PythonNativeFloat(),
                         'complex' : PythonNativeComplex(),
                         'int'     : PythonNativeInt(),
-                        'integer' : PythonNativeInt(),
                         'bool'    : PythonNativeBool(),
                         'b1'      : PythonNativeBool(),
                         'void'    : VoidType(),


### PR DESCRIPTION
Deprecate 'real' and 'integer' type annotations. Fixes https://github.com/pyccel/pyccel/issues/1786