### PR TITLE
Fix renamed function lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 -   Link and mention `devel` branch, not `master`.
 -   #1047 : Print the value of an unrecognised constant.
 -   #1903 : Fix memory leak when using type annotations on local variables.
+-   #1913 : Fix function calls to renamed functions.
 
 ### Changed
 

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -21,7 +21,7 @@ RECURSIVE_RESULTS_REQUIRED = ("A results type must be provided for recursive fun
                               "#$ header function FUNC_NAME(ARG_TYPES) results(RESULT_TYPES)\n")
 
 INCOMPATIBLE_TYPES = 'Incompatible types'
-INCOMPATIBLE_TYPES_IN_ASSIGNMENT = "Variable has already been defined with type '{}'. Type '{}' in assignment is incompatible"
+INCOMPATIBLE_TYPES_IN_ASSIGNMENT = "Object has already been defined with type '{}'. Type '{}' in assignment is incompatible"
 INCOMPATIBLE_REDEFINITION = 'Incompatible redefinition'
 INCOMPATIBLE_REDEFINITION_STACK_ARRAY = 'Cannot change shape of stack array, because it does not support memory reallocation. Avoid redefinition, or use standard heap array.'
 STACK_ARRAY_DEFINITION_IN_LOOP = 'Cannot create stack array in loop, because if does not support memory reallocation. Create array before loop, or use standard heap array.'

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -303,7 +303,7 @@ class BasicParser(object):
 
         Parameters
         ----------
-        func : FunctionDef | SympyFunction
+        func : FunctionDef | SympyFunction | Interface | FunctionAddress
             The function to be inserted into the scope.
         """
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -301,7 +301,10 @@ class BasicParser(object):
             self.insert_symbolic_function(func)
         elif isinstance(func, (FunctionDef, Interface, FunctionAddress)):
             container = self.scope.functions
-            container[func.name] = func
+            if func.pyccel_staging == 'syntactic':
+                container[self.scope.get_expected_name(func.name)] = func
+            else:
+                container[func.name] = func
         else:
             raise TypeError('Expected a Function definition')
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -295,7 +295,17 @@ class BasicParser(object):
         return self._blocking
 
     def insert_function(self, func):
-        """."""
+        """
+        Insert a function into the current scope.
+
+        Insert a function into the current scope under the final name by which it
+        will be known in the generated code.
+
+        Parameters
+        ----------
+        func : FunctionDef | SympyFunction
+            The function to be inserted into the scope.
+        """
 
         if isinstance(func, SympyFunction):
             self.insert_symbolic_function(func)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1593,7 +1593,14 @@ class SemanticParser(BasicParser):
         # TODO improve check type compatibility
         if not isinstance(var, Variable):
             name = var.name
-            errors.report(INCOMPATIBLE_TYPES_IN_ASSIGNMENT.format(type(var), class_type),
+            message = INCOMPATIBLE_TYPES_IN_ASSIGNMENT.format(type(var), class_type)
+            if var.pyccel_staging == "syntactic":
+                new_name = self.scope.get_expected_name(name)
+                if new_name != name:
+                    message += '\nThis error may be due to object renaming to avoid name clashes (language-specific or otherwise).'
+                    message += f'The conflict is with "{name}".'
+                    name = new_name
+            errors.report(message,
                     symbol=f'{name}={class_type}',
                     bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
                     severity='fatal')

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2054,8 +2054,7 @@ class SemanticParser(BasicParser):
 
             self.scope = mod_scope
 
-        for f in self.scope.functions.copy():
-            f = self.scope.functions[f]
+        for f in self.scope.functions.copy().values():
             if not f.is_semantic and not isinstance(f, InlineFunctionDef):
                 assert isinstance(f, FunctionDef)
                 self._visit(f)
@@ -2817,10 +2816,6 @@ class SemanticParser(BasicParser):
             pass
 
         func = self.scope.find(name, 'functions')
-
-        if func is None:
-            # Look for a syntactic FunctionDef in case of a function renamed due to name collisions
-            func = self.scope.find(expr.funcdef, 'functions')
 
         if func is None:
             name = str(expr.funcdef)
@@ -3736,7 +3731,7 @@ class SemanticParser(BasicParser):
 
         existing_semantic_funcs = []
         if not expr.is_semantic:
-            self.scope.functions.pop(expr.name, None)
+            self.scope.functions.pop(self.scope.get_expected_name(expr.name), None)
         elif isinstance(expr, Interface):
             existing_semantic_funcs = [*expr.functions]
             expr                    = expr.syntactic_node

--- a/tests/epyccel/modules/function_call_before_definition_2.py
+++ b/tests/epyccel/modules/function_call_before_definition_2.py
@@ -1,9 +1,12 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 def f():
-    return g()
+    return g() + do()
 
 def g():
     return 2
+
+def do():
+    return 3
 
 a = f()
 

--- a/tests/epyccel/modules/function_call_before_definition_2.py
+++ b/tests/epyccel/modules/function_call_before_definition_2.py
@@ -8,5 +8,9 @@ def g():
 def do():
     return 3
 
+def do_0001():
+    return 4
+
+
 a = f()
 

--- a/tests/errors/semantic/blocking/GENERATED_NAME_COLLISION.py
+++ b/tests/errors/semantic/blocking/GENERATED_NAME_COLLISION.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
 def f():
     do_0001 = 5
     return g() + do() + do_0001

--- a/tests/errors/semantic/blocking/GENERATED_NAME_COLLISION.py
+++ b/tests/errors/semantic/blocking/GENERATED_NAME_COLLISION.py
@@ -1,0 +1,11 @@
+def f():
+    do_0001 = 5
+    return g() + do() + do_0001
+
+def g():
+    return 2
+
+def do():
+    return 4
+
+a = f()


### PR DESCRIPTION
`FunctionDef` objects are annotated during the first `FunctionCall` where they are used. At this point they have not been renamed if there are name conflicts. Both the original and the collisionless name should therefore be used to locate the `FunctionDef`. The original name will retrieve the syntactic object while the collisionless name will retrieve the renamed function. Fixes #1913 