### PR TITLE
Fix gFTL installation 

### DIFF
--- a/.dict_custom.txt
+++ b/.dict_custom.txt
@@ -119,3 +119,4 @@ indexable
 traceback
 STC
 gFTL
+CMake

--- a/.github/actions/check_for_gftl/action.yml
+++ b/.github/actions/check_for_gftl/action.yml
@@ -13,7 +13,7 @@ runs:
         from os.path import exists, join
         pyccel_loc = pyccel.__path__[0]
         print(pyccel_loc)
-        assert exists(join(pyccel_loc,'extensions/gFTL/include/v2'))
+        assert exists(join(pyccel_loc,'extensions/gFTL/install/GFTL-1.13/include/v2'))
         if ${{ inputs.not_editable }}:
           assert not exists(join(pyccel_loc,'extensions/gFTL/doc'))
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,8 @@ We recommend using GFortran/GCC and Open-MPI.
 
 Pyccel also depends on several Python3 packages, which are automatically downloaded by pip, the Python Package Installer, during the installation process. In addition to these, unit tests require additional packages which are installed as optional dependencies with pip, while building the documentation requires [Sphinx](http://www.sphinx-doc.org/).
 
+In order to install Pyccel from source, CMake is additionally required to build the gFTL dependence.
+
 ### Linux Debian-Ubuntu-Mint
 
 To install all requirements on a Linux Ubuntu machine, just use APT, the Advanced Package Tool:

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -21,7 +21,7 @@ class CustomBuildHook(BuildHookInterface):
     *args : tuple
         See hatch docs.
     **kwds : dict
-        See hatch docs
+        See hatch docs.
     """
 
     def initialize(self, version, build_data):

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -15,6 +15,13 @@ class CustomBuildHook(BuildHookInterface):
     A class inheriting from BuildHookInterface which allows code to be run to create artifacts during the build stage
     of the package installation using hatch.
     See <https://hatch.pypa.io/latest/plugins/build-hook/reference> for more details.
+
+    Parameters
+    ----------
+    *args : tuple
+        See hatch docs.
+    **kwds : dict
+        See hatch docs
     """
 
     def initialize(self, version, build_data):

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -1,5 +1,6 @@
 """ A script to provide a hook which allows artifacts to be generated during installation of the package.
 """
+import glob
 import os
 from pathlib import Path
 import shutil
@@ -37,6 +38,8 @@ class CustomBuildHook(BuildHookInterface):
                         '--install-prefix', str(gFTL_folder / 'install')], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--build', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--install', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
+
+        build_data['artifacts'].extend(glob.glob(gFTL_folder / 'install' / 'GFTL-1.13' / 'include' / '*'))
 
         # Build pickle files
         pickle_folder = (Path(__file__).parent.parent / 'pyccel' / 'stdlib' / 'internal').absolute()

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -1,6 +1,5 @@
 """ A script to provide a hook which allows artifacts to be generated during installation of the package.
 """
-import glob
 import os
 from pathlib import Path
 import shutil
@@ -39,7 +38,7 @@ class CustomBuildHook(BuildHookInterface):
         subprocess.run([shutil.which('cmake'), '--build', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--install', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
 
-        build_data['artifacts'].extend(glob.glob(gFTL_folder / 'install' / 'GFTL-1.13' / 'include' / '*'))
+        build_data['artifacts'].extend((gFTL_folder / 'install' / 'GFTL-1.13' / 'include').glob('**/*'))
 
         # Build pickle files
         pickle_folder = (Path(__file__).parent.parent / 'pyccel' / 'stdlib' / 'internal').absolute()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ path = "pyccel/version.py"
 [tool.hatch.build.targets.wheel]
 artifacts = [
   "*.pyccel",
+  "pyccel/extensions/gFTL/install/GFTL-1.13/include/v2"
 ]
 include = [
   "pyccel/**/*.py",
@@ -57,8 +58,7 @@ include = [
   "pyccel/stdlib/**/*.h",
   "pyccel/stdlib/**/*.c",
   "pyccel/stdlib/**/*.f90",
-  "pyccel/extensions/STC/include",
-  "pyccel/extensions/gFTL/install/GFTL-1.13/include/v2"
+  "pyccel/extensions/STC/include"
 ]
 exclude = [
     "pyccel/extensions/STC/src",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ include = [
   "pyccel/stdlib/**/*.c",
   "pyccel/stdlib/**/*.f90",
   "pyccel/extensions/STC/include",
-  "pyccel/extensions/gFTL/include/v2"
+  "pyccel/extensions/gFTL/install/GFTL-1.13/include/v2"
 ]
 exclude = [
     "pyccel/extensions/STC/src",


### PR DESCRIPTION
The installation hook is updated to run cmake on gFTL during the installation process. This generates the .inc files which are used by the library. Fixes #1978

The CHANGELOG is not updated as the fix is not relevant compared to previous release version.