### PR TITLE
Add support for type aliases

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -102,7 +102,8 @@ disable=invalid-name,
         duplicate-code,
         cyclic-import, # Output not consistent between pylint calls. This should be reactivated if cyclic dependencies can be fixed.
         unused-wildcard-import, # Raised by everything not used in pyccel.errors.messages when using 'from pyccel.errors.messages import *'
-        isinstance-second-argument-not-valid-type # prevents doing isinstance(a, acceptable_iterable_types)
+        isinstance-second-argument-not-valid-type, # prevents doing isinstance(a, acceptable_iterable_types)
+        syntax-error # Ignore syntax errors (usually from testing future Python versions). If the file doesn't run this will be obvious in the tests
         
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 -   #1787 : Ensure `STC` is installed with Pyccel.
 -   #1656 : Ensure `gFTL` is installed with Pyccel.
 -   #1844 : Add line numbers and code to errors from built-in function calls.
+-   #1544 : Add support for `typing.TypeAlias`.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
 

--- a/docs/type_annotations.md
+++ b/docs/type_annotations.md
@@ -82,3 +82,25 @@ def f(a : 'T', b : 'T'):
 ```
 
 For more details, see the documentation for [templates](./templates.md).
+
+## Type Aliases
+
+Python also provides type alias objects as described in the Python docs (<https://docs.python.org/3/library/typing.html#type-aliases>). For the moment type parameter lists are not supported. Both the new Python 3.12 syntax and the old syntax are supported. Type aliases cannot be redefined. This allows the user to more easily change between different types. The type name will not appear in the underlying code.
+
+E.g.
+```python
+from typing import TypeAlias
+
+MyType : TypeAlias = float
+
+def set_i(x : 'MyType[:]', i : 'int', val : MyType):
+    x[i] = val
+```
+
+or:
+```python
+type MyType = float
+
+def set_i(x : 'MyType[:]', i : 'int', val : MyType):
+    x[i] = val
+```

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -251,7 +251,7 @@ def get_cls_base(class_type):
     NotImplementedError
         Raised if the base class cannot be found.
     """
-    if isinstance(class_type, CustomDataType):
+    if isinstance(class_type, (CustomDataType, SymbolicType)):
         return None
     elif class_type in literal_classes:
         return literal_classes[class_type]
@@ -265,8 +265,6 @@ def get_cls_base(class_type):
         return SetClass
     elif isinstance(class_type, DictType):
         return DictClass
-    elif isinstance(class_type, SymbolicType):
-        return None
     else:
         raise NotImplementedError(f"No class definition found for type {class_type}")
 

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -15,7 +15,7 @@ from .builtins   import PythonImag, PythonReal, PythonConjugate
 from .core       import ClassDef, PyccelFunctionDef
 from .datatypes  import (PythonNativeBool, PythonNativeInt, PythonNativeFloat,
                          PythonNativeComplex, StringType, TupleType, CustomDataType,
-                         HomogeneousListType, HomogeneousSetType)
+                         HomogeneousListType, HomogeneousSetType, SymbolicType)
 from .numpyext   import (NumpyShape, NumpySum, NumpyAmin, NumpyAmax,
                          NumpyImag, NumpyReal, NumpyTranspose,
                          NumpyConjugate, NumpySize, NumpyResultType, NumpyArray)
@@ -254,6 +254,8 @@ def get_cls_base(class_type):
         return ListClass
     elif isinstance(class_type, HomogeneousSetType):
         return SetClass
+    elif isinstance(class_type, SymbolicType):
+        return None
     else:
         raise NotImplementedError(f"No class definition found for type {class_type}")
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -192,15 +192,6 @@ class FixedSizeType(PyccelType, metaclass=Singleton):
     __slots__ = ()
 
     @property
-    def name(self):
-        """
-        The name of the class type.
-
-        The name of the class type.
-        """
-        return self._name # pylint: disable=no-member
-
-    @property
     def datatype(self):
         """
         The datatype of the object.

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -458,6 +458,16 @@ class CharType(FixedSizeType):
 
 #==============================================================================
 class TypeAlias(SymbolicType):
+    """
+    Class representing the type of a symbolic object describing a type descriptor.
+
+    Class representing the type of a symbolic object describing a type descriptor.
+    This type is equivalent to Python's built-in typing.TypeAlias.
+
+    See Also
+    --------
+    typing.TypeAlias : <https://docs.python.org/3/library/typing.html#typing.TypeAlias>
+    """
     __slots__ = ()
     _name = 'TypeAlias'
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -192,6 +192,15 @@ class FixedSizeType(PyccelType, metaclass=Singleton):
     __slots__ = ()
 
     @property
+    def name(self):
+        """
+        The name of the class type.
+
+        The name of the class type.
+        """
+        return self._name # pylint: disable=no-member
+
+    @property
     def datatype(self):
         """
         The datatype of the object.
@@ -459,6 +468,7 @@ class CharType(FixedSizeType):
 #==============================================================================
 class TypeAlias(SymbolicType):
     __slots__ = ()
+    _name = 'TypeAlias'
 
 #==============================================================================
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -457,6 +457,10 @@ class CharType(FixedSizeType):
     _primitive_type = PrimitiveCharacterType
 
 #==============================================================================
+class TypeAlias(SymbolicType):
+    __slots__ = ()
+
+#==============================================================================
 
 class ContainerType(PyccelType):
     """

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -38,6 +38,7 @@ __all__ = (
         'GenericType',
         'SymbolicType',
         'CharType',
+        'TypeAlias',
         # ------------ Container types ------------
         'TupleType',
         'HomogeneousContainerType',

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -466,7 +466,7 @@ class TypeAlias(SymbolicType):
 
     See Also
     --------
-    typing.TypeAlias : <https://docs.python.org/3/library/typing.html#typing.TypeAlias>
+    typing.TypeAlias : <https://docs.python.org/3/library/typing.html#typing.TypeAlias>.
     """
     __slots__ = ()
     _name = 'TypeAlias'

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -7,7 +7,7 @@
 """ Module containing objects from the typing module understood by pyccel
 """
 
-from .basic     import PyccelAstNode, TypedAstNode
+from .basic     import TypedAstNode
 from .core      import Module, PyccelFunctionDef
 from .datatypes import TypeAlias
 

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -48,6 +48,13 @@ class TypingFinal(TypedAstNode):
 
 #==============================================================================
 class TypingTypeAlias(TypedAstNode):
+    """
+    Class representing a call to the typing.TypeAlias construct.
+
+    Class representing a call to the typing.TypeAlias construct. This object
+    is only used for type annotations. It is useful for creating a PyccelFunctionDef
+    but instances should not be created.
+    """
     _static_type = TypeAlias()
 
 #==============================================================================

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -13,6 +13,7 @@ from .datatypes import TypeAlias
 
 __all__ = (
     'TypingFinal',
+    'TypingTypeAlias',
     'typing_mod'
 )
 
@@ -55,6 +56,8 @@ class TypingTypeAlias(TypedAstNode):
     is only used for type annotations. It is useful for creating a PyccelFunctionDef
     but instances should not be created.
     """
+    __slots__ = ()
+    _attribute_nodes = ()
     _static_type = TypeAlias()
 
 #==============================================================================

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -7,8 +7,9 @@
 """ Module containing objects from the typing module understood by pyccel
 """
 
-from .basic     import TypedAstNode
+from .basic     import PyccelAstNode, TypedAstNode
 from .core      import Module, PyccelFunctionDef
+from .datatypes import TypeAlias
 
 __all__ = (
     'TypingFinal',
@@ -46,9 +47,14 @@ class TypingFinal(TypedAstNode):
         return self._arg
 
 #==============================================================================
+class TypingTypeAlias(TypedAstNode):
+    _static_type = TypeAlias()
+
+#==============================================================================
 
 typing_funcs = {
         'Final': PyccelFunctionDef('Final', TypingFinal),
+        'TypeAlias': PyccelFunctionDef('TypeAlias', TypingTypeAlias),
     }
 
 typing_mod = Module('typing',

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -443,7 +443,10 @@ class CToPythonWrapper(Wrapper):
             The new function which raises the error.
         """
         func_args = [FunctionDefArgument(self.get_new_PyObject(n)) for n in ("self", "args", "kwargs")]
-        func_results = [FunctionDefResult(self.get_new_PyObject("result", is_temp=True))]
+        if self._error_exit_code is Nil():
+            func_results = [FunctionDefResult(self.get_new_PyObject("result", is_temp=True))]
+        else:
+            func_results = [FunctionDefResult(self.scope.get_temporary_variable(self._error_exit_code.class_type, "result"))]
         function = PyFunctionDef(name = name, arguments = func_args, results = func_results,
                 body = [FunctionCall(PyErr_SetString, [PyNotImplementedError,
                                         LiteralString(error_msg)]),

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2588,6 +2588,8 @@ class SemanticParser(BasicParser):
             raise errors.report(PYCCEL_RESTRICTION_TODO + ' Could not deduce type information',
                     severity='fatal', symbol=expr)
 
+    def _visit_VariableTypeAnnotation(self, expr):
+        return expr
 
     def _visit_DottedName(self, expr):
 
@@ -2955,11 +2957,12 @@ class SemanticParser(BasicParser):
 
             lhs = lhs.name
             if semantic_lhs_var.class_type is TypeAlias():
-                pyccel_stage.set_stage('syntactic')
-                type_annot = SyntacticTypeAnnotation(rhs)
-                pyccel_stage.set_stage('semantic')
-                rhs = self._visit(type_annot)
-                self.scope.insert_symbolic_alias(lhs, rhs)
+                if not isinstance(rhs, SyntacticTypeAnnotation):
+                    pyccel_stage.set_stage('syntactic')
+                    rhs = SyntacticTypeAnnotation(rhs)
+                    pyccel_stage.set_stage('semantic')
+                type_annot = self._visit(rhs)
+                self.scope.insert_symbolic_alias(lhs, type_annot)
                 return EmptyNode()
 
             try:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -42,6 +42,8 @@ from pyccel.ast.core import StarredArguments
 from pyccel.ast.core import CodeBlock
 from pyccel.ast.core import IndexedElement
 
+from pyccel.ast.datatypes import TypeAlias
+
 from pyccel.ast.bitwise_operators import PyccelRShift, PyccelLShift, PyccelBitXor, PyccelBitOr, PyccelBitAnd, PyccelInvert
 from pyccel.ast.operators import PyccelPow, PyccelAdd, PyccelMul, PyccelDiv, PyccelMod, PyccelFloorDiv
 from pyccel.ast.operators import PyccelEq,  PyccelNe,  PyccelLt,  PyccelLe,  PyccelGt,  PyccelGe
@@ -62,7 +64,7 @@ from pyccel.ast.variable  import DottedName, AnnotatedPyccelSymbol
 
 from pyccel.ast.internals import Slice, PyccelSymbol, PyccelFunction
 
-from pyccel.ast.type_annotations import SyntacticTypeAnnotation, UnionTypeAnnotation
+from pyccel.ast.type_annotations import SyntacticTypeAnnotation, UnionTypeAnnotation, VariableTypeAnnotation
 
 from pyccel.parser.base        import BasicParser
 from pyccel.parser.extend_tree import extend_tree
@@ -1353,6 +1355,17 @@ class SyntaxParser(BasicParser):
 
     def _visit_Starred(self, stmt):
         return StarredArguments(self._visit(stmt.value))
+
+    def _visit_TypeAlias(self, stmt):
+        if stmt.type_params:
+            errors.report("Type parameters are not yet supported on a type alias expression.\n"+PYCCEL_RESTRICTION_TODO,
+                    severity='error', symbol=stmt)
+        self._in_lhs_assign = True
+        name = self._visit(stmt.name)
+        self._in_lhs_assign = False
+        rhs = self._treat_type_annotation(stmt.value, self._visit(stmt.value))
+        type_annotation = UnionTypeAnnotation(VariableTypeAnnotation(TypeAlias(), is_const = True))
+        return Assign(AnnotatedPyccelSymbol(name, annotation=type_annotation), rhs)
 
 #==============================================================================
 

--- a/tests/epyccel/modules/Module_10.py
+++ b/tests/epyccel/modules/Module_10.py
@@ -1,0 +1,32 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+type MyType = float
+
+def set_i(x : 'MyType[:]', i : 'int', val : MyType):
+    x[i] = val
+
+def swap(x : 'MyType[:]', i : 'int', j : 'int'):
+    temp = x[i]
+    x[i] = x[j]
+    x[j] = temp
+
+def inplace_max(x : 'MyType[:]'):
+    n = x.shape[0]
+    # bubble sort
+    for j in range(n):
+        i = n-1-j
+        while i < n-1:
+            if x[i] > x[i+1]:
+                swap(x, i, i+1)
+            else:
+                i+=1
+    return x[-1]
+
+def f(x : 'MyType[:]', y : 'MyType[:]'):
+    n = x.shape[0]
+    for i in range(n):
+        set_i(x, i, float(i))
+    for i in range(n//3):
+        set_i(x[::3], i, -1.0)
+    b = inplace_max(y[:])
+    return b

--- a/tests/epyccel/modules/Module_9.py
+++ b/tests/epyccel/modules/Module_9.py
@@ -1,0 +1,33 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+from typing import TypeAlias
+
+MyType : TypeAlias = float
+
+def set_i(x : 'MyType[:]', i : 'int', val : 'float'):
+    x[i] = val
+
+def swap(x : 'MyType[:]', i : 'int', j : 'int'):
+    temp = x[i]
+    x[i] = x[j]
+    x[j] = temp
+
+def inplace_max(x : 'MyType[:]'):
+    n = x.shape[0]
+    # bubble sort
+    for j in range(n):
+        i = n-1-j
+        while i < n-1:
+            if x[i] > x[i+1]:
+                swap(x, i, i+1)
+            else:
+                i+=1
+    return x[-1]
+
+def f(x : 'MyType[:]', y : 'MyType[:]'):
+    n = x.shape[0]
+    for i in range(n):
+        set_i(x, i, float(i))
+    for i in range(n//3):
+        set_i(x[::3], i, -1.0)
+    b = inplace_max(y[:])
+    return b

--- a/tests/epyccel/modules/Module_9.py
+++ b/tests/epyccel/modules/Module_9.py
@@ -3,7 +3,7 @@ from typing import TypeAlias
 
 MyType : TypeAlias = float
 
-def set_i(x : 'MyType[:]', i : 'int', val : 'float'):
+def set_i(x : 'MyType[:]', i : 'int', val : MyType):
     x[i] = val
 
 def swap(x : 'MyType[:]', i : 'int', j : 'int'):

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 import sys
-import pytest
 import numpy as np
 import pytest
 from pyccel import epyccel

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -185,6 +185,7 @@ def test_awkward_names(language):
     assert mod.pure() == modnew.pure()
     assert mod.allocate(1) == modnew.allocate(1)
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP613 (TypeAlias) implemented in Python 3.10")
 def test_module_type_alias(language):
     import modules.Module_9 as mod
 

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -182,3 +182,23 @@ def test_awkward_names(language):
     assert mod.function() == modnew.function()
     assert mod.pure() == modnew.pure()
     assert mod.allocate(1) == modnew.allocate(1)
+
+def test_module_type_alias(language):
+    import modules.Module_9 as mod
+
+    modnew = epyccel(mod, language=language)
+
+    n_x = np.random.randint(4,20)
+    n_y = np.random.randint(4,20)
+
+    x = np.empty(n_x, dtype=float)
+    y = np.random.random_sample(n_y)
+
+    x_pyc = x.copy()
+    y_pyc = y.copy()
+
+    max_pyt = mod.f(x,y)
+    max_pyc = modnew.f(x_pyc, y_pyc)
+    assert np.isclose( max_pyt, max_pyc, rtol=1e-14, atol=1e-14 )
+    assert np.allclose( x, x_pyc, rtol=1e-14, atol=1e-14 )
+    assert np.allclose( y, y_pyc, rtol=1e-14, atol=1e-14 )

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
+import sys
 import numpy as np
+import pytest
 from pyccel import epyccel
 
 RTOL = 2e-14
@@ -185,6 +187,27 @@ def test_awkward_names(language):
 
 def test_module_type_alias(language):
     import modules.Module_9 as mod
+
+    modnew = epyccel(mod, language=language)
+
+    n_x = np.random.randint(4,20)
+    n_y = np.random.randint(4,20)
+
+    x = np.empty(n_x, dtype=float)
+    y = np.random.random_sample(n_y)
+
+    x_pyc = x.copy()
+    y_pyc = y.copy()
+
+    max_pyt = mod.f(x,y)
+    max_pyc = modnew.f(x_pyc, y_pyc)
+    assert np.isclose( max_pyt, max_pyc, rtol=1e-14, atol=1e-14 )
+    assert np.allclose( x, x_pyc, rtol=1e-14, atol=1e-14 )
+    assert np.allclose( y, y_pyc, rtol=1e-14, atol=1e-14 )
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP695 (type statement) implemented in Python 3.12")
+def test_module_type_alias_expression(language):
+    import modules.Module_10 as mod
 
     modnew = epyccel(mod, language=language)
 

--- a/tests/errors/semantic/blocking/TYPE_ALIAS_REASSIGN.py
+++ b/tests/errors/semantic/blocking/TYPE_ALIAS_REASSIGN.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
 from typing import TypeAlias
 
 MyType : TypeAlias = int

--- a/tests/errors/semantic/blocking/TYPE_ALIAS_REASSIGN.py
+++ b/tests/errors/semantic/blocking/TYPE_ALIAS_REASSIGN.py
@@ -1,0 +1,5 @@
+from typing import TypeAlias
+
+MyType : TypeAlias = int
+
+MyType = float

--- a/tests/errors/semantic/blocking/UNANNOTATED_TYPE_ALIAS.py
+++ b/tests/errors/semantic/blocking/UNANNOTATED_TYPE_ALIAS.py
@@ -1,0 +1,5 @@
+
+MyType = int
+
+def f(a : MyType):
+    pass

--- a/tests/errors/semantic/blocking/UNANNOTATED_TYPE_ALIAS.py
+++ b/tests/errors/semantic/blocking/UNANNOTATED_TYPE_ALIAS.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
 
 MyType = int
 

--- a/tests/errors/semantic/non_blocking/wrong_class_type_annotation.py
+++ b/tests/errors/semantic/non_blocking/wrong_class_type_annotation.py
@@ -11,4 +11,3 @@ class A:
 if __name__ == '__main__':
     myA : int = A()
 
-    print(myA.x)


### PR DESCRIPTION
Add support for non-parametrised type aliases as described at https://docs.python.org/3/library/typing.html#type-aliases. Fixes #1544

**Commit Summary**
- Add a `TypeAlias` datatype
- Add support for `typing.TypeAlias`
- Ensure errors are raised when symbolic objects are redefined
- Avoid `class_type.name` (only available for types of user-defined classes)
- Remove dead code "handling lambdify"
- Stop calling `insert_symbolic_function` (unused, see #330 )
- Add tests