### PR TITLE
Remove unused/unnecessary functions in `pyccel.parser.utilities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Removed unused and undocumented function `get_function_from_ast`.
 -   \[INTERNALS\] Remove unused parameters `expr`, `status` and `like` from `pyccel.ast.core.Assign`.
 -   \[INTERNALS\] Remove `pyccel.ast.utilities.builtin_functions`.
+-   \[INTERNALS\] Remove unused/unnecessary functions in `pyccel.parser.utilities` : `read_file`, `header_statement`, `accelerator_statement`, `get_module_name`, `view_tree`.
 
 ## \[1.11.2\] - 2024-03-05
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -66,7 +66,6 @@ from pyccel.ast.type_annotations import SyntacticTypeAnnotation, UnionTypeAnnota
 
 from pyccel.parser.base        import BasicParser
 from pyccel.parser.extend_tree import extend_tree
-from pyccel.parser.utilities   import read_file
 from pyccel.parser.utilities   import get_default_path
 
 from pyccel.parser.syntax.headers import parse as hdr_parse, types_meta
@@ -135,7 +134,8 @@ class SyntaxParser(BasicParser):
             # we don't use is_valid_filename_py since it uses absolute path
             # file extension
 
-            code = read_file(inputs)
+            with open(inputs, 'r', encoding="utf-8") as file:
+                code = file.read()
 
         self._code    = code
         self._context = []

--- a/pyccel/parser/utilities.py
+++ b/pyccel/parser/utilities.py
@@ -59,6 +59,11 @@ def get_default_path(name):
     ----------
     name : PyccelSymbol | DottedName
         The name of the source file for the import.
+
+    Returns
+    -------
+    PyccelSymbol | DottedName
+        The name of the Pyccel-compatible source file for the import.
     """
     name_ = str(name)
     name = pyccel_external_lib.get(name_, name_).split('.')

--- a/pyccel/parser/utilities.py
+++ b/pyccel/parser/utilities.py
@@ -7,15 +7,13 @@
 """This file contains different utilities for the Parser."""
 import os
 
-from sympy import srepr
-
 from pyccel.ast.variable       import DottedName
-from pyccel.parser.extend_tree import CommentLine
 from pyccel.ast.internals      import PyccelSymbol
 
-__all__ = ('pyccel_external_lib', 'read_file', 'is_valid_filename_py',
-            'is_valid_filename_pyh', 'header_statement', 'accelerator_statement',
-            'get_module_name', 'view_tree', 'get_default_path')
+__all__ = ('is_valid_filename_py',
+           'is_valid_filename_pyh',
+           'get_default_path',
+           'pyccel_external_lib')
 
 pyccel_external_lib = {"mpi4py"             : "pyccel.stdlib.external.mpi4py",
                        "scipy.linalg.lapack": "pyccel.stdlib.external.lapack",
@@ -25,13 +23,6 @@ pyccel_external_lib = {"mpi4py"             : "pyccel.stdlib.external.mpi4py",
                        "scipy.interpolate._fitpack":"pyccel.stdlib.external.fitpack"}
 
 #==============================================================================
-
-def read_file(filename):
-    """Returns the source code from a filename."""
-    f = open(filename)
-    code = f.read()
-    f.close()
-    return code
 
 #  ... checking the validity of the filenames, using absolute paths
 def _is_valid_filename(filename, ext):
@@ -55,76 +46,25 @@ def is_valid_filename_pyh(filename):
     return _is_valid_filename(filename, 'pyh')
 #  ...
 
-#  ...
-def header_statement(stmt, accel):
-    """Returns stmt if a header statement. otherwise it returns None.
-    this function can be used as the following
-    >>> if header_statement(stmt):
-        # do stuff
-        ...
-
-    """
-    if not isinstance(stmt, CommentLine): return None
-    if not stmt.value.startswith('#$'): return None
-
-    header = stmt.value[2:].lstrip()
-    if not header.startswith('header'): return None
-
-    return stmt.value
-#  ...
-
-# ... utilities for parsing OpenMP/OpenACC directives
-def accelerator_statement(stmt, accel):
-    """Returns stmt if an accelerator statement. otherwise it returns None.
-    this function can be used as the following
-    >>> if accelerator_statement(stmt, 'omp'):
-        # do stuff
-        ...
-
-    In general you can use the functions omp_statement and acc_statement
-    """
-    assert(accel in ['omp', 'acc'])
-
-    if not isinstance(stmt, CommentLine): return None
-    if not stmt.value.startswith('#$'): return None
-
-    directive = stmt.value[2:].lstrip()
-    if not directive.startswith(accel): return None
-
-    return stmt.value
-
-omp_statement = lambda x: accelerator_statement(x, 'omp')
-acc_statement = lambda x: accelerator_statement(x, 'acc')
-# ...
-
-def get_module_name( dotted_as_node ):
-    code_name = dotted_as_node.target
-    if (code_name != ""):
-        return [ code_name ]
-    else:
-        import_name = dotted_as_node.value
-        return import_name.dumps().split('.')
-
-
-#  ... utilities
-def view_tree(expr):
-    """Views a sympy expression tree."""
-    print (srepr(expr))
-#  ...
-
 def get_default_path(name):
-    """this function takes a an import name
-      and returns the path full bash of the library
-      if the library is in stdlib"""
-    name_ = name
-    if isinstance(name, (DottedName, PyccelSymbol)):
-        name_ = str(name)
-    if name_ in pyccel_external_lib.keys():
-        name = pyccel_external_lib[name_].split('.')
-        if len(name)>1:
-            return DottedName(*name)
-        else:
-            return name[0]
-    return name
+    """
+    Get the full path to the Pyccel description of the imported library.
+
+    This function takes the name of an import source. If the imported library is in
+    stdlib, it returns the full Python path to the stdlib equivalent library.
+    Otherwise the original name is returned. This equivalent library should be a
+    header file which describes all the functions which are supported by Pyccel.
+
+    Parameters
+    ----------
+    name : PyccelSymbol | DottedName
+        The name of the source file for the import.
+    """
+    name_ = str(name)
+    name = pyccel_external_lib.get(name_, name_).split('.')
+    if len(name)>1:
+        return DottedName(*name)
+    else:
+        return name[0]
 
 


### PR DESCRIPTION
Remove unused functions in `pyccel.parser.utilities` . In addition the function `read_file` is also removed. It is unnecessary to have a dedicated function for such a standard operation that can be written in 2 lines