### PR TITLE
Store annotated local variables to avoid memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 -   #1853 : Fix translation of a file whose name conflicts with Fortran keywords.
 -   Link and mention `devel` branch, not `master`.
 -   #1047 : Print the value of an unrecognised constant.
+-   #1903 : Fix memory leak when using type annotations on local variables
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to this project will be documented in this file.
 -   #1853 : Fix translation of a file whose name conflicts with Fortran keywords.
 -   Link and mention `devel` branch, not `master`.
 -   #1047 : Print the value of an unrecognised constant.
--   #1903 : Fix memory leak when using type annotations on local variables
+-   #1903 : Fix memory leak when using type annotations on local variables.
 
 ### Changed
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1682,9 +1682,10 @@ class SemanticParser(BasicParser):
                         status = 'unallocated'
 
                     new_expressions.append(Allocate(var, shape=d_var['shape'], status=status))
-                    self._allocs[-1].add(var)
 
-                    if status != 'unallocated':
+                    if status == 'unallocated':
+                        self._allocs[-1].add(var)
+                    else:
                         errors.report(ARRAY_REALLOCATION, symbol=var.name,
                             severity='warning',
                             bounding_box=(self.current_ast_node.lineno,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1690,8 +1690,6 @@ class SemanticParser(BasicParser):
                             severity='warning',
                             bounding_box=(self.current_ast_node.lineno,
                                 self.current_ast_node.col_offset))
-                    elif status == 'unallocated':
-                        self._allocs[-1].add(var)
             elif previous_allocations and previous_allocations[-1].get_user_nodes(IfSection) \
                         and not previous_allocations[-1].get_user_nodes((If)):
                 # If previously allocated in If still under construction

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1682,6 +1682,7 @@ class SemanticParser(BasicParser):
                         status = 'unallocated'
 
                     new_expressions.append(Allocate(var, shape=d_var['shape'], status=status))
+                    self._allocs[-1].add(var)
 
                     if status != 'unallocated':
                         errors.report(ARRAY_REALLOCATION, symbol=var.name,

--- a/tests/ndarrays/leaks_check.py
+++ b/tests/ndarrays/leaks_check.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
-from numpy import array, zeros
+from numpy import array, zeros, ones
 
 def create_array():
     a = array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])# pylint: disable=unused-variable
@@ -45,6 +45,9 @@ def arrays_in_multi_returns():
     b = zeros(4)
     return a, b, 4
 
+def type_annotated_numpy_array():
+    a : 'float[:]' = ones(5) # pylint: disable=unused-variable
+
 # testing garbage collecting in a Function
 
 if __name__ == '__main__':
@@ -56,6 +59,7 @@ if __name__ == '__main__':
     conditional_alloc(True,True)
     conditional_alloc(True,False)
     conditional_alloc(False,False)
+    type_annotated_numpy_array()
 
     # testing garbage collecting in a Program
 


### PR DESCRIPTION
Add annotated local variable to the `_allocs` variable so its deallocation node can be added in `_garbage_collector()`. This fixes #1903 