### PR TITLE
Fix Wrapper Documentation.

### DIFF
--- a/developer_docs/wrapper_stage.md
+++ b/developer_docs/wrapper_stage.md
@@ -20,7 +20,7 @@ The entry point for the class `Wrapper` is the function `wrap`.
 The `_wrap` function internally calls a function named `_wrap_X`, where `X` is the type of the object.
 These functions must have the form:
 ```python
-def _print_ClassName(self, stmt):
+def _wrap_ClassName(self, stmt):
     ...
     return Y
 ```


### PR DESCRIPTION
Correct a small issue in the wrapper documentation : 
From : 
```python
def _print_ClassName(self, stmt):
    ...
    return Y
```
To : 
```python
def _wrap_ClassName(self, stmt):
    ...
    return Y
```