### PR TITLE
Fix test failures with Intel compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## \[1.12.1\] - 2024-09-27
+## \[1.12.1\] - 2024-10-01
 
 ### Added
 

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -296,8 +296,7 @@ class PythonComplex(PyccelInternalFunction):
         return super().__new__(cls)
 
     def __init__(self, arg0, arg1 = LiteralFloat(0)):
-        self._is_cast = arg0.dtype is NativeComplex() or \
-                        isinstance(arg1, Literal) and arg1.python_value == 0
+        self._is_cast = isinstance(arg1, Literal) and arg1.python_value == 0
 
         if self._is_cast:
             self._real_part = self._real_cast(arg0)

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -296,7 +296,7 @@ class PythonComplex(PyccelInternalFunction):
         return super().__new__(cls)
 
     def __init__(self, arg0, arg1 = LiteralFloat(0)):
-        self._is_cast = arg0.dtype is NativeComplex() and \
+        self._is_cast = arg0.dtype is NativeComplex() or \
                         isinstance(arg1, Literal) and arg1.python_value == 0
 
         if self._is_cast:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1250,15 +1250,17 @@ class FCodePrinter(CodePrinter):
         return 'floor({}, kind={})'.format(arg_code, prec_code)
 
     def _print_PythonComplex(self, expr):
+        kind = self.print_kind(expr)
         if expr.is_cast:
-            var = self._print(expr.internal_var)
-            code = 'cmplx({0}, kind={1})'.format(var,
-                                self.print_kind(expr))
+            var = expr.internal_var
+            if var.dtype is NativeBool():
+                var = PythonInt(var)
+            var_code = self._print(var)
+            code = f'cmplx({var_code}, kind={kind})'
         else:
             real = self._print(expr.real)
             imag = self._print(expr.imag)
-            code = 'cmplx({0}, {1}, {2})'.format(real, imag,
-                                self.print_kind(expr))
+            code = f'cmplx({real}, {imag}, {kind})'
         return code
 
     def _print_PythonBool(self, expr):

--- a/tests/epyccel/recognised_functions/test_numpy_types.py
+++ b/tests/epyccel/recognised_functions/test_numpy_types.py
@@ -964,10 +964,11 @@ def test_numpy_complex_array_like_1d(language, get_complex):
     integer32 = randint(min_int32, max_int32, size=size, dtype=np.int32)
     integer64 = randint(min_int64, max_int64, size=size, dtype=np.int64)
 
-    fl = uniform(min_float / 2, max_float / 2, size = size)
+    # float32 is used as the maximum for all float types to avoid overflow errors
+    fl = uniform(min_float32 / 2, max_float32 / 2, size = size)
     fl32 = uniform(min_float32 / 2, max_float32 / 2, size = size)
     fl32 = np.float32(fl32)
-    fl64 = uniform(min_float64 / 2, max_float64 / 2, size = size)
+    fl64 = uniform(min_float32 / 2, max_float32 / 2, size = size)
 
     epyccel_func = epyccel(get_complex, language=language)
 
@@ -1008,10 +1009,11 @@ def test_numpy_complex_array_like_2d(language, get_complex):
     integer32 = randint(min_int32, max_int32, size=size, dtype=np.int32)
     integer64 = randint(min_int64, max_int64, size=size, dtype=np.int64)
 
-    fl = uniform(min_float / 2, max_float / 2, size = size)
+    # float32 is used as the maximum for all float types to avoid overflow errors
+    fl = uniform(min_float32 / 2, max_float32 / 2, size = size)
     fl32 = uniform(min_float32 / 2, max_float32 / 2, size = size)
     fl32 = np.float32(fl32)
-    fl64 = uniform(min_float64 / 2, max_float64 / 2, size = size)
+    fl64 = uniform(min_float32 / 2, max_float32 / 2, size = size)
 
     epyccel_func = epyccel(get_complex, language=language)
 

--- a/tests/epyccel/recognised_functions/test_numpy_types.py
+++ b/tests/epyccel/recognised_functions/test_numpy_types.py
@@ -7,7 +7,7 @@ import numpy as np
 from test_numpy_funcs import (min_int, max_int, min_int8, max_int8,
                                 min_int16, max_int16, min_int32, max_int32, max_int64, min_int64)
 from test_numpy_funcs import max_float, min_float, max_float32, min_float32,max_float64, min_float64
-from test_numpy_funcs import matching_types
+from test_numpy_funcs import matching_types, RTOL, ATOL, RTOL32, ATOL32
 
 from pyccel.decorators import template
 from pyccel.epyccel import epyccel
@@ -190,13 +190,11 @@ def test_numpy_bool_scalar(language):
     assert f_integer32_output == test_int32_output
     assert matching_types(f_integer32_output, test_int32_output)
 
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        f_integer64_output = epyccel_func(integer64)
-        test_int64_output = get_bool(integer64)
+    f_integer64_output = epyccel_func(integer64)
+    test_int64_output = get_bool(integer64)
 
-        assert f_integer64_output == test_int64_output
-        assert matching_types(f_integer64_output, test_int64_output)
+    assert f_integer64_output == test_int64_output
+    assert matching_types(f_integer64_output, test_int64_output)
 
     f_fl_output = epyccel_func(fl)
     test_float_output = get_bool(fl)
@@ -312,31 +310,29 @@ def test_numpy_int_scalar(language, function_boundaries):
     assert f_integer32_output == test_int32_output
     assert matching_types(f_integer32_output, test_int32_output)
 
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        f_integer64_output = epyccel_func(integer64)
-        test_int64_output = get_int(integer64)
+    f_integer64_output = epyccel_func(integer64)
+    test_int64_output = get_int(integer64)
 
-        assert f_integer64_output == test_int64_output
-        assert matching_types(f_integer64_output, test_int64_output)
+    assert f_integer64_output == test_int64_output
+    assert matching_types(f_integer64_output, test_int64_output)
 
-        f_fl_output = epyccel_func(fl)
-        test_float_output = get_int(fl)
+    f_fl_output = epyccel_func(fl)
+    test_float_output = get_int(fl)
 
-        assert f_fl_output == test_float_output
-        assert matching_types(f_fl_output, test_float_output)
+    assert f_fl_output == test_float_output
+    assert matching_types(f_fl_output, test_float_output)
 
-        f_fl64_output = epyccel_func(fl64)
-        test_float64_output = get_int(fl64)
+    f_fl64_output = epyccel_func(fl64)
+    test_float64_output = get_int(fl64)
 
-        assert f_fl64_output == test_float64_output
-        assert matching_types(f_fl64_output, test_float64_output)
+    assert f_fl64_output == test_float64_output
+    assert matching_types(f_fl64_output, test_float64_output)
 
-        f_fl32_output = epyccel_func(fl32)
-        test_float32_output = get_int(fl32)
+    f_fl32_output = epyccel_func(fl32)
+    test_float32_output = get_int(fl32)
 
-        assert f_fl32_output == test_float32_output
-        assert matching_types(f_fl32_output, test_float32_output)
+    assert f_fl32_output == test_float32_output
+    assert matching_types(f_fl32_output, test_float32_output)
 
 @template('T', ['bool[:]', 'int[:]', 'int8[:]', 'int16[:]', 'int32[:]', 'int64[:]', 'float[:]', 'float32[:]', 'float64[:]'])
 def get_int64_arr_1d(arr : 'T'):
@@ -399,12 +395,10 @@ def test_numpy_int_array_like_1d(language, function_boundaries):
     assert epyccel_func(integer16) == get_int(integer16)
     assert epyccel_func(integer) == get_int(integer)
     assert epyccel_func(integer32) == get_int(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_int(integer64)
-        assert epyccel_func(fl) == get_int(fl)
-        assert epyccel_func(fl64) == get_int(fl64)
-        assert epyccel_func(fl32) == get_int(fl32)
+    assert epyccel_func(integer64) == get_int(integer64)
+    assert epyccel_func(fl) == get_int(fl)
+    assert epyccel_func(fl64) == get_int(fl64)
+    assert epyccel_func(fl32) == get_int(fl32)
 
 @template('T', ['bool[:,:]', 'int[:,:]', 'int8[:,:]', 'int16[:,:]', 'int32[:,:]', 'int64[:,:]', 'float[:,:]', 'float32[:,:]', 'float64[:,:]'])
 def get_int64_arr_2d(arr : 'T'):
@@ -467,12 +461,10 @@ def test_numpy_int_array_like_2d(language, function_boundaries):
     assert epyccel_func(integer16) == get_int(integer16)
     assert epyccel_func(integer) == get_int(integer)
     assert epyccel_func(integer32) == get_int(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_int(integer64)
-        assert epyccel_func(fl) == get_int(fl)
-        assert epyccel_func(fl64) == get_int(fl64)
-        assert epyccel_func(fl32) == get_int(fl32)
+    assert epyccel_func(integer64) == get_int(integer64)
+    assert epyccel_func(fl) == get_int(fl)
+    assert epyccel_func(fl64) == get_int(fl64)
+    assert epyccel_func(fl32) == get_int(fl32)
 
 @template('T', ['bool', 'int', 'int8', 'int16', 'int32', 'int64', 'float', 'float32', 'float64'])
 def get_float(a : 'T'):
@@ -550,13 +542,11 @@ def test_numpy_float_scalar(language, get_float):
     assert f_integer32_output == test_int32_output
     assert matching_types(f_integer32_output, test_int32_output)
 
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        f_integer64_output = epyccel_func(integer64)
-        test_int64_output = get_float(integer64)
+    f_integer64_output = epyccel_func(integer64)
+    test_int64_output = get_float(integer64)
 
-        assert f_integer64_output == test_int64_output
-        assert matching_types(f_integer64_output, test_int64_output)
+    assert f_integer64_output == test_int64_output
+    assert matching_types(f_integer64_output, test_int64_output)
 
     f_fl_output = epyccel_func(fl)
     test_float_output = get_float(fl)
@@ -616,11 +606,9 @@ def test_numpy_float_array_like_1d(language, get_float):
     assert epyccel_func(integer16) == get_float(integer16)
     assert epyccel_func(integer) == get_float(integer)
     assert epyccel_func(integer32) == get_float(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_float(integer64)
-        assert epyccel_func(fl) == get_float(fl)
-        assert epyccel_func(fl64) == get_float(fl64)
+    assert epyccel_func(integer64) == get_float(integer64)
+    assert epyccel_func(fl) == get_float(fl)
+    assert epyccel_func(fl64) == get_float(fl64)
     assert epyccel_func(fl32) == get_float(fl32)
 
 @template('T', ['bool[:,:]', 'int[:,:]', 'int8[:,:]', 'int16[:,:]', 'int32[:,:]', 'int64[:,:]', 'float[:,:]', 'float32[:,:]', 'float64[:,:]'])
@@ -662,11 +650,9 @@ def test_numpy_float_array_like_2d(language, get_float):
     assert epyccel_func(integer16) == get_float(integer16)
     assert epyccel_func(integer) == get_float(integer)
     assert epyccel_func(integer32) == get_float(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_float(integer64)
-        assert epyccel_func(fl) == get_float(fl)
-        assert epyccel_func(fl64) == get_float(fl64)
+    assert epyccel_func(integer64) == get_float(integer64)
+    assert epyccel_func(fl) == get_float(fl)
+    assert epyccel_func(fl64) == get_float(fl64)
     assert epyccel_func(fl32) == get_float(fl32)
 
 def test_numpy_double_scalar(language):
@@ -727,13 +713,11 @@ def test_numpy_double_scalar(language):
     assert f_integer32_output == test_int32_output
     assert matching_types(f_integer32_output, test_int32_output)
 
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        f_integer64_output = epyccel_func(integer64)
-        test_int64_output = get_double(integer64)
+    f_integer64_output = epyccel_func(integer64)
+    test_int64_output = get_double(integer64)
 
-        assert f_integer64_output == test_int64_output
-        assert matching_types(f_integer64_output, test_int64_output)
+    assert f_integer64_output == test_int64_output
+    assert matching_types(f_integer64_output, test_int64_output)
 
     f_fl_output = epyccel_func(fl)
     test_float_output = get_double(fl)
@@ -785,11 +769,9 @@ def test_numpy_double_array_like_1d(language):
     assert epyccel_func(integer16) == get_double(integer16)
     assert epyccel_func(integer) == get_double(integer)
     assert epyccel_func(integer32) == get_double(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_double(integer64)
-        assert epyccel_func(fl) == get_double(fl)
-        assert epyccel_func(fl64) == get_double(fl64)
+    assert epyccel_func(integer64) == get_double(integer64)
+    assert epyccel_func(fl) == get_double(fl)
+    assert epyccel_func(fl64) == get_double(fl64)
     assert epyccel_func(fl32) == get_double(fl32)
 
 def test_numpy_double_array_like_2d(language):
@@ -823,11 +805,9 @@ def test_numpy_double_array_like_2d(language):
     assert epyccel_func(integer16) == get_double(integer16)
     assert epyccel_func(integer) == get_double(integer)
     assert epyccel_func(integer32) == get_double(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_double(integer64)
-        assert epyccel_func(fl) == get_double(fl)
-        assert epyccel_func(fl64) == get_double(fl64)
+    assert epyccel_func(integer64) == get_double(integer64)
+    assert epyccel_func(fl) == get_double(fl)
+    assert epyccel_func(fl64) == get_double(fl64)
     assert epyccel_func(fl32) == get_double(fl32)
 
 
@@ -906,13 +886,11 @@ def test_numpy_complex_scalar(language, get_complex):
     assert f_integer32_output == test_int32_output
     assert matching_types(f_integer32_output, test_int32_output)
 
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        f_integer64_output = epyccel_func(integer64)
-        test_int64_output = get_complex(integer64)
+    f_integer64_output = epyccel_func(integer64)
+    test_int64_output = get_complex(integer64)
 
-        assert f_integer64_output == test_int64_output
-        assert matching_types(f_integer64_output, test_int64_output)
+    assert f_integer64_output == test_int64_output
+    assert matching_types(f_integer64_output, test_int64_output)
 
     f_fl_output = epyccel_func(fl)
     test_float_output = get_complex(fl)
@@ -993,17 +971,19 @@ def test_numpy_complex_array_like_1d(language, get_complex):
 
     epyccel_func = epyccel(get_complex, language=language)
 
-    assert epyccel_func(bl) == get_complex(bl)
-    assert epyccel_func(integer8) == get_complex(integer8)
-    assert epyccel_func(integer16) == get_complex(integer16)
-    assert epyccel_func(integer) == get_complex(integer)
-    assert epyccel_func(integer32) == get_complex(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_complex(integer64)
-        assert epyccel_func(fl) == get_complex(fl)
-        assert epyccel_func(fl64) == get_complex(fl64)
-    assert epyccel_func(fl32) == get_complex(fl32)
+    is_complex64 = get_complex(bl).dtype == np.complex64
+    rtol = RTOL32 if is_complex64 else RTOL
+    atol = ATOL32 if is_complex64 else ATOL
+
+    assert np.allclose(epyccel_func(bl), get_complex(bl), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer8), get_complex(integer8), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer16), get_complex(integer16), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer), get_complex(integer), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer32), get_complex(integer32), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer64), get_complex(integer64), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(fl), get_complex(fl), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(fl64), get_complex(fl64), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(fl32), get_complex(fl32), rtol=rtol, atol=atol)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = [pytest.mark.fortran]),
@@ -1035,17 +1015,19 @@ def test_numpy_complex_array_like_2d(language, get_complex):
 
     epyccel_func = epyccel(get_complex, language=language)
 
-    assert epyccel_func(bl) == get_complex(bl)
-    assert epyccel_func(integer8) == get_complex(integer8)
-    assert epyccel_func(integer16) == get_complex(integer16)
-    assert epyccel_func(integer) == get_complex(integer)
-    assert epyccel_func(integer32) == get_complex(integer32)
-    # the if block should be removed after resolving (https://github.com/pyccel/pyccel/issues/735).
-    if sys.platform != 'win32':
-        assert epyccel_func(integer64) == get_complex(integer64)
-        assert epyccel_func(fl) == get_complex(fl)
-        assert epyccel_func(fl64) == get_complex(fl64)
-    assert epyccel_func(fl32) == get_complex(fl32)
+    is_complex64 = get_complex(bl).dtype == np.complex64
+    rtol = RTOL32 if is_complex64 else RTOL
+    atol = ATOL32 if is_complex64 else ATOL
+
+    assert np.allclose(epyccel_func(bl), get_complex(bl), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer8), get_complex(integer8), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer16), get_complex(integer16), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer), get_complex(integer), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer32), get_complex(integer32), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(integer64), get_complex(integer64), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(fl), get_complex(fl), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(fl64), get_complex(fl64), rtol=rtol, atol=atol)
+    assert np.allclose(epyccel_func(fl32), get_complex(fl32), rtol=rtol, atol=atol)
 
 def test_literal_complex64(language):
     def get_complex64():

--- a/tests/epyccel/recognised_functions/test_numpy_types.py
+++ b/tests/epyccel/recognised_functions/test_numpy_types.py
@@ -971,7 +971,7 @@ def test_numpy_complex_array_like_1d(language, get_complex):
 
     epyccel_func = epyccel(get_complex, language=language)
 
-    is_complex64 = get_complex(bl).dtype == np.complex64
+    is_complex64 = get_complex(bl)[-1].dtype == np.complex64
     rtol = RTOL32 if is_complex64 else RTOL
     atol = ATOL32 if is_complex64 else ATOL
 
@@ -1015,7 +1015,7 @@ def test_numpy_complex_array_like_2d(language, get_complex):
 
     epyccel_func = epyccel(get_complex, language=language)
 
-    is_complex64 = get_complex(bl).dtype == np.complex64
+    is_complex64 = get_complex(bl)[-1].dtype == np.complex64
     rtol = RTOL32 if is_complex64 else RTOL
     atol = ATOL32 if is_complex64 else ATOL
 


### PR DESCRIPTION
Fix the intel tests in the release branch. In this branch the only errors are due to a compiler bug. The bug has been reported [here](https://community.intel.com/t5/Intel-Fortran-Compiler/Compiler-Bug-cmplx-does-not-handle-Y-argument-correctly/m-p/1634388) but a simple workaround has been implemented. This therefore fixes #1932 

While fixing this I noticed Windows tests which should have been reactivated 2 years ago (#735 was fixed in January 2022). These tests are now reactivated