### PR TITLE
Fix missing allocation when returning an annotated array expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 -   #1732 : Fix multidimensional list indexing in Python.
 -   #1785 : Add missing cast when creating an array of booleans from non-boolean values.
 -   #1218 : Fix bug when assigning an array to a slice in Fortran.
+-   #1830 : Fix missing allocation when returning an annotated array expression.
 
 ### Changed
 -   #1720 : functions with the `@inline` decorator are no longer exposed to Python in the shared library.

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3855,6 +3855,9 @@ class SemanticParser(BasicParser):
         for o,r in zip(return_objs, results):
             v = o.var
             if not (isinstance(r, PyccelSymbol) and r == (v.name if isinstance(v, Variable) else v)):
+                # Create a syntactic obect to visit
+                if isinstance(v, Variable):
+                    v = PyccelSymbol(v.name)
                 a = self._visit(Assign(v, r, python_ast=expr.python_ast))
                 assigns.append(a)
                 if isinstance(a, ConstructorCall):

--- a/tests/epyccel/test_epyccel_return_arrays.py
+++ b/tests/epyccel/test_epyccel_return_arrays.py
@@ -889,3 +889,19 @@ def test_copy_f_to_default(language):
         assert pyth_out.dtype is pycc_out.dtype
         assert pyth_out.flags.c_contiguous == pycc_out.flags.c_contiguous
         assert pyth_out.flags.f_contiguous == pycc_out.flags.f_contiguous
+
+def test_annotated_return(language):
+    def annotated_return(b : 'float[:,:]', c : 'float[:,:]') -> 'float[:,:]':
+        return b + c
+
+    epyccel_func = epyccel(annotated_return, language=language)
+    fl_b = np.array(uniform(min_float / 2, max_float / 2, (3,4)))
+    fl_c = np.array(uniform(min_float / 2, max_float / 2, (3,4)))
+
+    pyth_out = annotated_return(fl_b, fl_c)
+    pycc_out = epyccel_func(fl_b, fl_c)
+
+    assert np.array_equal(pyth_out, pycc_out)
+    assert pyth_out.dtype is pycc_out.dtype
+    assert pyth_out.flags.c_contiguous == pycc_out.flags.c_contiguous
+    assert pyth_out.flags.f_contiguous == pycc_out.flags.f_contiguous


### PR DESCRIPTION
Fix missing allocation when returning an annotated array expression by ensuring a syntactic expression is passed to `_visit_Assign`