### PR TITLE
Fix missing loop in slice assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to this project will be documented in this file.
 -   #1930 : Preserve ordering of import targets.
 -   #1892 : Fix implementation of list function when an iterable is passed as parameter.
 -   #1972 : Simplified `printf` statement for Literal String.
+-   #2026 : Fix missing loop in slice assignment.
 
 ### Changed
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -756,8 +756,6 @@ class PyccelMinus(PyccelArithmeticOperator):
                 dtype = cls._calculate_type(arg1, arg2)
                 return convert_to_literal(arg1.python_value - arg2.python_value,
                                           dtype)
-            elif isinstance(arg2, Literal) and arg2 == 0:
-                return arg1
         if isinstance(arg1, LiteralFloat) and \
             isinstance(arg2, LiteralComplex) and \
             arg2.real == LiteralFloat(0):

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -756,6 +756,8 @@ class PyccelMinus(PyccelArithmeticOperator):
                 dtype = cls._calculate_type(arg1, arg2)
                 return convert_to_literal(arg1.python_value - arg2.python_value,
                                           dtype)
+            elif isinstance(arg2, Literal) and arg2 == 0:
+                return arg1
         if isinstance(arg1, LiteralFloat) and \
             isinstance(arg2, LiteralComplex) and \
             arg2.real == LiteralFloat(0):

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -571,13 +571,19 @@ def collect_loops(block, indices, new_index, language_has_vectors = False, resul
             lhs = line.lhs
             rhs = line.rhs
             if lhs.rank > rhs.rank:
-                for index_depth in range(lhs.rank-rhs.rank):
+                loop_len = []
+                n_new_loops = lhs.rank-rhs.rank
+                for index_depth in range(n_new_loops):
+                    loop_len.append(lhs.shape[0])
                     # If an index exists at the same depth, reuse it if not create one
                     if index_depth >= len(indices):
                         indices.append(new_index(PythonNativeInt(), 'i'))
                     index = indices[index_depth]
                     lhs = insert_index(lhs, index_depth, index)
-                collect_loops([Assign(lhs, rhs)], indices, new_index, language_has_vectors, result = result)
+                block = collect_loops([Assign(lhs, rhs)], indices, new_index, language_has_vectors)
+                for s in loop_len:
+                    block = LoopCollection(block, s, set([lhs]))
+                result.append(block)
 
             elif not language_has_vectors:
                 if isinstance(rhs, NumpyArray):

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -1592,8 +1592,8 @@ def array_2d_C_slice_stride_23(a : 'int[:,:]'):
 
 def copy_to_slice_issue_1218(n : int):
     from numpy import zeros, array
-    x = 1
-    arr = zeros((2, n))
+    x = 2
+    arr = zeros((3, n))
     arr[0:x, 0:6:2] = array([2, 5, 6])
     return arr
 


### PR DESCRIPTION
Fix missing loop in slice assignment by creating missing `LoopCollection` object. Fixes #2026 . Modify the existing test so it would fail on the `devel` branch.