### PR TITLE
Fix code exportation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 -   #1903 : Fix memory leak when using type annotations on local variables.
 -   #1913 : Fix function calls to renamed functions.
 -   #1927 : Improve error Message for missing target language compiler in Pyccel
--   #1933 : Fix code exportation
+-   #1933 : Improve code printing speed.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 -   #1903 : Fix memory leak when using type annotations on local variables.
 -   #1913 : Fix function calls to renamed functions.
 -   #1927 : Improve error Message for missing target language compiler in Pyccel
+-   #1933 : Fix code exportation
 
 ### Changed
 

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -219,15 +219,13 @@ class Codegen:
         # print module
         code = self._printer.doprint(self.ast)
         with open(filename, 'w', encoding="utf-8") as f:
-            for line in code:
-                f.write(line)
+            f.write(code)
 
         # print module header
         if header_ext is not None:
             code = self._printer.doprint(ModuleHeader(self.ast))
             with open(header_filename, 'w', encoding="utf-8") as f:
-                for line in code:
-                    f.write(line)
+                f.write(code)
 
         # print program
         prog_filename = None
@@ -237,7 +235,6 @@ class Codegen:
             prog_filename = os.path.join(folder,"prog_"+fname)
             code = self._printer.doprint(self.ast.program)
             with open(prog_filename, 'w') as f:
-                for line in code:
-                    f.write(line)
+                f.write(code)
 
         return filename, prog_filename


### PR DESCRIPTION
This PR fixes #1933 . Code exportation to the file was previously done one character at a time. Now it is done all at once