### PR TITLE
Fix missing allocations for lists in Fortran

### DIFF
--- a/.github/actions/valgrind_run/action.yml
+++ b/.github/actions/valgrind_run/action.yml
@@ -14,5 +14,8 @@ runs:
       run: |
         pyccel --language=c --flags="-g -O0" leaks_check.py
         valgrind --leak-check=full --error-exitcode=1 ./leaks_check
+        pyccel-clean -p
+        pyccel --language=fortran --flags="-g -O0" leaks_check.py
+        valgrind --leak-check=full --error-exitcode=1 ./leaks_check
       shell: bash
       working-directory: ./tests/stc_containers

--- a/.github/actions/valgrind_run/action.yml
+++ b/.github/actions/valgrind_run/action.yml
@@ -3,14 +3,14 @@ name: 'Pyccel valgrind script'
 runs:
   using: "composite"
   steps:
-    - name: Test with valgrind for memory leaks
+    - name: Test with valgrind for memory leaks in ndarrays
       run: |
         pyccel --language=c --flags="-g -O0" leaks_check.py
         valgrind --leak-check=full --error-exitcode=1 ./leaks_check
       shell: bash
       working-directory: ./tests/ndarrays
     
-    - name: Test with valgrind for memory leaks in stc_containers
+    - name: Test with valgrind for memory leaks in built-in containers
       run: |
         pyccel --language=c --flags="-g -O0" leaks_check.py
         valgrind --leak-check=full --error-exitcode=1 ./leaks_check

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -203,7 +203,7 @@ def compatible_operation(*args, language_has_vectors = True):
         Indicates if the language has support for vector
         operations of the same shape.
 
-    Results
+    Returns
     -------
     bool
         A boolean indicating if the operation is compatible.

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -28,6 +28,7 @@ from .sysext        import sys_mod
 
 from .numpyext      import (NumpyEmpty, NumpyArray, numpy_mod,
                             NumpyTranspose, NumpyLinspace)
+from .numpytypes    import NumpyNDArrayType
 from .operators     import PyccelAdd, PyccelMul, PyccelIs, PyccelArithmeticOperator
 from .operators     import PyccelUnarySub
 from .scipyext      import scipy_mod
@@ -203,7 +204,7 @@ def compatible_operation(*args, language_has_vectors = True):
     compatible : bool
                  A boolean indicating if the operation is compatible
     """
-    if language_has_vectors:
+    if language_has_vectors and isinstance(args[0].class_type, NumpyNDArrayType):
         # If the shapes don't match then an index must be required
         shapes = [a.shape[::-1] if a.order == 'F' else a.shape for a in args if a.rank != 0]
         shapes = set(tuple(d if d == LiteralInteger(1) else -1 for d in s) for s in shapes)

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -208,14 +208,13 @@ def compatible_operation(*args, language_has_vectors = True):
     bool
         A boolean indicating if the operation is compatible.
     """
-    class_type = args[0].class_type
-    if language_has_vectors and isinstance(class_type, NumpyNDArrayType):
+    if language_has_vectors and any(isinstance(a.class_type, NumpyNDArrayType) for a in args):
         # If the shapes don't match then an index must be required
         shapes = [a.shape[::-1] if a.order == 'F' else a.shape for a in args if a.rank != 0]
         shapes = set(tuple(d if d == LiteralInteger(1) else -1 for d in s) for s in shapes)
         order  = set(a.order for a in args if a.order is not None)
         return len(shapes) <= 1 and len(order) <= 1
-    elif isinstance(class_type, StringType):
+    elif any(isinstance(a.class_type, StringType) for a in args):
         return True
     else:
         return all(a.rank == 0 for a in args)

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -20,18 +20,18 @@ from .builtins      import (builtin_functions_dict,
                             PythonRange, PythonList, PythonTuple, PythonSet)
 from .cmathext      import cmath_mod
 from .datatypes     import HomogeneousTupleType, InhomogeneousTupleType, PythonNativeInt
+from .datatypes     import StringType
 from .internals     import PyccelFunction, Slice
 from .itertoolsext  import itertools_mod
 from .literals      import LiteralInteger, LiteralEllipsis, Nil
 from .mathext       import math_mod
-from .sysext        import sys_mod
-
 from .numpyext      import (NumpyEmpty, NumpyArray, numpy_mod,
                             NumpyTranspose, NumpyLinspace)
 from .numpytypes    import NumpyNDArrayType
 from .operators     import PyccelAdd, PyccelMul, PyccelIs, PyccelArithmeticOperator
 from .operators     import PyccelUnarySub
 from .scipyext      import scipy_mod
+from .sysext        import sys_mod
 from .typingext     import typing_mod
 from .variable      import Variable, IndexedElement
 
@@ -208,12 +208,15 @@ def compatible_operation(*args, language_has_vectors = True):
     bool
         A boolean indicating if the operation is compatible.
     """
-    if language_has_vectors and isinstance(args[0].class_type, NumpyNDArrayType):
+    class_type = args[0].class_type
+    if language_has_vectors and isinstance(class_type, NumpyNDArrayType):
         # If the shapes don't match then an index must be required
         shapes = [a.shape[::-1] if a.order == 'F' else a.shape for a in args if a.rank != 0]
         shapes = set(tuple(d if d == LiteralInteger(1) else -1 for d in s) for s in shapes)
         order  = set(a.order for a in args if a.order is not None)
         return len(shapes) <= 1 and len(order) <= 1
+    elif isinstance(class_type, StringType):
+        return True
     else:
         return all(a.rank == 0 for a in args)
 

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -189,20 +189,24 @@ def split_positional_keyword_arguments(*args):
 #==============================================================================
 def compatible_operation(*args, language_has_vectors = True):
     """
+    Indicates whether an operation only uses compatible arguments.
+
     Indicates whether an operation requires an index to be
-    correctly understood
+    correctly interpreted in the target language or if the arguments
+    are already compatible.
 
     Parameters
-    ==========
-    args      : list of TypedAstNode
-                The operator arguments
+    ----------
+    args : list of TypedAstNode
+        The operator arguments
     language_has_vectors : bool
-                Indicates if the language has support for vector
-                operations of the same shape
+        Indicates if the language has support for vector
+        operations of the same shape.
+
     Results
-    =======
-    compatible : bool
-                 A boolean indicating if the operation is compatible
+    -------
+    bool
+        A boolean indicating if the operation is compatible.
     """
     if language_has_vectors and isinstance(args[0].class_type, NumpyNDArrayType):
         # If the shapes don't match then an index must be required

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -189,16 +189,16 @@ def split_positional_keyword_arguments(*args):
 #==============================================================================
 def compatible_operation(*args, language_has_vectors = True):
     """
-    Indicates whether an operation only uses compatible arguments.
+    Indicate whether an operation only uses compatible arguments.
 
-    Indicates whether an operation requires an index to be
+    Indicate whether an operation requires an index to be
     correctly interpreted in the target language or if the arguments
     are already compatible.
 
     Parameters
     ----------
-    args : list of TypedAstNode
-        The operator arguments
+    *args : list of TypedAstNode
+        The operator arguments.
     language_has_vectors : bool
         Indicates if the language has support for vector
         operations of the same shape.

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2161,6 +2161,10 @@ class FCodePrinter(CodePrinter):
                 container = self._print(container_type)
                 size_code = self._print(expr.shape[0])
                 return f'{var_code} = {container}({size_code})\n'
+            elif expr.alloc_type == 'reserve':
+                var_code = self._print(expr.variable)
+                size_code = self._print(expr.shape[0])
+                return '{var_code} % reserve({size_code})\n'
             else:
                 return ''
         elif isinstance(class_type, (HomogeneousContainerType, DictType)):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3353,8 +3353,8 @@ class FCodePrinter(CodePrinter):
 
         if isinstance(base.class_type, HomogeneousListType):
             assert len(inds) == 1
-            assert not isinstance(ind, Slice)
             ind = inds[0]
+            assert not isinstance(ind, Slice)
             ind_code = self._print(PyccelAdd(inds[0], LiteralInteger(1), simplify=True))
             return f"{base_code}%of({ind_code})"
         elif isinstance(base.class_type, (NumpyNDArrayType, HomogeneousTupleType)):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2004,7 +2004,7 @@ class FCodePrinter(CodePrinter):
                 body_stmts.append(self._additional_code)
                 self._additional_code = ''
             body_stmts.append(line)
-        return ''.join(self._print(b) for b in body_stmts)
+        return ''.join(body_stmts)
 
     # TODO the ifs as they are are, is not optimal => use elif
     def _print_SymbolicAssign(self, expr):
@@ -2154,6 +2154,15 @@ class FCodePrinter(CodePrinter):
 
             return code
 
+        elif isinstance(class_type, HomogeneousListType):
+            if expr.alloc_type == 'resize':
+                var_code = self._print(expr.variable)
+                container_type = expr.variable.class_type
+                container = self._print(container_type)
+                size_code = self._print(expr.shape[0])
+                return f'{var_code} = {container}({size_code})\n'
+            else:
+                return ''
         elif isinstance(class_type, (HomogeneousContainerType, DictType)):
             return ''
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3352,11 +3352,11 @@ class FCodePrinter(CodePrinter):
                             PyccelAdd(_shape, ind, simplify = True), ind)
 
         if isinstance(base.class_type, HomogeneousListType):
-            if any(isinstance(i, Slice) for i in inds):
-                raise NotImplementedError("Slice indexing not implemented for lists")
-            inds = [PyccelAdd(i, LiteralInteger(1), simplify=True) for i in inds]
-            inds_code = ", ".join(self._print(i) for i in inds)
-            return f"{base_code}%of({inds_code})"
+            assert len(inds) == 1
+            assert not isinstance(ind, Slice)
+            ind = inds[0]
+            ind_code = self._print(PyccelAdd(inds[0], LiteralInteger(1), simplify=True))
+            return f"{base_code}%of({ind_code})"
         elif isinstance(base.class_type, (NumpyNDArrayType, HomogeneousTupleType)):
             inds_code = ", ".join(self._print(i) for i in inds)
             return f"{base_code}({inds_code})"

--- a/tests/codegen/fcode/test_fcode_codegen.py
+++ b/tests/codegen/fcode/test_fcode_codegen.py
@@ -15,7 +15,7 @@ base_dir = os.path.dirname(os.path.realpath(__file__))
 path_dir = os.path.join(base_dir, 'scripts')
 
 files = sorted(os.listdir(path_dir))
-failing_files = {'ListComprehension.py': 'List comprehension not yet implemented with gFTL',
+failing_files = {'ListComprehension.py': 'Lists of tuples not yet implemented with gFTL',
                  'lists.py': 'List slicing not yet implemented with gFTL',
                  'Functional_Stmts.py': 'List slicing not yet implemented with gFTL',
                  'complex_numbers.py': 'List slicing not yet implemented with gFTL',

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 from numpy.random import randint
 from numpy import equal
+import pytest
 
 
 from pyccel import epyccel

--- a/tests/epyccel/test_functionals.py
+++ b/tests/epyccel/test_functionals.py
@@ -1,25 +1,10 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 from numpy.random import randint
 from numpy import equal
-import pytest
 
 
 from pyccel import epyccel
 from modules import functionals
-
-@pytest.fixture( params=[
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="Fortran does not support list comprehensions. See #1948 (now applicable to Fortran)"),
-            pytest.mark.fortran]),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="C does not support list comprehensions. See #1948"),
-            pytest.mark.c]),
-        pytest.param("python", marks = pytest.mark.python)
-    ],
-    scope = "module"
-)
-def language(request):
-    return request.param
 
 def compare_epyccel(f, language, *args):
     f2 = epyccel(f, language=language)
@@ -62,11 +47,23 @@ def test_functional_for_2d_dependant_range(language):
     compare_epyccel(functionals.functional_for_2d_dependant_range_2, language)
     compare_epyccel(functionals.functional_for_2d_dependant_range_3, language)
 
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [
+            pytest.mark.skip(reason="lists of tuples are not yes supported"),
+            pytest.mark.fortran]
+        ),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="lists of tuples are not yes supported"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
 def test_functional_for_2d_array_range(language):
     idx = randint(28)
     compare_epyccel(functionals.functional_for_2d_array_range, language,idx)
 
-def test_functional_for_2d_array_range_const(language):
+def test_functional_for_2d_range_const(language):
     compare_epyccel(functionals.functional_for_2d_range_const, language)
 
 def test_functional_for_3d_range(language):

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -77,18 +77,6 @@ def test_double_loop_on_2d_array_F(language):
     f2( y )
     assert np.array_equal( x, y )
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="list comprehension not supported yet, related issue #1948"),
-            pytest.mark.fortran]
-        ),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="C does not support list indexing yet, related issue #1948"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_product_loop_on_2d_array_C(language):
 
     f1 = loops.product_loop_on_2d_array_C
@@ -101,18 +89,6 @@ def test_product_loop_on_2d_array_C(language):
     f2( y )
     assert np.array_equal( x, y )
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="list comprehension not supported yet, related issue #1948"),
-            pytest.mark.fortran]
-        ),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="C does not support list indexing yet, related issue #1948"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_product_loop_on_2d_array_F(language):
 
     f1 = loops.product_loop_on_2d_array_F
@@ -125,18 +101,6 @@ def test_product_loop_on_2d_array_F(language):
     f2( y )
     assert np.array_equal( x, y )
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="list comprehension not supported yet, related issue #1948"),
-            pytest.mark.fortran]
-        ),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="C does not support list indexing yet, related issue #1948"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_product_loop(language):
 
     f1 = loops.product_loop
@@ -150,10 +114,7 @@ def test_product_loop(language):
     assert np.array_equal( x, y )
 
 @pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="list comprehension not supported yet, related issue #1948"),
-            pytest.mark.fortran]
-        ),
+        pytest.param("fortran", marks = pytest.mark.fortran),
         pytest.param("c", marks = [
             pytest.mark.xfail(reason="Function in function not implemented in C"),
             pytest.mark.c]
@@ -189,18 +150,6 @@ def test_enumerate_on_1d_array_with_start(language):
     assert np.array_equal( f1(z, 5), f2(z, 5) )
     assert np.array_equal( f1(z,-2), f2(z,-2) )
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = [
-            pytest.mark.skip(reason="list comprehension not supported yet, related issue #1948"),
-            pytest.mark.fortran]
-        ),
-        pytest.param("c", marks = [
-            pytest.mark.skip(reason="C does not support list indexing yet, related issue #1948"),
-            pytest.mark.c]
-        ),
-        pytest.param("python", marks = pytest.mark.python)
-    )
-)
 def test_zip_prod(language):
 
     f1 = loops.zip_prod


### PR DESCRIPTION
Use the `Allocate.alloc_type` property to add missing allocations for lists in Fortran. Fixes #2036.

**Commit Summary**
- Activate leak checks for containers for Fortran
- Apply unravelling algorithms to lists
- Remove unnecessary `_print` call in `FCodePrinter._print_CodeBlock`
- Handle `resize` and `reserve` cases for list allocations in Fortran
- Simplify printing of list indexing
- Reactivate list comprehension tests