### PR TITLE
Improve Error Message for Missing Target Language Compiler in Pyccel

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Contributors
 * Farouk Ech-Charef
 * Mustapha Belbiad
 * Varadarajan Rengaraj
+* Said Mazouz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
 -   #1047 : Print the value of an unrecognised constant.
 -   #1903 : Fix memory leak when using type annotations on local variables.
 -   #1913 : Fix function calls to renamed functions.
+-   #1927 : Improve error Message for missing target language compiler in Pyccel
 
 ### Changed
 

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -388,7 +388,7 @@ def execute_pyccel(fname, *,
                 output_folder=pyccel_dirpath,
                 verbose=verbose)
     except Exception:
-        handle_error('Fortran compilation')
+        handle_error('compilation')
         raise
 
 


### PR DESCRIPTION
This pull request addresses issue #1927 by changing 'ERROR at Fortran compilation stage' to 'ERROR at compilation stage' when Pyccel cannot find the compiler for the target language