### PR TITLE
Add support for NumPy v2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install Pyccel with tests
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[test]
+          python -m pip install .[test] "numpy<2.0"
         shell: bash
       - name: Coverage install
         uses: ./.github/actions/coverage_install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 -   #1544 : Add support for `typing.TypeAlias`.
 -   #1583 : Allow inhomogeneous tuples in classes.
 -   #1915 : Add support for NumPy v2 `sign` function.
+-   #1988 : Add support for NumPy v2.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -6,6 +6,8 @@
 #------------------------------------------------------------------------------------------#
 """ Module containing objects from the numpy module understood by pyccel
 """
+from packaging.version import Version
+
 import numpy
 
 from pyccel.errors.errors import Errors
@@ -41,6 +43,7 @@ from .variable       import Variable, Constant, IndexedElement
 
 errors = Errors()
 pyccel_stage = PyccelStage()
+numpy_v1 = Version(numpy.__version__) < Version("2.0.0")
 
 __all__ = (
     'process_shape',
@@ -2051,6 +2054,27 @@ class NumpyFloor(NumpyUfuncUnary):
     """
     __slots__ = ()
     name = 'floor'
+
+    def _get_dtype(self, x):
+        """
+        Use the argument to calculate the dtype of the result.
+
+        Use the argument to calculate the dtype of the result.
+
+        Parameters
+        ----------
+        x : TypedAstNode
+            The argument passed to the function.
+
+        Returns
+        -------
+        PyccelType
+            The dtype of the result of the function.
+        """
+        if numpy_v1:
+            return super()._get_dtype(x)
+        else:
+            return process_dtype(x.dtype)
 
 class NumpyMod(NumpyUfuncBinary):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 dependencies = [
     "filelock >= 3.4.0",
-    "numpy >= 1.16, < 2.0",
+    "numpy >= 1.16",
     "sympy >= 1.2",
     "termcolor >= 1.0.0",
     "textx >= 2.2",

--- a/tests/epyccel/modules/openmp.py
+++ b/tests/epyccel/modules/openmp.py
@@ -210,7 +210,7 @@ def test_omp_get_initial_device():
 def test_omp_get_set_schedule():
     import numpy as np
     from pyccel.stdlib.internal.openmp import omp_get_schedule, omp_set_schedule
-    func_result = 0
+    func_result = np.int32(0)
     #$ omp parallel private(i)
     omp_set_schedule(np.int32(2), np.int32(3))
     _, chunk_size = omp_get_schedule()

--- a/tests/errors/semantic/non_blocking/INCOMPATIBLE_TYPES_IN_ASSIGNMENT_2.py
+++ b/tests/errors/semantic/non_blocking/INCOMPATIBLE_TYPES_IN_ASSIGNMENT_2.py
@@ -2,4 +2,4 @@
 import numpy as np
 
 a = np.float32(4)
-a += 5.0
+a += np.float64(5.0)

--- a/tests/internal/scripts/mpi/bcast.py
+++ b/tests/internal/scripts/mpi/bcast.py
@@ -27,9 +27,9 @@ if __name__ == '__main__':
 
     master = np.int32(1)
     if rank == master:
-        msg = rank + 1000
+        msg = int(rank) + 1000
     else:
-        msg = np.int32(0)
+        msg = 0
 
     length = np.int32(1)
     mpi_bcast (msg, length, MPI_INTEGER8, master, comm, ierr)

--- a/tests/internal/scripts/mpi/bcast.py
+++ b/tests/internal/scripts/mpi/bcast.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     if rank == master:
         msg = rank + 1000
     else:
-        msg = 0
+        msg = np.int32(0)
 
     length = np.int32(1)
     mpi_bcast (msg, length, MPI_INTEGER8, master, comm, ierr)


### PR DESCRIPTION
Add support for NumPy v2 by fixing the return type of `np.floor` and updating the tests.

**Commit Summary**
- Remove NumPy version restriction
- Ensure `np.floor` returns an integer in NumPy v2 and a float in NumPy v1 when given an integer argument
- Fix type changes due to mixing of native and NumPy scalar types