### PR TITLE
Fix minor doc bot issue (6 lines)

### DIFF
--- a/ci_tools/list_docs_tovalidate.py
+++ b/ci_tools/list_docs_tovalidate.py
@@ -33,9 +33,6 @@ def should_ignore(name):
     #ignore _print_ methods in the codegen.printing module
     if 'Printer._print_' in name:
         return True
-    #ignore _wrap_ methods in the codegen.wrapper module
-    if 'Wrapper._wrap_' in name:
-        return True
     return False
 
 if __name__ == '__main__':
@@ -81,16 +78,16 @@ if __name__ == '__main__':
                 # inside a function or a class is updated to include
                 # the name of the parent object.
                 if isinstance(node, (FunctionDef, ClassDef)):
-                    if should_ignore('.'.join([prefix, node.name])):
+                    if should_ignore(f'{prefix}.{node.name}'):
                         continue
                     if any((node.lineno <= x <= node.end_lineno
                             for x in line_nos)):
-                        objects.append('.'.join([prefix, node.name]))
+                        objects.append(f'{prefix}.{node.name}')
                     if isinstance(node, ClassDef):
                         obj_pref = node.name
                         for child in node.body:
                             if isinstance(child, (FunctionDef, ClassDef)):
-                                child.name = '.'.join([obj_pref, child.name])
+                                child.name = f'{obj_pref}.{child.name}'
                                 to_visit.append(child)
 
             for obj in objects:


### PR DESCRIPTION
While reviewing https://github.com/pyccel/pyccel-cuda/pull/49 I noticed that the bot does not check `_wrap_X` docstring formats. We decided that wrap functions should be documented, so they should be documented correctly. This PR stops ignoring these functions and makes minor improvements to the associated file by using f-strings instead of join.