### PR TITLE
Fix use of `_additional_code` in for loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable changes to this project will be documented in this file.
 -   #1972 : Simplified `printf` statement for Literal String.
 -   #2026 : Fix missing loop in slice assignment.
 -   #2008 : Ensure list/set/dict assignment is recognised as a reference.
+-   #2039 : Ensure expressions in the iterable of a for loops is calculated before the loop.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ All notable changes to this project will be documented in this file.
 -   #1972 : Simplified `printf` statement for Literal String.
 -   #2026 : Fix missing loop in slice assignment.
 -   #2008 : Ensure list/set/dict assignment is recognised as a reference.
--   #2039 : Ensure expressions in the iterable of a for loops is calculated before the loop.
+-   #2039 : Ensure any expressions in the iterable of a for loop are calculated before the loop.
 
 ### Changed
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2362,6 +2362,10 @@ class CCodePrinter(CodePrinter):
                 stop_condition = f'({step_code} > 0) ? ({counter} < {stop_code}) : ({counter} > {stop_code})'
             for_code = f'for ({counter} = {start_code}; {stop_condition}; {counter} += {step_code})\n'
 
+        if self._additional_code:
+            for_code = self._additional_code + for_code
+            self._additional_code = ''
+
         body = self._print(additional_assign) + self._print(expr.body)
 
         self.exit_scope()


### PR DESCRIPTION
Fix use of `CCodePrinter._additional_code` in for loops. Fixes #2039.