### PR TITLE
Fix usage of used_names in pyccel_to_sympy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 -   #1930 : Preserve ordering of import targets.
 -   #1951 : Fix return type for class whose argument cannot be wrapped.
 -   #1892 : Fix implementation of list function when an iterable is passed as parameter.
+-   #1924 : Fix internal error arising in Duplicate or list comprehensions.
 
 ### Changed
 

--- a/pyccel/ast/sympy_helper.py
+++ b/pyccel/ast/sympy_helper.py
@@ -23,8 +23,8 @@ from .operators import PyccelAdd, PyccelMul, PyccelPow, PyccelUnarySub
 from .operators import PyccelDiv, PyccelMinus, PyccelAssociativeParenthesis
 from .variable  import Variable
 
-__all__ = ('sympy_to_pyccel',
-           'pyccel_to_sympy')
+__all__ = ('pyccel_to_sympy',
+           'sympy_to_pyccel')
 
 #==============================================================================
 def sympy_to_pyccel(expr, symbol_map):

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -46,9 +46,9 @@ class Scope(object):
     parent_scope : Scope, default: None
         The enclosing scope.
 
-    used_symbols : set, default: None
-        A set of all the names which we know will appear in the scope and which
-        we therefore want to avoid when creating new names.
+    used_symbols : dict, default: None
+        A dictionary mapping all the names which we know will appear in the scope and which
+        we therefore want to avoid when creating new names to their collisionless name.
 
     original_symbols : dict, default: None
         A dictionary which maps names used in the code to the original name used

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -922,7 +922,7 @@ class SemanticParser(BasicParser):
                 length = length.python_value
             else:
                 symbol_map = {}
-                used_symbols = {}
+                used_symbols = set()
                 sympy_length = pyccel_to_sympy(length, symbol_map, used_symbols)
                 if isinstance(sympy_length, sp_Integer):
                     length = int(sympy_length)

--- a/tests/epyccel/modules/functionals.py
+++ b/tests/epyccel/modules/functionals.py
@@ -58,5 +58,5 @@ def functional_for_3d_range():
     return len(a), a[0], a[1], a[2], a[3]
 
 def unknown_length_functional(x : 'int[:]'):
-    a = [i for i in range(len(x)*2)]
+    a = [i*3 for i in range(len(x)*2)]
     return len(a), a[0], a[-1]

--- a/tests/epyccel/modules/functionals.py
+++ b/tests/epyccel/modules/functionals.py
@@ -56,3 +56,7 @@ def functional_for_2d_range_const():
 def functional_for_3d_range():
     a = [i*j for i in range(1,3) for j in range(i,4) for k in range(i,j)]
     return len(a), a[0], a[1], a[2], a[3]
+
+def unknown_length_functional(x : 'int[:]'):
+    a = [i for i in range(len(x)*2)]
+    return len(a), a[0], a[-1]

--- a/tests/epyccel/modules/tuples.py
+++ b/tests/epyccel/modules/tuples.py
@@ -40,6 +40,7 @@ __all__ = [
         'tuples_mul_homogeneous2',
         'tuples_mul_homogeneous3',
         'tuples_mul_homogeneous4',
+        'tuples_mul_homogeneous5',
         'tuples_mul_inhomogeneous',
         'tuples_mul_inhomogeneous2',
         'tuples_mul_homogeneous_2d',
@@ -301,6 +302,14 @@ def tuples_mul_homogeneous3():
 def tuples_mul_homogeneous4():
     s = 2
     b = (1,2,3)*s
+    i = 1
+    return b[0], b[i], b[2], b[3], b[4], b[5]
+
+def tuples_mul_homogeneous5():
+    import numpy as np
+    s = 2
+    a = np.ones(5)
+    b = (1,2,3)*(len(a)*s)
     i = 1
     return b[0], b[i], b[2], b[3], b[4], b[5]
 

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -69,3 +69,7 @@ def test_functional_for_2d_array_range_const(language):
 
 def test_functional_for_3d_range(language):
     compare_epyccel(functionals.functional_for_3d_range, language)
+
+def test_unknown_length_functional(language):
+    y = randint(100, size = 20)
+    compare_epyccel(functionals.unknown_length_functional, language, y)


### PR DESCRIPTION
`used_names` in `Scope` used to be a `set` however it was changed to a `dict` to map the Python unique names to their low-level equivalent. In `pyccel_to_sympy` there was 1 line which still used `used_names` as though it were a set. This causes errors if the code manages to hit this code block (see #1924 ). This MR corrects the docstrings which still described `used_names` as a `set` and fixes the broken line. Fixes #1924 