### PR TITLE
Add support for `in` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 -   #1657 : Add the appropriate Fortran language equivalent for declaring a Python `list` container using the gFTL library.
 -   #1658 : Add the appropriate Fortran language equivalent for declaring a Python `set` container using the gFTL library.
 -   #1944 : Add the appropriate Fortran language equivalent for declaring a Python `dict` container using the gFTL library.
+-   #2009 : Add support for `in` operator for `list`, `set` and `dict` containers.
 -   #1874 : Add C and Fortran support for the `len()` function for the `list` container.
 -   #1875 : Add C and Fortran support for the `len()` function for the `set` container.
 -   #1908 : Add C and Fortran support for the `len()` function for the `dict` container.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 -   #1657 : Add the appropriate Fortran language equivalent for declaring a Python `list` container using the gFTL library.
 -   #1658 : Add the appropriate Fortran language equivalent for declaring a Python `set` container using the gFTL library.
 -   #1944 : Add the appropriate Fortran language equivalent for declaring a Python `dict` container using the gFTL library.
--   #2009 : Add support for `in` operator for `list`, `set` and `dict` containers.
+-   #2009 : Add support for `in` operator for `list`, `set`, `dict` and class containers.
 -   #1874 : Add C and Fortran support for the `len()` function for the `list` container.
 -   #1875 : Add C and Fortran support for the `len()` function for the `set` container.
 -   #1908 : Add C and Fortran support for the `len()` function for the `dict` container.

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -56,6 +56,7 @@ __all__ = (
     'Relational',
     'PyccelIs',
     'PyccelIsNot',
+    'PyccelIn',
     'IfTernaryOperator'
 )
 
@@ -1282,6 +1283,46 @@ class PyccelIsNot(PyccelIs):
         # or the lhs is an  optional variable
         else:
             return "unknown"
+
+#==============================================================================
+
+class PyccelIn(PyccelBooleanOperator):
+    """
+    Represents an `in` expression in the code.
+
+    Represents an `in` expression in the code.
+
+    Parameters
+    ----------
+    element : TypedAstNode
+        The first argument passed to the operator.
+
+    container : TypedAstNode
+        The first argument passed to the operator.
+    """
+    __slots__ = ()
+    _precedence = 7
+
+    def __init__(self, element, container):
+        super().__init__(element, container)
+
+    @property
+    def element(self):
+        """
+        First operator argument.
+
+        First operator argument.
+        """
+        return self._args[0]
+
+    @property
+    def container(self):
+        """
+        Second operator argument.
+
+        Second operator argument.
+        """
+        return self._args[1]
 
 #==============================================================================
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -972,6 +972,20 @@ class CCodePrinter(CodePrinter):
         a = self._print(expr.args[0])
         return '!{}'.format(a)
 
+    def _print_PyccelIn(self, expr):
+        container_type = expr.container.class_type
+        element = self._print(expr.element)
+        container = self._print(ObjectAddress(expr.container))
+        c_type = self.get_c_type(expr.container.class_type)
+        if isinstance(container_type, (HomogeneousSetType, DictType)):
+            return f'{c_type}_contains({container}, {element})'
+        elif isinstance(container_type, HomogeneousListType):
+            return f'{c_type}_find({container}, {element}).ref != {c_type}_end({container}).ref'
+        else:
+            raise errors.report(PYCCEL_RESTRICTION_TODO,
+                    symbol = expr,
+                    severity='fatal')
+
     def _print_PyccelMod(self, expr):
         self.add_import(c_imports['math'])
         self.add_import(c_imports['pyc_math_c'])
@@ -1018,16 +1032,19 @@ class CCodePrinter(CodePrinter):
         if source.startswith('stc/') or source in import_header_guard_prefix:
             code = ''
             for t in expr.target:
-                dtype = t.object.class_type
+                class_type = t.object.class_type
                 container_type = t.local_alias
-                if isinstance(dtype, DictType):
-                    container_key_key = self.get_c_type(dtype.key_type)
-                    container_val_key = self.get_c_type(dtype.value_type)
+                if isinstance(class_type, DictType):
+                    container_key_key = self.get_c_type(class_type.key_type)
+                    container_val_key = self.get_c_type(class_type.value_type)
                     container_key = f'{container_key_key}_{container_val_key}'
                     element_decl = f'#define i_key {container_key_key}\n#define i_val {container_val_key}\n'
                 else:
-                    container_key = self.get_c_type(dtype.element_type)
+                    container_key = self.get_c_type(class_type.element_type)
                     element_decl = f'#define i_key {container_key}\n'
+                if isinstance(class_type, HomogeneousListType) and isinstance(class_type.element_type, FixedSizeNumericType) \
+                        and not isinstance(class_type.element_type.primitive_type, PrimitiveComplexType):
+                    element_decl += '#define i_use_cmp\n'
                 header_guard_prefix = import_header_guard_prefix.get(source, '')
                 header_guard = f'{header_guard_prefix}_{container_type.upper()}'
                 code += ''.join((f'#ifndef {header_guard}\n',

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3077,6 +3077,17 @@ class FCodePrinter(CodePrinter):
             return '{} == 0'.format(a)
         return '.not. {}'.format(a)
 
+    def _print_PyccelIn(self, expr):
+        container_type = expr.container.class_type
+        element = self._print(expr.element)
+        container = self._print(expr.container)
+        if isinstance(container_type, (HomogeneousSetType, DictType)):
+            return f'{container} % count({element}) /= 0'
+        else:
+            raise errors.report(PYCCEL_RESTRICTION_TODO,
+                    symbol = expr,
+                    severity='fatal')
+
     def _print_Header(self, expr):
         return ''
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -1091,6 +1091,11 @@ class PythonCodePrinter(CodePrinter):
     def _print_Concatenate(self, expr):
         return ' + '.join([self._print(a) for a in expr.args])
 
+    def _print_PyccelIn(self, expr):
+        element = self._print(expr.element)
+        container = self._print(expr.container)
+        return f'{element} in {container}'
+
     def _print_PyccelSymbol(self, expr):
         return expr
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2931,7 +2931,11 @@ class SemanticParser(BasicParser):
         container = self._visit(expr.container)
         container_type = container.class_type
         if isinstance(container_type, (DictType, HomogeneousSetType, HomogeneousListType)):
-            return PyccelIn(element, container)
+            element_type = container_type.key_type if isinstance(container_type, DictType) else container_type.element_type
+            if element.class_type == element_type:
+                return PyccelIn(element, container)
+            else:
+                return LiteralFalse()
 
         container_base = self.scope.find(str(container_type), 'classes') or get_cls_base(container_type)
         contains_method = container_base.get_method('__contains__', raise_error = isinstance(container_type, CustomDataType))

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -98,7 +98,7 @@ from pyccel.ast.omp import (OMP_For_Loop, OMP_Simd_Construct, OMP_Distribute_Con
 
 from pyccel.ast.operators import PyccelArithmeticOperator, PyccelIs, PyccelIsNot, IfTernaryOperator, PyccelUnarySub
 from pyccel.ast.operators import PyccelNot, PyccelAdd, PyccelMinus, PyccelMul, PyccelPow
-from pyccel.ast.operators import PyccelAssociativeParenthesis, PyccelDiv
+from pyccel.ast.operators import PyccelAssociativeParenthesis, PyccelDiv, PyccelIn
 
 from pyccel.ast.sympy_helper import sympy_to_pyccel, pyccel_to_sympy
 
@@ -2930,6 +2930,9 @@ class SemanticParser(BasicParser):
         element = self._visit(expr.element)
         container = self._visit(expr.container)
         container_type = container.class_type
+        if isinstance(container_type, (DictType, HomogeneousSetType, HomogeneousListType)):
+            return PyccelIn(element, container)
+
         container_base = self.scope.find(str(container_type), 'classes') or get_cls_base(container_type)
         contains_method = container_base.get_method('__contains__', raise_error = isinstance(container_type, CustomDataType))
         if contains_method:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2888,6 +2888,18 @@ class SemanticParser(BasicParser):
         else:
             return PyccelPow(base, exponent)
 
+    def _visit_PyccelIn(self, expr):
+        element = self._visit(expr.element)
+        container = self._visit(expr.container)
+        container_type = container.class_type
+        container_base = self.scope.find(str(container_type), 'classes') or get_cls_base(container_type)
+        contains_method = container_base.get_method('__contains__', raise_error = isinstance(container_type, CustomDataType))
+        if contains_method:
+            return contains_method(container, element)
+        else:
+            raise errors.report(f"In operator is not yet implemented for type {container_type}",
+                    severity='fatal', symbol=expr)
+
     def _visit_Lambda(self, expr):
         errors.report("Lambda functions are not currently supported",
                 symbol=expr, severity='fatal')

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -49,7 +49,7 @@ from pyccel.ast.operators import PyccelPow, PyccelAdd, PyccelMul, PyccelDiv, Pyc
 from pyccel.ast.operators import PyccelEq,  PyccelNe,  PyccelLt,  PyccelLe,  PyccelGt,  PyccelGe
 from pyccel.ast.operators import PyccelAnd, PyccelOr,  PyccelNot, PyccelMinus
 from pyccel.ast.operators import PyccelUnary, PyccelUnarySub
-from pyccel.ast.operators import PyccelIs, PyccelIsNot
+from pyccel.ast.operators import PyccelIs, PyccelIsNot, PyccelIn
 from pyccel.ast.operators import IfTernaryOperator
 from pyccel.ast.numpyext  import NumpyMatmul
 
@@ -713,6 +713,8 @@ class SyntaxParser(BasicParser):
             return PyccelIs(first, second)
         if isinstance(op, ast.IsNot):
             return PyccelIsNot(first, second)
+        if isinstance(op, ast.In):
+            return PyccelIn(first, second)
 
         return errors.report(PYCCEL_RESTRICTION_UNSUPPORTED_SYNTAX,
                       symbol = stmt,

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -13,170 +13,170 @@ from pyccel import epyccel
     ],
     scope = "module"
 )
-def language(request):
+def python_only_language(request):
     return request.param
 
-def test_dict_init(language):
+def test_dict_init(python_only_language):
     def dict_init():
         a = {1:1.0, 2:2.0}
         return a
-    epyc_dict_init = epyccel(dict_init, language = language)
+    epyc_dict_init = epyccel(dict_init, language = python_only_language)
     pyccel_result = epyc_dict_init()
     python_result = dict_init()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_dict_str_keys(language):
+def test_dict_str_keys(python_only_language):
     def dict_str_keys():
         a = {'a':1, 'b':2}
         return a
-    epyc_str_keys = epyccel(dict_str_keys, language = language)
+    epyc_str_keys = epyccel(dict_str_keys, language = python_only_language)
     pyccel_result = epyc_str_keys()
     python_result = dict_str_keys()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_dict_empty_init(language):
+def test_dict_empty_init(python_only_language):
     def dict_empty_init():
         a : 'dict[int, float]' = {}
         return a
-    epyc_dict_empty_init = epyccel(dict_empty_init, language = language)
+    epyc_dict_empty_init = epyccel(dict_empty_init, language = python_only_language)
     pyccel_result = epyc_dict_empty_init()
     python_result = dict_empty_init()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_dict_copy(language):
+def test_dict_copy(python_only_language):
     def dict_copy():
         a = {1:1.0,2:2.0}
         b = dict(a)
         return b
 
-    epyc_dict_copy = epyccel(dict_copy, language = language)
+    epyc_dict_copy = epyccel(dict_copy, language = python_only_language)
     pyccel_result = epyc_dict_copy()
     python_result = dict_copy()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_dict_kwarg_init(language):
+def test_dict_kwarg_init(python_only_language):
     def kwarg_init():
         b = dict(a=1, b=2) #pylint: disable=use-dict-literal
         return b
 
-    epyc_kwarg_init = epyccel(kwarg_init, language = language)
+    epyc_kwarg_init = epyccel(kwarg_init, language = python_only_language)
     pyccel_result = epyc_kwarg_init()
     python_result = kwarg_init()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_element(language) :
+def test_pop_element(python_only_language):
     def pop_element():
         a = {1:1.0, 2:2.0}
         return a.pop(1)
-    epyc_element = epyccel(pop_element, language = language)
+    epyc_element = epyccel(pop_element, language = python_only_language)
     pyccel_result = epyc_element()
     python_result = pop_element()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_default_element(language) :
+def test_pop_default_element(python_only_language):
     def pop_default_element():
         a = {1:True, 2:False}
         return a.pop(3, True)
-    epyc_default_element = epyccel(pop_default_element, language = language)
+    epyc_default_element = epyccel(pop_default_element, language = python_only_language)
     pyccel_result = epyc_default_element()
     python_result = pop_default_element()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_str_keys(language) :
+def test_pop_str_keys(python_only_language):
     def pop_str_keys():
         a = {'a':1, 'b':2}
         return a.pop('a')
-    epyc_str_keys = epyccel(pop_str_keys, language = language)
+    epyc_str_keys = epyccel(pop_str_keys, language = python_only_language)
     pyccel_result = epyc_str_keys()
     python_result = pop_str_keys()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
 @pytest.mark.skip("Returning tuples is not yet implemented. See #337")
-def test_pop_item(language):
+def test_pop_item(python_only_language):
     def pop_item():
         a = {1:1.0, 2:2.0}
         return a.popitem()
-    epyc_default_element = epyccel(pop_item, language = language)
+    epyc_default_element = epyccel(pop_item, language = python_only_language)
     pyccel_result = epyc_default_element()
     python_result = pop_item()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_item_elements(language):
+def test_pop_item_elements(python_only_language):
     def pop_item():
         a = {1:1.0, 2:2.0}
         b = a.popitem()
         return b[0], b[1]
-    epyc_default_element = epyccel(pop_item, language = language)
+    epyc_default_element = epyccel(pop_item, language = python_only_language)
     pyccel_result = epyc_default_element()
     python_result = pop_item()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_item_str_keys(language):
+def test_pop_item_str_keys(python_only_language):
     def pop_item_str_keys():
         a = {'a':1, 'b':2}
         b = a.popitem()
         return b[0], b[1]
-    epyc_default_element = epyccel(pop_item_str_keys, language = language)
+    epyc_default_element = epyccel(pop_item_str_keys, language = python_only_language)
     pyccel_result = epyc_default_element()
     python_result = pop_item_str_keys()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_pop_item_key(language):
+def test_pop_item_key(python_only_language):
     def pop_item():
         a = {1:1.0, 2:2.0}
         return a.popitem()[0]
-    epyc_default_element = epyccel(pop_item, language = language)
+    epyc_default_element = epyccel(pop_item, language = python_only_language)
     pyccel_result = epyc_default_element()
     python_result = pop_item()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_get_element(language) :
+def test_get_element(python_only_language):
     def get_element():
         a = {1:1.0, 2:2.0}
         return a.get(1)
-    epyc_element = epyccel(get_element, language = language)
+    epyc_element = epyccel(get_element, language = python_only_language)
     pyccel_result = epyc_element()
     python_result = get_element()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_get_default_element(language) :
+def test_get_default_element(python_only_language):
     def get_default_element():
         a = {1:True, 2:False}
         return a.get(3, True)
-    epyc_default_element = epyccel(get_default_element, language = language)
+    epyc_default_element = epyccel(get_default_element, language = python_only_language)
     pyccel_result = epyc_default_element()
     python_result = get_default_element()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_get_str_keys(language) :
+def test_get_str_keys(python_only_language):
     def get_str_keys():
         a = {'a':1, 'b':2}
         return a.get('a')
-    epyc_str_keys = epyccel(get_str_keys, language = language)
+    epyc_str_keys = epyccel(get_str_keys, language = python_only_language)
     pyccel_result = epyc_str_keys()
     python_result = get_str_keys()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_get_default_str_keys(language) :
+def test_get_default_str_keys(python_only_language):
     def get_default_str_keys():
         a = {'a':1, 'b':2}
         return a.get('c', 4)
-    epyc_str_keys = epyccel(get_default_str_keys, language = language)
+    epyc_str_keys = epyccel(get_default_str_keys, language = python_only_language)
     pyccel_result = epyc_str_keys()
     python_result = get_default_str_keys()
     assert isinstance(python_result, type(pyccel_result))

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -185,7 +185,7 @@ def test_get_default_str_keys(python_only_language):
 def test_dict_contains(language):
     def dict_contains():
         a = {1:1.0, 2:2.0, 3:3.0}
-        return (1 in a), (5 in a)
+        return (1 in a), (5 in a), (4.0 in a)
     epyc_func = epyccel(dict_contains, language = language)
     pyccel_result = epyc_func()
     python_result = dict_contains()

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -181,3 +181,13 @@ def test_get_default_str_keys(language) :
     python_result = get_default_str_keys()
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
+
+def test_dict_contains(language):
+    def dict_contains():
+        a = {1:1.0, 2:2.0, 3:3.0}
+        return (1 in a), (5 in a)
+    epyc_func = epyccel(dict_contains, language = language)
+    pyccel_result = epyc_func()
+    python_result = dict_contains()
+    assert isinstance(python_result, type(pyccel_result))
+    assert python_result == pyccel_result

--- a/tests/epyccel/test_epyccel_lists.py
+++ b/tests/epyccel/test_epyccel_lists.py
@@ -748,8 +748,8 @@ def test_homogenous_list_unknown_size_copy(limited_language):
 
 def test_list_contains(language):
     def list_contains():
-        a = [1, 3, 4, 7, 10]
-        return (1 in a), (5 in a)
+        a = [1, 3, 4, 7, 10, 3]
+        return (1 in a), (5 in a), (3 in a)
 
     epyc_list_contains = epyccel(list_contains, language = language)
     pyccel_result = epyc_list_contains()

--- a/tests/epyccel/test_epyccel_lists.py
+++ b/tests/epyccel/test_epyccel_lists.py
@@ -745,3 +745,14 @@ def test_homogenous_list_unknown_size_copy(limited_language):
     print(python_out)
 
     assert python_out == pyccel_out
+
+def test_list_contains(language):
+    def list_contains():
+        a = [1, 3, 4, 7, 10]
+        return (1 in a), (5 in a)
+
+    epyc_list_contains = epyccel(list_contains, language = language)
+    pyccel_result = epyc_list_contains()
+    python_result = list_contains()
+    assert isinstance(python_result, type(pyccel_result))
+    assert python_result == pyccel_result

--- a/tests/epyccel/test_epyccel_sets.py
+++ b/tests/epyccel/test_epyccel_sets.py
@@ -514,7 +514,7 @@ def test_set_contains(language):
     def union_int():
         a = {1,2,3,4,5,6,7,8}
         b = 2 in a
-        return b, (4 in a)
+        return b, (4 in a), (9 in a)
 
     epyccel_func = epyccel(union_int, language = language)
     pyccel_result = epyccel_func()

--- a/tests/epyccel/test_epyccel_sets.py
+++ b/tests/epyccel/test_epyccel_sets.py
@@ -509,3 +509,14 @@ def test_set_union_augoperator(language):
     python_result = union_int()
     assert python_result[0] == pyccel_result[0]
     assert set(python_result[1:]) == set(pyccel_result[1:])
+
+def test_set_contains(language):
+    def union_int():
+        a = {1,2,3,4,5,6,7,8}
+        b = 2 in a
+        return b, (4 in a)
+
+    epyccel_func = epyccel(union_int, language = language)
+    pyccel_result = epyccel_func()
+    python_result = union_int()
+    assert python_result == pyccel_result

--- a/tests/pyccel/scripts/classes/class_magic.py
+++ b/tests/pyccel/scripts/classes/class_magic.py
@@ -17,6 +17,9 @@ class A:
         self.x += other
         return self
 
+    def __contains__(self, other : int):
+        return self.x == other
+
 if __name__ == '__main__':
     my_a = A(4)
     left_add = my_a + 5
@@ -35,3 +38,6 @@ if __name__ == '__main__':
     my_a *= 3
 
     print(my_a.x)
+
+    print(3 in my_a)
+    print(30 in my_a)

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -821,10 +821,13 @@ def test_basic_header():
                                         "scripts/classes/class_temporary_in_constructor.py",
                                         "scripts/classes/class_with_non_target_array_arg.py",
                                         "scripts/classes/class_pointer.py",
-                                        "scripts/classes/class_magic.py",
                                         ] )
 def test_classes( test_file , language):
     pyccel_test(test_file, language=language)
+
+def test_class_magic(language):
+    pyccel_test("scripts/classes/class_magic.py", language=language,
+            output_dtype = [int]*6 + [bool]*2)
 
 def test_tuples_in_classes(language):
     test_file = "scripts/classes/tuples_in_classes.py"


### PR DESCRIPTION
Add support for `in` operator for `list`, `set` and `dict` containers for C Fortran and Python, as well as for classes.

**Commit Summary**
- Add `PyccelIn` class to describe the `in` operator
- Add C support for `in` operator for list/set/dict
- Add `#define i_use_cmp` to list declaration in C to activate sorting and searching functions
- Add `_define_gFTL_element` function in Fortran code printer to define types and operators for types inside container types
- Reduce duplication in `_build_gFTL_module`
- Add Fortran support for `in` operator for list/set/dict
- Add Python support for `in` operator for list/set/dict
- In semantic stage handle `PyccelIn` for built-in types and class `__contains__` magic method
- Add tests for `in` operator for lists/sets/dicts
- Add tests for `in` operator for classes
- Use `python_only_language` to allow some of the dictionary tests to be activated for other languages