### PR TITLE
Remove unnecessary set class (pyccel #2018)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ Contributors
 * Shoaib Moeen
 * Kush Choudhary
 * Emmmanuel Ferdman
+* Amir Movassaghi

--- a/pyccel/ast/builtin_methods/set_methods.py
+++ b/pyccel/ast/builtin_methods/set_methods.py
@@ -20,7 +20,6 @@ __all__ = (
     'SetDiscard',
     'SetMethod',
     'SetPop',
-    'SetRemove',
     'SetUnion',
     'SetUpdate'
 )
@@ -147,34 +146,6 @@ class SetPop(SetMethod):
     def __init__(self, set_variable):
         self._class_type = set_variable.class_type.element_type
         super().__init__(set_variable)
-
-#==============================================================================
-class SetRemove(SetMethod):
-    """
-    Represents a call to the .remove() method.
-
-    The remove() method removes the specified item from 
-    the set and updates the set. It doesn't return any value.
-
-    Parameters
-    ----------
-    set_variable : TypedAstNode
-        The set on which the method will operate.
-
-    item : TypedAstNode
-        The item to search for, and remove.
-    """
-    __slots__ = ()
-    _shape = None
-    _class_type = VoidType()
-    name = 'remove'
-
-    def __init__(self, set_variable, item) -> None:
-        if not isinstance(item, TypedAstNode):
-            raise TypeError(f"It is not possible to look for a {type(item).__name__} object in a set of {set_variable.dtype}")
-        if item.class_type != set_variable.class_type.element_type:
-            raise TypeError(f"Can't remove an element of type {item.dtype} from a set of {set_variable.dtype}")
-        super().__init__(set_variable, item)
 
 #==============================================================================
 class SetDiscard(SetMethod):

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -6,7 +6,7 @@
 This module contains all types which define a python class which is automatically recognised by pyccel
 """
 
-from pyccel.ast.builtin_methods.set_methods  import (SetAdd, SetClear, SetCopy, SetPop, SetRemove,
+from pyccel.ast.builtin_methods.set_methods  import (SetAdd, SetClear, SetCopy, SetPop,
                                                      SetDiscard, SetUpdate, SetUnion)
 from pyccel.ast.builtin_methods.list_methods import (ListAppend, ListInsert, ListPop,
                                                      ListClear, ListExtend, ListRemove,
@@ -163,7 +163,7 @@ SetClass = ClassDef('set',
             PyccelFunctionDef('copy', func_class = SetCopy),
             PyccelFunctionDef('discard', func_class = SetDiscard),
             PyccelFunctionDef('pop', func_class = SetPop),
-            PyccelFunctionDef('remove', func_class = SetRemove),
+            PyccelFunctionDef('remove', func_class = SetDiscard),
             PyccelFunctionDef('union', func_class = SetUnion),
             PyccelFunctionDef('update', func_class = SetUpdate),
             PyccelFunctionDef('__or__', func_class = SetUnion),


### PR DESCRIPTION
Remove the unnecessary class `SetRemove`. Fixes #2018

**Commit Summary**
- Delete `SetRemove` class from `ast/builtin_methods/set_methods.py`
- Replace `SetRemove` method with `SetDiscard` for `remove` keyword in `SetClass` methods in `ast/class_defs.py`