### PR TITLE
Flag `I` as a conflicting variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ All notable changes to this project will be documented in this file.
 -   #1924 : Fix internal error arising in Duplicate or list comprehensions.
 -   #1970 : Fix missing `TypeError` for wrong type passed as optional argument.
 -   #1985 : Fix implementation of `gcd` and `lcm` for C and Fortran.
+-   #1998 : Fix compiler error when using a variable named `I`.
 
 ## \[1.12.0\] - 2024-05-13
 

--- a/pyccel/naming/cnameclashchecker.py
+++ b/pyccel/naming/cnameclashchecker.py
@@ -37,7 +37,8 @@ class CNameClashChecker(LanguageNameClashChecker):
         'GET_INDEX_FUNC_H2', 'GET_INDEX_FUNC', 'GET_INDEX',
         'INDEX', 'GET_ELEMENT', 'free_array', 'free_pointer',
         'get_index', 'numpy_to_ndarray_strides',
-        'numpy_to_ndarray_shape', 'get_size', 'order_f', 'order_c', 'array_copy_data'])
+        'numpy_to_ndarray_shape', 'get_size', 'order_f', 'order_c', 'array_copy_data',
+        'I'])
 
     def has_clash(self, name, symbols):
         """

--- a/pyccel/naming/languagenameclashchecker.py
+++ b/pyccel/naming/languagenameclashchecker.py
@@ -19,6 +19,11 @@ class LanguageNameClashChecker(metaclass = Singleton):
     """
     keywords = None
 
+    def __init__(self): #pylint: disable=useless-parent-delegation
+        # This __init__ function is required so the Singleton can detect a signature
+        super().__init__()
+
+
     def _get_collisionless_name(self, name, symbols):
         """
         Get a name which doesn't collision with keywords or symbols.

--- a/pyccel/naming/languagenameclashchecker.py
+++ b/pyccel/naming/languagenameclashchecker.py
@@ -23,7 +23,6 @@ class LanguageNameClashChecker(metaclass = Singleton):
         # This __init__ function is required so the Singleton can detect a signature
         super().__init__()
 
-
     def _get_collisionless_name(self, name, symbols):
         """
         Get a name which doesn't collision with keywords or symbols.

--- a/tests/epyccel/modules/consts.py
+++ b/tests/epyccel/modules/consts.py
@@ -13,3 +13,5 @@ method = 3
 compl = 3+5j
 
 tiny = np.int32(4)
+
+I = 4

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -124,7 +124,7 @@ def test_module_6(language):
     modnew = epyccel(mod, language=language)
 
     atts = ('g', 'R0', 'rMin', 'rMax', 'skip_centre',
-            'method', 'compl', 'tiny')
+            'method', 'compl', 'tiny', 'I')
     for att in atts:
         mod_att = getattr(mod, att)
         modnew_att = getattr(modnew, att)


### PR DESCRIPTION
Add `I` to the list of names of variables which are not valid in C. Fixes #1998