### PR TITLE
Fix broken CI

### DIFF
--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -995,7 +995,7 @@ class Bot:
             The name which can be used as a key.
         """
         if '(' in name:
-            return name.split('(')[1].split(')')[0].split(', ')
+            return tuple(name.split('(')[1].split(')')[0].split(', '))
         elif 'Codacy' in name:
             return 'Codacy'
         else:


### PR DESCRIPTION
Split returns list which is non-hashable. Since #1949  a key in the bot is generated using a split. This PR converts this to a tuple which is hashable