### PR TITLE
Fix fstring errors in pyccel.ast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Remove class `ast.datatypes.DataType` (replaced by `ast.datatypes.PrimitiveType` and `ast.datatypes.PyccelType`).
 -   \[INTERNALS\] Remove unused properties `prefix` and `alias` from `CustomDataType`.
 -   \[INTERNALS\] Remove `ast.basic.TypedAstNode._dtype`. The datatype can still be accessed as it is contained within the class type.
+-   \[INTERNALS\] Removed unused and undocumented function `get_function_from_ast`.
 
 ## \[1.11.2\] - 2024-03-05
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -112,6 +112,13 @@ class AsName(PyccelAstNode):
     A class representing the renaming of an object such as a function or a
     variable. This usually occurs during an Import.
 
+    Parameters
+    ----------
+    obj : PyccelAstNode or PyccelAstNodeType
+        The variable, function, or module being renamed.
+    target : str
+        Name of variable or function in this context.
+
     Examples
     --------
     >>> from pyccel.ast.core import AsName, FunctionDef
@@ -121,13 +128,6 @@ class AsName(PyccelAstNode):
     old as new
     >>> AsName(NumpyFull, 'fill_func')
     full as fill_func
-
-    Parameters
-    ----------
-    obj : PyccelAstNode or PyccelAstNodeType
-        The variable, function, or module being renamed.
-    target : str
-        Name of variable or function in this context.
     """
     __slots__ = ('_obj', '_target')
     _attribute_nodes = ()
@@ -2172,7 +2172,7 @@ class Return(PyccelAstNode):
     expr : TypedAstNode
         The expression to return.
 
-    stmts : PyccelAstNode
+    stmt : PyccelAstNode
         Any assign statements in the case of expression return.
     """
     __slots__ = ('_expr', '_stmt')

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -106,9 +106,11 @@ __all__ = (
 
 
 class AsName(PyccelAstNode):
-
     """
-    Represents a renaming of a variable, used with Import.
+    Represents a renaming of an object, used with Import.
+
+    A class representing the renaming of an object such as a function or a
+    variable. This usually occurs during an Import.
 
     Examples
     --------
@@ -121,11 +123,11 @@ class AsName(PyccelAstNode):
     full as fill_func
 
     Parameters
-    ==========
-    obj    : PyccelAstNode or PyccelAstNodeType
-             The variable, function, or module being renamed
+    ----------
+    obj : PyccelAstNode or PyccelAstNodeType
+        The variable, function, or module being renamed.
     target : str
-             name of variable or function in this context
+        Name of variable or function in this context.
     """
     __slots__ = ('_obj', '_target')
     _attribute_nodes = ()
@@ -531,6 +533,8 @@ class Allocate(PyccelAstNode):
 #------------------------------------------------------------------------------
 class Deallocate(PyccelAstNode):
     """
+    Class representing memory deallocation.
+
     Represents memory deallocation (usually of an array) for code generation.
     This is relevant to low-level target languages, such as C or Fortran,
     where the programmer must take care of heap memory deallocation.
@@ -544,7 +548,6 @@ class Deallocate(PyccelAstNode):
     -----
     An object of this class is immutable, although it contains a reference to a
     mutable Variable object.
-
     """
     __slots__ = ('_variable',)
     _attribute_nodes = ('_variable',)
@@ -767,7 +770,7 @@ class SymbolicAssign(PyccelAstNode):
         super().__init__()
 
     def __str__(self):
-        return f'{self.lhs} := {self.rhs}'
+        return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
 
     @property
     def lhs(self):
@@ -3708,19 +3711,23 @@ class ClassDef(ScopedAstNode):
 
 
 class Import(PyccelAstNode):
+    """
+    Represents inclusion of dependencies in the code.
 
-    """Represents inclusion of dependencies in the code.
+    Represents the importation of targets from another source code. This is
+    usually used to represent an import statement in the original code but
+    it is also used to import language/library specific dependencies.
 
     Parameters
     ----------
     source : str, DottedName, AsName
-        the module from which we import
+        The module from which we import.
     target : str, AsName, list, tuple
-        targets to import
+        Targets to import.
     ignore_at_print : bool
-        indicates whether the import should be printed
+        Indicates whether the import should be printed.
     mod : Module
-        The module describing the source
+        The module describing the source.
 
     Examples
     --------
@@ -3769,6 +3776,28 @@ class Import(PyccelAstNode):
 
     @staticmethod
     def _format(i):
+        """
+        Format a string passed to this file into a Pyccel object.
+
+        Format a string passed to this file into a Pyccel object or confirm
+        that it is already correctly formatted.
+
+        Parameters
+        ----------
+        i : obj
+            The object to be formatted.
+
+        Returns
+        -------
+        DottedName | PyccelSymbol | AsName
+            The formatted object.
+
+        Raises
+        ------
+        TypeError
+            Raised if the input is not a string or one of the acceptable
+            output types.
+        """
         if isinstance(i, str):
             if '.' in i:
                 return DottedName(*i.split('.'))

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2208,7 +2208,7 @@ class Return(PyccelAstNode):
         else:
             code = ''
         exprs = ','.join(repr(e) for e in self.expr)
-        return code+"Return({exprs})"
+        return code+f"Return({exprs})"
 
 class FunctionDef(ScopedAstNode):
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -10,7 +10,6 @@ from pyccel.errors.errors     import Errors
 from pyccel.errors.messages   import RECURSIVE_RESULTS_REQUIRED
 
 from pyccel.utilities.stage   import PyccelStage
-from pyccel.utilities.strings import create_incremented_string
 
 from .basic     import PyccelAstNode, TypedAstNode, iterable, ScopedAstNode
 from .builtins  import (PythonEnumerate, PythonLen, PythonMap, PythonTuple,

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -4424,13 +4424,15 @@ class IfSection(PyccelAstNode):
         return f"IfSec({self.condition}, {self.body})"
 
 class If(PyccelAstNode):
+    """
+    Represents an if statement in the code.
 
-    """Represents a if statement in the code.
+    Represents an if statement in the code.
 
     Parameters
     ----------
-    args : IfSection
-           All arguments are sections of the complete If block
+    *args : IfSection
+        All arguments are sections of the complete If block.
 
     Examples
     --------

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2162,15 +2162,18 @@ class ConstructorCall(FunctionCall):
 
 
 class Return(PyccelAstNode):
+    """
+    Represents a return statement in a function in the code.
 
-    """Represents a function return in the code.
+    Represents a return statement in a function in the code.
 
     Parameters
     ----------
     expr : TypedAstNode
         The expression to return.
 
-    stmts :represent assign stmts in the case of expression return
+    stmts : PyccelAstNode
+        Any assign statements in the case of expression return.
     """
     __slots__ = ('_expr', '_stmt')
     _attribute_nodes = ('_expr', '_stmt')
@@ -4097,7 +4100,7 @@ class SymbolicPrint(PyccelAstNode):
         for i in expr:
             if not isinstance(i, (Lambda, SymbolicAssign,
                               SympyFunction)):
-                raise TypeError(f'Expecting Lambda, SymbolicAssign, SympyFunction for {i}')
+                raise TypeError('Expecting Lambda, SymbolicAssign, SympyFunction for {}'.format(i))
 
         self._expr = expr
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3787,7 +3787,7 @@ class Import(PyccelAstNode):
 
         Parameters
         ----------
-        i : obj
+        i : Any
             The object to be formatted.
 
         Returns

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -163,10 +163,7 @@ class AsName(PyccelAstNode):
         return self._obj
 
     def __repr__(self):
-        return '{0} as {1}'.format(str(self.name), str(self.target))
-
-    def __str__(self):
-        return '{0} as {1}'.format(str(self.name), str(self.target))
+        return f'{self.name} as {self.target}'
 
     def __eq__(self, string):
         if isinstance(string, str):
@@ -222,10 +219,10 @@ class Duplicate(TypedAstNode):
         return self._length
 
     def __str__(self):
-        return '{} * {}'.format(str(self.val), str(self.length))
+        return f'{self.val} * {self.length}'
 
     def __repr__(self):
-        return '{} * {}'.format(repr(self.val), repr(self.length))
+        return f'{repr(self.val)} * {repr(self.length)}'
 
 class Concatenate(TypedAstNode):
     """
@@ -332,10 +329,10 @@ class Assign(PyccelAstNode):
             self.set_current_ast(python_ast)
 
     def __str__(self):
-        return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
+        return f'{self.lhs} := {self.rhs}'
 
     def __repr__(self):
-        return '({0} := {1})'.format(repr(self.lhs), repr(self.rhs))
+        return f'{repr(self.lhs)} := {repr(self.rhs)}'
 
     @property
     def lhs(self):
@@ -439,14 +436,14 @@ class Allocate(PyccelAstNode):
     def __init__(self, variable, *, shape, order, status, like = None):
 
         if not isinstance(variable, (Variable, PointerCast)):
-            raise TypeError("Can only allocate a 'Variable' object, got {} instead".format(type(variable)))
+            raise TypeError(f"Can only allocate a 'Variable' object, got {type(variable)} instead")
 
         if variable.on_stack:
             # Variable may only be a pointer in the wrapper
             raise ValueError("Variable must be allocatable")
 
         if shape and not isinstance(shape, (int, tuple, list)):
-            raise TypeError("Cannot understand 'shape' parameter of type '{}'".format(type(shape)))
+            raise TypeError(f"Cannot understand 'shape' parameter of type '{type(shape)}'")
 
         if variable.rank != len(shape):
             raise ValueError("Incompatible rank in variable allocation")
@@ -456,10 +453,10 @@ class Allocate(PyccelAstNode):
             raise ValueError("Incompatible order in variable allocation")
 
         if not isinstance(status, str):
-            raise TypeError("Cannot understand 'status' parameter of type '{}'".format(type(status)))
+            raise TypeError(f"Cannot understand 'status' parameter of type '{type(status)}'")
 
         if status not in ('allocated', 'unallocated', 'unknown'):
-            raise ValueError("Value of 'status' not allowed: '{}'".format(status))
+            raise ValueError(f"Value of 'status' not allowed: '{status}'")
 
         self._variable = variable
         self._shape    = shape
@@ -518,8 +515,7 @@ class Allocate(PyccelAstNode):
         return self._like
 
     def __str__(self):
-        return 'Allocate({}, shape={}, order={}, status={})'.format(
-                str(self.variable), str(self.shape), str(self.order), str(self.status))
+        return f'Allocate({self.variable}, shape={self.shape}, order={self.order}, status={self.status})'
 
     def __eq__(self, other):
         if isinstance(other, Allocate):
@@ -558,7 +554,7 @@ class Deallocate(PyccelAstNode):
     def __init__(self, variable):
 
         if not isinstance(variable, Variable):
-            raise TypeError("Can only allocate a 'Variable' object, got {} instead".format(type(variable)))
+            raise TypeError(f"Can only allocate a 'Variable' object, got {type(variable)} instead")
 
         self._variable = variable
         super().__init__()
@@ -640,7 +636,7 @@ class CodeBlock(PyccelAstNode):
             self._body = tuple([*obj, *self.body])
 
     def __repr__(self):
-        return 'CodeBlock({})'.format(self.body)
+        return f'CodeBlock({self.body})'
 
     def __reduce_ex__(self, i):
         """ Used by pickle to create an object of this class.
@@ -731,7 +727,7 @@ class AliasAssign(PyccelAstNode):
         super().__init__()
 
     def __str__(self):
-        return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
+        return f'{self.lhs} := {self.rhs}'
 
     @property
     def lhs(self):
@@ -772,7 +768,7 @@ class SymbolicAssign(PyccelAstNode):
         super().__init__()
 
     def __str__(self):
-        return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
+        return f'{self.lhs} := {self.rhs}'
 
     @property
     def lhs(self):
@@ -851,10 +847,7 @@ class AugAssign(Assign):
         super().__init__(lhs, rhs, status, like, python_ast=python_ast)
 
     def __repr__(self):
-        return '{0} {1}= {2}'.format(str(self.lhs), self.op, str(self.rhs))
-
-    def __str__(self):
-        return '{0} {1}= {2}'.format(str(self.lhs), self.op, str(self.rhs))
+        return f'{self.lhs} {self.op}= {self.rhs}'
 
     @property
     def op(self):
@@ -1430,7 +1423,7 @@ class Iterable(PyccelAstNode):
         elif hasattr(iterable, 'n_indices') and hasattr(iterable, 'to_range'):
             self._num_indices_required = iterable.n_indices
         else:
-            raise TypeError("Unknown iterator type {}".format(type(iterable)))
+            raise TypeError(f"Unknown iterator type {type(iterable)}")
 
         super().__init__()
 
@@ -1678,15 +1671,15 @@ class FunctionCallArgument(PyccelAstNode):
 
     def __repr__(self):
         if self.has_keyword:
-            return 'FunctionCallArgument({} = {})'.format(self.keyword, repr(self.value))
+            return f'FunctionCallArgument({self.keyword} = {repr(self.value)})'
         else:
-            return 'FunctionCallArgument({})'.format(repr(self.value))
+            return f'FunctionCallArgument({repr(self.value)})'
 
     def __str__(self):
         if self.has_keyword:
-            return '{} = {}'.format(self.keyword, str(self.value))
+            return f'{self.keyword} = {self.value}'
         else:
-            return '{}'.format(str(self.value))
+            return f'{self.value}'
 
 class FunctionDefArgument(TypedAstNode):
     """
@@ -1865,19 +1858,15 @@ class FunctionDefArgument(TypedAstNode):
 
     def __str__(self):
         if self.has_default:
-            argument = str(self.name)
-            value = str(self.value)
-            return '{0}={1}'.format(argument, value)
+            return f'{self.name}={self.value}'
         else:
             return str(self.name)
 
     def __repr__(self):
         if self.has_default:
-            argument = str(self.name)
-            value = str(self.value)
-            return 'FunctionDefArgument({0}={1})'.format(argument, value)
+            return f'FunctionDefArgument({self.name}={self.value})'
         else:
-            return 'FunctionDefArgument({})'.format(repr(self.name))
+            return f'FunctionDefArgument({repr(self.name)})'
 
 class FunctionDefResult(TypedAstNode):
     """
@@ -1955,7 +1944,7 @@ class FunctionDefResult(TypedAstNode):
         return self._is_argument
 
     def __repr__(self):
-        return 'FunctionDefResult({})'.format(repr(self.var))
+        return f'FunctionDefResult({repr(self.var)})'
 
     def __str__(self):
         return str(self.var)
@@ -2107,7 +2096,8 @@ class FunctionCall(TypedAstNode):
         return self._interface_name
 
     def __repr__(self):
-        return '{}({})'.format(self.func_name, ', '.join(str(a) for a in self.args))
+        args = ', '.join(str(a) for a in self.args)
+        return f'{self.func_name}({args})'
 
     @classmethod
     def _ignore(cls, c):
@@ -2212,7 +2202,8 @@ class Return(PyccelAstNode):
             code = repr(self.stmt)+';'
         else:
             code = ''
-        return code+"Return({})".format(','.join([repr(e) for e in self.expr]))
+        exprs = ','.join(repr(e) for e in self.expr)
+        return code+"Return({exprs})"
 
 class FunctionDef(ScopedAstNode):
 
@@ -2762,10 +2753,7 @@ class FunctionDef(ScopedAstNode):
         result = 'None' if len(self.results) == 0 else \
                     ', '.join(str(r) for r in self.results)
         args = ', '.join(str(a) for a in self.arguments)
-        return '{name}({args}) -> {result}'.format(
-                name   = self.name,
-                args   = args,
-                result = result)
+        return f'{self.name}({args}) -> {result}'
 
     @property
     def is_unused(self):
@@ -3790,7 +3778,7 @@ class Import(PyccelAstNode):
         if isinstance(i, (DottedName, AsName, PyccelSymbol)):
             return i
         else:
-            raise TypeError('Expecting a string, PyccelSymbol DottedName, given {}'.format(type(i)))
+            raise TypeError(f'Expecting a string, PyccelSymbol DottedName, given {type(i)}')
 
     @property
     def target(self):
@@ -3813,11 +3801,10 @@ class Import(PyccelAstNode):
     def __str__(self):
         source = str(self.source)
         if len(self.target) == 0:
-            return 'import {source}'.format(source=source)
+            return f'import {source}'
         else:
             target = ', '.join([str(i) for i in self.target])
-            return 'from {source} import {target}'.format(source=source,
-                    target=target)
+            return f'from {source} import {target}'
 
     def define_target(self, new_target):
         """
@@ -3892,7 +3879,7 @@ class FuncAddressDeclare(PyccelAstNode):
         ):
 
         if not isinstance(variable, FunctionAddress):
-            raise TypeError('variable must be of type FunctionAddress, given {0}'.format(variable))
+            raise TypeError(f'variable must be of type FunctionAddress, given {variable}')
 
         if intent:
             if not intent in ['in', 'out', 'inout']:
@@ -3980,7 +3967,7 @@ class Declare(PyccelAstNode):
         module_variable = False
         ):
         if not isinstance(variable, Variable):
-            raise TypeError('var must be of type Variable, given {0}'.format(variable))
+            raise TypeError(f'var must be of type Variable, given {variable}')
 
         if intent:
             if not intent in ['in', 'out', 'inout']:
@@ -4031,7 +4018,7 @@ class Declare(PyccelAstNode):
         return self._module_variable
 
     def __repr__(self):
-        return 'Declare({})'.format(repr(self.variable))
+        return f'Declare({repr(self.variable)})'
 
 class Break(PyccelAstNode):
 
@@ -4082,7 +4069,7 @@ class SymbolicPrint(PyccelAstNode):
         for i in expr:
             if not isinstance(i, (Lambda, SymbolicAssign,
                               SympyFunction)):
-                raise TypeError('Expecting Lambda, SymbolicAssign, SympyFunction for {}'.format(i))
+                raise TypeError(f'Expecting Lambda, SymbolicAssign, SympyFunction for {i}')
 
         self._expr = expr
 
@@ -4184,7 +4171,7 @@ class Comment(PyccelAstNode):
         return self._text
 
     def __str__(self):
-        return '# {0}'.format(str(self.text))
+        return f'# {self.text}'
 
     def __reduce_ex__(self, i):
         """ Used by pickle to create an object of this class.
@@ -4403,7 +4390,7 @@ class IfSection(PyccelAstNode):
         return iter((self.condition, self.body))
 
     def __str__(self):
-        return "IfSec({},{})".format(str(self.condition), str(self.body))
+        return f"IfSec({self.condition}, {self.body})"
 
 class If(PyccelAstNode):
 
@@ -4447,7 +4434,8 @@ class If(PyccelAstNode):
         return [b.body for b in self._blocks]
 
     def __str__(self):
-        return "If({})".format(','.join(str(b) for b in self.blocks))
+        blocks = ','.join(str(b) for b in self.blocks)
+        return f"If({blocks})"
 
 class StarredArguments(PyccelAstNode):
     __slots__ = ('_starred_obj',)

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -271,7 +271,7 @@ class Slice(PyccelAstNode):
             stop = ''
         else:
             stop = str(self.stop)
-        return '{0} : {1}'.format(start, stop)
+        return f'{start} : {stop}'
 
 
 class PyccelSymbol(str, Immutable):

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -69,8 +69,8 @@ def get_numpy_max_acceptable_version_file():
     numpy_max_acceptable_version = [1, 19]
     numpy_current_version = [int(v) for v in np.version.version.split('.')[:2]]
     numpy_api_acceptable_version = min(numpy_max_acceptable_version, numpy_current_version)
-    numpy_api_macro = '# define NPY_NO_DEPRECATED_API NPY_{}_{}_API_VERSION\n'.format(
-        *numpy_api_acceptable_version)
+    major, minor = numpy_api_acceptable_version
+    numpy_api_macro = f'# define NPY_NO_DEPRECATED_API NPY_{major}_{minor}_API_VERSION\n'
 
     return '#ifndef NPY_NO_DEPRECATED_API\n'+ \
             numpy_api_macro+\

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -60,11 +60,18 @@ class PyccelPyArrayObject(FixedSizeType):
 
 def get_numpy_max_acceptable_version_file():
     """
+    Get the macro specifying the last acceptable numpy version.
+
     Get the macro specifying the last acceptable numpy version. If numpy is more
     recent than this then deprecation warnings are shown.
 
     The last acceptable numpy version is 1.19. If the current version is older
-    than this then the last acceptable numpy version is the current version
+    than this then the last acceptable numpy version is the current version.
+
+    Returns
+    -------
+    str
+        A string containing the code which defines the macro.
     """
     numpy_max_acceptable_version = [1, 19]
     numpy_current_version = [int(v) for v in np.version.version.split('.')[:2]]

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -60,13 +60,13 @@ class PyccelPyArrayObject(FixedSizeType):
 
 def get_numpy_max_acceptable_version_file():
     """
-    Get the macro specifying the last acceptable numpy version.
+    Get the macro specifying the most recent acceptable NumPy version.
 
-    Get the macro specifying the last acceptable numpy version. If numpy is more
-    recent than this then deprecation warnings are shown.
+    Get the macro specifying the most recent acceptable NumPy version.
+    If NumPy is more recent than this then deprecation warnings are shown.
 
-    The last acceptable numpy version is 1.19. If the current version is older
-    than this then the last acceptable numpy version is the current version.
+    The most recent acceptable NumPy version is 1.19. If the current version is older
+    than this then the last acceptable NumPy version is the current version.
 
     Returns
     -------
@@ -88,14 +88,14 @@ PyArray_Check = FunctionDef(name      = 'PyArray_Check',
                             arguments = [FunctionDefArgument(Variable(PyccelPyObject(), name = 'o'))],
                             results   = [FunctionDefResult(Variable(PythonNativeBool(), name='b'))])
 
-# numpy array to c ndarray : function definition in pyccel/stdlib/cwrapper/cwrapper_ndarrays.c
+# NumPy array to c ndarray : function definition in pyccel/stdlib/cwrapper/cwrapper_ndarrays.c
 pyarray_to_ndarray = FunctionDef(
                 name      = 'pyarray_to_ndarray',
                 arguments = [FunctionDefArgument(Variable(PyccelPyObject(), 'a', memory_handling = 'alias'))],
                 body      = [],
                 results   = [FunctionDefResult(Variable(NumpyNDArrayType(GenericType()), 'array'))])
 
-# numpy array check elements : function definition in pyccel/stdlib/cwrapper/cwrapper_ndarrays.c
+# NumPy array check elements : function definition in pyccel/stdlib/cwrapper/cwrapper_ndarrays.c
 pyarray_check = FunctionDef(
                 name      = 'pyarray_check',
                 arguments = [
@@ -219,7 +219,7 @@ numpy_dtype_registry = {PythonNativeBool()    : numpy_bool_type,
                         NumpyComplex128Type() : numpy_cdouble_type,
                         NumpyComplex256Type() : numpy_clongdouble_type}
 
-# Needed to check for numpy arguments type
+# Needed to check for NumPy arguments type
 check_type_registry.update({
     NumpyInt8Type()       : 'PyIs_Int8',
     NumpyInt16Type()      : 'PyIs_Int16',

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -638,7 +638,7 @@ class NumpyNewArray(PyccelInternalFunction):
 
         order = str(order).strip('\'"')
         if order not in ('C', 'F'):
-            raise ValueError('unrecognized order = {}'.format(order))
+            raise ValueError(f'unrecognized order = {order}')
         return order
 
 #==============================================================================
@@ -670,7 +670,7 @@ class NumpyArray(NumpyNewArray):
     def __init__(self, arg, dtype=None, order='K', ndmin=None):
 
         if not isinstance(arg, (PythonTuple, PythonList, Variable, IndexedElement)):
-            raise TypeError('Unknown type of  %s.' % type(arg))
+            raise TypeError(f'Unknown type of  {type(arg)}')
 
         is_homogeneous_tuple = isinstance(arg.class_type, HomogeneousTupleType)
         # Inhomogeneous tuples can contain homogeneous data if it is inhomogeneous due to pointers
@@ -830,7 +830,7 @@ class NumpySum(PyccelInternalFunction):
 
     def __init__(self, arg):
         if not isinstance(arg, TypedAstNode):
-            raise TypeError('Unknown type of  %s.' % type(arg))
+            raise TypeError(f'Unknown type of {type(arg)}.')
         super().__init__(arg)
         lowest_possible_type = process_dtype(PythonNativeInt())
         if isinstance(arg.dtype.primitive_type, (PrimitiveBooleanType, PrimitiveIntegerType)) and \
@@ -863,7 +863,7 @@ class NumpyProduct(PyccelInternalFunction):
 
     def __init__(self, arg):
         if not isinstance(arg, TypedAstNode):
-            raise TypeError('Unknown type of  %s.' % type(arg))
+            raise TypeError(f'Unknown type of {type(arg)}.')
         super().__init__(arg)
         self._arg = PythonList(arg) if arg.rank == 0 else self._args[0]
         lowest_possible_type = process_dtype(PythonNativeInt())
@@ -904,9 +904,9 @@ class NumpyMatmul(PyccelInternalFunction):
             return
 
         if not isinstance(a, TypedAstNode):
-            raise TypeError('Unknown type of  %s.' % type(a))
+            raise TypeError('Unknown type of {type(a)}.')
         if not isinstance(b, TypedAstNode):
-            raise TypeError('Unknown type of  %s.' % type(a))
+            raise TypeError('Unknown type of {type(a)}.')
 
         args      = (a, b)
         type_info = NumpyResultType(*args)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -921,9 +921,9 @@ class NumpyMatmul(PyccelInternalFunction):
             return
 
         if not isinstance(a, TypedAstNode):
-            raise TypeError('Unknown type of {type(a)}.')
+            raise TypeError(f'Unknown type of {type(a)}.')
         if not isinstance(b, TypedAstNode):
-            raise TypeError('Unknown type of {type(a)}.')
+            raise TypeError(f'Unknown type of {type(a)}.')
 
         args      = (a, b)
         type_info = NumpyResultType(*args)

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -656,8 +656,7 @@ class NumpyNewArray(PyccelInternalFunction):
             return None
 
         order = str(order).strip('\'"')
-        if order not in ('C', 'F'):
-            raise TypeError(f'unrecognized order = {order}')
+        assert order in ('C', 'F')
         return order
 
 #==============================================================================
@@ -742,8 +741,7 @@ class NumpyArray(NumpyNewArray):
             # ... Determine ordering
             order = str(order).strip("\'")
 
-            if order not in ('K', 'A', 'C', 'F'):
-                raise TypeError(f"Cannot recognize '{order}' order")
+            assert order in ('K', 'A', 'C', 'F')
 
             if order in ('K', 'A'):
                 order = arg.order or 'C'

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -633,7 +633,7 @@ class NumpyNewArray(PyccelInternalFunction):
     @staticmethod
     def _process_order(rank, order):
         """
-        Process the order to get an order in the format expected by Pyccel.
+        Treat the order to get an order in the format expected by Pyccel.
 
         Process the order passed to the array creation function to get an order
         in the format expected by Pyccel. The final format should be a string

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -632,13 +632,32 @@ class NumpyNewArray(PyccelInternalFunction):
     #--------------------------------------------------------------------------
     @staticmethod
     def _process_order(rank, order):
+        """
+        Process the order to get an order in the format expected by Pyccel.
+
+        Process the order passed to the array creation function to get an order
+        in the format expected by Pyccel. The final format should be a string
+        containing either 'C' or 'F'.
+
+        Parameters
+        ----------
+        rank : int
+            The rank of the array being created.
+        order : str | LiteralString
+            The order of the array as specified by the user or the subclass.
+
+        Returns
+        -------
+        str | None
+            The order in the format expected by Pyccel.
+        """
 
         if rank < 2:
             return None
 
         order = str(order).strip('\'"')
         if order not in ('C', 'F'):
-            raise ValueError(f'unrecognized order = {order}')
+            raise TypeError(f'unrecognized order = {order}')
         return order
 
 #==============================================================================
@@ -724,7 +743,7 @@ class NumpyArray(NumpyNewArray):
             order = str(order).strip("\'")
 
             if order not in ('K', 'A', 'C', 'F'):
-                raise ValueError(f"Cannot recognize '{order}' order")
+                raise TypeError(f"Cannot recognize '{order}' order")
 
             if order in ('K', 'A'):
                 order = arg.order or 'C'

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -28,7 +28,7 @@ from .datatypes      import InhomogeneousTupleType, ContainerType
 from .internals      import PyccelInternalFunction, Slice
 from .internals      import PyccelArraySize, PyccelArrayShapeElement
 
-from .literals       import LiteralInteger, LiteralFloat, LiteralComplex, LiteralString, convert_to_literal
+from .literals       import LiteralInteger, LiteralString, convert_to_literal
 from .literals       import LiteralTrue, LiteralFalse
 from .literals       import Nil
 from .mathext        import MathCeil

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -190,19 +190,6 @@ def builtin_import(expr):
     return []
 
 #==============================================================================
-def get_function_from_ast(ast, func_name):
-    node = None
-    for stmt in ast:
-        if isinstance(stmt, FunctionDef) and str(stmt.name) == func_name:
-            node = stmt
-            break
-
-    if node is None:
-        print(f'> could not find {func_name}')
-
-    return node
-
-#==============================================================================
 def split_positional_keyword_arguments(*args):
     """ Create a list of positional arguments and a dictionary of keyword arguments
     """

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -198,7 +198,7 @@ def get_function_from_ast(ast, func_name):
             break
 
     if node is None:
-        print('> could not find {}'.format(func_name))
+        print(f'> could not find {func_name}')
 
     return node
 
@@ -347,7 +347,7 @@ def insert_index(expr, pos, index_var):
         return expr[index_var]
 
     else:
-        raise NotImplementedError("Expansion not implemented for type : {}".format(type(expr)))
+        raise NotImplementedError(f"Expansion not implemented for type : {type(expr)}")
 
 #==============================================================================
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -143,7 +143,7 @@ class Variable(TypedAstNode):
             raise ValueError("Variable name can't be empty")
 
         if not isinstance(name, (str, DottedName)):
-            raise TypeError('Expecting a string or DottedName, given {0}'.format(type(name)))
+            raise TypeError(f'Expecting a string or DottedName, given {type(name)}')
         self._name = name
 
         if memory_handling not in ('heap', 'stack', 'alias'):
@@ -787,9 +787,7 @@ class Constant(Variable):
         return self._value
 
     def __str__(self):
-        name = str(self.name)
-        value = str(self.value)
-        return '{0}={1}'.format(name, value)
+        return f'{self.name}={self.value}'
 
 
 
@@ -910,10 +908,12 @@ class IndexedElement(TypedAstNode):
         return self._indices
 
     def __str__(self):
-        return '{}[{}]'.format(self.base, ','.join(str(i) for i in self.indices))
+        indices = ','.join(str(i) for i in self.indices)
+        return f'{self.base}[{indices}]'
 
     def __repr__(self):
-        return '{}[{}]'.format(repr(self.base), ','.join(repr(i) for i in self.indices))
+        indices = ','.join(repr(i) for i in self.indices)
+        return f'{repr(self.base)}[{indices}]'
 
     def __getitem__(self, *args):
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -14,7 +14,6 @@ from pyccel.ast.core       import IfSection, FunctionDef, Module, PyccelFunction
 from pyccel.ast.datatypes  import HomogeneousTupleType, HomogeneousListType
 from pyccel.ast.functionalexpr import FunctionalFor
 from pyccel.ast.literals   import LiteralTrue, LiteralString
-from pyccel.ast.literals   import LiteralInteger, LiteralFloat, LiteralComplex
 from pyccel.ast.numpyext   import numpy_target_swap
 from pyccel.ast.numpyext   import NumpyArray, NumpyNonZero, NumpyResultType
 from pyccel.ast.numpytypes import NumpyNumericType

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -11,13 +11,13 @@ import warnings
 from pyccel.ast.bind_c        import BindCFunctionDef, BindCPointer, BindCFunctionDefArgument
 from pyccel.ast.bind_c        import BindCModule, BindCVariable, BindCFunctionDefResult
 from pyccel.ast.bind_c        import BindCClassDef, BindCClassProperty
-from pyccel.ast.builtins      import PythonTuple, PythonRange
+from pyccel.ast.builtins      import PythonTuple
 from pyccel.ast.class_defs    import StackArrayClass
 from pyccel.ast.core          import Interface, If, IfSection, Return, FunctionCall
 from pyccel.ast.core          import FunctionDef, FunctionDefArgument, FunctionDefResult
 from pyccel.ast.core          import Assign, AliasAssign, Deallocate, Allocate
 from pyccel.ast.core          import Import, Module, AugAssign, CommentBlock
-from pyccel.ast.core          import FunctionAddress, Declare, ClassDef, For, AsName
+from pyccel.ast.core          import FunctionAddress, Declare, ClassDef, AsName
 from pyccel.ast.cwrapper      import PyModule, PyccelPyObject, PyArgKeywords, PyModule_Create
 from pyccel.ast.cwrapper      import PyArg_ParseTupleNode, Py_None, PyClassDef, PyModInitFunc
 from pyccel.ast.cwrapper      import py_to_c_registry, check_type_registry, PyBuildValueNode
@@ -26,7 +26,7 @@ from pyccel.ast.cwrapper      import PyAttributeError
 from pyccel.ast.cwrapper      import C_to_Python, PyFunctionDef, PyInterface
 from pyccel.ast.cwrapper      import PyModule_AddObject, Py_DECREF, PyObject_TypeCheck
 from pyccel.ast.cwrapper      import Py_INCREF, PyType_Ready, WrapperCustomDataType
-from pyccel.ast.cwrapper      import PyList_New, PyList_Append, PyList_Size, PyList_GetItem, PyList_SetItem
+from pyccel.ast.cwrapper      import PyList_New, PyList_Append, PyList_GetItem, PyList_SetItem
 from pyccel.ast.cwrapper      import PyccelPyTypeObject, PyCapsule_New, PyCapsule_Import
 from pyccel.ast.cwrapper      import PySys_GetObject, PyUnicode_FromString, PyGetSetDefElement
 from pyccel.ast.c_concepts    import ObjectAddress, PointerCast, CStackArray, CNativeInt


### PR DESCRIPTION
Apply some more Pylint fixes. Namely:
- Fix fstring errors in pyccel.ast
- Fix several unused-import errors

Docstrings are also added to satisfy CI. Some deprecated code is removed:
- `get_function_from_ast` which was unused