### PR TITLE
Optimise min/max to avoid unnecessary temporary variables

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,4 @@ Contributors
 * Said Mazouz
 * Shoaib Moeen
 * Kush Choudhary
+* Emmmanuel Ferdman

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+-   #2025 : Optimize min/max to avoid temp variables when exist
 -   #1720 : Add support for `Ellipsis` as the only index for an array.
 -   #1787 : Ensure STC is installed with Pyccel.
 -   #1656 : Ensure gFTL is installed with Pyccel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   #2025 : Optimise min/max to avoid temp variables when exist
+-   #2025 : Optimise min/max to avoid unnecessary temporary variables.
 -   #1720 : Add support for `Ellipsis` as the only index for an array.
 -   #1787 : Ensure STC is installed with Pyccel.
 -   #1656 : Ensure gFTL is installed with Pyccel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   #2025 : Optimise min/max to avoid unnecessary temporary variables.
 -   #1720 : Add support for `Ellipsis` as the only index for an array.
 -   #1787 : Ensure STC is installed with Pyccel.
 -   #1656 : Ensure gFTL is installed with Pyccel.
@@ -53,6 +52,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+-   #2025 : Optimise min/max to avoid unnecessary temporary variables.
 -   #1720 : Fix Undefined Variable error when the function definition is after the variable declaration.
 -   #1763 Use `np.result_type` to avoid mistakes in non-trivial NumPy type promotion rules.
 -   Fix some cases where a Python built-in type is returned in place of a NumPy type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   #2025 : Optimize min/max to avoid temp variables when exist
+-   #2025 : Optimise min/max to avoid temp variables when exist
 -   #1720 : Add support for `Ellipsis` as the only index for an array.
 -   #1787 : Ensure STC is installed with Pyccel.
 -   #1656 : Ensure gFTL is installed with Pyccel.

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -714,6 +714,8 @@ class CCodePrinter(CodePrinter):
             return "fmin({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         elif arg.dtype.primitive_type is PrimitiveIntegerType() and len(arg) == 2:
+            if isinstance(arg[0], Variable) and isinstance(arg[1], Variable):
+                return f"({self._print(arg[0])} < {self._print(arg[1])} ? {self._print(arg[0])} : {self._print(arg[1])})"
             arg1 = self.scope.get_temporary_variable(PythonNativeInt())
             arg2 = self.scope.get_temporary_variable(PythonNativeInt())
             assign1 = Assign(arg1, arg[0])
@@ -732,6 +734,8 @@ class CCodePrinter(CodePrinter):
             return "fmax({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         elif arg.dtype.primitive_type is PrimitiveIntegerType() and len(arg) == 2:
+            if isinstance(arg[0], Variable) and isinstance(arg[1], Variable):
+                return f"({self._print(arg[0])} > {self._print(arg[1])} ? {self._print(arg[0])} : {self._print(arg[1])})"
             arg1 = self.scope.get_temporary_variable(PythonNativeInt())
             arg2 = self.scope.get_temporary_variable(PythonNativeInt())
             assign1 = Assign(arg1, arg[0])

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -714,14 +714,22 @@ class CCodePrinter(CodePrinter):
             return "fmin({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         elif arg.dtype.primitive_type is PrimitiveIntegerType() and len(arg) == 2:
-            if isinstance(arg[0], Variable) and isinstance(arg[1], Variable):
-                return f"({self._print(arg[0])} < {self._print(arg[1])} ? {self._print(arg[0])} : {self._print(arg[1])})"
-            arg1 = self.scope.get_temporary_variable(PythonNativeInt())
-            arg2 = self.scope.get_temporary_variable(PythonNativeInt())
-            assign1 = Assign(arg1, arg[0])
-            assign2 = Assign(arg2, arg[1])
-            self._additional_code += self._print(assign1)
-            self._additional_code += self._print(assign2)
+            if isinstance(arg[0], Variable):
+                arg1 = self._print(arg[0])
+            else:
+                arg1_temp = self.scope.get_temporary_variable(PythonNativeInt())
+                assign1 = Assign(arg1_temp, arg[0])
+                self._additional_code += self._print(assign1)
+                arg1 = self._print(arg1_temp)
+
+            if isinstance(arg[1], Variable):
+                arg2 = self._print(arg[1])
+            else:
+                arg2_temp = self.scope.get_temporary_variable(PythonNativeInt())
+                assign2 = Assign(arg2_temp, arg[1])
+                self._additional_code += self._print(assign2)
+                arg2 = self._print(arg2_temp)
+
             return f"({arg1} < {arg2} ? {arg1} : {arg2})"
         else:
             return errors.report("min in C is only supported for 2 scalar arguments", symbol=expr,
@@ -734,14 +742,22 @@ class CCodePrinter(CodePrinter):
             return "fmax({}, {})".format(self._print(arg[0]),
                                          self._print(arg[1]))
         elif arg.dtype.primitive_type is PrimitiveIntegerType() and len(arg) == 2:
-            if isinstance(arg[0], Variable) and isinstance(arg[1], Variable):
-                return f"({self._print(arg[0])} > {self._print(arg[1])} ? {self._print(arg[0])} : {self._print(arg[1])})"
-            arg1 = self.scope.get_temporary_variable(PythonNativeInt())
-            arg2 = self.scope.get_temporary_variable(PythonNativeInt())
-            assign1 = Assign(arg1, arg[0])
-            assign2 = Assign(arg2, arg[1])
-            self._additional_code += self._print(assign1)
-            self._additional_code += self._print(assign2)
+            if isinstance(arg[0], Variable):
+                arg1 = self._print(arg[0])
+            else:
+                arg1_temp = self.scope.get_temporary_variable(PythonNativeInt())
+                assign1 = Assign(arg1_temp, arg[0])
+                self._additional_code += self._print(assign1)
+                arg1 = self._print(arg1_temp)
+
+            if isinstance(arg[1], Variable):
+                arg2 = self._print(arg[1])
+            else:
+                arg2_temp = self.scope.get_temporary_variable(PythonNativeInt())
+                assign2 = Assign(arg2_temp, arg[1])
+                self._additional_code += self._print(assign2)
+                arg2 = self._print(arg2_temp)
+
             return f"({arg1} > {arg2} ? {arg1} : {arg2})"
         else:
             return errors.report("max in C is only supported for 2 scalar arguments", symbol=expr,

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -188,6 +188,26 @@ def test_min_expr(language):
     assert np.array_equal(epyc_f(*int_args), f(*int_args))
     assert np.allclose(epyc_f(*float_args), f(*float_args), rtol=RTOL, atol=ATOL)
 
+def test_min_temp_var_first_arg(language):
+    def f(x: 'int', y: 'int'):
+        return min(x + 1, y)
+
+    epyc_f = epyccel(f, language=language)
+
+    x, y = randint(min_int, max_int), randint(min_int, max_int)
+
+    assert epyc_f(x, y) == f(x, y)
+
+def test_min_temp_var_second_arg(language):
+    def f(x: 'int', y: 'int'):
+        return min(x, y + 2)
+
+    epyc_f = epyccel(f, language=language)
+
+    x, y = randint(min_int, max_int), randint(min_int, max_int)
+
+    assert epyc_f(x, y) == f(x, y)
+
 def test_max_2_args_i(language):
     def f(x : 'int', y : 'int'):
         return max(x, y)
@@ -286,6 +306,26 @@ def test_max_expr(language):
 
     assert np.array_equal(epyc_f(*int_args), f(*int_args))
     assert np.allclose(epyc_f(*float_args), f(*float_args), rtol=RTOL, atol=ATOL)
+
+def test_max_temp_var_first_arg(language):
+    def f(x: 'int', y: 'int'):
+        return max(x + 1, y)
+
+    epyc_f = epyccel(f, language=language)
+
+    x, y = randint(min_int, max_int), randint(min_int, max_int)
+
+    assert epyc_f(x, y) == f(x, y)
+
+def test_max_temp_var_second_arg(language):
+    def f(x: 'int', y: 'int'):
+        return max(x, y + 2)
+
+    epyc_f = epyccel(f, language=language)
+
+    x, y = randint(min_int, max_int), randint(min_int, max_int)
+
+    assert epyc_f(x, y) == f(x, y)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),


### PR DESCRIPTION
# PR Summary
Fixes: #2025

The PR optimizes the generated C code by reducing unnecessary temporary variables in min/max functions when direct variable inputs are used.

For example:
```python
if __name__ == '__main__':
    a = 3
    b = 4
    c = min(a,b)
    d = max(a,b)
    e = min(a+b, a-b)
```
previously leads to the following generated output:
```C
int main()
{
    int64_t a;
    int64_t b;
    int64_t c;
    int64_t d;
    int64_t e;
    int64_t Dummy_0000;
    int64_t Dummy_0001;
    int64_t Dummy_0002;
    int64_t Dummy_0003;
    int64_t Dummy_0004;
    int64_t Dummy_0005;
    a = INT64_C(3);
    b = INT64_C(4);
    Dummy_0000 = a;
    Dummy_0001 = b;
    c = (Dummy_0000 < Dummy_0001 ? Dummy_0000 : Dummy_0001);
    Dummy_0002 = a;
    Dummy_0003 = b;
    d = (Dummy_0002 > Dummy_0003 ? Dummy_0002 : Dummy_0003);
    Dummy_0004 = a + b;
    Dummy_0005 = a - b;
    e = (Dummy_0004 < Dummy_0005 ? Dummy_0004 : Dummy_0005);
    return 0;
}
```
But now it will lead to the following generated output:
```C
int main()
{
    int64_t a;
    int64_t b;
    int64_t c;
    int64_t d;
    int64_t e;
    int64_t Dummy_0000;
    int64_t Dummy_0001;
    a = INT64_C(3);
    b = INT64_C(4);
    c = (a < b ? a : b);
    d = (a > b ? a : b);
    Dummy_0000 = a + b;
    Dummy_0001 = a - b;
    e = (Dummy_0000 < Dummy_0001 ? Dummy_0000 : Dummy_0001);
    return 0;
}
```
    