### PR TITLE
Support variable declarations in c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ All notable changes to this project will be documented in this file.
 -   #1844 : Add line numbers and code to errors from built-in function calls.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
--   #1847 : Support `list()` and `set()` declarations in c.
+-   #1655 : \[LISTS\] Support variable declarations in C
+-   #1659 : \[SETS\] Support variable declarations in C
+
 ### Fixed
 
 -   #1720 : Fix Undefined Variable error when the function definition is after the variable declaration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,10 @@ All notable changes to this project will be documented in this file.
 -   #1787 : Ensure `STC` is installed with Pyccel.
 -   #1656 : Ensure `gFTL` is installed with Pyccel.
 -   #1844 : Add line numbers and code to errors from built-in function calls.
+-   #1655 : Add the appropriate C language equivalent for declaring a Python `list` container using the `STC` library.
+-   #1659 : Add the appropriate C language equivalent for declaring a Python `set` container using the `STC` library. 
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
--   #1655 : \[LISTS\] Support variable declarations in C
--   #1659 : \[SETS\] Support variable declarations in C
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 -   #1844 : Add line numbers and code to errors from built-in function calls.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
-
+-   #1847 : Support `list()` and `set()` declarations in c.
 ### Fixed
 
 -   #1720 : Fix Undefined Variable error when the function definition is after the variable declaration.

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -1262,7 +1262,6 @@ builtin_functions_dict = {
     'min'      : PythonMin,
     'not'      : PyccelNot,
     'map'      : PythonMap,
-    'set'      : PythonSet,
     'str'      : LiteralString,
     'type'     : PythonType,
     'tuple'    : PythonTupleFunction,

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -760,10 +760,10 @@ class HomogeneousListType(HomogeneousContainerType, metaclass = ArgumentSingleto
         self._element_type = element_type
         self._order = 'C' if (element_type.order == 'C' or element_type.rank == 1) else None
         super().__init__()
-    
+
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self._element_type == other._element_type \
-                and self._order == other._order  
+                and self._order == other._order
 
     def __hash__(self):
         return hash((self.__class__, self._element_type, self._order))

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -442,6 +442,12 @@ class GenericType(FixedSizeType):
     @lru_cache
     def __add__(self, other):
         return other
+    
+    def __eq__(self, other):
+        return True
+
+    def __hash__(self):
+        return hash(self.__class__)
 
 class SymbolicType(FixedSizeType):
     """
@@ -754,6 +760,13 @@ class HomogeneousListType(HomogeneousContainerType, metaclass = ArgumentSingleto
         self._element_type = element_type
         self._order = 'C' if (element_type.order == 'C' or element_type.rank == 1) else None
         super().__init__()
+    
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._element_type == other._element_type \
+              and self._order == other._order  
+
+    def __hash__(self):
+        return hash((self.__class__, self._element_type, self._order))
 
 class HomogeneousSetType(HomogeneousContainerType, metaclass = ArgumentSingleton):
     """
@@ -776,6 +789,12 @@ class HomogeneousSetType(HomogeneousContainerType, metaclass = ArgumentSingleton
         assert isinstance(element_type, PyccelType)
         self._element_type = element_type
         super().__init__()
+    
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._element_type == other._element_type
+
+    def __hash__(self):
+        return hash((self.__class__, self._element_type))
 
 #==============================================================================
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -149,6 +149,16 @@ class PyccelType:
     is expected when calling a bitwise comparison operator on objects of these types.
     """
     __slots__ = ()
+    _name = None
+
+    @property
+    def name(self):
+        """
+        Get the name of the pyccel type.
+        
+        Get the name of the pyccel type.
+        """
+        return self._name
 
     def __init__(self): #pylint: disable=useless-parent-delegation
         # This __init__ function is required so the ArgumentSingleton can
@@ -488,16 +498,6 @@ class HomogeneousContainerType(ContainerType):
     This is the case for objects such as arrays, lists, etc.
     """
     __slots__ = ()
-    _name = None
-
-    @property
-    def name(self):
-        """
-        Get the name of the container.
-        
-        Get the name of the container.
-        """
-        return self._name
 
     @property
     def datatype(self):

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -442,7 +442,7 @@ class GenericType(FixedSizeType):
     @lru_cache
     def __add__(self, other):
         return other
-    
+
     def __eq__(self, other):
         return True
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -760,10 +760,10 @@ class HomogeneousListType(HomogeneousContainerType, metaclass = ArgumentSingleto
         self._element_type = element_type
         self._order = 'C' if (element_type.order == 'C' or element_type.rank == 1) else None
         super().__init__()
-
+    
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self._element_type == other._element_type \
-              and self._order == other._order  
+                and self._order == other._order  
 
     def __hash__(self):
         return hash((self.__class__, self._element_type, self._order))
@@ -789,7 +789,7 @@ class HomogeneousSetType(HomogeneousContainerType, metaclass = ArgumentSingleton
         assert isinstance(element_type, PyccelType)
         self._element_type = element_type
         super().__init__()
-    
+
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self._element_type == other._element_type
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -760,7 +760,7 @@ class HomogeneousListType(HomogeneousContainerType, metaclass = ArgumentSingleto
         self._element_type = element_type
         self._order = 'C' if (element_type.order == 'C' or element_type.rank == 1) else None
         super().__init__()
-    
+
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self._element_type == other._element_type \
               and self._order == other._order  

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -216,22 +216,14 @@ class Codegen:
         header_filename = f'{filename}.{header_ext}'
         filename = f'{filename}.{ext}'
 
-        check = set()
-        # print module header
-        if header_ext is not None:
-            code = self._printer.doprint(ModuleHeader(self.ast))
-            with open(header_filename, 'w', encoding="utf-8") as f:
-                for line in code:
-                    check.add(line)
-                    f.write(line)
-
         # print module
         code = self._printer.doprint(self.ast)
         with open(filename, 'w', encoding="utf-8") as f:
             for line in code:
                 f.write(line)
 
-        if header_ext is not None and self.ast:
+        # print module header
+        if header_ext is not None:
             code = self._printer.doprint(ModuleHeader(self.ast))
             with open(header_filename, 'w', encoding="utf-8") as f:
                 for line in code:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -21,7 +21,6 @@ from pyccel.codegen.codegen        import Codegen
 from pyccel.codegen.utilities      import recompile_object
 from pyccel.codegen.utilities      import copy_internal_library
 from pyccel.codegen.utilities      import internal_libs
-from pyccel.codegen.utilities      import external_libs
 from pyccel.codegen.python_wrapper import create_shared_library
 from pyccel.naming                 import name_clash_checkers
 from pyccel.utilities.stage        import PyccelStage
@@ -338,10 +337,10 @@ def execute_pyccel(fname, *,
 
     # Iterate over the external_libs list and determine if the printer
     # requires an external lib to be included.
-    for ext_lib_name, ext_src_folder in external_libs.items():
-        if ext_lib_name in codegen.get_printer_imports():
-
-            lib_dest_path = copy_internal_library(ext_src_folder, pyccel_dirpath)
+    
+    result = [key for key in codegen.get_printer_imports() if key.startswith('stc')]
+    if result[0]:
+        lib_dest_path = copy_internal_library('stc', pyccel_dirpath)
 
     if convert_only:
         # Change working directory back to starting point

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -21,6 +21,7 @@ from pyccel.codegen.codegen        import Codegen
 from pyccel.codegen.utilities      import recompile_object
 from pyccel.codegen.utilities      import copy_internal_library
 from pyccel.codegen.utilities      import internal_libs
+from pyccel.codegen.utilities      import external_libs
 from pyccel.codegen.python_wrapper import create_shared_library
 from pyccel.naming                 import name_clash_checkers
 from pyccel.utilities.stage        import PyccelStage
@@ -337,8 +338,10 @@ def execute_pyccel(fname, *,
 
     # Iterate over the external_libs list and determine if the printer
     # requires an external lib to be included.
-    if [key for key in codegen.get_printer_imports() if key.startswith('stc')] :
-        lib_dest_path = copy_internal_library('stc', pyccel_dirpath)
+    for key in codegen.get_printer_imports():
+        lib_name = key.split("/", 1)[0]
+        if lib_name in external_libs:
+            lib_dest_path = copy_internal_library(lib_name, pyccel_dirpath)
 
     if convert_only:
         # Change working directory back to starting point

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -337,7 +337,6 @@ def execute_pyccel(fname, *,
 
     # Iterate over the external_libs list and determine if the printer
     # requires an external lib to be included.
-    
     if [key for key in codegen.get_printer_imports() if key.startswith('stc')] :
         lib_dest_path = copy_internal_library('stc', pyccel_dirpath)
 

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -338,8 +338,7 @@ def execute_pyccel(fname, *,
     # Iterate over the external_libs list and determine if the printer
     # requires an external lib to be included.
     
-    result = [key for key in codegen.get_printer_imports() if key.startswith('stc')]
-    if result[0]:
+    if [key for key in codegen.get_printer_imports() if key.startswith('stc')] :
         lib_dest_path = copy_internal_library('stc', pyccel_dirpath)
 
     if convert_only:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -830,7 +830,7 @@ class CCodePrinter(CodePrinter):
         self._current_module = expr
         for item in expr.imports:
             self.rename_imported_methods(item)
-        for classDef in  expr.classes: 
+        for classDef in  expr.classes:
             class_scope = classDef.scope
             for method in classDef.methods:
                 if not method.is_inline:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -965,7 +965,7 @@ class CCodePrinter(CodePrinter):
                                   f'#define _{container_type.upper()}',
                                   f'#define i_type {container_type}',
                                   f'#define i_key {container_type[index:]}',
-                                  f'#include "{_ + "/" +container[0]}.h"',
+                                  f'#include "{"extensions/STC/include/"+ _ + "/" +container[0]}.h"',
                                   '#endif\n'))
 
         # Get with a default value is not used here as it is

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1187,9 +1187,9 @@ class CCodePrinter(CodePrinter):
             key = (primitive_type, dtype.precision)
         elif isinstance(dtype, (HomogeneousSetType, HomogeneousListType)):
             container_type = 'hset_' if dtype.name == 'set' else 'vec_'
-            vec_dtype = self.find_in_dtype_registry(dtype.element_type)
-            i_type = container_type + vec_dtype.replace(' ', '_')
-            self.add_import(Import('stc/' + i_type + "/" + vec_dtype, Module('stc/' + i_type, (), ())))
+            element_type = self.find_in_dtype_registry(dtype.element_type)
+            i_type = container_type + element_type.replace(' ', '_')
+            self.add_import(Import('stc/' + i_type + "/" + element_type, Module('stc/' + i_type, (), ())))
             return i_type
         else:
             key = dtype

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1302,14 +1302,14 @@ class CCodePrinter(CodePrinter):
         rank  = expr.rank
 
         if rank > 0:
-            if isinstance(class_type, NumpyNDArrayType):
-                if rank > 15:
+            if isinstance(expr.class_type, (HomogeneousSetType, HomogeneousListType)):
+                    dtype = self.find_in_type_registry(expr.class_type)
+                    return dtype
+            if expr.is_ndarray or isinstance(expr.class_type, HomogeneousContainerType):
+                if expr.rank > 15:
                     errors.report(UNSUPPORTED_ARRAY_RANK, symbol=expr, severity='fatal')
                 self.add_import(c_imports['ndarrays'])
                 dtype = 't_ndarray'
-            elif isinstance(class_type, (HomogeneousSetType, HomogeneousListType)):
-                dtype = self.find_in_type_registry(expr.class_type)
-                return dtype
             else:
                 errors.report(PYCCEL_RESTRICTION_TODO+' (rank>0)', symbol=expr, severity='fatal')
         elif not isinstance(class_type, CustomDataType):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -802,7 +802,19 @@ class CCodePrinter(CodePrinter):
                 #endif // {name}_H\n")
 
     def rename_imported_methods(self, expr):
-         if expr.source_module and expr.source_module is not self._current_module:
+        """
+        Rename Imported Methods.
+
+        This function is responsible for renaming methods of classes from
+        the imported modules, ensuring that the names are correct 
+        by prefixing them with their class names.
+
+        Parameters
+        ----------
+        expr : Import
+            The import found in the module being renamed.
+        """
+        if expr.source_module and expr.source_module is not self._current_module:
             for classDef in expr.source_module.classes:
                 class_scope = classDef.scope
                 for method in classDef.methods:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1305,7 +1305,7 @@ class CCodePrinter(CodePrinter):
             if isinstance(expr.class_type, (HomogeneousSetType, HomogeneousListType)):
                     dtype = self.find_in_type_registry(expr.class_type)
                     return dtype
-            if expr.is_ndarray or isinstance(expr.class_type, HomogeneousContainerType):
+            if isinstance(expr.class_type,(HomogeneousTupleType, NumpyNDArrayType)):
                 if expr.rank > 15:
                     errors.report(UNSUPPORTED_ARRAY_RANK, symbol=expr, severity='fatal')
                 self.add_import(c_imports['ndarrays'])

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1207,7 +1207,7 @@ class CCodePrinter(CodePrinter):
 
         Raises
         ------
-        PYCCEL_RESTRICTION_TODO
+        PyccelCodegenError
             If the dtype is not found in the dtype_registry.
         """
         if isinstance(dtype, FixedSizeNumericType):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -225,10 +225,6 @@ c_library_headers = (
 
 import_dict = {'omp_lib' : 'omp' }
 
-import_stc = {'hset' : 'SET',
-              'vec'  : 'VEC'
-              }
-
 c_imports = {n : Import(n, Module(n, (), ())) for n in
                 ['stdlib',
                  'math',

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -403,7 +403,7 @@ class CCodePrinter(CodePrinter):
 
         order = lhs.order
         lhs_dtype = lhs.dtype
-        declare_dtype = self.find_in_type_registry(lhs_dtype)
+        declare_dtype = self.get_c_type(lhs_dtype)
         if isinstance(lhs.class_type, NumpyNDArrayType):
             #set dtype to the C struct types
             dtype = self.find_in_ndarray_type_registry(lhs_dtype)
@@ -496,7 +496,7 @@ class CCodePrinter(CodePrinter):
         rhs = expr.rhs
         lhs = expr.lhs
         code_init = ''
-        declare_dtype = self.find_in_type_registry(rhs.dtype)
+        declare_dtype = self.get_c_type(rhs.dtype)
 
         if rhs.fill_value is not None:
             if isinstance(rhs.fill_value, Literal):
@@ -524,7 +524,7 @@ class CCodePrinter(CodePrinter):
             String containing the rhs of the initialization of a stack array.
         """
         var = expr
-        dtype = self.find_in_type_registry(var.dtype)
+        dtype = self.get_c_type(var.dtype)
         if isinstance(var.class_type, NumpyNDArrayType):
             np_dtype = self.find_in_ndarray_type_registry(var.dtype)
         elif isinstance(var.class_type, HomogeneousContainerType):
@@ -534,7 +534,7 @@ class CCodePrinter(CodePrinter):
         shape = ", ".join(self._print(i) for i in var.alloc_shape)
         tot_shape = self._print(functools.reduce(
             lambda x,y: PyccelMul(x,y,simplify=True), var.alloc_shape))
-        declare_dtype = self.find_in_type_registry(NumpyInt64Type())
+        declare_dtype = self.get_c_type(NumpyInt64Type())
 
         dummy_array_name = self.scope.get_new_name('array_dummy')
         buffer_array = "{dtype} {name}[{size}];\n".format(
@@ -645,19 +645,20 @@ class CCodePrinter(CodePrinter):
 
         return code
 
-    def init_stc_container(self, expr, container_var):
+    def init_stc_container(self, expr, assignment_var):
         """
         Generate the initialization of an STC container in C.
 
-        This method generates and prints the C code for initializing a container using the STC `init()` method.
+        This method generates and prints the C code for initializing a container using the STC `c_init()` method.
 
         Parameters
         ----------
         expr : TypedAstNode
             The object representing the container being printed (e.g., PythonList, PythonSet).
     
-        container_var : str
-            The variable name to which the container is being assigned.
+        assignment_var : Assign
+            The assignment node where the Python container (rhs) is being initialized 
+            and saved into a variable (lhs).
         
         Returns
         -------
@@ -665,9 +666,9 @@ class CCodePrinter(CodePrinter):
             The generated C code for the container initialization.
         """
 
-        dtype = self.find_in_type_registry(container_var.lhs.class_type)
+        dtype = self.get_c_type(assignment_var.lhs.class_type)
         keyraw = '{' + ', '.join(self._print(a) for a in expr.args) + '}'
-        init = f'{container_var.lhs.name} = c_init({dtype}, {keyraw});\n'
+        init = f'{assignment_var.lhs.name} = c_init({dtype}, {keyraw});\n'
         return init
 
     def rename_imported_methods(self, expr):
@@ -680,7 +681,7 @@ class CCodePrinter(CodePrinter):
 
         Parameters
         ----------
-        expr : Tuple of ClassDef objects
+        expr : iterable[ClassDef]
             The ClassDef objects found in the module being renamed.
         """
         for classDef in expr:
@@ -755,13 +756,13 @@ class CCodePrinter(CodePrinter):
 
     def _print_PythonFloat(self, expr):
         value = self._print(expr.arg)
-        type_name = self.find_in_type_registry(expr.dtype)
+        type_name = self.get_c_type(expr.dtype)
         return '({0})({1})'.format(type_name, value)
 
     def _print_PythonInt(self, expr):
         self.add_import(c_imports['stdint'])
         value = self._print(expr.arg)
-        type_name = self.find_in_type_registry(expr.dtype)
+        type_name = self.get_c_type(expr.dtype)
         return '({0})({1})'.format(type_name, value)
 
     def _print_PythonBool(self, expr):
@@ -795,7 +796,7 @@ class CCodePrinter(CodePrinter):
         else:
             value = self._print(PyccelAssociativeParenthesis(PyccelAdd(expr.real,
                             PyccelMul(expr.imag, LiteralImaginaryUnit()))))
-        type_name = self.find_in_type_registry(expr.dtype)
+        type_name = self.get_c_type(expr.dtype)
         return '({0})({1})'.format(type_name, value)
 
     def _print_LiteralImaginaryUnit(self, expr):
@@ -1181,19 +1182,20 @@ class CCodePrinter(CodePrinter):
             code += formatted_args_to_printf(args_format, args, end)
         return code
 
-    def find_in_type_registry(self, dtype):
+    def get_c_type(self, dtype):
         """
-        Find the corresponding C dtype in the dtype_registry or the STC container type.
+        Find the corresponding C type of the PyccelType.
 
-        This function searches for the corresponding C data type in the `dtype_registry`.
-        If the provided dtype is a container (like `HomogeneousSetType` or
-        `HomogeneousListType`), it identifies the scalar type of the container and returns
-        the appropriate type for the `STC` container.
-        It raises a `PYCCEL_RESTRICTION_TODO` error if the dtype is not found in the registry.
+        For scalar types, this function searches for the corresponding C data type
+        in the `dtype_registry`.  If the provided type is a container (like
+        `HomogeneousSetType` or `HomogeneousListType`),  it recursively identifies
+        the type of an element of the container and uses it to calculate the
+        appropriate type for the `STC` container.
+        A `PYCCEL_RESTRICTION_TODO` error is raised if the dtype is not found in the registry.
 
         Parameters
         ----------
-        dtype : DataType or ContainerType
+        dtype : PyccelType
             The data type of the expression. This can be a fixed-size numeric type,
             a primitive type, or a container type.
 
@@ -1212,7 +1214,7 @@ class CCodePrinter(CodePrinter):
             primitive_type = dtype.primitive_type
             if isinstance(primitive_type, PrimitiveComplexType):
                 self.add_import(c_imports['complex'])
-                return f'{self.find_in_type_registry(dtype.element_type)} complex'
+                return f'{self.get_c_type(dtype.element_type)} complex'
             elif isinstance(primitive_type, PrimitiveIntegerType):
                 self.add_import(c_imports['stdint'])
             elif isinstance(dtype, PythonNativeBool):
@@ -1222,7 +1224,7 @@ class CCodePrinter(CodePrinter):
             key = (primitive_type, dtype.precision)
         elif isinstance(dtype, (HomogeneousSetType, HomogeneousListType)):
             container_type = 'hset_' if dtype.name == 'set' else 'vec_'
-            element_type = self.find_in_type_registry(dtype.element_type)
+            element_type = self.get_c_type(dtype.element_type)
             i_type = container_type + element_type.replace(' ', '_')
             self.add_import(Import(f'stc/{i_type}/{element_type}', Module(f'stc/{i_type}', (), ())))
             return i_type
@@ -1235,7 +1237,6 @@ class CCodePrinter(CodePrinter):
             raise errors.report(PYCCEL_RESTRICTION_TODO, #pylint: disable=raise-missing-from
                     symbol = dtype,
                     severity='fatal')
-
 
     def find_in_ndarray_type_registry(self, dtype):
         """
@@ -1303,7 +1304,7 @@ class CCodePrinter(CodePrinter):
 
         if rank > 0:
             if isinstance(expr.class_type, (HomogeneousSetType, HomogeneousListType)):
-                dtype = self.find_in_type_registry(expr.class_type)
+                dtype = self.get_c_type(expr.class_type)
                 return dtype
             if isinstance(expr.class_type,(HomogeneousTupleType, NumpyNDArrayType)):
                 if expr.rank > 15:
@@ -1313,7 +1314,7 @@ class CCodePrinter(CodePrinter):
             else:
                 errors.report(PYCCEL_RESTRICTION_TODO+' (rank>0)', symbol=expr, severity='fatal')
         elif not isinstance(class_type, CustomDataType):
-            dtype = self.find_in_type_registry(expr.dtype)
+            dtype = self.get_c_type(expr.dtype)
         else:
             dtype = self._print(expr.class_type)
 
@@ -1397,11 +1398,11 @@ class CCodePrinter(CodePrinter):
         if n_results == 1:
             ret_type = self.get_declare_type(result_vars[0])
         elif n_results > 1:
-            ret_type = self.find_in_type_registry(PythonNativeInt())
+            ret_type = self.get_c_type(PythonNativeInt())
             arg_vars.extend(result_vars)
             self._additional_args.append(result_vars) # Ensure correct result for is_c_pointer
         else:
-            ret_type = self.find_in_type_registry(VoidType())
+            ret_type = self.get_c_type(VoidType())
 
         name = expr.name
         if not arg_vars:
@@ -1499,7 +1500,7 @@ class CCodePrinter(CodePrinter):
             after using this function.
         """
         if expr.dtype != dtype:
-            cast=self.find_in_type_registry(dtype)
+            cast=self.get_c_type(dtype)
             return '({}){{}}'.format(cast)
         return '{}'
 
@@ -1611,7 +1612,7 @@ class CCodePrinter(CodePrinter):
                 dtype = self.find_in_ndarray_type_registry(numpy_precision_map[(variable.dtype.primitive_type, variable.dtype.precision)])
             else:
                 raise NotImplementedError(f"Don't know how to index {variable.class_type} type")
-            shape_dtype = self.find_in_type_registry(NumpyInt64Type())
+            shape_dtype = self.get_c_type(NumpyInt64Type())
             shape_Assign = "("+ shape_dtype +"[]){" + shape + "}"
             is_view = 'false' if variable.on_heap else 'true'
             order = "order_f" if expr.order == "F" else "order_c"
@@ -1630,7 +1631,7 @@ class CCodePrinter(CodePrinter):
     def _print_Deallocate(self, expr):
         if isinstance(expr.variable.class_type, (HomogeneousListType, HomogeneousSetType)):
             variable_address = self._print(ObjectAddress(expr.variable))
-            container_type = self.find_in_type_registry(expr.variable.class_type)
+            container_type = self.get_c_type(expr.variable.class_type)
             return f'{container_type}_drop({variable_address});\n'
         if isinstance(expr.variable, InhomogeneousTupleVariable):
             return ''.join(self._print(Deallocate(v)) for v in expr.variable)
@@ -1802,7 +1803,7 @@ class CCodePrinter(CodePrinter):
                     args.append(self._print(arg))
         code_args = ', '.join(args)
         if expr.dtype.primitive_type is PrimitiveIntegerType():
-            cast_type = self.find_in_type_registry(expr.dtype)
+            cast_type = self.get_c_type(expr.dtype)
             return f'({cast_type}){func_name}({code_args})'
         return f'{func_name}({code_args})'
 
@@ -2114,7 +2115,7 @@ class CCodePrinter(CodePrinter):
         code = ' / '.join(self._print(a if a.dtype.primitive_type is PrimitiveFloatingPointType()
                                         else NumpyFloat(a)) for a in expr.args)
         if (need_to_cast):
-            cast_type = self.find_in_type_registry(expr.dtype)
+            cast_type = self.get_c_type(expr.dtype)
             return "({})floor({})".format(cast_type, code)
         return "floor({})".format(code)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1189,7 +1189,7 @@ class CCodePrinter(CodePrinter):
             container_type = 'hset_' if dtype.name == 'set' else 'vec_'
             element_type = self.find_in_dtype_registry(dtype.element_type)
             i_type = container_type + element_type.replace(' ', '_')
-            self.add_import(Import('stc/' + i_type + "/" + element_type, Module('stc/' + i_type, (), ())))
+            self.add_import(Import(f'stc/{i_type}/{element_type}', Module(f'stc/{i_type}', (), ())))
             return i_type
         else:
             key = dtype

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -995,16 +995,15 @@ class CCodePrinter(CodePrinter):
             source = source.name[-1]
         else:
             source = self._print(source)
-        if expr.target:
-            if source.startswith('stc/'):
-                stc_name, container_type, container_key = source.split("/")
-                container = container_type.split("_")
-                return '\n'.join((f'#ifndef _{container_type.upper()}',
-                                  f'#define _{container_type.upper()}',
-                                  f'#define i_type {container_type}',
-                                  f'#define i_key {container_key}',
-                                  f'#include "{stc_name + "/" + container[0]}.h"',
-                                  '#endif\n'))
+        if source.startswith('stc/'):
+            stc_name, container_type, container_key = source.split("/")
+            container = container_type.split("_")
+            return '\n'.join((f'#ifndef _{container_type.upper()}',
+                              f'#define _{container_type.upper()}',
+                              f'#define i_type {container_type}',
+                              f'#define i_key {container_key}',
+                              f'#include "{stc_name + "/" + container[0]}.h"',
+                              '#endif\n'))
 
         # Get with a default value is not used here as it is
         # slower and on most occasions the import will not be in the

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1591,7 +1591,7 @@ class CCodePrinter(CodePrinter):
     def _print_Deallocate(self, expr):
         if isinstance(expr.variable.class_type, (HomogeneousListType, HomogeneousSetType)):
             variable_address = self._print(ObjectAddress(expr.variable))
-            dtype = self.find_in_dtype_registry(expr.variable.dtype).replace(" ", "_")
+            dtype = self.find_in_dtype_registry(expr.variable.class_type.element_type).replace(" ", "_")
             container_type = "hset_"if isinstance(expr.variable.class_type, HomogeneousSetType) else "vec_"
             return f'{container_type}{dtype}_drop({variable_address});\n'
         if isinstance(expr.variable, InhomogeneousTupleVariable):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1195,8 +1195,7 @@ class CCodePrinter(CodePrinter):
             key = (primitive_type, dtype.precision)
         elif isinstance(dtype, (HomogeneousSetType, HomogeneousListType)):
             container_type = 'hset_' if dtype.name == 'set' else 'vec_'
-            if not isinstance(dtype.element_type, GenericType):
-                vec_dtype = self.find_in_dtype_registry(dtype.element_type)
+            vec_dtype = self.find_in_dtype_registry(dtype.element_type)
             i_type = container_type + vec_dtype.replace(' ', '_')
             self.add_import(Import('stc/' + i_type + "/" + vec_dtype, Module('stc/' + i_type, (), ())))
             return i_type

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2010,7 +2010,7 @@ class CCodePrinter(CodePrinter):
         else:
             return call_code
 
-    def init_lists_or_sets(self, expr, container_var):
+    def init_stc_container(self, expr, container_var):
         """
         Generate the initialization of an STC container in C.
 
@@ -2178,7 +2178,7 @@ class CCodePrinter(CodePrinter):
             return prefix_code+self.arrayFill(expr)
         lhs = self._print(expr.lhs)
         if isinstance(rhs, (PythonList, PythonSet)):
-            return prefix_code+self.init_lists_or_sets(rhs, expr)
+            return prefix_code+self.init_stc_container(rhs, expr)
         rhs = self._print(expr.rhs)
         return prefix_code+'{} = {};\n'.format(lhs, rhs)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1269,7 +1269,6 @@ class CCodePrinter(CodePrinter):
             if isinstance(class_type, NumpyNDArrayType):
                 if rank > 15:
                     errors.report(UNSUPPORTED_ARRAY_RANK, symbol=expr, severity='fatal')
-                    return dtype
                 self.add_import(c_imports['ndarrays'])
                 dtype = 't_ndarray'
             elif isinstance(class_type, (HomogeneousSetType, HomogeneousListType)):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -645,6 +645,31 @@ class CCodePrinter(CodePrinter):
 
         return code
 
+    def init_stc_container(self, expr, container_var):
+        """
+        Generate the initialization of an STC container in C.
+
+        This method generates and prints the C code for initializing a container using the STC `init()` method.
+
+        Parameters
+        ----------
+        expr : TypedAstNode
+            The object representing the container being printed (e.g., PythonList, PythonSet).
+    
+        container_var : str
+            The variable name to which the container is being assigned.
+        
+        Returns
+        -------
+        str
+            The generated C code for the container initialization.
+        """
+
+        dtype = self.find_in_type_registry(container_var.lhs.class_type)
+        keyraw = '{' + ', '.join(self._print(a) for a in expr.args) + '}'
+        init = f'{container_var.lhs.name} = c_init({dtype}, {keyraw});\n'
+        return init
+
     def rename_imported_methods(self, expr):
         """
         Rename class methods from user-defined imports.
@@ -2010,31 +2035,6 @@ class CCodePrinter(CodePrinter):
             return f'{call_code};\n'
         else:
             return call_code
-
-    def init_stc_container(self, expr, container_var):
-        """
-        Generate the initialization of an STC container in C.
-
-        This method generates and prints the C code for initializing a container using the STC `init()` method.
-
-        Parameters
-        ----------
-        expr : TypedAstNode
-            The object representing the container being printed (e.g., PythonList, PythonSet).
-    
-        container_var : str
-            The variable name to which the container is being assigned.
-        
-        Returns
-        -------
-        str
-            The generated C code for the container initialization.
-        """
-
-        dtype = self.find_in_type_registry(container_var.lhs.class_type)
-        keyraw = '{' + ', '.join([self._print(a) for a in expr.args]) + '}'
-        init = f'{container_var.lhs.name} = c_init({dtype}, {keyraw});\n'
-        return init
 
     def _print_Return(self, expr):
         code = ''

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -800,10 +800,24 @@ class CCodePrinter(CodePrinter):
                 {classes}\n \
                 {funcs}\n \
                 #endif // {name}_H\n")
+    
+    def rename_imported_methods(self, expr):
+         if expr.source_module and expr.source_module is not self._current_module:
+            for classDef in expr.source_module.classes:
+                class_scope = classDef.scope
+                for method in classDef.methods:
+                    if not method.is_inline:
+                        class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
+                for interface in classDef.interfaces:
+                    for func in interface.functions:
+                        if not func.is_inline:
+                            class_scope.rename_function(func, f"{classDef.name}__{func.name.lstrip('__')}")
 
     def _print_Module(self, expr):
         self.set_scope(expr.scope)
         self._current_module = expr
+        for item in expr.imports:
+            self.rename_imported_methods(item)
         for classDef in  expr.classes: 
             class_scope = classDef.scope
             for method in classDef.methods:
@@ -972,16 +986,6 @@ class CCodePrinter(CodePrinter):
         if source in import_dict: # pylint: disable=consider-using-get
             source = import_dict[source]
 
-        if expr.source_module and expr.source_module is not self._current_module:
-            for classDef in expr.source_module.classes:
-                class_scope = classDef.scope
-                for method in classDef.methods:
-                    if not method.is_inline:
-                        class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
-                for interface in classDef.interfaces:
-                    for func in interface.functions:
-                        if not func.is_inline:
-                            class_scope.rename_function(func, f"{classDef.name}__{func.name.lstrip('__')}")
 
         if source is None:
             return ''

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -818,7 +818,7 @@ class CCodePrinter(CodePrinter):
         global_variables = ''.join([self._print(d) for d in expr.declarations])
 
         # Print imports last to be sure that all additional_imports have been collected
-        imports = Import(expr.name, Module(expr.name,(),()))
+        imports = Import(self.scope.get_python_name(expr.name), Module(expr.name,(),()))
         imports = self._print(imports)
 
         code = ('{imports}\n'

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -668,7 +668,8 @@ class CCodePrinter(CodePrinter):
 
         dtype = self.get_c_type(assignment_var.lhs.class_type)
         keyraw = '{' + ', '.join(self._print(a) for a in expr.args) + '}'
-        init = f'{assignment_var.lhs.name} = c_init({dtype}, {keyraw});\n'
+        container_name = self._print(assignment_var.lhs)
+        init = f'{container_name} = c_init({dtype}, {keyraw});\n'
         return init
 
     def rename_imported_methods(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1274,14 +1274,15 @@ class CCodePrinter(CodePrinter):
         rank  = expr.rank
 
         if rank > 0:
-            if expr.is_ndarray or isinstance(expr.class_type, HomogeneousContainerType):
-                if expr.rank > 15:
+            if isinstance(class_type, NumpyNDArrayType):
+                if rank > 15:
                     errors.report(UNSUPPORTED_ARRAY_RANK, symbol=expr, severity='fatal')
-                if isinstance(expr.class_type, (HomogeneousSetType, HomogeneousListType)):
-                    dtype = self.find_in_dtype_registry(expr.class_type)
                     return dtype
                 self.add_import(c_imports['ndarrays'])
                 dtype = 't_ndarray'
+            elif isinstance(class_type, (HomogeneousSetType, HomogeneousListType)):
+                dtype = self.find_in_dtype_registry(expr.class_type)
+                return dtype
             else:
                 errors.report(PYCCEL_RESTRICTION_TODO+' (rank>0)', symbol=expr, severity='fatal')
         elif not isinstance(class_type, CustomDataType):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -25,7 +25,7 @@ from pyccel.ast.operators import PyccelAdd, PyccelMul, PyccelMinus, PyccelLt, Py
 from pyccel.ast.operators import PyccelAssociativeParenthesis, PyccelMod
 from pyccel.ast.operators import PyccelUnarySub, IfTernaryOperator
 
-from pyccel.ast.datatypes import PythonNativeInt, PythonNativeBool, VoidType, GenericType
+from pyccel.ast.datatypes import PythonNativeInt, PythonNativeBool, VoidType
 from pyccel.ast.datatypes import TupleType, FixedSizeNumericType
 from pyccel.ast.datatypes import CustomDataType, StringType, HomogeneousTupleType, HomogeneousListType, HomogeneousSetType
 from pyccel.ast.datatypes import PrimitiveBooleanType, PrimitiveIntegerType, PrimitiveFloatingPointType, PrimitiveComplexType
@@ -1303,8 +1303,8 @@ class CCodePrinter(CodePrinter):
 
         if rank > 0:
             if isinstance(expr.class_type, (HomogeneousSetType, HomogeneousListType)):
-                    dtype = self.find_in_type_registry(expr.class_type)
-                    return dtype
+                dtype = self.find_in_type_registry(expr.class_type)
+                return dtype
             if isinstance(expr.class_type,(HomogeneousTupleType, NumpyNDArrayType)):
                 if expr.rank > 15:
                     errors.report(UNSUPPORTED_ARRAY_RANK, symbol=expr, severity='fatal')

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1605,9 +1605,8 @@ class CCodePrinter(CodePrinter):
     def _print_Deallocate(self, expr):
         if isinstance(expr.variable.class_type, (HomogeneousListType, HomogeneousSetType)):
             variable_address = self._print(ObjectAddress(expr.variable))
-            dtype = self.find_in_type_registry(expr.variable.class_type.element_type).replace(" ", "_")
-            container_type = "hset_"if isinstance(expr.variable.class_type, HomogeneousSetType) else "vec_"
-            return f'{container_type}{dtype}_drop({variable_address});\n'
+            container_type = self.find_in_type_registry(expr.variable.class_type)
+            return f'{container_type}_drop({variable_address});\n'
         if isinstance(expr.variable, InhomogeneousTupleVariable):
             return ''.join(self._print(Deallocate(v)) for v in expr.variable)
         variable_address = self._print(ObjectAddress(expr.variable))

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -776,18 +776,11 @@ class CCodePrinter(CodePrinter):
                 classes += self._print(classDef.docstring)
             classes += f"struct {classDef.name} {{\n"
             classes += ''.join(self._print(Declare(var)) for var in classDef.attributes)
-            class_scope = classDef.scope
             for method in classDef.methods:
-                if not method.is_inline:
-                    if method.name.startswith(classDef.name) == False:
-                        class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
                     funcs += f"{self.function_signature(method)};\n"
             for interface in classDef.interfaces:
                 for func in interface.functions:
-                    if not func.is_inline:
-                        if method.name.startswith(classDef.name) == False:
-                            class_scope.rename_function(func, f"{classDef.name}__{func.name.lstrip('__')}")
-                        funcs += f"{self.function_signature(func)};\n"
+                    funcs += f"{self.function_signature(func)};\n"
             classes += "};\n"
         funcs += '\n'.join(f"{self.function_signature(f)};" for f in expr.module.funcs if not f.is_inline)
 
@@ -811,6 +804,15 @@ class CCodePrinter(CodePrinter):
     def _print_Module(self, expr):
         self.set_scope(expr.scope)
         self._current_module = expr
+        for classDef in  expr.classes: 
+            class_scope = classDef.scope
+            for method in classDef.methods:
+                if not method.is_inline:
+                    class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
+            for interface in classDef.interfaces:
+                for func in interface.functions:
+                    if not func.is_inline:
+                        class_scope.rename_function(func, f"{classDef.name}__{func.name.lstrip('__')}")
         body    = ''.join(self._print(i) for i in expr.body)
 
         global_variables = ''.join([self._print(d) for d in expr.declarations])

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -800,7 +800,7 @@ class CCodePrinter(CodePrinter):
                 {classes}\n \
                 {funcs}\n \
                 #endif // {name}_H\n")
-    
+
     def rename_imported_methods(self, expr):
          if expr.source_module and expr.source_module is not self._current_module:
             for classDef in expr.source_module.classes:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -956,16 +956,14 @@ class CCodePrinter(CodePrinter):
         else:
             source = self._print(source)
         if expr.target:
-            dtype = expr.target.pop().name
             if source.startswith('stc/'):
-                _,container_type = source.split("/")
+                stc_name, container_type, container_key = source.split("/")
                 container = container_type.split("_")
-                index = len(container[0]) + 1
                 return '\n'.join((f'#ifndef _{container_type.upper()}',
                                   f'#define _{container_type.upper()}',
                                   f'#define i_type {container_type}',
-                                  f'#define i_key {container_type[index:]}',
-                                  f'#include "{_ + "/" +container[0]}.h"',
+                                  f'#define i_key {container_key}',
+                                  f'#include "{stc_name + "/" + container[0]}.h"',
                                   '#endif\n'))
 
         # Get with a default value is not used here as it is
@@ -1188,7 +1186,7 @@ class CCodePrinter(CodePrinter):
             if not isinstance(dtype.element_type, GenericType):
                 vec_dtype = self.find_in_dtype_registry(dtype.element_type)
             i_type = container_type + vec_dtype.replace(' ', '_')
-            self.add_import(Import('stc/' + i_type, Module('stc/' + i_type, (), ())))
+            self.add_import(Import('stc/' + i_type + "/" + vec_dtype, Module('stc/' + i_type, (), ())))
             return i_type
         else:
             key = dtype

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -660,13 +660,13 @@ class CCodePrinter(CodePrinter):
         """
         for classDef in expr:
             class_scope = classDef.scope
-        for method in classDef.methods:
-            if not method.is_inline:
-                class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
-        for interface in classDef.interfaces:
-            for func in interface.functions:
-                if not func.is_inline:
-                    class_scope.rename_function(func, f"{classDef.name}__{func.name.lstrip('__')}")
+            for method in classDef.methods:
+                if not method.is_inline:
+                    class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
+            for interface in classDef.interfaces:
+                for func in interface.functions:
+                    if not func.is_inline:
+                        class_scope.rename_function(func, f"{classDef.name}__{func.name.lstrip('__')}")
 
     # ============ Elements ============ #
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -965,7 +965,7 @@ class CCodePrinter(CodePrinter):
                                   f'#define _{container_type.upper()}',
                                   f'#define i_type {container_type}',
                                   f'#define i_key {container_type[index:]}',
-                                  f'#include "{"extensions/STC/include/"+ _ + "/" +container[0]}.h"',
+                                  f'#include "{_ + "/" +container[0]}.h"',
                                   '#endif\n'))
 
         # Get with a default value is not used here as it is

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -27,6 +27,9 @@ __all__ = ['copy_internal_library','recompile_object']
 #==============================================================================
 language_extension = {'fortran':'f90', 'c':'c', 'python':'py'}
 
+#==============================================================================
+# map external libraries inside pyccel/extensions with their path
+external_libs = {"stc"  : "STC/include"}
 
 #==============================================================================
 # map internal libraries to their folders inside pyccel/stdlib and their compile objects
@@ -107,8 +110,8 @@ def copy_internal_library(lib_folder, pyccel_dirpath, extra_files = None):
         The location that the files were copied to.
     """
     # get lib path (stdlib_path/lib_name or ext_path/lib_name)
-    if lib_folder == "stc":
-        lib_path = os.path.join(ext_path, "STC", "include", lib_folder)
+    if lib_folder in external_libs:
+        lib_path = os.path.join(ext_path, external_libs[lib_folder], lib_folder)
     else:
         lib_path = os.path.join(stdlib_path, lib_folder)
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -27,10 +27,6 @@ __all__ = ['copy_internal_library','recompile_object']
 #==============================================================================
 language_extension = {'fortran':'f90', 'c':'c', 'python':'py'}
 
-#==============================================================================
-# map external libraries to their folders inside pyccel/extensions
-external_libs = {"stc/vec"      : "stc",
-                 "stc/hset"     : "stc",}
 
 #==============================================================================
 # map internal libraries to their folders inside pyccel/stdlib and their compile objects

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -485,8 +485,7 @@ class FortranToCWrapper(Wrapper):
             return expr.clone(expr.name, new_class = BindCArrayVariable, wrapper_function = func,
                                 original_variable = expr)
         else:
-            raise NotImplementedError("Containers cannot be wrapped yet")
-
+            raise NotImplementedError(f"Objects of type {expr.class_type} cannot be wrapped yet")
     def _wrap_DottedVariable(self, expr):
         """
         Create all objects necessary to expose a class attribute to C.

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -485,7 +485,7 @@ class FortranToCWrapper(Wrapper):
             return expr.clone(expr.name, new_class = BindCArrayVariable, wrapper_function = func,
                                 original_variable = expr)
         else:
-            raise NotImplementedError("Lists cannot be wrapped yet")
+            raise NotImplementedError("Containers cannot be wrapped yet")
 
     def _wrap_DottedVariable(self, expr):
         """

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -22,6 +22,7 @@ from pyccel.ast.internals import Slice
 from pyccel.ast.literals import LiteralInteger, Nil, LiteralTrue
 from pyccel.ast.operators import PyccelIsNot, PyccelMul
 from pyccel.ast.variable import Variable, IndexedElement, DottedVariable
+from pyccel.ast.numpyext import NumpyNDArrayType
 from pyccel.parser.scope import Scope
 from .wrapper import Wrapper
 
@@ -451,7 +452,7 @@ class FortranToCWrapper(Wrapper):
         """
         if isinstance(expr.class_type, FixedSizeNumericType):
             return expr.clone(expr.name, new_class = BindCVariable)
-        else:
+        elif isinstance(expr.class_type, NumpyNDArrayType):
             scope = self.scope
             func_name = scope.get_new_name('bind_c_'+expr.name.lower())
             func_scope = scope.new_child_scope(func_name)
@@ -483,6 +484,8 @@ class FortranToCWrapper(Wrapper):
                           original_function = expr)
             return expr.clone(expr.name, new_class = BindCArrayVariable, wrapper_function = func,
                                 original_variable = expr)
+        else:
+            raise NotImplementedError("Lists cannot be wrapped yet")
 
     def _wrap_DottedVariable(self, expr):
         """

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -486,6 +486,7 @@ class FortranToCWrapper(Wrapper):
                                 original_variable = expr)
         else:
             raise NotImplementedError(f"Objects of type {expr.class_type} cannot be wrapped yet")
+
     def _wrap_DottedVariable(self, expr):
         """
         Create all objects necessary to expose a class attribute to C.

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1621,7 +1621,7 @@ class SemanticParser(BasicParser):
             # to remove memory leaks
             new_expressions.append(Deallocate(var))
 
-        elif class_type != var.class_type and not isinstance(class_type.datatype, GenericType):
+        elif class_type != var.class_type:
             if is_augassign:
                 tmp_result = PyccelAdd(var, rhs)
                 result_type = tmp_result.class_type

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -61,10 +61,10 @@ from pyccel.ast.core import Assert
 from pyccel.ast.class_defs import NumpyArrayClass, TupleClass, get_cls_base
 
 from pyccel.ast.datatypes import CustomDataType, PyccelType, TupleType, VoidType, GenericType
-from pyccel.ast.datatypes import PrimitiveIntegerType, HomogeneousListType, StringType, SymbolicType, HomogeneousSetType
+from pyccel.ast.datatypes import PrimitiveIntegerType, StringType, SymbolicType
 from pyccel.ast.datatypes import PythonNativeBool, PythonNativeInt, PythonNativeFloat
 from pyccel.ast.datatypes import DataTypeFactory, PrimitiveFloatingPointType
-from pyccel.ast.datatypes import InhomogeneousTupleType, HomogeneousTupleType, HomogeneousSetType
+from pyccel.ast.datatypes import InhomogeneousTupleType, HomogeneousTupleType, HomogeneousSetType, HomogeneousListType
 from pyccel.ast.datatypes import PrimitiveComplexType, FixedSizeNumericType
 
 from pyccel.ast.functionalexpr import FunctionalSum, FunctionalMax, FunctionalMin, GeneratorComprehension, FunctionalFor

--- a/tests/epyccel/modules/array_consts.py
+++ b/tests/epyccel/modules/array_consts.py
@@ -6,7 +6,6 @@ b = np.array([1,2,3,4,5])
 c = np.zeros((2,3), dtype=np.int32)
 d = np.array([1+2j, 3+4j])
 e = np.empty((2,3,4))
-F = [False for _ in range(5)]
 
 def update_a():
     a[:] = a+1

--- a/tests/epyccel/modules/list_comprehension.py
+++ b/tests/epyccel/modules/list_comprehension.py
@@ -1,4 +1,4 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 
-F = [False for _ in range(5)]
+A = [False for _ in range(5)]
 

--- a/tests/epyccel/modules/list_comprehension.py
+++ b/tests/epyccel/modules/list_comprehension.py
@@ -1,0 +1,3 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+F = [False for _ in range(5)]

--- a/tests/epyccel/modules/list_comprehension.py
+++ b/tests/epyccel/modules/list_comprehension.py
@@ -1,3 +1,4 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 
 F = [False for _ in range(5)]
+

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -4030,7 +4030,7 @@ def test_array_float_nested_C_array_initialization_3(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="List indexing is not yet supported in C"),
+            pytest.mark.xfail(reason="List indexing is not yet supported in C, related issue #1876"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -4027,7 +4027,15 @@ def test_array_float_nested_C_array_initialization_3(language):
 #==============================================================================
 # NUMPY SUM
 #==============================================================================
-
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="List indexing is not yet supported in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_arr_bool_sum(language):
     f1 = arrays.arr_bool_sum
     f2 = epyccel(f1, language = language)

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -130,15 +130,6 @@ def test_module_6(language):
         assert mod_att == modnew_att
         assert type(mod_att) is type(modnew_att)
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = [
-            pytest.mark.xfail(reason="List indexing is not yet supported in C"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_module_7(language):
     import modules.array_consts as mod
 
@@ -150,8 +141,6 @@ def test_module_7(language):
         modnew_att = getattr(modnew, att)
         assert np.array_equal(mod_att, modnew_att)
         assert mod_att.dtype == modnew_att.dtype
-
-    assert np.array_equal(mod.F, modnew.F)
 
     modnew.update_a()
     mod.update_a()
@@ -180,6 +169,22 @@ def test_module_7(language):
     mod.reset_a()
     mod.reset_c()
     mod.reset_e()
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="List indexing is not yet supported in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_module_8(language):
+    import modules.array_consts as mod
+
+    modnew = epyccel(mod, language=language)
+
+    assert np.array_equal(mod.F, modnew.F)
 
 def test_awkward_names(language):
     import modules.awkward_names as mod

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -172,11 +172,11 @@ def test_module_7(language):
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = [
-            pytest.mark.xfail(reason="List wrapper is not implemented yet."),
+            pytest.mark.xfail(reason="List wrapper is not implemented yet, related issue #1911"),
             pytest.mark.fortran]
             ),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="List indexing is not yet supported in C"),
+            ppytest.mark.xfail(reason="List indexing is not yet supported in C, related issue #1876"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -176,7 +176,7 @@ def test_module_7(language):
             pytest.mark.fortran]
             ),
         pytest.param("c", marks = [
-            ppytest.mark.xfail(reason="List indexing is not yet supported in C, related issue #1876"),
+            pytest.mark.xfail(reason="List indexing is not yet supported in C, related issue #1876"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -171,7 +171,10 @@ def test_module_7(language):
     mod.reset_e()
 
 @pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("fortran", marks = [
+            pytest.mark.xfail(reason="List wrapper is not implemented yet."),
+            pytest.mark.fortran]
+            ),
         pytest.param("c", marks = [
             pytest.mark.xfail(reason="List indexing is not yet supported in C"),
             pytest.mark.c]
@@ -180,7 +183,7 @@ def test_module_7(language):
     )
 )
 def test_module_8(language):
-    import modules.array_consts as mod
+    import modules.list_comprehension as mod
 
     modnew = epyccel(mod, language=language)
 

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
+import pytest
 import numpy as np
 from pyccel import epyccel
 
@@ -129,6 +130,15 @@ def test_module_6(language):
         assert mod_att == modnew_att
         assert type(mod_att) is type(modnew_att)
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="List indexing is not yet supported in C"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_module_7(language):
     import modules.array_consts as mod
 

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -187,7 +187,7 @@ def test_module_8(language):
 
     modnew = epyccel(mod, language=language)
 
-    assert np.array_equal(mod.F, modnew.F)
+    assert np.array_equal(mod.A, modnew.A)
 
 def test_awkward_names(language):
     import modules.awkward_names as mod

--- a/tests/epyccel/test_epyccel_variable_annotations.py
+++ b/tests/epyccel/test_epyccel_variable_annotations.py
@@ -191,6 +191,7 @@ def test_homogeneous_set_annotation_int(language):
     assert epyc_homogeneous_set_annotation() == homogeneous_set_annotation()
     assert isinstance(epyc_homogeneous_set_annotation(), type(homogeneous_set_annotation()))
 
+@parametrize_languages()
 def test_homogeneous_set_without_annotation(language):
     def homogeneous_set():
         a = {1, 2, 3, 4} #pylint: disable=unused-variable

--- a/tests/epyccel/test_epyccel_variable_annotations.py
+++ b/tests/epyccel/test_epyccel_variable_annotations.py
@@ -10,14 +10,17 @@ from pyccel import epyccel
 from pyccel.errors.errors import PyccelSemanticError, Errors
 from pyccel.decorators import allow_negative_index, stack_array
 
-def parametrize_languages():
-    return pytest.mark.parametrize('language', [
-        pytest.param("c", marks=pytest.mark.c),
-        pytest.param("fortran", marks=[
-            pytest.mark.skip(reason="Variable declaration not implemented in fortran"),
+@pytest.fixture( params=[
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("fortran", marks = [
+            pytest.mark.xfail(reason="Variable declaration not implemented in fortran, related issues #1657 1658"),
             pytest.mark.fortran]),
-        pytest.param("python", marks=pytest.mark.python)
-    ])
+        pytest.param("python", marks = pytest.mark.python)
+    ],
+    scope = "module"
+)
+def stc_language(request):
+    return request.param
 
 def test_local_type_annotation(language):
     def local_type_annotation():
@@ -175,106 +178,88 @@ def test_homogeneous_tuple_2_annotation_str(language):
     assert epyc_homogeneous_tuple_annotation() == homogeneous_tuple_annotation()
     assert isinstance(epyc_homogeneous_tuple_annotation(), type(homogeneous_tuple_annotation()))
 
-@pytest.mark.parametrize( 'language', [
-        pytest.param("c", marks = pytest.mark.c),
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="Variable declaration not implemented in fortran"),
-            pytest.mark.fortran]),
-        pytest.param("python", marks = pytest.mark.python)
-    ]
-)
-def test_homogeneous_set_annotation_int(language):
+def test_homogeneous_set_annotation_int(stc_language):
     def homogeneous_set_annotation ():
         a : 'set[int]' #pylint: disable=unused-variable
         a = {1, 2, 3, 4}
-    epyc_homogeneous_set_annotation =  epyccel(homogeneous_set_annotation, language=language)
+    epyc_homogeneous_set_annotation =  epyccel(homogeneous_set_annotation, language=stc_language)
     assert epyc_homogeneous_set_annotation() == homogeneous_set_annotation()
     assert isinstance(epyc_homogeneous_set_annotation(), type(homogeneous_set_annotation()))
 
-@parametrize_languages()
-def test_homogeneous_set_without_annotation(language):
+def test_homogeneous_set_without_annotation(stc_language):
     def homogeneous_set():
         a = {1, 2, 3, 4} #pylint: disable=unused-variable
-    epyc_homogeneous_set =  epyccel(homogeneous_set, language=language)
+    epyc_homogeneous_set =  epyccel(homogeneous_set, language=stc_language)
     assert epyc_homogeneous_set() == homogeneous_set()
     assert isinstance(epyc_homogeneous_set(), type(homogeneous_set()))
 
-@parametrize_languages()
-def test_homogeneous_set_annotation_float(language):
+def test_homogeneous_set_annotation_float(stc_language):
     def homogeneous_set_annotation ():
         a : 'set[float]' #pylint: disable=unused-variable
         a = {1.5, 2.5, 3.3, 4.3}
-    epyc_homogeneous_set_annotation =  epyccel(homogeneous_set_annotation, language=language)
+    epyc_homogeneous_set_annotation =  epyccel(homogeneous_set_annotation, language=stc_language)
     assert epyc_homogeneous_set_annotation() == homogeneous_set_annotation()
     assert isinstance(epyc_homogeneous_set_annotation(), type(homogeneous_set_annotation()))
 
-@parametrize_languages()
-def test_homogeneous_set_annotation_bool(language):
+def test_homogeneous_set_annotation_bool(stc_language):
     def homogeneous_set_annotation ():
         a : 'set[bool]' #pylint: disable=unused-variable
         a = {False, True, False, True} #pylint: disable=duplicate-value
-    epyc_homogeneous_set_annotation =  epyccel(homogeneous_set_annotation, language=language)
+    epyc_homogeneous_set_annotation =  epyccel(homogeneous_set_annotation, language=stc_language)
     assert epyc_homogeneous_set_annotation() == homogeneous_set_annotation()
     assert isinstance(epyc_homogeneous_set_annotation(), type(homogeneous_set_annotation()))
 
-@parametrize_languages()
-def test_homogeneous_set_annotation_complex(language):
+def test_homogeneous_set_annotation_complex(stc_language):
     def homogeneous_set_annotation():
         a: 'set[complex]'  # pylint: disable=unused-variable
         a = {1+1j, 2+2j, 3+3j, 4+4j}
-    epyc_homogeneous_set_annotation = epyccel(homogeneous_set_annotation, language=language)
+    epyc_homogeneous_set_annotation = epyccel(homogeneous_set_annotation, language=stc_language)
     assert epyc_homogeneous_set_annotation() == homogeneous_set_annotation()
     assert isinstance(epyc_homogeneous_set_annotation(), type(homogeneous_set_annotation()))
 
-@parametrize_languages()
-def test_homogeneous_list_annotation_int(language):
+def test_homogeneous_list_annotation_int(stc_language):
     def homogeneous_list_annotation():
         a: 'list[int]'  # pylint: disable=unused-variable
         a = [1, 2, 3, 4]
-    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=language)
+    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=stc_language)
     assert epyc_homogeneous_list_annotation() == homogeneous_list_annotation()
     assert isinstance(epyc_homogeneous_list_annotation(), type(homogeneous_list_annotation()))
 
-@parametrize_languages()
-def test_homogeneous_list_without_annotation(language):
+def test_homogeneous_list_without_annotation(stc_language):
     def homogeneous_list():
         a = [1, 2, 3, 4] # pylint: disable=unused-variable
-    epyc_homogeneous_list = epyccel(homogeneous_list, language=language)
+    epyc_homogeneous_list = epyccel(homogeneous_list, language=stc_language)
     assert epyc_homogeneous_list() == homogeneous_list()
     assert isinstance(epyc_homogeneous_list(), type(homogeneous_list()))
 
-@parametrize_languages()
-def test_homogeneous_list_annotation_float(language):
+def test_homogeneous_list_annotation_float(stc_language):
     def homogeneous_list_annotation():
         a: 'list[float]'  # pylint: disable=unused-variable
         a = [1.1, 2.2, 3.3, 4.4]
-    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=language)
+    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=stc_language)
     assert epyc_homogeneous_list_annotation() == homogeneous_list_annotation()
     assert isinstance(epyc_homogeneous_list_annotation(), type(homogeneous_list_annotation()))
 
-@parametrize_languages()
-def test_homogeneous_list_annotation_bool(language):
+def test_homogeneous_list_annotation_bool(stc_language):
     def homogeneous_list_annotation():
         a: 'list[bool]'  # pylint: disable=unused-variable
         a = [False, True, True, False]
-    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=language)
+    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=stc_language)
     assert epyc_homogeneous_list_annotation() == homogeneous_list_annotation()
     assert isinstance(epyc_homogeneous_list_annotation(), type(homogeneous_list_annotation()))
 
-@parametrize_languages()
-def test_homogeneous_list_annotation_complex(language):
+def test_homogeneous_list_annotation_complex(stc_language):
     def homogeneous_list_annotation():
         a: 'list[complex]'  # pylint: disable=unused-variable
         a = [1+1j, 2+2j, 3+3j, 4+4j]
-    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=language)
+    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=stc_language)
     assert epyc_homogeneous_list_annotation() == homogeneous_list_annotation()
     assert isinstance(epyc_homogeneous_list_annotation(), type(homogeneous_list_annotation()))
 
-@parametrize_languages()
-def test_homogeneous_list_annotation_embedded_complex(language):
+def test_homogeneous_list_annotation_embedded_complex(stc_language):
     def homogeneous_list_annotation():
         a : 'list[complex]' = [1j, 2j]
         b = [a] # pylint: disable=unused-variable
-    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=language)
+    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=stc_language)
     assert epyc_homogeneous_list_annotation() == homogeneous_list_annotation()
     assert isinstance(epyc_homogeneous_list_annotation(), type(homogeneous_list_annotation()))

--- a/tests/epyccel/test_epyccel_variable_annotations.py
+++ b/tests/epyccel/test_epyccel_variable_annotations.py
@@ -217,6 +217,14 @@ def test_homogeneous_set_annotation_complex(stc_language):
     assert epyc_homogeneous_set_annotation() == homogeneous_set_annotation()
     assert isinstance(epyc_homogeneous_set_annotation(), type(homogeneous_set_annotation()))
 
+def test_homogeneous_empty_list_annotation_int(stc_language):
+    def homogeneous_list_annotation():
+        a: 'list[int]'  # pylint: disable=unused-variable
+        a = []
+    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=stc_language)
+    assert epyc_homogeneous_list_annotation() == homogeneous_list_annotation()
+    assert isinstance(epyc_homogeneous_list_annotation(), type(homogeneous_list_annotation()))
+
 def test_homogeneous_list_annotation_int(stc_language):
     def homogeneous_list_annotation():
         a: 'list[int]'  # pylint: disable=unused-variable

--- a/tests/epyccel/test_epyccel_variable_annotations.py
+++ b/tests/epyccel/test_epyccel_variable_annotations.py
@@ -269,3 +269,12 @@ def test_homogeneous_list_annotation_complex(language):
     epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=language)
     assert epyc_homogeneous_list_annotation() == homogeneous_list_annotation()
     assert isinstance(epyc_homogeneous_list_annotation(), type(homogeneous_list_annotation()))
+
+@parametrize_languages()
+def test_homogeneous_list_annotation_embedded_complex(language):
+    def homogeneous_list_annotation():
+        a : 'list[complex]' = [1j, 2j]
+        b = [a] # pylint: disable=unused-variable
+    epyc_homogeneous_list_annotation = epyccel(homogeneous_list_annotation, language=language)
+    assert epyc_homogeneous_list_annotation() == homogeneous_list_annotation()
+    assert isinstance(epyc_homogeneous_list_annotation(), type(homogeneous_list_annotation()))

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -10,7 +10,7 @@ from modules import functionals
 @pytest.fixture( params=[
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
             pytest.mark.c]),
         pytest.param("python", marks = pytest.mark.python)
     ],

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -1,9 +1,23 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 from numpy.random import randint
 from numpy import equal
+import pytest
+
 
 from pyccel import epyccel
 from modules import functionals
+
+@pytest.fixture( params=[
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.c]),
+        pytest.param("python", marks = pytest.mark.python)
+    ],
+    scope = "module"
+)
+def language(request):
+    return request.param
 
 def compare_epyccel(f, language, *args):
     f2 = epyccel(f, language=language)

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -77,6 +77,15 @@ def test_double_loop_on_2d_array_F(language):
     f2( y )
     assert np.array_equal( x, y )
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_product_loop_on_2d_array_C(language):
 
     f1 = loops.product_loop_on_2d_array_C
@@ -89,6 +98,15 @@ def test_product_loop_on_2d_array_C(language):
     f2( y )
     assert np.array_equal( x, y )
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_product_loop_on_2d_array_F(language):
 
     f1 = loops.product_loop_on_2d_array_F
@@ -101,6 +119,15 @@ def test_product_loop_on_2d_array_F(language):
     f2( y )
     assert np.array_equal( x, y )
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_product_loop(language):
 
     f1 = loops.product_loop
@@ -150,6 +177,15 @@ def test_enumerate_on_1d_array_with_start(language):
     assert np.array_equal( f1(z, 5), f2(z, 5) )
     assert np.array_equal( f1(z,-2), f2(z,-2) )
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = [
+            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_zip_prod(language):
 
     f1 = loops.zip_prod

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -80,7 +80,7 @@ def test_double_loop_on_2d_array_F(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -101,7 +101,7 @@ def test_product_loop_on_2d_array_C(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -122,7 +122,7 @@ def test_product_loop_on_2d_array_F(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -180,7 +180,7 @@ def test_enumerate_on_1d_array_with_start(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet."),
+            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)


### PR DESCRIPTION
This feature pull request adds the appropriate C language equivalent for declaring `list` and `set` containers in Python, as well as freeing their memory, with the help of the STC library. This fixes #1655 and #1659.

**Commit Summary**
- Copy STC files to the destination path using `copy_internal_library()`.
- Change the order of printing the module and the module header in `codegen` to determine the appropriate STC macros.
- Perform the appropriate class method renaming in `_print_Module()` instead of `_print_Module_Header()`.
- Determine the right STC container type and construct its macros, as well as the container variable name (`i_type` macro).
- Generate the deallocation node of a container using the STC method `container_X_drop(&container_var)`.
- Generate the initialization of an STC container in C using the method `c_init()`.
- Add tests to check the initialization of `list` and `set` using different data types.