### PR TITLE
Ensure workflows run on main branch

### DIFF
--- a/.github/workflows/anaconda_linux.yml
+++ b/.github/workflows/anaconda_linux.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           mpi_type: openmpi
       - name: "Setup"
+        if: github.event_name != 'push'
         id: token
         run: |
           pip install jwt requests
@@ -108,7 +109,7 @@ jobs:
           path: .coverage
           retention-days: 1
       - name: "Post completed"
-        if: always()
+        if: always() && github.event_name != 'push'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}
         shell: bash -l {0}

--- a/.github/workflows/anaconda_linux.yml
+++ b/.github/workflows/anaconda_linux.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: devel
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           mpi_type: msmpi
       - name: "Setup"
+        if: github.event_name != 'push'
         id: token
         run: |
           python -m pip install jwt requests
@@ -88,7 +89,7 @@ jobs:
         with:
           shell_cmd: 'bash -l -eo pipefail {0}'
       - name: "Post completed"
-        if: always()
+        if: always() && github.event_name != 'push'
         run: |
           which python
           python --version

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: devel
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: devel
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           python-version: ${{ needs.Python_version_picker.outputs.python_version }}
       - name: "Setup"
+        if: github.event_name != 'push'
         id: token
         run: |
           pip install jwt requests
@@ -102,6 +103,6 @@ jobs:
           path: .coverage
           retention-days: 1
       - name: "Post completed"
-        if: always()
+        if: always() && github.event_name != 'push'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }} ${{ steps.valgrind.outcome }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
       - name: "Setup"
+        if: github.event_name != 'push'
         id: token
         run: |
           pip install jwt requests
@@ -105,6 +106,6 @@ jobs:
           path: .coverage
           retention-days: 1
       - name: "Post completed"
-        if: always()
+        if: always() && github.event_name != 'push'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }} ${{ steps.valgrind.outcome }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: devel
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           python-version: ${{ needs.Python_version_picker.outputs.python_version }}
       - name: "Setup"
+        if: github.event_name != 'push'
         id: token
         run: |
           pip install jwt requests
@@ -87,6 +88,6 @@ jobs:
         timeout-minutes: 20
         uses: ./.github/actions/pytest_parallel
       - name: "Post completed"
-        if: always()
+        if: always() && github.event_name != 'push'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: devel
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}

--- a/.github/workflows/pickle.yml
+++ b/.github/workflows/pickle.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
   push:
-    branches: devel
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}

--- a/.github/workflows/pickle.yml
+++ b/.github/workflows/pickle.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           python-version: ${{ needs.Python_version_picker.outputs.python_version }}
       - name: "Setup"
+        if: github.event_name != 'push'
         id: token
         run: |
           pip install jwt requests
@@ -99,7 +100,7 @@ jobs:
         with:
           not_editable: "${{ matrix.editable_string == '-e' && 'False' || 'True' }}"
       - name: "Post completed"
-        if: always()
+        if: always() && github.event_name != 'push'
         run: |
           python ci_tools/basic_json_check_output.py --statuses ${{ steps.pickle.outcome }} ${{ steps.pickle_check.outcome }} ${{ steps.stc_check.outcome }} ${{ steps.gFTL_check.outcome}} --reasons "Installation failed." "Pickled files were not found in installaion." "STC was not found during installation." "gFTL was not found during installation."
           python ci_tools/complete_check_run.py ${{ steps.pickle.outcome }} ${{ steps.pickle_check.outcome }} ${{ steps.stc_check.outcome }} ${{ steps.gFTL_check.outcome}}

--- a/.github/workflows/pickle_wheel.yml
+++ b/.github/workflows/pickle_wheel.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: devel
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}

--- a/.github/workflows/pickle_wheel.yml
+++ b/.github/workflows/pickle_wheel.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           python-version: ${{ needs.Python_version_picker.outputs.python_version }}
       - name: "Setup"
+        if: github.event_name != 'push'
         id: token
         run: |
           pip install jwt requests
@@ -86,7 +87,7 @@ jobs:
         id: gFTL_check
         uses: ./.github/actions/check_for_gftl
       - name: "Post completed"
-        if: always()
+        if: always() && github.event_name != 'push'
         run: |
           python ci_tools/basic_json_check_output.py --statuses ${{ steps.pickle.outcome }} ${{ steps.pickle_check.outcome }} ${{ steps.stc_check.outcome }} ${{ steps.gFTL_check.outcome}} --reasons "Installation failed." "Pickled files were not found in installaion." "STC was not found during installation." "gFTL was not found during installation."
           python ci_tools/complete_check_run.py ${{ steps.pickle.outcome }} ${{ steps.pickle_check.outcome }} ${{ steps.stc_check.outcome }} ${{ steps.gFTL_check.outcome}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           python-version: ${{ needs.Python_version_picker.outputs.python_version }}
       - name: "Setup"
+        if: github.event_name != 'push'
         id: token
         run: |
           pip install jwt requests
@@ -90,6 +91,6 @@ jobs:
         timeout-minutes: 20
         uses: ./.github/actions/pytest_parallel
       - name: "Post completed"
-        if: always()
+        if: always() && github.event_name != 'push'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: devel
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}


### PR DESCRIPTION
The workflows are configured to run on the `devel` branch and are also triggered by workflow dispatch actions. When the branches are triggered by pushes the results are reported twice as they are reported via the push and via the bot.
This PR changes the workflow configuration so the tests are also run on the `main` branch and so that the bot reporting is only run on workflow_dispatch events.

This was tested in a commit that has since been reverted