### PR TITLE
Clean STC imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] `PyccelFunction` objects which do not represent objects in memory have the type `SymbolicType`.
 -   \[INTERNALS\] Rename `_visit` functions called from a `FunctionCall` which don't match the documented naming pattern to `_build` functions.
 -   \[INTERNALS\] Remove unnecessary argument `kind` to `Errors.set_target`.
+-   \[INTERNALS\] Handle STC imports with Pyccel objects.
 
 ### Deprecated
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -35,13 +35,13 @@ external_libs = {"stc"  : "STC/include",}
 # map internal libraries to their folders inside pyccel/stdlib and their compile objects
 # The compile object folder will be in the pyccel dirpath
 internal_libs = {
-    "ndarrays"     : ("ndarrays", CompileObj("ndarrays.c",folder="ndarrays")),
-    "pyc_math_f90" : ("math", CompileObj("pyc_math_f90.f90",folder="math")),
-    "pyc_math_c"   : ("math", CompileObj("pyc_math_c.c",folder="math")),
-    "cwrapper"     : ("cwrapper", CompileObj("cwrapper.c",folder="cwrapper", accelerators=('python',))),
-    "numpy_f90"    : ("numpy", CompileObj("numpy_f90.f90",folder="numpy")),
-    "numpy_c"      : ("numpy", CompileObj("numpy_c.c",folder="numpy")),
-    "STC_Extensions" : ("STC_Extensions", CompileObj("Set_Extensions.h",folder="STC_Extensions", has_target_file = False)),
+    "ndarrays"       : ("ndarrays", CompileObj("ndarrays.c",folder="ndarrays")),
+    "pyc_math_f90"   : ("math", CompileObj("pyc_math_f90.f90",folder="math")),
+    "pyc_math_c"     : ("math", CompileObj("pyc_math_c.c",folder="math")),
+    "cwrapper"       : ("cwrapper", CompileObj("cwrapper.c",folder="cwrapper", accelerators=('python',))),
+    "numpy_f90"      : ("numpy", CompileObj("numpy_f90.f90",folder="numpy")),
+    "numpy_c"        : ("numpy", CompileObj("numpy_c.c",folder="numpy")),
+    "Set_extensions" : ("STC_Extensions", CompileObj("Set_Extensions.h", folder="STC_Extensions", has_target_file = False)),
 }
 internal_libs["cwrapper_ndarrays"] = ("cwrapper_ndarrays", CompileObj("cwrapper_ndarrays.c",folder="cwrapper_ndarrays",
                                                              accelerators = ('python',),


### PR DESCRIPTION
Handling imports by separating concepts with limiters is potentially error prone. It also results in lots of special cases being written to handle each individual import. This PR unifies the strategy by using existing Pyccel concepts. An `Import` now takes the source file as the source argument (instead of the string containing limiters) and an `AsName` as the target. The object in the `AsName` is the PyccelType being handled by this import (described by a VariableTypeAnnotation) and the `target` (local name) of the `AsName` is the C name of this object.