### PR TITLE
Fix unreleased file lock

### DIFF
--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
     - name: Test C translation
-      run: python -m pytest -n auto -rX ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=ndarrays -sxv 2>&1 | tee s1_outfile.out
+      run: python -m pytest -n auto -rX ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=ndarrays 2>&1 | tee s1_outfile.out
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
       id: pytest_1

--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
     - name: Test C translation
-      run: python -m pytest -n auto -rX ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=ndarrays 2>&1 | tee s1_outfile.out
+      run: python -m pytest -n auto -rX ${FLAGS} -m "not (parallel or xdist_incompatible) and c ${{ inputs.pytest_mark }}" --ignore=ndarrays -sxv 2>&1 | tee s1_outfile.out
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests
       id: pytest_1

--- a/pyccel/codegen/compiling/file_locks.py
+++ b/pyccel/codegen/compiling/file_locks.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/devel/LICENSE for full license details.      #
+#------------------------------------------------------------------------------------------#
+"""
+Module handling classes which handle file locking to avoid deadlocks.
+"""
+from filelock import FileLock
+
+class FileLockSet:
+    """
+    Class for grouping file locks.
+
+    A class which groups file locks. By grouping these the locking can
+    be handled via a context manager which reduces the risk of the locks
+    not being correctly released.
+
+    Parameters
+    ----------
+    locks : iterable[FileLock], optional
+        The locks that should be stored in the FileLockSet.
+    """
+    def __init__(self, locks = ()):
+        assert all(isinstance(l, FileLock) for l in locks)
+        self._locks = list(locks)
+
+    def __enter__(self):
+        for l in self._locks:
+            l.acquire()
+
+    def __exit__(self, *args):
+        for l in self._locks:
+            l.acquire()
+
+    def append(self, new_lock):
+        """
+        Add a new lock to the FileLockSet.
+
+        Add a new lock to the FileLockSet.
+
+        Parameters
+        ----------
+        new_lock : FileLock
+            The new lock.
+        """
+        assert isinstance(new_lock, FileLock)
+        self._locks.append(new_lock)

--- a/pyccel/codegen/compiling/file_locks.py
+++ b/pyccel/codegen/compiling/file_locks.py
@@ -30,8 +30,9 @@ class FileLockSet:
             l.acquire()
 
     def __exit__(self, *args):
-        for l in self._locks:
-            l.acquire()
+        # Release the locks
+        for l in reversed(self._locks):
+            l.release()
 
     def append(self, new_lock):
         """

--- a/pyccel/codegen/compiling/file_locks.py
+++ b/pyccel/codegen/compiling/file_locks.py
@@ -29,7 +29,7 @@ class FileLockSet:
         for l in self._locks:
             l.acquire()
 
-    def __exit__(self, *args):
+    def __exit__(self, exc_type, exc_value, traceback):
         # Release the locks
         for l in reversed(self._locks):
             l.release()

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -128,8 +128,10 @@ def copy_internal_library(lib_folder, pyccel_dirpath, extra_files = None):
         else:
             to_create = False
             # If folder exists check if it needs updating
-            src_files = os.listdir(lib_path)
-            dst_files = [f for f in os.listdir(lib_dest_path) if not f.endswith('.lock')]
+            src_files = [os.path.relpath(os.path.join(root, f), lib_path) \
+                    for root, dirs, files in os.walk(lib_path) for f in files]
+            dst_files = [os.path.join(root, f) for root, dirs, files in os.walk(lib_dest_path) \
+                                               for f in files if not f.endswith('.lock')]
             # Check if all files are present in destination
             to_update = any(s not in dst_files for s in src_files)
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -130,8 +130,9 @@ def copy_internal_library(lib_folder, pyccel_dirpath, extra_files = None):
             # If folder exists check if it needs updating
             src_files = [os.path.relpath(os.path.join(root, f), lib_path) \
                     for root, dirs, files in os.walk(lib_path) for f in files]
-            dst_files = [os.path.join(root, f) for root, dirs, files in os.walk(lib_dest_path) \
-                                               for f in files if not f.endswith('.lock')]
+            dst_files = [os.path.relpath(os.path.join(root, f), lib_dest_path) \
+                    for root, dirs, files in os.walk(lib_dest_path) \
+                    for f in files if not f.endswith('.lock')]
             # Check if all files are present in destination
             to_update = any(s not in dst_files for s in src_files)
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -14,7 +14,8 @@ from filelock import FileLock
 import pyccel.stdlib as stdlib_folder
 import pyccel.extensions as ext_folder
 
-from .compiling.basic     import CompileObj
+from .compiling.basic      import CompileObj
+from .compiling.file_locks import FileLockSet
 
 # get path to pyccel/stdlib/lib_name
 stdlib_path = os.path.dirname(stdlib_folder.__file__)
@@ -145,36 +146,32 @@ def copy_internal_library(lib_folder, pyccel_dirpath, extra_files = None):
                     with open(os.path.join(lib_dest_path, filename), 'w') as f:
                         f.writelines(contents)
         elif to_update:
-            locks = []
+            locks = FileLockSet()
             for s in src_files:
                 base, ext = os.path.splitext(s)
                 if ext != '.h':
                     locks.append(FileLock(os.path.join(lib_dest_path, base+'.o.lock')))
             # Acquire locks to avoid compilation problems
-            for l in locks:
-                l.acquire()
-            # Remove all files in destination directory
-            for d in dst_files:
-                d_file = os.path.join(lib_dest_path, d)
-                try:
-                    os.remove(d_file)
-                except FileNotFoundError:
-                    # Don't call error in case of temporary compilation file that has disappeared
-                    # since reading the folder
-                    pass
-            # Copy all files from the source to the destination
-            for s in src_files:
-                shutil.copyfile(os.path.join(lib_path, s),
-                        os.path.join(lib_dest_path, s))
-            # Create any requested extra files
-            if extra_files:
-                for filename, contents in extra_files.items():
-                    extra_file = os.path.join(lib_dest_path, filename)
-                    with open(extra_file, 'w', encoding="utf-8") as f:
-                        f.writelines(contents)
-            # Release the locks
-            for l in locks:
-                l.release()
+            with locks:
+                # Remove all files in destination directory
+                for d in dst_files:
+                    d_file = os.path.join(lib_dest_path, d)
+                    try:
+                        os.remove(d_file)
+                    except FileNotFoundError:
+                        # Don't call error in case of temporary compilation file that has disappeared
+                        # since reading the folder
+                        pass
+                # Copy all files from the source to the destination
+                for s in src_files:
+                    shutil.copyfile(os.path.join(lib_path, s),
+                            os.path.join(lib_dest_path, s))
+                # Create any requested extra files
+                if extra_files:
+                    for filename, contents in extra_files.items():
+                        extra_file = os.path.join(lib_dest_path, filename)
+                        with open(extra_file, 'w', encoding="utf-8") as f:
+                            f.writelines(contents)
     return lib_dest_path
 
 #==============================================================================


### PR DESCRIPTION
The C tests occasionally fail in a way that causes a deadlock which only resolved when the code times out after an hour. This was happening due to 2 problems:
1. `copy_internal_library` was not designed to handle copying folders with subfolders leading to a `PermissionError` when calling `os.remove`
2. If an unhandled error is raised after the file lock is acquired the lock is never released.

This PR fixes this problem by handling subfolders using `os.walk` and ensuring that locks are always released using a context manager.

This change is not mentioned in the CHANGELOG as the bug was introduced after the last release.