### PR TITLE
Simplify printf statement.

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1211,7 +1211,7 @@ class CCodePrinter(CodePrinter):
                                                 file=expr.file)],
                                  unravelled = True)
                 code += self._print(body)
-            elif isinstance(f.class_type, StringType):
+            elif isinstance(f, LiteralString):
                 arg_format, arg = self.get_print_format_and_arg(f)
                 if isinstance(arg, str):
                     arg = self._undo_print_LiteralString(arg)


### PR DESCRIPTION
This PR simplifies the printf statement in C Language.
fixes #1966 

## Input:
`print("Hello world")`

## Previous Output:
`printf("%s\n", "Hello world");`

## Output now:
`printf("Hello world.\n");`