### PR TITLE
[DICT] Add Python support for dict initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 -   #1787 : Ensure `STC` is installed with Pyccel.
 -   #1656 : Ensure `gFTL` is installed with Pyccel.
 -   #1844 : Add line numbers and code to errors from built-in function calls.
+-   #1894 : Add Python support for dict initialisation with `{}`.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 -   #1787 : Ensure `STC` is installed with Pyccel.
 -   #1656 : Ensure `gFTL` is installed with Pyccel.
 -   #1844 : Add line numbers and code to errors from built-in function calls.
--   #1894 : Add Python support for dict initialisation with `{}`.
+-   #1895 : Add Python support for dict initialisation with `{}`.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
 

--- a/ci_tools/check_pylint_commands.py
+++ b/ci_tools/check_pylint_commands.py
@@ -20,7 +20,8 @@ accepted_pylint_commands = {re.compile('.*/IMPORTING_EXISTING_IDENTIFIED3.py'):[
                             re.compile('tests/codegen/fcode/scripts/precision.py'):['unused-variable'],
                             re.compile('tests/semantic/scripts/expressions.py'):['unused-variable'],
                             re.compile('tests/semantic/scripts/calls.py'):['unused-variable'],
-                            re.compile('tests/pyccel/project_class_imports/.*'):['relative-beyond-top-level'] # ignore Codacy bad pylint call
+                            re.compile('tests/pyccel/project_class_imports/.*'):['relative-beyond-top-level'], # ignore Codacy bad pylint call
+                            re.compile('tests/errors/syntax_errors/import_star.py'):['wildcard-import']
                            }
 
 def run_pylint(file, flag, messages):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -858,7 +858,7 @@ class PythonDict(PyccelFunction):
 
     def __str__(self):
         args = ', '.join(f'{k}: {v}' for k,v in self)
-        return f'({args})'
+        return f'{{{args}}}'
 
     def __repr__(self):
         args = ', '.join(f'{repr(k)}: {repr(v)}' for k,v in self)

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -38,6 +38,7 @@ __all__ = (
     'PythonComplex',
     'PythonComplexProperty',
     'PythonConjugate',
+    'PythonDict',
     'PythonEnumerate',
     'PythonFloat',
     'PythonImag',

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -20,6 +20,7 @@ from .datatypes import GenericType, PythonNativeComplex, PrimitiveComplexType
 from .datatypes import HomogeneousTupleType, InhomogeneousTupleType
 from .datatypes import HomogeneousListType, HomogeneousContainerType
 from .datatypes import FixedSizeNumericType, HomogeneousSetType, SymbolicType
+from .datatypes import DictType
 from .internals import PyccelFunction, Slice, PyccelArrayShapeElement
 from .literals  import LiteralInteger, LiteralFloat, LiteralComplex, Nil
 from .literals  import Literal, LiteralImaginaryUnit, convert_to_literal
@@ -824,30 +825,30 @@ class PythonDict(PyccelFunction):
         return zip(self._keys, self._values)
 
     def __str__(self):
-￼        args = ', '.join(f'{k}: {v}' for k,v in self)
-￼        return f'({args})'
-￼
-￼    def __repr__(self):
-￼        args = ', '.join(f'{repr(k)}: {repr(v)}' for k,v in self)
-￼        return f'PythonDict({args})'
-￼
-￼    @property
-￼    def keys(self):
-￼        """
-￼        The keys of the new dictionary.
-￼
-￼        The keys of the new dictionary.
-￼        """
-￼        return self._keys
-￼
-￼    @property
-￼    def values(self):
-￼        """
-￼        The values of the new dictionary.
-￼
-￼        The values of the new dictionary.
-￼        """
-￼        return self._values
+        args = ', '.join(f'{k}: {v}' for k,v in self)
+        return f'({args})'
+
+    def __repr__(self):
+        args = ', '.join(f'{repr(k)}: {repr(v)}' for k,v in self)
+        return f'PythonDict({args})'
+
+    @property
+    def keys(self):
+        """
+        The keys of the new dictionary.
+
+        The keys of the new dictionary.
+        """
+        return self._keys
+
+    @property
+    def values(self):
+        """
+        The values of the new dictionary.
+
+        The values of the new dictionary.
+        """
+        return self._values
 
 #==============================================================================
 class PythonMap(PyccelFunction):

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -10,7 +10,6 @@ from pyccel.ast.builtin_methods.set_methods  import SetAdd, SetClear, SetCopy, S
 from pyccel.ast.builtin_methods.list_methods import (ListAppend, ListInsert, ListPop,
                                                      ListClear, ListExtend, ListRemove,
                                                      ListCopy, ListSort)
-from pyccel.ast.builtin_methods.dict_methods  import DictPop
 
 from .builtins   import PythonImag, PythonReal, PythonConjugate
 from .core       import ClassDef, PyccelFunctionDef

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -10,12 +10,13 @@ from pyccel.ast.builtin_methods.set_methods  import SetAdd, SetClear, SetCopy, S
 from pyccel.ast.builtin_methods.list_methods import (ListAppend, ListInsert, ListPop,
                                                      ListClear, ListExtend, ListRemove,
                                                      ListCopy, ListSort)
+from pyccel.ast.builtin_methods.dict_methods  import DictPop
 
 from .builtins   import PythonImag, PythonReal, PythonConjugate
 from .core       import ClassDef, PyccelFunctionDef
 from .datatypes  import (PythonNativeBool, PythonNativeInt, PythonNativeFloat,
                          PythonNativeComplex, StringType, TupleType, CustomDataType,
-                         HomogeneousListType, HomogeneousSetType)
+                         HomogeneousListType, HomogeneousSetType, DictType)
 from .numpyext   import (NumpyShape, NumpySum, NumpyAmin, NumpyAmax,
                          NumpyImag, NumpyReal, NumpyTranspose,
                          NumpyConjugate, NumpySize, NumpyResultType, NumpyArray)
@@ -23,16 +24,17 @@ from .numpytypes import NumpyNumericType, NumpyNDArrayType
 
 __all__ = (
     'BooleanClass',
-    'IntegerClass',
-    'FloatClass',
     'ComplexClass',
+    'DictClass',
+    'FloatClass',
+    'IntegerClass',
+    'ListClass',
+    'NumpyArrayClass',
     'SetClass',
     'StringClass',
-    'NumpyArrayClass',
     'TupleClass',
-    'ListClass',
-    'literal_classes',
     'get_cls_base',
+    'literal_classes',
 )
 
 #=======================================================================================
@@ -166,6 +168,12 @@ SetClass = ClassDef('set',
 
 #=======================================================================================
 
+DictClass = ClassDef('dict',
+        methods=[
+        ])
+
+#=======================================================================================
+
 TupleClass = ClassDef('tuple',
         methods=[
             #index
@@ -254,6 +262,8 @@ def get_cls_base(class_type):
         return ListClass
     elif isinstance(class_type, HomogeneousSetType):
         return SetClass
+    elif isinstance(class_type, DictType):
+        return DictClass
     else:
         raise NotImplementedError(f"No class definition found for type {class_type}")
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -948,23 +948,23 @@ class DictType(ContainerType, metaclass = ArgumentSingleton):
 
     Parameters
     ----------
-    index_type : PyccelType
+    key_type : PyccelType
         The type of the keys of the homogeneous dictionary.
     value_type : PyccelType
         The type of the values of the homogeneous dictionary.
     """
-    __slots__ = ('_index_type', '_value_type')
-    _name = 'map'
+    __slots__ = ('_key_type', '_value_type')
+    _name = 'dict'
     _container_rank = 1
     _order = None
 
-    def __init__(self, index_type, value_type):
-        self._index_type = index_type
+    def __init__(self, key_type, value_type):
+        self._key_type = key_type
         self._value_type = value_type
         super().__init__()
 
     def __str__(self):
-        return f'map[{self._index_type.name}, {self._value_type.name}]'
+        return f'dict[{self._key_type}, {self._value_type}]'
 
     def __reduce__(self):
         """
@@ -980,7 +980,7 @@ class DictType(ContainerType, metaclass = ArgumentSingleton):
         args
             A tuple containing any arguments to be passed to the callable.
         """
-        return (self.__class__, (self._index_type, self._value_type))
+        return (self.__class__, (self._key_type, self._value_type))
 
     @property
     def datatype(self):
@@ -989,7 +989,56 @@ class DictType(ContainerType, metaclass = ArgumentSingleton):
 
         The datatype of the object.
         """
-        return self._index_type.datatype
+        return self._key_type.datatype
+
+    @property
+    def key_type(self):
+        """
+        The type of the keys of the object.
+
+        The type of the keys of the object.
+        """
+        return self._key_type
+
+    @property
+    def value_type(self):
+        """
+        The type of the values of the object.
+
+        The type of the values of the object.
+        """
+        return self._value_type
+
+    @property
+    def container_rank(self):
+        """
+        Number of dimensions of the container.
+
+        Number of dimensions of the object described by the container. This is
+        equal to the number of values required to index an element of this container.
+        """
+        return 1
+
+    @property
+    def rank(self):
+        """
+        Number of dimensions of the object.
+
+        Number of dimensions of the object. If the object is a scalar then
+        this is equal to 0.
+        """
+        return self._container_rank
+
+    @property
+    def order(self):
+        """
+        The data layout ordering in memory.
+
+        Indicates whether the data is stored in row-major ('C') or column-major
+        ('F') format. This is only relevant if rank > 1. When it is not relevant
+        this function returns None.
+        """
+        return None
 
 #==============================================================================
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -430,6 +430,10 @@ class PythonCodePrinter(CodePrinter):
         args = ', '.join(self._print(i) for i in expr.args)
         return '{'+args+'}'
 
+    def _print_PythonDict(self, expr):
+        args = ', '.join(f'{self._print(k)}: {self._print(v)}' for k,v in expr)
+        return '{'+args+'}'
+
     def _print_PythonBool(self, expr):
         return 'bool({})'.format(self._print(expr.arg))
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -22,7 +22,7 @@ from pyccel.utilities.strings import random_string
 from pyccel.ast.basic         import PyccelAstNode, TypedAstNode, ScopedAstNode
 
 from pyccel.ast.builtins import PythonPrint, PythonTupleFunction
-from pyccel.ast.builtins import PythonComplex
+from pyccel.ast.builtins import PythonComplex, PythonDict, PythonDictFunction
 from pyccel.ast.builtins import builtin_functions_dict, PythonImag, PythonReal
 from pyccel.ast.builtins import PythonList, PythonConjugate , PythonSet
 from pyccel.ast.builtins import (PythonRange, PythonZip, PythonEnumerate,
@@ -65,7 +65,7 @@ from pyccel.ast.datatypes import PrimitiveIntegerType, HomogeneousListType, Stri
 from pyccel.ast.datatypes import PythonNativeBool, PythonNativeInt, PythonNativeFloat
 from pyccel.ast.datatypes import DataTypeFactory, PrimitiveFloatingPointType
 from pyccel.ast.datatypes import InhomogeneousTupleType, HomogeneousTupleType
-from pyccel.ast.datatypes import PrimitiveComplexType, FixedSizeNumericType
+from pyccel.ast.datatypes import PrimitiveComplexType, FixedSizeNumericType, DictType
 
 from pyccel.ast.functionalexpr import FunctionalSum, FunctionalMax, FunctionalMin, GeneratorComprehension, FunctionalFor
 
@@ -1626,7 +1626,7 @@ class SemanticParser(BasicParser):
             if raise_error:
                 name = var.name
                 rhs_str = str(rhs)
-                errors.report(INCOMPATIBLE_TYPES_IN_ASSIGNMENT.format(repr(var.class_type), repr(class_type)),
+                errors.report(INCOMPATIBLE_TYPES_IN_ASSIGNMENT.format(var.class_type, class_type),
                     symbol=f'{name}={rhs_str}',
                     bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
                     severity='error')
@@ -1864,6 +1864,30 @@ class SemanticParser(BasicParser):
 
         return list(parent.values())
 
+    def _convert_syntactic_object_to_type_annotation(self, syntactic_annotation):
+        """
+        Convert an arbitrary syntactic object to a type annotation.
+
+        Convert an arbitrary syntactic object to a type annotation. This means that
+        the syntactic object is wrapped in a SyntacticTypeAnnotation (if necessary).
+        This ensures that a type annotation is obtained instead of e.g. a function.
+
+        Parameters
+        ----------
+        syntactic_annotation : PyccelAstNode
+            A syntactic object that needs to be visited as a type annotation.
+
+        Returns
+        -------
+        SyntacticTypeAnnotation
+            A syntactic object that will be recognised as a type annotation.
+        """
+        if not isinstance(syntactic_annotation, SyntacticTypeAnnotation):
+            pyccel_stage.set_stage('syntactic')
+            syntactic_annotation = SyntacticTypeAnnotation(dtype=syntactic_annotation)
+            pyccel_stage.set_stage('semantic')
+        return syntactic_annotation
+
     def _get_indexed_type(self, base, args, expr):
         """
         Extract a type annotation from an IndexedElement.
@@ -1919,13 +1943,8 @@ class SemanticParser(BasicParser):
                         severity='fatal', symbol=expr)
             rank = 1
             if len(args) == 2 and args[1] is LiteralEllipsis():
-                syntactic_annotation = args[0]
-                if not isinstance(syntactic_annotation, SyntacticTypeAnnotation):
-                    pyccel_stage.set_stage('syntactic')
-                    syntactic_annotation = SyntacticTypeAnnotation(dtype=syntactic_annotation)
-                    pyccel_stage.set_stage('semantic')
+                syntactic_annotation = self._convert_syntactic_object_to_type_annotation(args[0])
                 internal_datatypes = self._visit(syntactic_annotation)
-                type_annotations = []
                 if dtype_cls is PythonTupleFunction:
                     class_type = HomogeneousTupleType
                 elif dtype_cls is PythonList:
@@ -1933,8 +1952,16 @@ class SemanticParser(BasicParser):
                 else:
                     raise errors.report(f"Unknown annotation base {base}\n"+PYCCEL_RESTRICTION_TODO,
                             severity='fatal', symbol=expr)
-                for u in internal_datatypes.type_list:
-                    type_annotations.append(VariableTypeAnnotation(class_type(u.class_type), u.is_const))
+                type_annotations = [VariableTypeAnnotation(class_type(u.class_type), u.is_const)
+                                    for u in internal_datatypes.type_list]
+                return UnionTypeAnnotation(*type_annotations)
+            elif len(args) == 2 and dtype_cls is PythonDictFunction:
+                syntactic_key_annotation = self._convert_syntactic_object_to_type_annotation(args[0])
+                syntactic_val_annotation = self._convert_syntactic_object_to_type_annotation(args[1])
+                key_types = self._visit(syntactic_key_annotation)
+                val_types = self._visit(syntactic_val_annotation)
+                type_annotations = [VariableTypeAnnotation(DictType(k.class_type, v.class_type)) \
+                                    for k,v in zip(key_types.type_list, val_types.type_list)]
                 return UnionTypeAnnotation(*type_annotations)
             else:
                 raise errors.report("Cannot handle non-homogenous type index\n"+PYCCEL_RESTRICTION_TODO,
@@ -2234,6 +2261,16 @@ class SemanticParser(BasicParser):
         except TypeError as e:
             message = str(e)
             errors.report(message, symbol=expr,
+                severity='fatal')
+        return expr
+
+    def _visit_PythonDict(self, expr):
+        keys = [self._visit(k) for k in expr.keys]
+        vals = [self._visit(v) for v in expr.values]
+        try:
+            expr = PythonDict(keys, vals)
+        except TypeError as e:
+            errors.report(str(e), symbol=expr,
                 severity='fatal')
         return expr
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -22,7 +22,7 @@ from pyccel.utilities.strings import random_string
 from pyccel.ast.basic         import PyccelAstNode, TypedAstNode, ScopedAstNode
 
 from pyccel.ast.builtins import PythonPrint, PythonTupleFunction
-from pyccel.ast.builtins import PythonComplex, PythonDict, PythonDictFunction
+from pyccel.ast.builtins import PythonComplex, PythonDict
 from pyccel.ast.builtins import builtin_functions_dict, PythonImag, PythonReal
 from pyccel.ast.builtins import PythonList, PythonConjugate , PythonSet
 from pyccel.ast.builtins import (PythonRange, PythonZip, PythonEnumerate,
@@ -65,7 +65,7 @@ from pyccel.ast.datatypes import PrimitiveIntegerType, HomogeneousListType, Stri
 from pyccel.ast.datatypes import PythonNativeBool, PythonNativeInt, PythonNativeFloat
 from pyccel.ast.datatypes import DataTypeFactory, PrimitiveFloatingPointType
 from pyccel.ast.datatypes import InhomogeneousTupleType, HomogeneousTupleType
-from pyccel.ast.datatypes import PrimitiveComplexType, FixedSizeNumericType, DictType
+from pyccel.ast.datatypes import PrimitiveComplexType, FixedSizeNumericType
 
 from pyccel.ast.functionalexpr import FunctionalSum, FunctionalMax, FunctionalMin, GeneratorComprehension, FunctionalFor
 
@@ -1626,7 +1626,7 @@ class SemanticParser(BasicParser):
             if raise_error:
                 name = var.name
                 rhs_str = str(rhs)
-                errors.report(INCOMPATIBLE_TYPES_IN_ASSIGNMENT.format(var.class_type, class_type),
+                errors.report(INCOMPATIBLE_TYPES_IN_ASSIGNMENT.format(repr(var.class_type), repr(class_type)),
                     symbol=f'{name}={rhs_str}',
                     bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
                     severity='error')
@@ -1864,30 +1864,6 @@ class SemanticParser(BasicParser):
 
         return list(parent.values())
 
-    def _convert_syntactic_object_to_type_annotation(self, syntactic_annotation):
-        """
-        Convert an arbitrary syntactic object to a type annotation.
-
-        Convert an arbitrary syntactic object to a type annotation. This means that
-        the syntactic object is wrapped in a SyntacticTypeAnnotation (if necessary).
-        This ensures that a type annotation is obtained instead of e.g. a function.
-
-        Parameters
-        ----------
-        syntactic_annotation : PyccelAstNode
-            A syntactic object that needs to be visited as a type annotation.
-
-        Returns
-        -------
-        SyntacticTypeAnnotation
-            A syntactic object that will be recognised as a type annotation.
-        """
-        if not isinstance(syntactic_annotation, SyntacticTypeAnnotation):
-            pyccel_stage.set_stage('syntactic')
-            syntactic_annotation = SyntacticTypeAnnotation(dtype=syntactic_annotation)
-            pyccel_stage.set_stage('semantic')
-        return syntactic_annotation
-
     def _get_indexed_type(self, base, args, expr):
         """
         Extract a type annotation from an IndexedElement.
@@ -1943,8 +1919,13 @@ class SemanticParser(BasicParser):
                         severity='fatal', symbol=expr)
             rank = 1
             if len(args) == 2 and args[1] is LiteralEllipsis():
-                syntactic_annotation = self._convert_syntactic_object_to_type_annotation(args[0])
+                syntactic_annotation = args[0]
+                if not isinstance(syntactic_annotation, SyntacticTypeAnnotation):
+                    pyccel_stage.set_stage('syntactic')
+                    syntactic_annotation = SyntacticTypeAnnotation(dtype=syntactic_annotation)
+                    pyccel_stage.set_stage('semantic')
                 internal_datatypes = self._visit(syntactic_annotation)
+                type_annotations = []
                 if dtype_cls is PythonTupleFunction:
                     class_type = HomogeneousTupleType
                 elif dtype_cls is PythonList:
@@ -1952,16 +1933,8 @@ class SemanticParser(BasicParser):
                 else:
                     raise errors.report(f"Unknown annotation base {base}\n"+PYCCEL_RESTRICTION_TODO,
                             severity='fatal', symbol=expr)
-                type_annotations = [VariableTypeAnnotation(class_type(u.class_type), u.is_const)
-                                    for u in internal_datatypes.type_list]
-                return UnionTypeAnnotation(*type_annotations)
-            elif len(args) == 2 and dtype_cls is PythonDictFunction:
-                syntactic_key_annotation = self._convert_syntactic_object_to_type_annotation(args[0])
-                syntactic_val_annotation = self._convert_syntactic_object_to_type_annotation(args[1])
-                key_types = self._visit(syntactic_key_annotation)
-                val_types = self._visit(syntactic_val_annotation)
-                type_annotations = [VariableTypeAnnotation(DictType(k.class_type, v.class_type)) \
-                                    for k,v in zip(key_types.type_list, val_types.type_list)]
+                for u in internal_datatypes.type_list:
+                    type_annotations.append(VariableTypeAnnotation(class_type(u.class_type), u.is_const))
                 return UnionTypeAnnotation(*type_annotations)
             else:
                 raise errors.report("Cannot handle non-homogenous type index\n"+PYCCEL_RESTRICTION_TODO,

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -51,7 +51,7 @@ from pyccel.ast.operators import PyccelIs, PyccelIsNot
 from pyccel.ast.operators import IfTernaryOperator
 from pyccel.ast.numpyext  import NumpyMatmul
 
-from pyccel.ast.builtins import PythonTuple, PythonList, PythonSet
+from pyccel.ast.builtins import PythonTuple, PythonList, PythonSet, PythonDict
 from pyccel.ast.builtins import PythonPrint, Lambda
 from pyccel.ast.headers  import MetaVariable, FunctionHeader, MethodHeader
 from pyccel.ast.literals import LiteralInteger, LiteralFloat, LiteralComplex
@@ -399,8 +399,7 @@ class SyntaxParser(BasicParser):
             return old
 
     def _visit_Dict(self, stmt):
-        errors.report(PYCCEL_RESTRICTION_TODO,
-                symbol=stmt, severity='error')
+        return PythonDict(self._visit(stmt.keys), self._visit(stmt.values))
 
     def _visit_NoneType(self, stmt):
         return Nil()

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -16,7 +16,7 @@ from pyccel import epyccel
 def language(request):
     return request.param
 
-def test_dict_init(language) :
+def test_dict_init(language):
     def dict_init():
         a = {1:1.0, 2:2.0}
         return a
@@ -26,7 +26,7 @@ def test_dict_init(language) :
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_dict_str_keys(language) :
+def test_dict_str_keys(language):
     def dict_str_keys():
         a = {'a':1, 'b':2}
         return a

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -1,0 +1,37 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+import pytest
+from pyccel import epyccel
+
+@pytest.fixture( params=[
+        pytest.param("fortran", marks = [
+            pytest.mark.skip(reason="dict methods not implemented in fortran"),
+            pytest.mark.fortran]),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="dict methods not implemented in c"),
+            pytest.mark.c]),
+        pytest.param("python", marks = pytest.mark.python)
+    ],
+    scope = "module"
+)
+def language(request):
+    return request.param
+
+def test_dict_init(language) :
+    def dict_init():
+        a = {1:1.0, 2:2.0}
+        return a
+    epyc_dict_init = epyccel(dict_init, language = language)
+    pyccel_result = epyc_dict_init()
+    python_result = dict_init()
+    assert isinstance(python_result, type(pyccel_result))
+    assert python_result == pyccel_result
+
+def test_dict_str_keys(language) :
+    def dict_str_keys():
+        a = {'a':1, 'b':2}
+        return a
+    epyc_str_keys = epyccel(dict_str_keys, language = language)
+    pyccel_result = epyc_str_keys()
+    python_result = dict_str_keys()
+    assert isinstance(python_result, type(pyccel_result))
+    assert python_result == pyccel_result

--- a/tests/errors/syntax_blockers/ex1.py
+++ b/tests/errors/syntax_blockers/ex1.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
-{a: 2, 'b':4}
 ~a
 
 #$ this is invalid comment

--- a/tests/errors/syntax_errors/dict_str_keys.py
+++ b/tests/errors/syntax_errors/dict_str_keys.py
@@ -1,2 +1,0 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring
-a = {'a': 1, 'b':2}

--- a/tests/errors/syntax_errors/import_star.py
+++ b/tests/errors/syntax_errors/import_star.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring
-from dict_str_keys import *
+# pylint: disable=missing-function-docstring, missing-module-docstring, wildcard-import
+from nargs import *
 
-print(a)
+print(f())


### PR DESCRIPTION
Add support for the initialisation of a dictionary via a call to `{}`. Syntactic, semantic and Python printing support is added. The `DictType` datatype is expanded to match the expected description from the docs. Fixes #1895