### PR TITLE
Update deprecated action (4 lines)

### DIFF
--- a/.github/workflows/anaconda_linux.yml
+++ b/.github/workflows/anaconda_linux.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           shell_cmd: "bash -l {0}"
       - name: Save code coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-artifact
           path: .coverage

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -97,7 +97,7 @@ jobs:
         continue-on-error: True
         uses: ./.github/actions/coverage_collection
       - name: Save code coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-artifact
           path: .coverage

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,7 +100,7 @@ jobs:
         continue-on-error: True
         uses: ./.github/actions/coverage_collection
       - name: Save code coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-artifact
           path: .coverage

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           name: coverage-artifact
           path: .coverage
-          retention-days: 1
+          retention-days: 3
       - name: "Post completed"
         if: always() && github.event_name != 'push'
         run:


### PR DESCRIPTION
Version 3 of the `upload-artifact` action has been issued with a [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).
![image](https://github.com/pyccel/pyccel/assets/25363473/4fb4e722-e11d-4f50-9105-ce33f82a24d7)

This PR updates the version as requested. It also increases the retention time for the linux artifact to reduce problems when the coverage bot tries to run after the artifact has expired.