### PR TITLE
Remove unused symbolic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Remove `pyccel.ast.utilities.builtin_functions`.
 -   \[INTERNALS\] Remove unused/unnecessary functions in `pyccel.parser.utilities` : `read_file`, `header_statement`, `accelerator_statement`, `get_module_name`, `view_tree`.
 -   \[INTERNALS\] Remove unused functions `Errors.unset_target`, and `Errors.reset_target`.
+-   \[INTERNALS\] Remove unused classes `SymbolicAssign` and `SymbolicPrint`.
 
 ## \[1.12.1\] - 2024-10-01
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -16,13 +16,12 @@ from .basic     import PyccelAstNode, TypedAstNode, iterable, ScopedAstNode
 from .bitwise_operators import PyccelBitOr, PyccelBitAnd
 
 from .builtins  import (PythonEnumerate, PythonLen, PythonMap, PythonTuple,
-                        PythonRange, PythonZip, PythonBool, Lambda)
+                        PythonRange, PythonZip, PythonBool)
 
 from .c_concepts import PointerCast
 
-from .datatypes import (PyccelType, SymbolicType, HomogeneousTupleType,
-                        PythonNativeBool, InhomogeneousTupleType,
-                        VoidType)
+from .datatypes import (PyccelType, HomogeneousTupleType, VoidType
+                        PythonNativeBool, InhomogeneousTupleType)
 
 from .internals import PyccelSymbol, PyccelFunction, apply_pickle
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -347,31 +347,6 @@ class Assign(PyccelAstNode):
         cond = cond or isinstance(rhs, Variable) and rhs.is_alias
         return cond
 
-    @property
-    def is_symbolic_alias(self):
-        """
-        Returns True if the assignment is a symbolic alias.
-
-        Returns True if the assignment is a symbolic alias.
-        """
-
-        # TODO to be improved when handling classes
-        # TODO: Is this useful?
-
-        lhs = self.lhs
-        rhs = self.rhs
-        if isinstance(lhs, Variable):
-            return isinstance(lhs.class_type, SymbolicType)
-        elif isinstance(lhs, PyccelSymbol):
-            if isinstance(rhs, PythonRange):
-                return True
-            elif isinstance(rhs, Variable):
-                return isinstance(rhs.class_type, SymbolicType)
-            elif isinstance(rhs, PyccelSymbol):
-                return True
-
-        return False
-
 #------------------------------------------------------------------------------
 class Allocate(PyccelAstNode):
     """

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -91,7 +91,6 @@ __all__ = (
     'SeparatorComment',
     'StarredArguments',
     'SymbolicAssign',
-    'SymbolicPrint',
     'SympyFunction',
     'While',
     'With',
@@ -4157,44 +4156,6 @@ class Raise(PyccelAstNode):
     __slots__ = ()
     _attribute_nodes = ()
 
-
-
-class SymbolicPrint(PyccelAstNode):
-
-    """Represents a print function of symbolic expressions in the code.
-
-    Parameters
-    ----------
-    expr : TypedAstNode
-        The expression to print
-
-    Examples
-    --------
-    >>> from pyccel.ast.internals import symbols
-    >>> from pyccel.ast.core import Print
-    >>> n,m = symbols('n,m')
-    >>> Print(('results', n,m))
-    Print((results, n, m))
-    """
-    __slots__ = ('_expr',)
-    _attribute_nodes = ('_expr',)
-
-    def __init__(self, expr):
-        if not iterable(expr):
-            raise TypeError('Expecting an iterable')
-
-        for i in expr:
-            if not isinstance(i, (Lambda, SymbolicAssign,
-                              SympyFunction)):
-                raise TypeError('Expecting Lambda, SymbolicAssign, SympyFunction for {}'.format(i))
-
-        self._expr = expr
-
-        super().__init__()
-
-    @property
-    def expr(self):
-        return self._expr
 
 
 class Del(PyccelAstNode):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -20,7 +20,7 @@ from .builtins  import (PythonEnumerate, PythonLen, PythonMap, PythonTuple,
 
 from .c_concepts import PointerCast
 
-from .datatypes import (PyccelType, HomogeneousTupleType, VoidType
+from .datatypes import (PyccelType, HomogeneousTupleType, VoidType,
                         PythonNativeBool, InhomogeneousTupleType)
 
 from .internals import PyccelSymbol, PyccelFunction, apply_pickle

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -90,7 +90,6 @@ __all__ = (
     'Return',
     'SeparatorComment',
     'StarredArguments',
-    'SymbolicAssign',
     'SympyFunction',
     'While',
     'With',
@@ -725,47 +724,6 @@ class AliasAssign(PyccelAstNode):
 
     def __str__(self):
         return f'{self.lhs} := {self.rhs}'
-
-    @property
-    def lhs(self):
-        return self._lhs
-
-    @property
-    def rhs(self):
-        return self._rhs
-
-
-class SymbolicAssign(PyccelAstNode):
-
-    """Represents symbolic aliasing for code generation. An alias is any statement of the
-    form `lhs := rhs` where
-
-    Parameters
-    ----------
-    lhs : PyccelSymbol
-
-    rhs : Range
-
-    Examples
-    --------
-    >>> from pyccel.ast.internals import PyccelSymbol
-    >>> from pyccel.ast.core import SymbolicAssign
-    >>> from pyccel.ast.core import Range
-    >>> r = Range(0, 3)
-    >>> y = PyccelSymbol('y')
-    >>> SymbolicAssign(y, r)
-
-    """
-    __slots__ = ('_lhs', '_rhs')
-    _attribute_nodes = ('_lhs', '_rhs')
-
-    def __init__(self, lhs, rhs):
-        self._lhs = lhs
-        self._rhs = rhs
-        super().__init__()
-
-    def __str__(self):
-        return '{0} := {1}'.format(str(self.lhs), str(self.rhs))
 
     @property
     def lhs(self):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2001,14 +2001,6 @@ class FCodePrinter(CodePrinter):
             body_stmts.append(line)
         return ''.join(self._print(b) for b in body_stmts)
 
-    # TODO the ifs as they are are, is not optimal => use elif
-    def _print_SymbolicAssign(self, expr):
-        errors.report(FOUND_SYMBOLIC_ASSIGN,
-                      symbol=expr.lhs, severity='warning')
-
-        stmt = Comment(str(expr))
-        return self._print_Comment(stmt)
-
     def _print_NumpyReal(self, expr):
         value = self._print(expr.internal_var)
         code = 'Real({0}, {1})'.format(value, self.print_kind(expr))

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1149,11 +1149,6 @@ class FCodePrinter(CodePrinter):
 
         return arg_format, arg
 
-    def _print_SymbolicPrint(self, expr):
-        # for every expression we will generate a print
-        code = '\n'.join(f"print *, 'sympy> {a}'" for a in expr.expr)
-        return code + '\n'
-
     def _print_Comment(self, expr):
         comments = self._print(expr.text)
         return '!' + comments + '\n'

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -19,7 +19,6 @@ from pyccel.version import __version__
 
 from pyccel.ast.builtins import Lambda
 
-from pyccel.ast.core import SymbolicAssign
 from pyccel.ast.core import FunctionDef, Interface, FunctionAddress
 from pyccel.ast.core import SympyFunction
 from pyccel.ast.core import Import, AsName
@@ -324,9 +323,6 @@ class BasicParser(object):
         container = self.scope.symbolic_functions
         if isinstance(func, SympyFunction):
             container[func.name] = func
-        elif isinstance(func, SymbolicAssign) and isinstance(func.rhs,
-                Lambda):
-            container[func.lhs] = func.rhs
         else:
             raise TypeError('Expected a symbolic_function')
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -45,7 +45,6 @@ from pyccel.ast.core import ClassDef
 from pyccel.ast.core import For
 from pyccel.ast.core import Module
 from pyccel.ast.core import While
-from pyccel.ast.core import SymbolicPrint
 from pyccel.ast.core import Del
 from pyccel.ast.core import Program
 from pyccel.ast.core import EmptyNode
@@ -4290,20 +4289,7 @@ class SemanticParser(BasicParser):
 #                   bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
 #                   severity='fatal')
 
-        if is_symbolic(args[0]):
-            _args = []
-            for a in args:
-                f = self.scope.find(a.name, 'symbolic_functions')
-                if f is None:
-                    _args.append(a)
-                else:
-
-                    # TODO improve: how can we print SymbolicAssign as  lhs = rhs
-
-                    _args.append(f)
-            return SymbolicPrint(_args)
-        else:
-            return PythonPrint(args)
+        return PythonPrint(args)
 
     def _visit_ClassDef(self, expr):
         # TODO - improve the use and def of interfaces

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -36,7 +36,7 @@ from pyccel.ast.builtin_methods.set_methods  import SetAdd, SetUnion
 from pyccel.ast.core import Comment, CommentBlock, Pass
 from pyccel.ast.core import If, IfSection
 from pyccel.ast.core import Allocate, Deallocate
-from pyccel.ast.core import Assign, AliasAssign, SymbolicAssign
+from pyccel.ast.core import Assign, AliasAssign
 from pyccel.ast.core import AugAssign, CodeBlock
 from pyccel.ast.core import Return, FunctionDefArgument, FunctionDefResult
 from pyccel.ast.core import ConstructorCall, InlineFunctionDef

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3426,13 +3426,7 @@ class SemanticParser(BasicParser):
                     else:
                         self._indicate_pointer_target(l, r, expr)
 
-                elif new_expr.is_symbolic_alias:
-                    new_expr = SymbolicAssign(l, r)
-
-                    # in a symbolic assign, the rhs can be a lambda expression
-                    # it is then treated as a def node
-
-                    F = self.scope.find(l, 'symbolic_functions')
+                elif isinstance(l.class_type, SymbolicType):
                     errors.report(PYCCEL_RESTRICTION_TODO,
                                   bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
                                   severity='fatal')


### PR DESCRIPTION
Remove unused classes `SymbolicAssign`, `SymbolicPrint` and the method `Assign.is_symbolic_alias`. These objects come from handling of symbolic methods which existed in Pyccel many years ago but is either broken or handled differently now. The type `SymbolicType` makes these objects unnecessary.