### PR TITLE
Use `PyccelAstNode.pyccel_staging` in `SemanticParser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Stop storing `FunctionDef`, `ClassDef`, and `Import` objects inside `CodeBlock`s.
 -   \[INTERNALS\] Remove the `order` argument from the `pyccel.ast.core.Allocate` constructor.
 -   \[INTERNALS\] Remove `rank` and `order` arguments from `pyccel.ast.variable.Variable` constructor.
+-   \[INTERNALS\] Enforce correct value for `pyccel_staging`.
+-   \[INTERNALS\] Allow visiting objects containing both syntactic and semantic elements in `SemanticParser`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Remove the `order` argument from the `pyccel.ast.core.Allocate` constructor.
 -   \[INTERNALS\] Remove `rank` and `order` arguments from `pyccel.ast.variable.Variable` constructor.
 -   \[INTERNALS\] Ensure `SemanticParser.infer_type` returns all documented information.
--   \[INTERNALS\] Enforce correct value for `pyccel_staging`.
+-   \[INTERNALS\] Enforce correct value for `pyccel_staging` property of `PyccelAstNode`.
 -   \[INTERNALS\] Allow visiting objects containing both syntactic and semantic elements in `SemanticParser`.
 
 ### Deprecated

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4564,10 +4564,15 @@ class SemanticParser(BasicParser):
             for hd in header:
                 for i,_ in enumerate(hd.dtypes):
                     self.scope.insert_symbol(f'arg_{i}')
-                arguments = [FunctionDefArgument(self._visit(AnnotatedPyccelSymbol(f'arg_{i}', annotation = arg))[0]) \
+                pyccel_stage.set_stage('syntactic')
+                syntactic_args = [AnnotatedPyccelSymbol(f'arg_{i}', annotation = arg) \
                         for i, arg in enumerate(hd.dtypes)]
-                results = [FunctionDefResult(self._visit(AnnotatedPyccelSymbol(f'out_{i}', annotation = arg))[0]) \
+                syntactic_results = [AnnotatedPyccelSymbol(f'out_{i}', annotation = arg) \
                         for i, arg in enumerate(hd.results)]
+                pyccel_stage.set_stage('semantic')
+
+                arguments = [FunctionDefArgument(self._visit(a)[0]) for a in syntactic_args]
+                results = [FunctionDefResult(self._visit(r)[0]) for r in syntactic_results]
                 interfaces.append(FunctionDef(f_name, arguments, results, []))
 
             # TODO -> Said: must handle interface

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1940,7 +1940,7 @@ class SemanticParser(BasicParser):
         
         Parameters
         ----------
-        expr : pyccel.ast.basic.PyccelAstNode
+        expr : pyccel.ast.basic.PyccelAstNode | PyccelSymbol
             Object to visit of type X.
         
         Returns


### PR DESCRIPTION
`PyccelAstNode`s have a `pyccel_staging` property. This is not used which makes it hard to detect when it is set incorrectly. Separately we often want to create a partially syntactic object (e.g. when unravelling an assignment where the `rhs` has been visited and the `lhs` is an inhomogeneous tuple). This PR uses the `pyccel_staging` property to facilitate the implementation of the latter situation. This is done by exiting `SemanticParser._visit` immediately if the object passed to the function is already a semantic object. As the property is now used it is obvious when it has not been correctly set. These cases are therefore fixed