### PR TITLE
Improve bot functions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -74,6 +74,11 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: cobertura.xml
+      - name: Add remote
+        if: env.PR_REPO != 'pyccel/pyccel'
+        run: |
+          git remote add -f pyccel git@github.com:pyccel/pyccel.git
+        shell: bash
       - name: Collect diff information
         run: |
           git fetch

--- a/ci_tools/bot_comment_react.py
+++ b/ci_tools/bot_comment_react.py
@@ -76,10 +76,7 @@ if __name__ == '__main__':
             bot.warn_untrusted()
 
     elif command_words[:3] == ['mark', 'as', 'ready']:
-        if bot.is_user_trusted(event['comment']['user']['login']):
-            bot.request_mark_as_ready()
-        else:
-            bot.warn_untrusted()
+        bot.request_mark_as_ready(event['comment']['user']['login'])
 
     elif command_words[:2] == ['trust', 'user'] and len(command_words)==3 and event['comment']['user']['login'] in trust_givers:
 

--- a/ci_tools/bot_ready_for_review.py
+++ b/ci_tools/bot_ready_for_review.py
@@ -19,7 +19,4 @@ if __name__ == '__main__':
 
     bot = Bot(pr_id = pr_id)
 
-    if bot.is_user_trusted(event['sender']['login']):
-        bot.request_mark_as_ready()
-    else:
-        bot.warn_untrusted()
+    bot.request_mark_as_ready(event['sender']['login'])

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -557,7 +557,7 @@ class Bot:
             self.mark_as_draft()
             return False
 
-        if bot.is_user_trusted(user):
+        if self.is_user_trusted(user):
             states = self.run_tests(pr_test_keys)
 
             if 'failure' in states:
@@ -576,7 +576,7 @@ class Bot:
 
                 return True
         else:
-            bot.warn_untrusted()
+            self.warn_untrusted()
             return False
 
     def mark_as_ready(self, following_review):


### PR DESCRIPTION
Make some minor improvements to the bot:
- Allow bot to check checklist, description etc before bailing due to lack of trust.
- Allow running when user trust is indicated with @.
- Add @jalalium to trust givers
- Ensure pyccel/pyccel is available as a remote when running coverage on a fork