### PR TITLE
Fix translation of classes containing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to this project will be documented in this file.
 -   #2008 : Ensure list/set/dict assignment is recognised as a reference.
 -   #2039 : Ensure any expressions in the iterable of a for loop are calculated before the loop.
 -   #2013 : Stop limiting the length of strings to 128 characters.
+-   #2078 : Fix translation of classes containing comments.
 
 ### Changed
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1030,7 +1030,7 @@ class SyntaxParser(BasicParser):
             if isinstance(visited_i, FunctionDef):
                 methods.append(visited_i)
                 visited_i.arguments[0].bound_argument = True
-            elif isinstance(visited_i, Pass):
+            elif isinstance(visited_i, (Pass, Comment)):
                 continue
             elif isinstance(visited_i, AnnotatedPyccelSymbol):
                 attributes.append(visited_i)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1032,6 +1032,8 @@ class SyntaxParser(BasicParser):
                 visited_i.arguments[0].bound_argument = True
             elif isinstance(visited_i, (Pass, Comment)):
                 continue
+            elif isinstance(visited_i, CodeBlock) and all(isinstance(x, Comment) for x in visited_i.body):
+                continue
             elif isinstance(visited_i, AnnotatedPyccelSymbol):
                 attributes.append(visited_i)
             elif isinstance(visited_i, CommentBlock):

--- a/tests/epyccel/classes/classes_1.py
+++ b/tests/epyccel/classes/classes_1.py
@@ -19,6 +19,7 @@ class Point(object):
         return self._x
 
     #--------------------------------------
+    #--------------------------------------
     def get_X(self):
         return self._X
 

--- a/tests/epyccel/classes/classes_1.py
+++ b/tests/epyccel/classes/classes_1.py
@@ -6,15 +6,19 @@ class Point(object):
         self._X = 10
         self._x = x
 
+    #--------------------------------------
     def __del__(self):
         pass
 
+    #--------------------------------------
     def translate(self, a : 'float[:]'):
         self._x[:]   =  self._x + a
 
+    #--------------------------------------
     def get_x(self):
         return self._x
 
+    #--------------------------------------
     def get_X(self):
         return self._X
 


### PR DESCRIPTION
Fix translation of classes containing comments by discarding the comments. Fixes #2078 