### PR TITLE
Add C support for list.pop method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   #1720 : Add support for `Ellipsis` as the only index for an array.
+-   #1689 : Add Python support for list method `append()`.
+-   #1691 : Add Python support for list method `clear()`.
 -   #1694 : Add Python support for list method `extend()`.
+-   #1692 : Add Python support for list method `insert()`.
 -   #1700 : Add Python support for list method `sort()`.
 -   #1696 : Add Python support for list method `copy()`.
 -   #1693 : Add Python support for list method `remove()`.
+-   #1690 : Add Python and C support for list method `pop()`.
 -   #1739 : Add abstract class `SetMethod` to handle calls to various set methods.
 -   #1739 : Add Python support for set method `clear()`.
 -   #1740 : Add Python support for set method `copy()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   #1720 : Add support for `Ellipsis` as the only index for an array.
--   #1689 : Add Python support for list method `append()`.
--   #1691 : Add Python support for list method `clear()`.
 -   #1694 : Add Python support for list method `extend()`.
--   #1692 : Add Python support for list method `insert()`.
 -   #1700 : Add Python support for list method `sort()`.
 -   #1696 : Add Python support for list method `copy()`.
 -   #1693 : Add Python support for list method `remove()`.
--   #1690 : Add Python and C support for list method `pop()`.
+-   #1690 : Add C support for list method `pop()`.
 -   #1739 : Add abstract class `SetMethod` to handle calls to various set methods.
 -   #1739 : Add Python support for set method `clear()`.
 -   #1740 : Add Python support for set method `copy()`.

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -87,7 +87,7 @@ Python contains a limited number of builtin functions defined [here](https://doc
 | `insert` | Python-only |
 | `max` | No |
 | `min` | No |
-| `pop` | Python-only |
+| `pop` | Python and C only |
 | `remove` | Python-only |
 | `reverse` | No |
 | `sort` | Python-only |

--- a/pyccel/ast/builtin_methods/list_methods.py
+++ b/pyccel/ast/builtin_methods/list_methods.py
@@ -89,6 +89,15 @@ class ListAppend(ListMethod):
             raise TypeError(f"Expecting an argument of the same type as the elements of the list ({expected_type}) but received {new_elem.class_type}")
         super().__init__(list_obj, new_elem)
 
+    @property
+    def new_elem(self):
+        """
+        The element to be appended to the list.
+
+        The element to be appended to the list.
+        """
+        return self._args[0]
+
 #==============================================================================
 class ListPop(ListMethod) :
     """
@@ -116,6 +125,15 @@ class ListPop(ListMethod) :
         self._shape = (None if len(list_obj.shape) == 1 else tuple(list_obj.shape[1:]))
         self._class_type = list_obj.class_type.element_type
         super().__init__(list_obj, index_element)
+
+    @property
+    def index_element(self):
+        """
+        The current index value for the element to be popped.
+
+        The current index value for the element to be popped.
+        """
+        return self._args[0]
 
 #==============================================================================
 class ListClear(ListMethod) :

--- a/pyccel/ast/builtin_methods/list_methods.py
+++ b/pyccel/ast/builtin_methods/list_methods.py
@@ -89,15 +89,6 @@ class ListAppend(ListMethod):
             raise TypeError(f"Expecting an argument of the same type as the elements of the list ({expected_type}) but received {new_elem.class_type}")
         super().__init__(list_obj, new_elem)
 
-    @property
-    def new_elem(self):
-        """
-        The element to be appended to the list.
-
-        The element to be appended to the list.
-        """
-        return self._args[0]
-
 #==============================================================================
 class ListPop(ListMethod) :
     """

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -13,7 +13,7 @@ from pyccel.errors.errors   import Errors
 from pyccel.utilities.stage import PyccelStage
 
 from .basic     import PyccelAstNode, TypedAstNode
-from .datatypes import PyccelType, InhomogeneousTupleType
+from .datatypes import PyccelType, InhomogeneousTupleType, HomogeneousListType, HomogeneousSetType, DictType
 from .internals import PyccelArrayShapeElement, Slice, PyccelSymbol
 from .internals import apply_pickle
 from .literals  import LiteralInteger, Nil, LiteralEllipsis
@@ -236,7 +236,7 @@ class Variable(TypedAstNode):
         bool
             Whether or not the variable shape can change in the i-th dimension.
         """
-        return self.is_alias
+        return self.is_alias or isinstance(self.class_type, (HomogeneousListType, HomogeneousSetType, DictType))
 
     def set_changeable_shape(self):
         """

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2627,7 +2627,7 @@ class CCodePrinter(CodePrinter):
                         f'{lhs} = (*{tmp_var});\n'
                         f'{c_type}_erase_at({list_obj}, ({c_type}_iter){{.ref = {tmp_var}}});\n')
             else:
-                errors.report("If an index is passed to pop. Please save the result to a variable.",
+                raise errors.report("If an index is passed to pop. Please save the result to a variable.",
                         severity='fatal', symbol=expr)
         else:
             pop_elem = f'{c_type}_pull({list_obj})'

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2627,7 +2627,8 @@ class CCodePrinter(CodePrinter):
                         f'{lhs} = (*{tmp_var});\n'
                         f'{c_type}_erase_at({list_obj}, ({c_type}_iter){{.ref = {tmp_var}}});\n')
             else:
-                raise NotImplementedError("Save listpop to variable")
+                errors.report("If an index is passed to pop. Please save the result to a variable.",
+                        severity='fatal', symbol=expr)
         else:
             pop_elem = f'{c_type}_pull({list_obj})'
             if isinstance(expr.current_user_node, Assign):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1653,7 +1653,7 @@ class CCodePrinter(CodePrinter):
 
     def _print_PyccelArrayShapeElement(self, expr):
         arg = expr.arg
-        if isinstance(arg.class_type, NumpyNDArrayType):
+        if isinstance(arg.class_type, (NumpyNDArrayType, HomogeneousTupleType)):
             idx = self._print(expr.index)
             if self.is_c_pointer(arg):
                 arg_code = self._print(ObjectAddress(arg))

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -15,8 +15,6 @@ from pyccel.ast.builtins  import PythonRange, PythonComplex
 from pyccel.ast.builtins  import PythonPrint, PythonType
 from pyccel.ast.builtins  import PythonList, PythonTuple, PythonSet, PythonDict, PythonLen
 
-from pyccel.ast.builtin_methods.list_methods import ListPop
-
 from pyccel.ast.core      import Declare, For, CodeBlock
 from pyccel.ast.core      import FuncAddressDeclare, FunctionCall, FunctionCallArgument
 from pyccel.ast.core      import Allocate, Deallocate

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2636,12 +2636,6 @@ class CCodePrinter(CodePrinter):
             else:
                 return pop_elem
 
-    def _print_ListAppend(self, expr):
-        c_type = self.get_c_type(expr.list_obj.class_type)
-        list_obj = self._print(ObjectAddress(expr.list_obj))
-        new_elem = self._print(expr.new_elem)
-        return f'{c_type}_push({list_obj}, {new_elem});\n'
-
     #=================== MACROS ==================
 
     def _print_MacroShape(self, expr):

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -36,13 +36,14 @@ external_libs = {"stc"  : "STC/include",}
 # map internal libraries to their folders inside pyccel/stdlib and their compile objects
 # The compile object folder will be in the pyccel dirpath
 internal_libs = {
-    "ndarrays"       : ("ndarrays", CompileObj("ndarrays.c",folder="ndarrays")),
-    "pyc_math_f90"   : ("math", CompileObj("pyc_math_f90.f90",folder="math")),
-    "pyc_math_c"     : ("math", CompileObj("pyc_math_c.c",folder="math")),
-    "cwrapper"       : ("cwrapper", CompileObj("cwrapper.c",folder="cwrapper", accelerators=('python',))),
-    "numpy_f90"      : ("numpy", CompileObj("numpy_f90.f90",folder="numpy")),
-    "numpy_c"        : ("numpy", CompileObj("numpy_c.c",folder="numpy")),
-    "Set_extensions" : ("STC_Extensions", CompileObj("Set_Extensions.h", folder="STC_Extensions", has_target_file = False)),
+    "ndarrays"        : ("ndarrays", CompileObj("ndarrays.c",folder="ndarrays")),
+    "pyc_math_f90"    : ("math", CompileObj("pyc_math_f90.f90",folder="math")),
+    "pyc_math_c"      : ("math", CompileObj("pyc_math_c.c",folder="math")),
+    "cwrapper"        : ("cwrapper", CompileObj("cwrapper.c",folder="cwrapper", accelerators=('python',))),
+    "numpy_f90"       : ("numpy", CompileObj("numpy_f90.f90",folder="numpy")),
+    "numpy_c"         : ("numpy", CompileObj("numpy_c.c",folder="numpy")),
+    "Set_extensions"  : ("STC_Extensions", CompileObj("Set_Extensions.h", folder="STC_Extensions", has_target_file = False)),
+    "List_extensions" : ("STC_Extensions", CompileObj("List_Extensions.h", folder="STC_Extensions", has_target_file = False)),
 }
 internal_libs["cwrapper_ndarrays"] = ("cwrapper_ndarrays", CompileObj("cwrapper_ndarrays.c",folder="cwrapper_ndarrays",
                                                              accelerators = ('python',),

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -931,7 +931,7 @@ class SemanticParser(BasicParser):
                 bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
                 severity='fatal')
 
-        if isinstance(val.class_type, HomogeneousTupleType):
+        if isinstance(val.class_type, (HomogeneousTupleType, HomogeneousListType)):
             return Duplicate(val, length)
         else:
             if isinstance(length, LiteralInteger):

--- a/pyccel/stdlib/STC_Extensions/List_extensions.h
+++ b/pyccel/stdlib/STC_Extensions/List_extensions.h
@@ -1,0 +1,27 @@
+#ifndef LIST_EXTENSIONS_H
+#define LIST_EXTENSIONS_H
+
+
+#define _c_MEMB(name) c_JOIN(i_type, name)
+
+// This function represents a call to the .pop() method.
+// i_type: Class type (e.g., hset_int64_t).
+// i_key: Data type of the elements in the set (e.g., int64_t).
+
+static inline i_key _c_MEMB(_pull_elem)(i_type* self, intptr_t pop_idx) {
+    // Get the iterator for the specified element using (_advance) and (_begin)
+    _c_MEMB(_iter) itr = _c_MEMB(_advance)(_c_MEMB(_begin)(self), pop_idx);
+
+    // If the element is found then remove it from the list
+    if (itr.ref) 
+    {
+        i_key value = *(itr.ref);
+        _c_MEMB(_erase_at)(self, itr); // Remove the element by value using "_erase_at".
+        return value;
+    }
+    return *(itr.ref); // Return the element that is being popped.
+}
+
+#undef i_type
+#undef i_key
+#endif

--- a/pyccel/stdlib/STC_Extensions/Set_extensions.h
+++ b/pyccel/stdlib/STC_Extensions/Set_extensions.h
@@ -19,4 +19,6 @@ static inline i_key _c_MEMB(_pop)(i_type* self) {
     return *(itr.ref); // Return the element that is being popped.
 }
 
+#undef i_type
+#undef i_key
 #endif

--- a/tests/epyccel/test_epyccel_lists.py
+++ b/tests/epyccel/test_epyccel_lists.py
@@ -29,31 +29,31 @@ def language(request):
 def stc_language(request):
     return request.param
 
-def test_pop_last_element(language) :
+def test_pop_last_element(stc_language) :
     def pop_last_element():
         a = [1,3,45]
         return a.pop()
-    epyc_last_element = epyccel(pop_last_element, language = language)
+    epyc_last_element = epyccel(pop_last_element, language = stc_language)
     pyccel_result = epyc_last_element()
     python_result = pop_last_element()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_list_bool(language) :
+def test_pop_list_bool(stc_language) :
     def pop_last_element():
         a = [True, False, True]
         return a.pop()
-    epyc_last_element = epyccel(pop_last_element, language = language)
+    epyc_last_element = epyccel(pop_last_element, language = stc_language)
     pyccel_result = epyc_last_element()
     python_result = pop_last_element()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_list_float(language) :
+def test_pop_list_float(stc_language) :
     def pop_last_element():
         a = [1.5 , 3.1, 4.5]
         return a.pop()
-    epyc_last_element = epyccel(pop_last_element, language = language)
+    epyc_last_element = epyccel(pop_last_element, language = stc_language)
     pyccel_result = epyc_last_element()
     python_result = pop_last_element()
     assert isinstance(python_result, type(pyccel_result))
@@ -94,32 +94,32 @@ def test_pop_list_of_ndarrays(language) :
     assert isinstance(python_result, type(pyccel_result))
     assert np.array_equal(python_result, pyccel_result)
 
-def test_pop_specific_index(language) :
+def test_pop_specific_index(stc_language) :
     def pop_specific_index():
         a = [1j,3j,45j]
         return a.pop(1)
-    epyc_specific_index = epyccel(pop_specific_index, language = language)
+    epyc_specific_index = epyccel(pop_specific_index, language = stc_language)
     python_result = pop_specific_index()
     pyccel_result = epyc_specific_index()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_negative_index(language) :
+def test_pop_negative_index(stc_language) :
     def pop_negative_index():
         a = [1j,3j,45j]
         return a.pop(-1)
-    epyc_negative_index = epyccel(pop_negative_index, language = language)
+    epyc_negative_index = epyccel(pop_negative_index, language = stc_language)
     python_result = pop_negative_index()
     pyccel_result = epyc_negative_index()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_2(language) :
+def test_pop_2(stc_language) :
     def pop_2():
         a = [1.7,2.7,45.0]
         a.pop()
         return a.pop(-1)
-    pop_2_epyc = epyccel(pop_2, language = language)
+    pop_2_epyc = epyccel(pop_2, language = stc_language)
     python_result = pop_2()
     pyccel_result = pop_2_epyc()
     assert isinstance(python_result, type(pyccel_result))

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -80,7 +80,7 @@ def test_double_loop_on_2d_array_F(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
+            pytest.mark.skip(reason="C does not support list indexing yet, related issue #1948"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -101,7 +101,7 @@ def test_product_loop_on_2d_array_C(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
+            pytest.mark.skip(reason="C does not support list indexing yet, related issue #1948"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -122,7 +122,7 @@ def test_product_loop_on_2d_array_F(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
+            pytest.mark.skip(reason="C does not support list indexing yet, related issue #1948"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)
@@ -180,7 +180,7 @@ def test_enumerate_on_1d_array_with_start(language):
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
-            pytest.mark.xfail(reason="C does not support list indexing yet, related issue #1876"),
+            pytest.mark.skip(reason="C does not support list indexing yet, related issue #1948"),
             pytest.mark.c]
         ),
         pytest.param("python", marks = pytest.mark.python)


### PR DESCRIPTION
Add C support for list.pop method in an assign or without an index element. In order to handle negative indices `_print_PyccelArrayShapeElement` is updated to handle STC objects and `Variable.shape_can_change` is corrected.