### PR TITLE
Unify import strategy

### DIFF
--- a/.github/workflows/anaconda_linux.yml
+++ b/.github/workflows/anaconda_linux.yml
@@ -108,6 +108,7 @@ jobs:
           name: coverage-artifact
           path: .coverage
           retention-days: 1
+          include-hidden-files: true
       - name: "Post completed"
         if: always() && github.event_name != 'push'
         run:

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -102,6 +102,7 @@ jobs:
           name: coverage-artifact
           path: .coverage
           retention-days: 1
+          include-hidden-files: true
       - name: "Post completed"
         if: always() && github.event_name != 'push'
         run:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -105,6 +105,7 @@ jobs:
           name: coverage-artifact-${{ matrix.python_version }}
           path: .coverage
           retention-days: 3
+          include-hidden-files: true
       - name: "Post completed"
         if: always() && github.event_name != 'push'
         run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Remove unnecessary argument `kind` to `Errors.set_target`.
 -   \[INTERNALS\] Handle STC imports with Pyccel objects.
 -   \[INTERNALS\] Stop using ndarrays as an intermediate step to return arrays from Fortran code.
+-   \[INTERNALS\] Unify the strategy for handling additional imports in the printing stage for different languages.
 
 ### Deprecated
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -314,28 +314,6 @@ class CCodePrinter(CodePrinter):
         self._current_module = None
         self._in_header = False
 
-    def get_additional_imports(self):
-        """return the additional imports collected in printing stage"""
-        return self._additional_imports.keys()
-
-    def add_import(self, import_obj):
-        """
-        Add a new import to the current context.
-
-        Add a new import to the current context. This allows the import to be recognised
-        at the compiling/linking stage. If the source of the import is not new then any
-        new targets are added to the Import object.
-
-        Parameters
-        ----------
-        import_obj : Import
-            The AST node describing the import.
-        """
-        if import_obj.source not in self._additional_imports:
-            self._additional_imports[import_obj.source] = import_obj
-        elif import_obj.target:
-            self._additional_imports[import_obj.source].define_target(import_obj.target)
-
     def _format_code(self, lines):
         return self.indent_code(lines)
 

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -56,7 +56,17 @@ class CodePrinter:
         return ''.join(self._format_code(lines))
 
     def get_additional_imports(self):
-        """return the additional imports collected in printing stage"""
+        """
+        Get any additional imports collected during the printing stage.
+
+        Get any additional imports collected during the printing stage.
+        This is necessary to correctly compile the files.
+
+        Returns
+        -------
+        iterable[str]
+            An iterable of the include strings.
+        """
         return self._additional_imports.keys()
 
     def add_import(self, import_obj):

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -29,6 +29,7 @@ class CodePrinter:
     language = None
     def __init__(self):
         self._scope = None
+        self._additional_imports = {}
 
     def doprint(self, expr):
         """
@@ -53,6 +54,28 @@ class CodePrinter:
 
         # Format the output
         return ''.join(self._format_code(lines))
+
+    def get_additional_imports(self):
+        """return the additional imports collected in printing stage"""
+        return self._additional_imports.keys()
+
+    def add_import(self, import_obj):
+        """
+        Add a new import to the current context.
+
+        Add a new import to the current context. This allows the import to be recognised
+        at the compiling/linking stage. If the source of the import is not new then any
+        new targets are added to the Import object.
+
+        Parameters
+        ----------
+        import_obj : Import
+            The AST node describing the import.
+        """
+        if import_obj.source not in self._additional_imports:
+            self._additional_imports[import_obj.source] = import_obj
+        elif import_obj.target:
+            self._additional_imports[import_obj.source].define_target(import_obj.target)
 
     @property
     def scope(self):


### PR DESCRIPTION
Unify the strategy for handling additional imports in the printing stage for different languages. This allows `get_additional_imports` and `add_import` to be moved to the superclass `codegen.printing.CodePrinter` and will make it easier to handle different import strategies (e.g. #1657)

**Commit Summary**
- Move `get_additional_imports` to `codegen.printing.CodePrinter`
- Move `add_import` to `codegen.printing.CodePrinter`
- Use a dictionary for imports in `codegen.printing.FCodePrinter` to match what is done in `codegen.printing.CCodePrinter`
- Change the storage type of the `_additional_imports` dict in `codegen.printing.PythonCodePrinter` to match what is done in `codegen.printing.CCodePrinter`