### PR TITLE
Pin NumPy to < 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+-   #1920 : Add a maximum version for NumPy.
 -   #1836 : Move `epyccel` module to `pyccel.commands.epyccel` and add support for shortcut import `from pyccel import epyccel`.
 -   #1720 : functions with the `@inline` decorator are no longer exposed to Python in the shared library.
 -   #1720 : Error raised when incompatible arguments are passed to an `inlined` function is now fatal.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 dependencies = [
     "filelock >= 3.4.0",
-    "numpy >= 1.16",
+    "numpy >= 1.16, < 2.0",
     "sympy >= 1.2",
     "termcolor >= 1.0.0",
     "textx >= 2.2",


### PR DESCRIPTION
Pin NumPy to < 2.0 to avoid errors due to sign implementation change as seen in #1915 