### PR TITLE
Use Python version to make artifact name unique (1 line)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Save code coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-artifact
+          name: coverage-artifact-${{ matrix.python_version }}
           path: .coverage
           retention-days: 3
       - name: "Post completed"


### PR DESCRIPTION
The updated version of `upload-artifact` means that you cannot upload multiple artifacts with the same name. This is problematic on the `devel` branch as the same job is run for multiple Python versions. The easy fix for this is to add the version to the artifact name. Local tests show that the artifacts can still be retrieved with a partial name.