### PR TITLE
Use yaml file instead of deprecated .docstr_coverage file

### DIFF
--- a/.docstr.yaml
+++ b/.docstr.yaml
@@ -1,6 +1,3 @@
-paths:
-  - pyccel
-  - ci_tools
 skip_magic: True
 skip_init: True
 fail_under: 0

--- a/.docstr.yaml
+++ b/.docstr.yaml
@@ -2,9 +2,9 @@ skip_magic: True
 skip_init: True
 fail_under: 0
 ignore_patterns:
-  ".*/pyccel/parser/syntactic.py":
-    - "SyntaxParser._visit_.*"
-  ".*/pyccel/parser/semantic.py":
+  "syntactic":
     - "_visit_.*"
-  ".*/pyccel/codegen/printing/.*code.py":
+  "semantic":
+    - "_visit_.*"
+  ".*code":
     - "_print_.*"

--- a/.docstr.yaml
+++ b/.docstr.yaml
@@ -2,9 +2,9 @@ skip_magic: True
 skip_init: True
 fail_under: 0
 ignore_patterns:
-  pyccel/parser/syntactic.py:
+  ".*/pyccel/parser/syntactic.py":
+    - "SyntaxParser._visit_.*"
+  ".*/pyccel/parser/semantic.py":
     - "_visit_.*"
-  pyccel/parser/semantic.py:
-    - "_visit_.*"
-  pyccel/codegen/printing/*code.py:
+  ".*/pyccel/codegen/printing/.*code.py":
     - "_print_.*"

--- a/.docstr.yaml
+++ b/.docstr.yaml
@@ -1,0 +1,13 @@
+paths:
+  - pyccel
+  - ci_tools
+skip_magic: True
+skip_init: True
+fail_under: 0
+ignore_patterns:
+  pyccel/parser/syntactic.py:
+    - "_visit_.*"
+  pyccel/parser/semantic.py:
+    - "_visit_.*"
+  pyccel/codegen/printing/*code.py:
+    - "_print_.*"

--- a/.docstr_coverage
+++ b/.docstr_coverage
@@ -1,3 +1,0 @@
-.*code _print_.*
-semantic _visit_.*
-syntactic _visit_.*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,8 +74,7 @@ jobs:
       - name: Check doc coverage
         id: doc_coverage
         run: |
-          docstr-coverage --skip-magic --skip-init --fail-under=0 --docstr-ignore-file=base/.docstr_coverage base/pyccel base/ci_tools 2>&1 | tee base_cov
-          #docstr-coverage --config=base/.docstr.yaml base/pyccel base/ci_tools 2>&1 | tee base_cov
+          docstr-coverage --config=base/.docstr.yaml base/pyccel base/ci_tools 2>&1 | tee base_cov
           docstr-coverage --config=compare/.docstr.yaml compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
           export PYTHONPATH=compare
           python compare/ci_tools/summarise_doccoverage.py compare_cov base_cov $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,8 +75,8 @@ jobs:
         id: doc_coverage
         run: |
           echo "${{ github.event.pull_request.base.sha }}"
-          docstr-coverage --config=base/.docstr.yaml 2>&1 | tee base_cov
-          docstr-coverage --config=compare/..docstr.yaml 2>&1 | tee compare_cov
+          docstr-coverage --config=base/.docstr.yaml base/pyccel base/ci_tools 2>&1 | tee base_cov
+          docstr-coverage --config=compare/..docstr.yaml compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
           export PYTHONPATH=compare
           python compare/ci_tools/summarise_doccoverage.py compare_cov base_cov $GITHUB_STEP_SUMMARY
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,7 +77,7 @@ jobs:
           echo "----------------------------------------------------------- Checking base -------------------------------------------------------------------------"
           docstr-coverage --skip-magic --skip-init --fail-under=0 --docstr-ignore-file=base/.docstr_coverage base/pyccel base/ci_tools 2>&1 | tee base_cov
           echo "----------------------------------------------------------- Checking head -------------------------------------------------------------------------"
-          docstr-coverage --config=compare/..docstr.yaml compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
+          docstr-coverage --config=compare/.docstr.yaml compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
           echo "----------------------------------------------------------- Done -------------------------------------------------------------------------"
           export PYTHONPATH=compare
           python compare/ci_tools/summarise_doccoverage.py compare_cov base_cov $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,11 +74,8 @@ jobs:
       - name: Check doc coverage
         id: doc_coverage
         run: |
-          echo "----------------------------------------------------------- Checking base -------------------------------------------------------------------------"
-          docstr-coverage --skip-magic --skip-init --fail-under=0 --docstr-ignore-file=base/.docstr_coverage base/pyccel base/ci_tools 2>&1 | tee base_cov
-          echo "----------------------------------------------------------- Checking head -------------------------------------------------------------------------"
+          docstr-coverage --config=base/.docstr.yaml base/pyccel base/ci_tools 2>&1 | tee base_cov
           docstr-coverage --config=compare/.docstr.yaml compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
-          echo "----------------------------------------------------------- Done -------------------------------------------------------------------------"
           export PYTHONPATH=compare
           python compare/ci_tools/summarise_doccoverage.py compare_cov base_cov $GITHUB_STEP_SUMMARY
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,7 +74,8 @@ jobs:
       - name: Check doc coverage
         id: doc_coverage
         run: |
-          docstr-coverage --config=base/.docstr.yaml base/pyccel base/ci_tools 2>&1 | tee base_cov
+          docstr-coverage --skip-magic --skip-init --fail-under=0 --docstr-ignore-file=base/.docstr_coverage base/pyccel base/ci_tools 2>&1 | tee base_cov
+          #docstr-coverage --config=base/.docstr.yaml base/pyccel base/ci_tools 2>&1 | tee base_cov
           docstr-coverage --config=compare/.docstr.yaml compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
           export PYTHONPATH=compare
           python compare/ci_tools/summarise_doccoverage.py compare_cov base_cov $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,7 @@ jobs:
         id: doc_coverage
         run: |
           echo "${{ github.event.pull_request.base.sha }}"
-          docstr-coverage --config=base/.docstr.yaml base/pyccel base/ci_tools 2>&1 | tee base_cov
+          docstr-coverage --skip-magic --skip-init --fail-under=0 --docstr-ignore-file=base/.docstr_coverage base/pyccel base/ci_tools 2>&1 | tee base_cov
           docstr-coverage --config=compare/..docstr.yaml compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
           export PYTHONPATH=compare
           python compare/ci_tools/summarise_doccoverage.py compare_cov base_cov $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,9 +74,11 @@ jobs:
       - name: Check doc coverage
         id: doc_coverage
         run: |
-          echo "${{ github.event.pull_request.base.sha }}"
+          echo "----------------------------------------------------------- Checking base -------------------------------------------------------------------------"
           docstr-coverage --skip-magic --skip-init --fail-under=0 --docstr-ignore-file=base/.docstr_coverage base/pyccel base/ci_tools 2>&1 | tee base_cov
+          echo "----------------------------------------------------------- Checking head -------------------------------------------------------------------------"
           docstr-coverage --config=compare/..docstr.yaml compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
+          echo "----------------------------------------------------------- Done -------------------------------------------------------------------------"
           export PYTHONPATH=compare
           python compare/ci_tools/summarise_doccoverage.py compare_cov base_cov $GITHUB_STEP_SUMMARY
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,8 +75,8 @@ jobs:
         id: doc_coverage
         run: |
           echo "${{ github.event.pull_request.base.sha }}"
-          docstr-coverage --skip-magic --skip-init --fail-under=0 --docstr-ignore-file=base/.docstr_coverage base/pyccel base/ci_tools 2>&1 | tee base_cov
-          docstr-coverage --skip-magic --skip-init --fail-under=0 --docstr-ignore-file=compare/.docstr_coverage compare/pyccel compare/ci_tools 2>&1 | tee compare_cov
+          docstr-coverage --config=base/.docstr.yaml 2>&1 | tee base_cov
+          docstr-coverage --config=compare/..docstr.yaml 2>&1 | tee compare_cov
           export PYTHONPATH=compare
           python compare/ci_tools/summarise_doccoverage.py compare_cov base_cov $GITHUB_STEP_SUMMARY
         shell: bash


### PR DESCRIPTION
According to the docstring of `docstr-coverage`, the flag `--docstr-ignore-file` is deprecated. A json config file should be used instead. This PR updates our methodology to use that flag