### PR TITLE
Correct results type for untransalatable function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to this project will be documented in this file.
 -   #1927 : Improve error Message for missing target language compiler in Pyccel
 -   #1933 : Improve code printing speed.
 -   #1930 : Preserve ordering of import targets.
--   #1951 : Fix return type for class taking unwrappable argument
+-   #1951 : Fix return type for class whose argument cannot be wrapped.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 -   #1927 : Improve error Message for missing target language compiler in Pyccel
 -   #1933 : Improve code printing speed.
 -   #1930 : Preserve ordering of import targets.
+-   #1951 : Fix return type for class taking unwrappable argument
 
 ### Changed
 

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -443,7 +443,10 @@ class CToPythonWrapper(Wrapper):
             The new function which raises the error.
         """
         func_args = [FunctionDefArgument(self.get_new_PyObject(n)) for n in ("self", "args", "kwargs")]
-        func_results = [FunctionDefResult(self.get_new_PyObject("result", is_temp=True))]
+        if self._error_exit_code is Nil():
+            func_results = [FunctionDefResult(self.get_new_PyObject("result", is_temp=True))]
+        else:
+            func_results = [FunctionDefResult(self.scope.get_temporary_variable(self._error_exit_code.class_type, "result"))]
         function = PyFunctionDef(name = name, arguments = func_args, results = func_results,
                 body = [FunctionCall(PyErr_SetString, [PyNotImplementedError,
                                         LiteralString(error_msg)]),


### PR DESCRIPTION
The MacOS runner has been updated which has led to a warning being upgraded to an error, breaking our CI.

It seems that there are some untransalatable functions which should return integers instead of `PythonObject*`s. This information can be deduced from the type of `self._error_exit_code`. Correcting the return type fixes the CI. Fixes #1951 