### PR TITLE
Add Python support for dict.copy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,3 +38,4 @@ Contributors
 * Mohammed Ayaz Shaikh
 * Amir Movassaghi
 * Leonardo Merlin Paloschi
+* Joao Antonio Gomes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 ## \[UNRELEASED\]
 
 ### Added
-
--   #1880 : Add Python support for dict method `clear()`
+-   #1881 : Add Python support for dict method `copy()`.
+-   #1880 : Add Python support for dict method `clear()`.
 -   #1720 : Add support for `Ellipsis` as the only index for an array.
 -   #1787 : Ensure STC is installed with Pyccel.
 -   #1656 : Ensure gFTL is installed with Pyccel.

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -121,7 +121,7 @@ Python contains a limited number of builtin functions defined [here](https://doc
 | Method | Supported |
 |----------|-----------|
 | `clear` | Python-only |
-| `copy` | No |
+| `copy` | Python-only |
 | `get` | Python-only |
 | `items` | No |
 | `keys` | No |

--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -280,5 +280,3 @@ class DictCopy(DictMethod):
         dict_type = dict_obj.class_type
         self._class_type = dict_type
         super().__init__(dict_obj)
-
-#==============================================================================

--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -280,19 +280,3 @@ class DictCopy(DictMethod):
         dict_type = dict_obj.class_type
         self._class_type = dict_type
         super().__init__(dict_obj)
-        self.dict_obj = dict_obj
-
-    def copy(self):
-        """
-        Manually copy the dictionary, replacing the default .copy() method.
-
-        Returns
-        -------
-        dict
-            A new dictionary with copied key-value pairs.
-        """
-        copied_dict = {}
-        for key in self.dict_obj:
-            copied_dict[key] = self.dict_obj[key]
-        return copied_dict
-

--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -265,14 +265,14 @@ class DictCopy(DictMethod):
     """
     Represents a call to the .copy() method.
 
-    The copy() method returns a shallow copy of the dictionary.
+    This class provides a manual copy implementation for compatibility with Pyccel.
 
     Parameters
     ----------
     dict_obj : TypedAstNode
-        The object from which the method is called.
+        The dictionary object from which the method is called.
     """
-    __slots__ = ('_class_type',)
+    __slots__ = ('_class_type', 'dict_obj')
     _shape = None
     name = 'copy'
 
@@ -280,3 +280,18 @@ class DictCopy(DictMethod):
         dict_type = dict_obj.class_type
         self._class_type = dict_type
         super().__init__(dict_obj)
+        self.dict_obj = dict_obj
+
+    def __call__(self):
+        """
+        Perform a manual copy of the dictionary.
+
+        Returns
+        -------
+        dict
+            A new dictionary with copied key-value pairs.
+        """
+        copied_dict = {}
+        for key in self.dict_obj:
+            copied_dict[key] = self.dict_obj[key]
+        return copied_dict

--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -265,14 +265,14 @@ class DictCopy(DictMethod):
     """
     Represents a call to the .copy() method.
 
-    This class provides a manual copy implementation for compatibility with Pyccel.
+    The copy() method returns a shallow copy of the dictionary.
 
     Parameters
     ----------
     dict_obj : TypedAstNode
-        The dictionary object from which the method is called.
+        The object from which the method is called.
     """
-    __slots__ = ('_class_type', 'dict_obj')
+    __slots__ = ('_class_type',)
     _shape = None
     name = 'copy'
 
@@ -282,9 +282,9 @@ class DictCopy(DictMethod):
         super().__init__(dict_obj)
         self.dict_obj = dict_obj
 
-    def __call__(self):
+    def copy(self):
         """
-        Perform a manual copy of the dictionary.
+        Manually copy the dictionary, replacing the default .copy() method.
 
         Returns
         -------
@@ -295,3 +295,4 @@ class DictCopy(DictMethod):
         for key in self.dict_obj:
             copied_dict[key] = self.dict_obj[key]
         return copied_dict
+

--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -15,6 +15,7 @@ from pyccel.ast.internals import PyccelFunction
 
 
 __all__ = ('DictClear',
+           'DictCopy',
            'DictGet',
            'DictMethod',
            'DictPop',
@@ -257,3 +258,27 @@ class DictClear(DictMethod) :
 
     def __init__(self, dict_obj):
         super().__init__(dict_obj)
+
+#==============================================================================
+
+class DictCopy(DictMethod):
+    """
+    Represents a call to the .copy() method.
+
+    The copy() method returns a shallow copy of the dictionary.
+
+    Parameters
+    ----------
+    dict_obj : TypedAstNode
+        The object from which the method is called.
+    """
+    __slots__ = ('_class_type',)
+    _shape = None
+    name = 'copy'
+
+    def __init__(self, dict_obj):
+        dict_type = dict_obj.class_type
+        self._class_type = dict_type
+        super().__init__(dict_obj)
+
+#==============================================================================

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -11,7 +11,7 @@ from pyccel.ast.builtin_methods.set_methods  import (SetAdd, SetClear, SetCopy, 
 from pyccel.ast.builtin_methods.list_methods import (ListAppend, ListInsert, ListPop,
                                                      ListClear, ListExtend, ListRemove,
                                                      ListCopy, ListSort)
-from pyccel.ast.builtin_methods.dict_methods import (DictPop, DictPopitem, DictGet, DictClear,
+from pyccel.ast.builtin_methods.dict_methods import (DictPop, DictPopitem, DictGet, DictClear,DictCopy,
                                                      DictSetDefault)
 
 from .builtins   import PythonImag, PythonReal, PythonConjugate
@@ -175,6 +175,7 @@ SetClass = ClassDef('set',
 
 DictClass = ClassDef('dict',
         methods=[
+            PyccelFunctionDef('copy', func_class = DictCopy),
             PyccelFunctionDef('clear', func_class = DictClear),
             PyccelFunctionDef('get', func_class = DictGet),
             PyccelFunctionDef('pop', func_class = DictPop),

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -47,16 +47,47 @@ def test_dict_empty_init(python_only_language):
     assert python_result == pyccel_result
 
 def test_dict_copy(python_only_language):
-    def dict_copy():
-        a = {1:1.0,2:2.0}
-        b = dict(a)
+    # Caso 1: Dicionário simples com inteiros e floats
+    def dict_copy_simple():
+        a = {1: 1.0, 2: 2.0}
+        b = dict(a)()
         return b
 
-    epyc_dict_copy = epyccel(dict_copy, language = python_only_language)
-    pyccel_result = epyc_dict_copy()
-    python_result = dict_copy()
-    assert isinstance(python_result, type(pyccel_result))
-    assert python_result == pyccel_result
+    # Compilando a função simples
+    epyc_dict_copy_simple = epyccel(dict_copy_simple, language=python_only_language)
+    pyccel_result_simple = epyc_dict_copy_simple()
+    python_result_simple = dict_copy_simple()
+
+    # Verificação para o dicionário simples
+    assert isinstance(python_result_simple, type(pyccel_result_simple))
+    assert python_result_simple == pyccel_result_simple
+
+    # Caso 2: Dicionário com diferentes tipos de chave e valor
+    def dict_copy_mixed():
+        a = {'a': 1, 2: 'b', 3.5: [1, 2, 3]}
+        b = dict(a)()
+        return b
+
+    # Compilando a função para dicionário misto
+    epyc_dict_copy_mixed = epyccel(dict_copy_mixed, language=python_only_language)
+    pyccel_result_mixed = epyc_dict_copy_mixed()
+    python_result_mixed = dict_copy_mixed()
+
+    # Verificação para o dicionário misto
+    assert isinstance(python_result_mixed, type(pyccel_result_mixed))
+    assert python_result_mixed == pyccel_result_mixed
+
+    # Caso 3: Verificação de tipo e inicialização da classe
+    a = {1: 'x', 2: 'y'}
+    dict_copy_instance = DictCopy(a)
+    assert dict_copy_instance.dict_obj == a
+    assert dict_copy_instance._class_type == type(a)
+
+    # Verificação da cópia manual
+    copied_dict = dict_copy_instance()
+    assert copied_dict == a
+    assert copied_dict is not a  # Deve ser uma cópia nova
+
 
 def test_dict_kwarg_init(python_only_language):
     def kwarg_init():

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -47,41 +47,16 @@ def test_dict_empty_init(python_only_language):
     assert python_result == pyccel_result
 
 def test_dict_copy(python_only_language):
-    # Case 1: Basic dictionary copy test with simple data types
     def dict_copy():
-        a = {1: 1.0, 2: 2.0}
-        b = dict(a)  # Using the built-in dict() method to copy the dictionary
+        a = {1:1.0,2:2.0}
+        b = dict(a)
         return b
 
-    epyc_dict_copy = epyccel(dict_copy, language=python_only_language)
+    epyc_dict_copy = epyccel(dict_copy, language = python_only_language)
     pyccel_result = epyc_dict_copy()
     python_result = dict_copy()
-
-    # Verifying the results for the simple dictionary
-    assert isinstance(python_result, type(pyccel_result)), "Types do not match"
-    assert python_result == pyccel_result, "Results do not match"
-
-    # Case 2: Test dictionary copy with mixed keys and values
-    def dict_copy_mixed():
-        a = {'a': 1, 2: 'b', 3.5: [1, 2, 3]}
-        b = dict(a)  # Using the built-in dict() method to copy the dictionary
-        return b
-
-    epyc_dict_copy_mixed = epyccel(dict_copy_mixed, language=python_only_language)
-    pyccel_result_mixed = epyc_dict_copy_mixed()
-    python_result_mixed = dict_copy_mixed()
-
-    # Verifying the results for the mixed dictionary
-    assert isinstance(python_result_mixed, type(pyccel_result_mixed)), "Types do not match"
-    assert python_result_mixed == pyccel_result_mixed, "Results do not match"
-
-    # Case 3: Integrity check - copied dictionary should not be a reference to the original
-    a = {1: 'x', 2: 'y'}
-    copied_dict = dict(a)  # Using the built-in dict() method to copy the dictionary
-
-    assert copied_dict == a, "The copied dictionary should match the original"
-    assert copied_dict is not a, "The copied dictionary should not be a reference to the original"
-
+    assert isinstance(python_result, type(pyccel_result))
+    assert python_result == pyccel_result
 
 def test_dict_kwarg_init(python_only_language):
     def kwarg_init():

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -58,6 +58,7 @@ def test_dict_copy(python_only_language):
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
+
 def test_dict_kwarg_init(python_only_language):
     def kwarg_init():
         b = dict(a=1, b=2) #pylint: disable=use-dict-literal
@@ -228,3 +229,13 @@ def test_dict_clear(python_only_language):
     python_result = dict_clear()
     assert python_result == pyccel_result
 
+
+def test_dict_copy_method(python_only_language):
+    def dict_copy():
+        a = {1:1.0, 2:2.0}
+        b = a.copy()
+        return b
+    epyc_dict_copy = epyccel(dict_copy, language = python_only_language)
+    pyccel_result = epyc_dict_copy()
+    python_result = dict_copy()
+    assert python_result == pyccel_result

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -239,3 +239,4 @@ def test_dict_copy_method(python_only_language):
     pyccel_result = epyc_dict_copy()
     python_result = dict_copy()
     assert python_result == pyccel_result
+    

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -228,12 +228,3 @@ def test_dict_clear(python_only_language):
     python_result = dict_clear()
     assert python_result == pyccel_result
 
-def test_dict_copy(python_only_language):
-    def dict_copy():
-        a = {1:1.0, 2:2.0}
-        b = a.copy()
-        return b
-    epyc_dict_copy = epyccel(dict_copy, language = python_only_language)
-    pyccel_result = epyc_dict_copy()
-    python_result = dict_copy()
-    assert python_result == pyccel_result

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -228,3 +228,12 @@ def test_dict_clear(python_only_language):
     python_result = dict_clear()
     assert python_result == pyccel_result
 
+def test_dict_copy(python_only_language):
+    def dict_copy():
+        a = {1:1.0, 2:2.0}
+        b = a.copy()
+        return b
+    epyc_dict_copy = epyccel(dict_copy, language = python_only_language)
+    pyccel_result = epyc_dict_copy()
+    python_result = dict_copy()
+    assert python_result == pyccel_result

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -47,46 +47,40 @@ def test_dict_empty_init(python_only_language):
     assert python_result == pyccel_result
 
 def test_dict_copy(python_only_language):
-    # Caso 1: Dicionário simples com inteiros e floats
-    def dict_copy_simple():
+    # Case 1: Basic dictionary copy test with simple data types
+    def dict_copy():
         a = {1: 1.0, 2: 2.0}
-        b = dict(a)()
+        b = dict(a)  # Using the built-in dict() method to copy the dictionary
         return b
 
-    # Compilando a função simples
-    epyc_dict_copy_simple = epyccel(dict_copy_simple, language=python_only_language)
-    pyccel_result_simple = epyc_dict_copy_simple()
-    python_result_simple = dict_copy_simple()
+    epyc_dict_copy = epyccel(dict_copy, language=python_only_language)
+    pyccel_result = epyc_dict_copy()
+    python_result = dict_copy()
 
-    # Verificação para o dicionário simples
-    assert isinstance(python_result_simple, type(pyccel_result_simple))
-    assert python_result_simple == pyccel_result_simple
+    # Verifying the results for the simple dictionary
+    assert isinstance(python_result, type(pyccel_result)), "Types do not match"
+    assert python_result == pyccel_result, "Results do not match"
 
-    # Caso 2: Dicionário com diferentes tipos de chave e valor
+    # Case 2: Test dictionary copy with mixed keys and values
     def dict_copy_mixed():
         a = {'a': 1, 2: 'b', 3.5: [1, 2, 3]}
-        b = dict(a)()
+        b = dict(a)  # Using the built-in dict() method to copy the dictionary
         return b
 
-    # Compilando a função para dicionário misto
     epyc_dict_copy_mixed = epyccel(dict_copy_mixed, language=python_only_language)
     pyccel_result_mixed = epyc_dict_copy_mixed()
     python_result_mixed = dict_copy_mixed()
 
-    # Verificação para o dicionário misto
-    assert isinstance(python_result_mixed, type(pyccel_result_mixed))
-    assert python_result_mixed == pyccel_result_mixed
+    # Verifying the results for the mixed dictionary
+    assert isinstance(python_result_mixed, type(pyccel_result_mixed)), "Types do not match"
+    assert python_result_mixed == pyccel_result_mixed, "Results do not match"
 
-    # Caso 3: Verificação de tipo e inicialização da classe
+    # Case 3: Integrity check - copied dictionary should not be a reference to the original
     a = {1: 'x', 2: 'y'}
-    dict_copy_instance = DictCopy(a)
-    assert dict_copy_instance.dict_obj == a
-    assert dict_copy_instance._class_type == type(a)
+    copied_dict = dict(a)  # Using the built-in dict() method to copy the dictionary
 
-    # Verificação da cópia manual
-    copied_dict = dict_copy_instance()
-    assert copied_dict == a
-    assert copied_dict is not a  # Deve ser uma cópia nova
+    assert copied_dict == a, "The copied dictionary should match the original"
+    assert copied_dict is not a, "The copied dictionary should not be a reference to the original"
 
 
 def test_dict_kwarg_init(python_only_language):


### PR DESCRIPTION
Changes made to the files `dict_methods.py`, `class_defs.py`, `test_epyccel_dicts.py`, and `builtin-functions.md` to add Python support for `dict.copy`. Fixes #1881