### PR TITLE
Bot fixes and improvements

### DIFF
--- a/ci_tools/bot_clean_up.py
+++ b/ci_tools/bot_clean_up.py
@@ -31,6 +31,9 @@ if __name__ == '__main__':
         pr_id = 0
 
     name_key = bot.get_name_key(name)
+    if isinstance(name_key, tuple):
+        # Ignore Python version
+        name_key = name_key[0]
 
     runs = bot.get_check_runs()
 
@@ -46,11 +49,14 @@ if __name__ == '__main__':
 
     for q in queued_runs:
         q_name = q['name']
-        deps = test_dependencies.get(bot.get_name_key(q_name), ())
+        q_key = bot.get_name_key(q_name)
+        if not isinstance(q_key, tuple):
+            # Not a Pyccel triggered test
+            continue
+        deps = test_dependencies.get(q_key[0], ())
         if name_key in deps:
             if all(d in successful_runs for d in deps):
-                q_key = q_name.split('(')[1].split(')')[0].strip()
-                q_name, python_version = q_key.split(',')
+                q_name, python_version = q_key
                 workflow_ids = None
                 if q_name == 'coverage':
                     workflow_ids = [int(r['details_url'].split('/')[-1]) for r in runs if r['conclusion'] == "success" and '(' in r['name']]

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -308,16 +308,20 @@ class Bot:
                     assert p.returncode == 0
 
                 commit_log = [o.split(' ')[0] for o in out.split('\n')]
-                print(commit_log)
                 idx = next((i for i,c in enumerate(commit_log) if c ==self._base), len(commit_log))
                 commit_log = commit_log[:idx+1]
 
             for t in tests:
                 pv = python_version or default_python_versions[t]
                 key = (t, pv)
-                if key in already_triggered_names:
-                    states.append(check_runs[key]['conclusion'])
-                    continue
+                if key in check_runs:
+                    current_conclusion = check_runs[key]['conclusion']
+                    if current_conclusion:
+                        workflow_id = int(check_runs[key]['details_url'].split('/')[-1])
+                        force_run = not self._GAI.has_valid_artifacts(workflow_id)
+                    if key in already_triggered_names and not force_run:
+                        states.append(check_runs[key]['conclusion'])
+                        continue
                 name = f"{test_names[t]} ({t}, {pv})"
                 if not force_run and not self.is_test_required(commit_log, name, t, states):
                     continue
@@ -331,11 +335,14 @@ class Bot:
                 print(already_triggered_names, deps)
                 if all(d in success_names for d in deps):
                     workflow_ids = None
+                    ready = True
                     if t == 'coverage':
                         print([r['details_url'] for r in check_runs.values() if r['conclusion'] == "success"])
                         workflow_ids = [int(r['details_url'].split('/')[-1]) for r in check_runs.values() if r['conclusion'] == "success" and '(' in r['name']]
-                    print("Running test")
-                    self.run_test(t, pv, posted["id"], workflow_ids)
+                        ready = all(self._GAI.has_valid_artifacts(w) for w in workflow_ids)
+                    if ready:
+                        print("Running test")
+                        self.run_test(t, pv, posted["id"], workflow_ids)
             return states
 
     def run_test(self, test, python_version, check_run_id, workflow_ids = None):

--- a/ci_tools/bot_tools/github_api_interactions.py
+++ b/ci_tools/bot_tools/github_api_interactions.py
@@ -883,6 +883,29 @@ class GitHubAPIInteractions:
 
         return success
 
+    def has_valid_artifacts(self, run_id):
+        """
+        Check if all the artifacts associated with a run id are valid (i.e. not expired).
+
+        Check if all the artifacts associated with a run id are valid (i.e. not expired).
+        This is done by collecting all artifacts associated with a run id using the GitHub
+        API as described here:
+        <https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts>
+
+        Parameters
+        ----------
+        run_id : int
+            The id of the run to be investigated.
+
+        Returns
+        -------
+        bool
+            True if all artifacts are valid. False otherwise.
+        """
+        url = f"https://api.github.com/repos/{self._org}/{self._repo}/actions/runs/{run_id}/artifacts"
+        artifacts = self._post_request("GET", url).json()['artifacts']
+        return all(not a['expired'] for a in artifacts)
+
     def get_headers(self):
         """
         Get the header which is always passed to the API.


### PR DESCRIPTION
Update `ci_tools/bot_clean_up.py` to correctly handle the new output of `get_name_key`.

Improve the bot to retrigger linux tests if the artifacts have expired and the coverage is requested.