### PR TITLE
Raise NumPy wrong argument error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to this project will be documented in this file.
 -   #1836 : Move `epyccel` module to `pyccel.commands.epyccel` and add support for shortcut import `from pyccel import epyccel`.
 -   #1720 : functions with the `@inline` decorator are no longer exposed to Python in the shared library.
 -   #1720 : Error raised when incompatible arguments are passed to an `inlined` function is now fatal.
+-   #1964 : Improve the error message when the wrong type is passed as a NumPy array argument.
 -   \[INTERNALS\] `FunctionDef` is annotated when it is called, or at the end of the `CodeBlock` if it is never called.
 -   \[INTERNALS\] `InlinedFunctionDef` is only annotated if it is called.
 -   \[INTERNALS\] Build `utilities.metaclasses.ArgumentSingleton` on the fly to ensure correct docstrings.

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from .bind_c            import BindCPointer
 
-from .datatypes         import PythonNativeBool, GenericType, VoidType, FixedSizeType
+from .datatypes         import PythonNativeBool, GenericType, VoidType, FixedSizeType, CharType
 
 from .cwrapper          import PyccelPyObject, check_type_registry, c_to_py_registry, pytype_parse_registry
 
@@ -101,6 +101,7 @@ pyarray_to_ndarray = FunctionDef(
 pyarray_check = FunctionDef(
                 name      = 'pyarray_check',
                 arguments = [
+                        FunctionDefArgument(Variable(CharType(), 'name', memory_handling='alias')),
                         FunctionDefArgument(Variable(PyccelPyObject(), 'a', memory_handling='alias')),
                         FunctionDefArgument(Variable(CNativeInt(), 'dtype')),
                         FunctionDefArgument(Variable(CNativeInt(), 'rank')),

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -14,6 +14,7 @@ from pyccel.ast.core       import Import, Module, Declare
 from pyccel.ast.cwrapper   import PyBuildValueNode, PyCapsule_New, PyCapsule_Import, PyModule_Create
 from pyccel.ast.cwrapper   import Py_None, WrapperCustomDataType
 from pyccel.ast.cwrapper   import PyccelPyObject, PyccelPyTypeObject
+from pyccel.ast.datatypes  import CharType
 from pyccel.ast.literals   import LiteralString, Nil, LiteralInteger
 from pyccel.ast.numpy_wrapper import PyccelPyArrayObject
 from pyccel.ast.c_concepts import ObjectAddress
@@ -88,7 +89,7 @@ class CWrapperCodePrinter(CCodePrinter):
         """
         if isinstance(a.dtype, (WrapperCustomDataType, BindCPointer)):
             return True
-        elif isinstance(a, (PyBuildValueNode, PyCapsule_New, PyCapsule_Import, PyModule_Create)):
+        elif isinstance(a, (PyBuildValueNode, PyCapsule_New, PyCapsule_Import, PyModule_Create, LiteralString)):
             return True
         else:
             return CCodePrinter.is_c_pointer(self,a)
@@ -158,6 +159,8 @@ class CWrapperCodePrinter(CCodePrinter):
         """
         if expr.dtype is BindCPointer():
             return 'void*'
+        if isinstance(expr.class_type, CharType):
+            return 'char*' if expr.is_alias else 'char'
         return CCodePrinter.get_declare_type(self, expr)
 
     def _handle_is_operator(self, Op, expr):

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -14,7 +14,6 @@ from pyccel.ast.core       import Import, Module, Declare
 from pyccel.ast.cwrapper   import PyBuildValueNode, PyCapsule_New, PyCapsule_Import, PyModule_Create
 from pyccel.ast.cwrapper   import Py_None, WrapperCustomDataType
 from pyccel.ast.cwrapper   import PyccelPyObject, PyccelPyTypeObject
-from pyccel.ast.datatypes  import CharType
 from pyccel.ast.literals   import LiteralString, Nil, LiteralInteger
 from pyccel.ast.numpy_wrapper import PyccelPyArrayObject
 from pyccel.ast.c_concepts import ObjectAddress
@@ -159,8 +158,6 @@ class CWrapperCodePrinter(CCodePrinter):
         """
         if expr.dtype is BindCPointer():
             return 'void*'
-        if isinstance(expr.class_type, CharType):
-            return 'char*' if expr.is_alias else 'char'
         return CCodePrinter.get_declare_type(self, expr)
 
     def _handle_is_operator(self, Op, expr):

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -297,15 +297,19 @@ class CToPythonWrapper(Wrapper):
             else:
                 flag = numpy_flag_c_contig
 
-            check_func = pyarray_check if raise_error else is_numpy_array
-            # No error code required as the error is raised inside pyarray_check
+            if raise_error:
+                check_func = pyarray_check
+                func_call = FunctionCall(check_func, [ObjectAddress(LiteralString(arg.name)), py_obj, type_ref, LiteralInteger(rank), flag])
+            else:
+                check_func = is_numpy_array
 
-            func_call = FunctionCall(check_func, [py_obj, type_ref, LiteralInteger(rank), flag])
+                func_call = FunctionCall(check_func, [py_obj, type_ref, LiteralInteger(rank), flag])
         else:
             errors.report(f"Can't check the type of an array of {dtype}\n"+PYCCEL_RESTRICTION_TODO,
                     symbol=arg, severity='fatal')
 
         if raise_error and not isinstance(arg.class_type, NumpyNDArrayType):
+            # No error code required for arrays as the error is raised inside pyarray_check
             message = LiteralString(f"Expected an argument of type {arg.class_type} for argument {arg.name}")
             python_error = FunctionCall(PyErr_SetString, [PyTypeError, message])
             error_code = (python_error,)

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -282,7 +282,7 @@ class CToPythonWrapper(Wrapper):
                                results   = [FunctionDefResult(Variable(dtype, name = 'v'))])
 
             func_call = FunctionCall(func, [py_obj])
-        else:
+        elif isinstance(arg.class_type, NumpyNDArrayType):
             try :
                 type_ref = numpy_dtype_registry[dtype]
             except KeyError:
@@ -301,8 +301,11 @@ class CToPythonWrapper(Wrapper):
             # No error code required as the error is raised inside pyarray_check
 
             func_call = FunctionCall(check_func, [py_obj, type_ref, LiteralInteger(rank), flag])
+        else:
+            errors.report(f"Can't check the type of an array of {dtype}\n"+PYCCEL_RESTRICTION_TODO,
+                    symbol=arg, severity='fatal')
 
-        if raise_error:
+        if raise_error and not isinstance(arg.class_type, NumpyNDArrayType):
             message = LiteralString(f"Expected an argument of type {arg.class_type} for argument {arg.name}")
             python_error = FunctionCall(PyErr_SetString, [PyTypeError, message])
             error_code = (python_error,)

--- a/pyccel/stdlib/cwrapper_ndarrays/cwrapper_ndarrays.c
+++ b/pyccel/stdlib/cwrapper_ndarrays/cwrapper_ndarrays.c
@@ -367,6 +367,8 @@ bool	pyarray_check(char* name, PyObject *o, int dtype, int rank, int flag)
 
     char* array_rank = _check_pyarray_rank(a, rank);
     if (array_rank != NULL) {
+        if (!correct_type)
+            strcat(error, ", ");
         strcat(error, array_rank);
         free(array_rank);
         correct_type = false;
@@ -375,6 +377,8 @@ bool	pyarray_check(char* name, PyObject *o, int dtype, int rank, int flag)
     if (rank > 1) {
         char* array_order = _check_pyarray_order(a, flag);
         if (array_order != NULL) {
+            if (!correct_type)
+                strcat(error, ", ");
             strcat(error, array_order);
             free(array_order);
             correct_type = false;

--- a/pyccel/stdlib/cwrapper_ndarrays/cwrapper_ndarrays.c
+++ b/pyccel/stdlib/cwrapper_ndarrays/cwrapper_ndarrays.c
@@ -334,6 +334,7 @@ PyObject* ndarray_to_pyarray(t_ndarray o)
  * Check Python Object (DataType, Rank, Order):
  *
  * 	Parameters	:
+ * 	    name  : the name of the argument (used for error output)
  *		a 	  : python array object
  *      dtype : desired data type enum
  *		rank  : desired rank
@@ -341,7 +342,7 @@ PyObject* ndarray_to_pyarray(t_ndarray o)
  * 	Returns		:
  *		return true if no error occurred otherwise it will return false
  */
-bool	pyarray_check(PyObject *o, int dtype, int rank, int flag)
+bool	pyarray_check(char* name, PyObject *o, int dtype, int rank, int flag)
 {
     char* array_type = _check_pyarray_type(o);
 	if (array_type != NULL) {
@@ -352,20 +353,23 @@ bool	pyarray_check(PyObject *o, int dtype, int rank, int flag)
 
     PyArrayObject* a = (PyArrayObject*)o;
 
-    char error[600];
-    error[0] = '\0';
+    bool correct_type = true;
+    char error[800];
+    sprintf(error, "Wrong argument type for argument %s : ", name);
 
 	// check array element type / rank / order
     char* array_dtype = _check_pyarray_dtype(a, dtype);
     if (array_dtype != NULL) {
         strcat(error, array_dtype);
         free(array_dtype);
+        correct_type = false;
     }
 
     char* array_rank = _check_pyarray_rank(a, rank);
     if (array_rank != NULL) {
         strcat(error, array_rank);
         free(array_rank);
+        correct_type = false;
     }
 
     if (rank > 1) {
@@ -373,16 +377,14 @@ bool	pyarray_check(PyObject *o, int dtype, int rank, int flag)
         if (array_order != NULL) {
             strcat(error, array_order);
             free(array_order);
+            correct_type = false;
         }
     }
 
-    if (error[0] != '\0') {
-		PyErr_Format(PyExc_TypeError, error);
-        return false;
+    if (!correct_type) {
+		PyErr_SetString(PyExc_TypeError, error);
     }
-    else {
-        return true;
-    }
+    return correct_type;
 }
 
 bool	is_numpy_array(PyObject *o, int dtype, int rank, int flag)

--- a/pyccel/stdlib/cwrapper_ndarrays/cwrapper_ndarrays.h
+++ b/pyccel/stdlib/cwrapper_ndarrays/cwrapper_ndarrays.h
@@ -44,7 +44,7 @@ PyObject* fortran_ndarray_to_pyarray(t_ndarray o);
 
 
 /* arrays checkers and helpers */
-bool	pyarray_check(PyObject *o, int dtype, int rank, int flag);
+bool	pyarray_check(char* name, PyObject *o, int dtype, int rank, int flag);
 bool	is_numpy_array(PyObject *o, int dtype, int rank, int flag);
 
 void    *nd_data(t_ndarray *a);


### PR DESCRIPTION
When an argument of the wrong type is passed to a Pyccel function the following error is raised:
```
TypeError: Expected an argument of type int32[:] for argument x
```
for an array this error is not very detailed as it does not specify if the problem is due to the rank, the data type, or the order. The error message containing these details is actually set in `pyarray_check`, however the error is overwritten by the code in the cwrapper (which is added to also raise errors for other types, e.g scalars). The only additional information in the error message is the name of the variable which has the incorrect type.

This PR adds the name as an argument to the function `pyarray_check` and stops the wrapper from overwriting the generated error message. The error message is now:
```
TypeError: Wrong argument type for argument x : argument dtype must be Int32, not Int64, argument rank must be 2, not 3, argument does not have the expected ordering (C)
```

**Commit Summary**
- Add the `name` argument to `pyarray_check`
- Allow the use of a `LiteralString` as a `char*` argument in the C wrapper
- Stop overwriting the `PyErr` string if the type check is carried out for an ND array