### PR TITLE
Fix type bugs with NumPy v2

### DIFF
--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -414,7 +414,7 @@ def max_precision(objs : list, allow_native : bool = True):
         if ndarray_list:
             return get_final_precision(max(ndarray_list, key=attrgetter('precision')))
         if numpy_v1:
-            return max((get_final_precision(o) for o in objs), default = -1)
+            return max((get_final_precision(o) for o in objs))
         else:
             return get_final_precision(max(objs, key = lambda o : o.precision))
 

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -414,7 +414,7 @@ def max_precision(objs : list, allow_native : bool = True):
         if ndarray_list:
             return get_final_precision(max(ndarray_list, key=attrgetter('precision')))
         if numpy_v1:
-            return max(get_final_precision(o) for o in objs, default = -1)
+            return max((get_final_precision(o) for o in objs), default = -1)
         else:
             return get_final_precision(max(objs, key = lambda o : o.precision))
 

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -414,7 +414,7 @@ def max_precision(objs : list, allow_native : bool = True):
         if ndarray_list:
             return get_final_precision(max(ndarray_list, key=attrgetter('precision')))
         if numpy_v1:
-            return max((get_final_precision(o) for o in objs))
+            return max(get_final_precision(o) for o in objs)
         else:
             return get_final_precision(max(objs, key = lambda o : o.precision))
 

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -414,7 +414,7 @@ def max_precision(objs : list, allow_native : bool = True):
         if ndarray_list:
             return get_final_precision(max(ndarray_list, key=attrgetter('precision')))
         if numpy_v1:
-            return max(get_final_precision(o) for o in objs)
+            return max(get_final_precision(o) for o in objs, default = -1)
         else:
             return get_final_precision(max(objs, key = lambda o : o.precision))
 

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -7,6 +7,9 @@
 File containing basic classes which are used throughout pyccel.
 To avoid circular imports this file should only import from basic, datatypes, and literals
 """
+from packaging.version import Version
+
+import numpy as np
 
 from operator import attrgetter
 from pyccel.utilities.stage import PyccelStage
@@ -16,6 +19,7 @@ from .datatypes import NativeInteger, default_precision
 from .literals  import LiteralInteger
 
 pyccel_stage = PyccelStage()
+numpy_v1 = Version(np.__version__) < Version("2.0.0")
 
 __all__ = (
     'PrecomputedCode',
@@ -409,7 +413,10 @@ def max_precision(objs : list, allow_native : bool = True):
         ndarray_list = [o for o in objs if getattr(o, 'is_ndarray', False)]
         if ndarray_list:
             return get_final_precision(max(ndarray_list, key=attrgetter('precision')))
-        return max(get_final_precision(o) for o in objs)
+        if numpy_v1:
+            return max(get_final_precision(o) for o in objs)
+        else:
+            return get_final_precision(max(objs, key = lambda o : o.precision))
 
 
 def get_final_precision(obj):

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -5152,6 +5152,7 @@ def test_numpy_matmul_array_like_2x2d(language):
         cast = type(min_for_type)
         min_test = -np.sqrt(abs(min_for_type) / size[0])
         max_test = np.sqrt(abs(max_for_type) / size[0])
+        print(min_test, max_test, cast(min_test), cast(max_test))
         return cast(min_test), cast(max_test)
 
     integer8 = randint(*calculate_max_values(min_int8, max_int8), size=size, dtype=np.int8)
@@ -5387,10 +5388,13 @@ def test_numpy_linspace_scalar(language):
 
     @template('T', ['int', 'int8', 'int16', 'int32', 'int64', 'float', 'float32', 'float64'])
     def get_linspace(start : 'T', steps : int, num : int):
-        from numpy import linspace
+        from numpy import linspace, float64
         stop = start + steps
         b = linspace(start, stop, num)
-        return b
+        x = float64(0.0)
+        for bi in b:
+            x += bi
+        return x
 
     def test_linspace(start : 'complex64', end : 'complex64'):
         from numpy import linspace
@@ -5443,29 +5447,29 @@ def test_numpy_linspace_scalar(language):
     assert (np.allclose(x, out))
     arr = np.zeros
     x = randint(1, 60)
-    assert np.allclose(epyccel_func(integer8, x, 30), get_linspace(integer8, x, 30), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer8, x, 100)[0], get_linspace(integer8, x, 100)[0])
+    assert np.isclose(epyccel_func(integer8, x, 30), get_linspace(integer8, x, 30), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer8, x, 100), get_linspace(integer8, x, 100))
     x = randint(100, 200)
-    assert np.allclose(epyccel_func(integer, x, 30), get_linspace(integer, x, 30), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer, x, 100)[0], get_linspace(integer, x, 100)[0])
+    assert np.isclose(epyccel_func(integer, x, 30), get_linspace(integer, x, 30), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer, x, 100), get_linspace(integer, x, 100))
     x = randint(100, 200)
-    assert np.allclose(epyccel_func(integer16, x, 30), get_linspace(integer16, x, 30), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer16, x, 100)[0], get_linspace(integer16, x, 100)[0])
+    assert np.isclose(epyccel_func(integer16, x, 30), get_linspace(integer16, x, 30), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer16, x, 100), get_linspace(integer16, x, 100))
     x = randint(100, 200)
-    assert np.allclose(epyccel_func(integer32, x, 30), get_linspace(integer32, x, 30), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer32, x, 100)[0], get_linspace(integer32, x, 100)[0])
+    assert np.isclose(epyccel_func(integer32, x, 30), get_linspace(integer32, x, 30), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer32, x, 100), get_linspace(integer32, x, 100))
     x = randint(100, 200)
-    assert np.allclose(epyccel_func(integer64, x, 200), get_linspace(integer64, x, 200), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer64, x, 100)[0], get_linspace(integer64, x, 100)[0])
+    assert np.isclose(epyccel_func(integer64, x, 200), get_linspace(integer64, x, 200), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer64, x, 100), get_linspace(integer64, x, 100))
     x = randint(100, 200)
-    assert np.allclose(epyccel_func(fl, x, 100), get_linspace(fl, x, 100), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(fl, x, 100)[0], get_linspace(fl, x, 100)[0])
+    assert np.isclose(epyccel_func(fl, x, 100), get_linspace(fl, x, 100), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(fl, x, 100), get_linspace(fl, x, 100))
     x = randint(100, 200)
-    assert np.allclose(epyccel_func(fl32, x, 200), get_linspace(fl32, x, 200), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(fl32, x, 100)[0], get_linspace(fl32, x, 100)[0])
+    assert np.isclose(epyccel_func(fl32, x, 200), get_linspace(fl32, x, 200), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(fl32, x, 100), get_linspace(fl32, x, 100))
     x = randint(100, 200)
-    assert np.allclose(epyccel_func(fl64, x, 200), get_linspace(fl64, x, 200), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(fl64, x, 100)[0], get_linspace(fl64, x, 100)[0])
+    assert np.isclose(epyccel_func(fl64, x, 200), get_linspace(fl64, x, 200), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(fl64, x, 100), get_linspace(fl64, x, 100))
 
     epyccel_func1 = epyccel(test_linspace, language=language)
     epyccel_func2 = epyccel(test_linspace2, language=language)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -2404,6 +2404,16 @@ def test_sum_real(language):
     x = rand(10)
     assert(isclose(f1(x), sum_call(x), rtol=RTOL, atol=ATOL))
 
+def test_sum_type(language):
+    def sum_call(x : 'float32[:]'):
+        from numpy import sum as np_sum
+        return np_sum(x)
+
+    f1 = epyccel(sum_call, language = language)
+    x = rand(10).astype(np.float32)
+    assert isclose(f1(x), sum_call(x), rtol=RTOL32, atol=ATOL32)
+    assert matching_types(f1(x), sum_call(x))
+
 def test_sum_phrase(language):
     def sum_phrase(x : 'float[:]', y : 'float[:]'):
         from numpy import sum as np_sum
@@ -5152,7 +5162,6 @@ def test_numpy_matmul_array_like_2x2d(language):
         cast = type(min_for_type)
         min_test = -np.sqrt(abs(min_for_type) / size[0])
         max_test = np.sqrt(abs(max_for_type) / size[0])
-        print(min_test, max_test, cast(min_test), cast(max_test))
         return cast(min_test), cast(max_test)
 
     integer8 = randint(*calculate_max_values(min_int8, max_int8), size=size, dtype=np.int8)
@@ -5391,10 +5400,7 @@ def test_numpy_linspace_scalar(language):
         from numpy import linspace
         stop = start + steps
         b = linspace(start, stop, num)
-        x = 0.0
-        for bi in b:
-            x += bi
-        return x
+        return b
 
     def test_linspace(start : 'complex64', end : 'complex64'):
         from numpy import linspace
@@ -5447,29 +5453,29 @@ def test_numpy_linspace_scalar(language):
     assert (np.allclose(x, out))
     arr = np.zeros
     x = randint(1, 60)
-    assert np.isclose(epyccel_func(integer8, x, 30), get_linspace(integer8, x, 30), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer8, x, 100), get_linspace(integer8, x, 100))
+    assert np.allclose(epyccel_func(integer8, x, 30), get_linspace(integer8, x, 30), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer8, x, 100)[0], get_linspace(integer8, x, 100)[0])
     x = randint(100, 200)
-    assert np.isclose(epyccel_func(integer, x, 30), get_linspace(integer, x, 30), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer, x, 100), get_linspace(integer, x, 100))
+    assert np.allclose(epyccel_func(integer, x, 30), get_linspace(integer, x, 30), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer, x, 100)[0], get_linspace(integer, x, 100)[0])
     x = randint(100, 200)
-    assert np.isclose(epyccel_func(integer16, x, 30), get_linspace(integer16, x, 30), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer16, x, 100), get_linspace(integer16, x, 100))
+    assert np.allclose(epyccel_func(integer16, x, 30), get_linspace(integer16, x, 30), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer16, x, 100)[0], get_linspace(integer16, x, 100)[0])
     x = randint(100, 200)
-    assert np.isclose(epyccel_func(integer32, x, 30), get_linspace(integer32, x, 30), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer32, x, 100), get_linspace(integer32, x, 100))
+    assert np.allclose(epyccel_func(integer32, x, 30), get_linspace(integer32, x, 30), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer32, x, 100)[0], get_linspace(integer32, x, 100)[0])
     x = randint(100, 200)
-    assert np.isclose(epyccel_func(integer64, x, 200), get_linspace(integer64, x, 200), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(integer64, x, 100), get_linspace(integer64, x, 100))
+    assert np.allclose(epyccel_func(integer64, x, 200), get_linspace(integer64, x, 200), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(integer64, x, 100)[0], get_linspace(integer64, x, 100)[0])
     x = randint(100, 200)
-    assert np.isclose(epyccel_func(fl, x, 100), get_linspace(fl, x, 100), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(fl, x, 100), get_linspace(fl, x, 100))
+    assert np.allclose(epyccel_func(fl, x, 100), get_linspace(fl, x, 100), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(fl, x, 100)[0], get_linspace(fl, x, 100)[0])
     x = randint(100, 200)
-    assert np.isclose(epyccel_func(fl32, x, 200), get_linspace(fl32, x, 200), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(fl32, x, 100), get_linspace(fl32, x, 100))
+    assert np.allclose(epyccel_func(fl32, x, 200), get_linspace(fl32, x, 200), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(fl32, x, 100)[0], get_linspace(fl32, x, 100)[0])
     x = randint(100, 200)
-    assert np.isclose(epyccel_func(fl64, x, 200), get_linspace(fl64, x, 200), rtol=RTOL, atol=ATOL)
-    assert matching_types(epyccel_func(fl64, x, 100), get_linspace(fl64, x, 100))
+    assert np.allclose(epyccel_func(fl64, x, 200), get_linspace(fl64, x, 200), rtol=RTOL, atol=ATOL)
+    assert matching_types(epyccel_func(fl64, x, 100)[0], get_linspace(fl64, x, 100)[0])
 
     epyccel_func1 = epyccel(test_linspace, language=language)
     epyccel_func2 = epyccel(test_linspace2, language=language)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -2404,16 +2404,6 @@ def test_sum_real(language):
     x = rand(10)
     assert(isclose(f1(x), sum_call(x), rtol=RTOL, atol=ATOL))
 
-def test_sum_type(language):
-    def sum_call(x : 'float32[:]'):
-        from numpy import sum as np_sum
-        return np_sum(x)
-
-    f1 = epyccel(sum_call, language = language)
-    x = rand(10).astype(np.float32)
-    assert isclose(f1(x), sum_call(x), rtol=RTOL32, atol=ATOL32)
-    assert matching_types(f1(x), sum_call(x))
-
 def test_sum_phrase(language):
     def sum_phrase(x : 'float[:]', y : 'float[:]'):
         from numpy import sum as np_sum


### PR DESCRIPTION
After NumPy v2 the NumPy precision is preferred over the precision provided by any native Python types involved in calculations. This causes the result types of arithmetic operators to change. This was not a problem in the devel branch due to our use of `np.result_type` to calculate the types using information about both the type and the precision.

This PR fixes the problem to prepare the patch release. It does this by ignoring native types. The fix handles most cases but is not perfect. It is very difficult to do better without making the changes in #1756.