### PR TITLE
Improve Windows install

### DIFF
--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -52,10 +52,8 @@ runs:
         curl https://github.com/microsoft/Microsoft-MPI/releases/download/v10.1.1/msmpisdk.msi -o msmpisdk.msi
         #
         # Install MS MPI
-        ./msmpisetup.exe -unattend -verbose
-        sleep 30
-        msiexec /quiet /i msmpisdk.msi
-        sleep 1
+        Start-Process msmpisetup.exe -Wait -ArgumentList '-unattend -verbose'
+￼       Start-Process msiexec -Wait -ArgumentList '/quiet /i msmpisdk.msi'
         echo "MS MPI runtime and SDK installed"
       shell: powershell
     - name: Setup MPI

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -53,7 +53,7 @@ runs:
         #
         # Install MS MPI
         Start-Process msmpisetup.exe -Wait -ArgumentList '-unattend -verbose'
-￼       Start-Process msiexec -Wait -ArgumentList '/quiet /i msmpisdk.msi'
+        Start-Process msiexec -Wait -ArgumentList '/quiet /i msmpisdk.msi'
         echo "MS MPI runtime and SDK installed"
       shell: powershell
     - name: Setup MPI


### PR DESCRIPTION
The windows installation uses a `sleep` command because we were unsure how to wait for the executable to finish and also prevent it from asking the user for input. This probably leads to the CI being slower than necessary and definitely occasionally leads to the CI crashing when the executable takes longer than we hoped. This PR is derived from #1180 where I found the necessary commands to wait for the execution.