### PR TITLE
Fix macOS gfortran installation

### DIFF
--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -10,7 +10,7 @@ runs:
         GFORTRAN_HOME=$(which gfortran || true)
         echo "GFORTRAN_HOME : $GFORTRAN_HOME"
         if [[ ! -f "$GFORTRAN_HOME" ]]; then
-          gfort=$(find $PATH -name gfortran-* | tail -n 1)
+          gfort=$(find ${PATH//:/\/ } -name gfortran-* | tail -n 1)
           echo "Found $gfort"
           ln -s ${gfort} /opt/homebrew/bin/gfortran
         fi

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -11,6 +11,7 @@ runs:
         which gcc
         ls /usr/bin
         ls /usr/local/bin/
+        which gfortran-13
         GFORTRAN_FILE=$(which gfortran)
         echo $GFORTRAN_FILE
         if [[ ! -f "$GFORTRAN_FILE" ]]; then

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -7,7 +7,7 @@ runs:
       run: |
         brew install open-mpi
         brew install libomp
-        GFORTRAN_HOME=$(which gfortran | true)
+        GFORTRAN_HOME=$(which gfortran || true)
         echo "GFORTRAN_HOME : $GFORTRAN_HOME"
         if [[ ! -f "$GFORTRAN_HOME" ]]; then
           gfort=$(find / -name gfortran-* | tail -n 1)

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -5,10 +5,13 @@ runs:
   steps:
     - name: Install MPI, OpenMP
       run: |
-        brew install gcc # Ensure gfortran is installed
         brew install open-mpi
         brew install libomp
-        if [[ ! -f "/usr/local/bin/gfortran" ]]; then
+        GFORTRAN_FILE=$(which gfortran)
+        echo $GFORTRAN_FILE
+        if [[ ! -f "$GFORTRAN_FILE" ]]; then
+          ls /usr/local/bin/
+          which gcc
           gfort=$(ls /usr/local/bin/gfortran-* | tail -n 1)
           ln -s ${gfort} /usr/local/bin/gfortran
         fi

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - name: Install MPI, OpenMP
       run: |
+        brew install gcc # Ensure gfortran is installed
         brew install open-mpi
         brew install libomp
         GFORTRAN_FILE=$(which gfortran)

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -12,7 +12,8 @@ runs:
         if [[ ! -f "$GFORTRAN_HOME" ]]; then
           gfort=$(find ${PATH//:/\/ } -name 'gfortran-*' | tail -n 1 || true)
           echo "Found $gfort"
-          ln -s ${gfort} /opt/homebrew/bin/gfortran
+          folder=$(dirname ${gfort})
+          ln -s ${gfort} ${folder}/gfortran
         fi
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -10,7 +10,7 @@ runs:
         GFORTRAN_HOME=$(which gfortran || true)
         echo "GFORTRAN_HOME : $GFORTRAN_HOME"
         if [[ ! -f "$GFORTRAN_HOME" ]]; then
-          gfort=$(find ${PATH//:/\/ } -name gfortran-* | tail -n 1)
+          gfort=$(find ${PATH//:/\/ } -name gfortran-* || true | tail -n 1)
           echo "Found $gfort"
           ln -s ${gfort} /opt/homebrew/bin/gfortran
         fi

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -5,21 +5,14 @@ runs:
   steps:
     - name: Install MPI, OpenMP
       run: |
-        brew install gfortran # Ensure gfortran is installed
         brew install open-mpi
         brew install libomp
-        which gcc
-        gcc --version
-        ls /usr/bin
-        ls /usr/local/bin/
-        which gfortran-13
-        GFORTRAN_FILE=$(which gfortran)
-        echo $GFORTRAN_FILE
-        if [[ ! -f "$GFORTRAN_FILE" ]]; then
-          ls /usr/local/bin/
-          which gcc
-          gfort=$(ls /usr/local/bin/gfortran-* | tail -n 1)
-          ln -s ${gfort} /usr/local/bin/gfortran
+        GFORTRAN_HOME=$(which gfortran | true)
+        echo "GFORTRAN_HOME : $GFORTRAN_HOME"
+        if [[ ! -f "$GFORTRAN_HOME" ]]; then
+          gfort=$(find / -name gfortran-* | tail -n 1)
+          echo "Found $gfort"
+          ln -s ${gfort} /opt/homebrew/bin/gfortran
         fi
         echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -10,7 +10,7 @@ runs:
         GFORTRAN_HOME=$(which gfortran || true)
         echo "GFORTRAN_HOME : $GFORTRAN_HOME"
         if [[ ! -f "$GFORTRAN_HOME" ]]; then
-          gfort=$(sudo find / -name gfortran-* | tail -n 1)
+          gfort=$(find $PATH -name gfortran-* | tail -n 1)
           echo "Found $gfort"
           ln -s ${gfort} /opt/homebrew/bin/gfortran
         fi

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -9,6 +9,8 @@ runs:
         brew install open-mpi
         brew install libomp
         which gcc
+        ls /usr/bin
+        ls /usr/local/bin/
         GFORTRAN_FILE=$(which gfortran)
         echo $GFORTRAN_FILE
         if [[ ! -f "$GFORTRAN_FILE" ]]; then

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - name: Install MPI, OpenMP
       run: |
+        brew install gcc # Ensure gfortran is installed
         brew install open-mpi
         brew install libomp
         if [[ ! -f "/usr/local/bin/gfortran" ]]; then

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -10,7 +10,7 @@ runs:
         GFORTRAN_HOME=$(which gfortran || true)
         echo "GFORTRAN_HOME : $GFORTRAN_HOME"
         if [[ ! -f "$GFORTRAN_HOME" ]]; then
-          gfort=$(find / -name gfortran-* | tail -n 1)
+          gfort=$(sudo find / -name gfortran-* | tail -n 1)
           echo "Found $gfort"
           ln -s ${gfort} /opt/homebrew/bin/gfortran
         fi

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -5,9 +5,10 @@ runs:
   steps:
     - name: Install MPI, OpenMP
       run: |
-        brew install gcc # Ensure gfortran is installed
+        brew install gfortran # Ensure gfortran is installed
         brew install open-mpi
         brew install libomp
+        which gcc
         GFORTRAN_FILE=$(which gfortran)
         echo $GFORTRAN_FILE
         if [[ ! -f "$GFORTRAN_FILE" ]]; then

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -10,7 +10,7 @@ runs:
         GFORTRAN_HOME=$(which gfortran || true)
         echo "GFORTRAN_HOME : $GFORTRAN_HOME"
         if [[ ! -f "$GFORTRAN_HOME" ]]; then
-          gfort=$(find ${PATH//:/\/ } -name gfortran-* || true | tail -n 1)
+          gfort=$(find ${PATH//:/\/ } -name 'gfortran-*' | tail -n 1 || true)
           echo "Found $gfort"
           ln -s ${gfort} /opt/homebrew/bin/gfortran
         fi

--- a/.github/actions/macos_install/action.yml
+++ b/.github/actions/macos_install/action.yml
@@ -9,6 +9,7 @@ runs:
         brew install open-mpi
         brew install libomp
         which gcc
+        gcc --version
         ls /usr/bin
         ls /usr/local/bin/
         which gfortran-13


### PR DESCRIPTION
The default directory for gfortran has changed so our CI was failing in the installation. This PR determines the location programatically to prevent the problem arising again.