### PR TITLE
Minor coverage bot issue (4 lines)

### DIFF
--- a/ci_tools/coverage_analysis_tools.py
+++ b/ci_tools/coverage_analysis_tools.py
@@ -259,10 +259,10 @@ def get_json_summary(untested, content_lines, existing_comments, diff):
             else:
                 end_line = line_indices[-1]
             last_valid_line = start_line
-            last_valid_line_idx = next(i for i in diff[f]['addition'] if i == last_valid_line)
-            for i in diff[f]['addition'][last_valid_line_idx:]:
-                if i-last_valid_line < 6:
-                    last_valid_line = i
+            last_valid_line_idx = next(k for k,l in enumerate(diff[f]['addition']) if l == last_valid_line)
+            for k in diff[f]['addition'][last_valid_line_idx:]:
+                if k-last_valid_line < 6:
+                    last_valid_line = k
                 else:
                     break
             end_line = min(end_line, last_valid_line)


### PR DESCRIPTION
The coverage bot is only showing 1 line errors. This makes it hard to understand the error as people often assume that the error is on all displayed lines (6 lines are shown for context when the error is on a single line). This is not what the coverage bot is designed to do but two minor errors in the script are causing such display problems.
1. The last_valid_line_idx was incorrectly defined
2. `i` was used for a loop inside a loop over `i` leading to the value in the outer loop being incorrectly overwritten