### PR TITLE
Allow the use of a list comprehension to initialise an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to this project will be documented in this file.
 -   #2008 : Ensure list/set/dict assignment is recognised as a reference.
 -   #2039 : Ensure any expressions in the iterable of a for loop are calculated before the loop.
 -   #2013 : Stop limiting the length of strings to 128 characters.
+-   #2082 : Allow the use of a list comprehension to initialise an array.
 
 ### Changed
 

--- a/ci_tools/check_pylint_commands.py
+++ b/ci_tools/check_pylint_commands.py
@@ -23,6 +23,7 @@ accepted_pylint_commands = {re.compile('.*/IMPORTING_EXISTING_IDENTIFIED3.py'):[
                             re.compile('tests/pyccel/project_class_imports/.*'):['relative-beyond-top-level'], # ignore Codacy bad pylint call
                             re.compile('tests/errors/syntax_errors/import_star.py'):['wildcard-import'],
                             re.compile('tests/stc_containers/leaks_check.py'):['unused-variable'],
+                            re.compile('tests/epyccel/modules/arrays.py'):['reimported'], # Repeat NumPy imports due to functions being translated individually
                            }
 
 def run_pylint(file, flag, messages):

--- a/pyccel/ast/functionalexpr.py
+++ b/pyccel/ast/functionalexpr.py
@@ -53,9 +53,12 @@ class FunctionalFor(TypedAstNode):
                   Dummy_0 += 1
               ```
               Index is `Dummy_0`.
+    target_type : PyccelSymbol, optional
+        The type of the result of the functional for. This is useful at
+        the syntactic stage to pass along the final type of the lhs (list/set/array/etc).
     """
     __slots__ = ('_loops','_expr', '_lhs', '_indices','_index',
-            '_shape','_class_type')
+            '_shape','_class_type', '_target_type')
     _attribute_nodes = ('_loops','_expr', '_lhs', '_indices','_index')
 
     def __init__(
@@ -64,13 +67,15 @@ class FunctionalFor(TypedAstNode):
         expr=None,
         lhs=None,
         indices=None,
-        index=None
+        index=None,
+        target_type=None
         ):
         self._loops   = loops
         self._expr    = expr
         self._lhs     = lhs
         self._indices = indices
         self._index   = index
+        self._target_type = target_type
         super().__init__()
 
         if pyccel_stage != 'syntactic':
@@ -96,6 +101,16 @@ class FunctionalFor(TypedAstNode):
     @property
     def index(self):
         return self._index
+
+    @property
+    def target_type(self):
+        """
+        The type of the result of the functional for.
+
+        The type of the result of the functional for. This is useful at
+        the syntactic stage to pass along the final type of the lhs (list/set/array/etc).
+        """
+        return self._target_type
 
 #==============================================================================
 class GeneratorComprehension(FunctionalFor):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3804,6 +3804,11 @@ class SemanticParser(BasicParser):
         try:
             class_type = type_container[conversion_func.cls_name](class_type)
         except TypeError:
+            if class_type.rank > 0:
+                errors.report("ND comprehension expressions cannot be saved directly to an array yet.\n"+PYCCEL_RESTRICTION_TODO,
+                              symbol=expr,
+                              severity='fatal')
+
             class_type = type_container[conversion_func.cls_name](numpy_process_dtype(class_type), rank=1, order=None)
         d_var['class_type'] = class_type
         shape = [dim]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3789,7 +3789,7 @@ class SemanticParser(BasicParser):
                 cls_base = get_cls_base(first.class_type)
                 if cls_base is None:
                     cls_base = self.scope.find(str(first.class_type), 'classes')
-                conversion_func = cls_base.get_method(rhs_name)
+                conversion_func = cls_base.get_method(target_type_name.name[-1])
         else:
             conversion_func = self.scope.find(target_type_name, 'functions')
             if conversion_func is None:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3786,10 +3786,7 @@ class SemanticParser(BasicParser):
             if isinstance(first, Module):
                 conversion_func = first[target_type_name.name[-1]]
             else:
-                cls_base = get_cls_base(first.class_type)
-                if cls_base is None:
-                    cls_base = self.scope.find(str(first.class_type), 'classes')
-                conversion_func = cls_base.get_method(target_type_name.name[-1])
+                conversion_func = None
         else:
             conversion_func = self.scope.find(target_type_name, 'functions')
             if conversion_func is None:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -150,6 +150,7 @@ type_container = {
                    PythonTupleFunction : HomogeneousTupleType,
                    PythonListFunction : HomogeneousListType,
                    PythonSetFunction : HomogeneousSetType,
+                   NumpyArray : NumpyNDArrayType,
                   }
 
 #==============================================================================
@@ -3757,7 +3758,7 @@ class SemanticParser(BasicParser):
             dim = sympy_to_pyccel(dim, idx_subs)
         except TypeError:
             errors.report(PYCCEL_RESTRICTION_LIST_COMPREHENSION_SIZE + f'\n Deduced size : {dim}',
-                          bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
+                          symbol=expr,
                           severity='fatal')
 
         # TODO find a faster way to calculate dim
@@ -3777,7 +3778,33 @@ class SemanticParser(BasicParser):
                           severity='fatal')
 
         d_var['memory_handling'] = 'heap'
-        class_type = HomogeneousListType(class_type)
+        target_type_name = expr.target_type
+        if isinstance(target_type_name, DottedName):
+            lhs = target_type_name.name[0] if len(target_type_name.name) == 2 \
+                    else DottedName(*target_type_name.name[:-1])
+            first = self._visit(lhs)
+            if isinstance(first, Module):
+                conversion_func = first[target_type_name.name[-1]]
+            else:
+                cls_base = get_cls_base(first.class_type)
+                if cls_base is None:
+                    cls_base = self.scope.find(str(first.class_type), 'classes')
+                conversion_func = cls_base.get_method(rhs_name)
+        else:
+            conversion_func = self.scope.find(target_type_name, 'functions')
+            if conversion_func is None:
+                if target_type_name in builtin_functions_dict:
+                    conversion_func = PyccelFunctionDef(target_type_name,
+                                            builtin_functions_dict[target_type_name])
+        if conversion_func is None:
+            errors.report("Unrecognised output type from functional for.\n"+PYCCEL_RESTRICTION_TODO,
+                          symbol=expr,
+                          severity='fatal')
+
+        try:
+            class_type = type_container[conversion_func.cls_name](class_type)
+        except TypeError:
+            class_type = type_container[conversion_func.cls_name](numpy_process_dtype(class_type), rank=1, order=None)
         d_var['class_type'] = class_type
         shape = [dim]
         if d_var['shape']:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1160,13 +1160,15 @@ class SyntaxParser(BasicParser):
 
         generators = list(self._visit(stmt.generators))
 
-        if not isinstance(self._context[-2],ast.Assign):
+        assignment = next((c for c in reversed(self._context) if isinstance(c, ast.Assign)), None)
+
+        if assignment is None:
             errors.report(PYCCEL_RESTRICTION_LIST_COMPREHENSION_ASSIGN,
                           symbol = stmt,
                           severity='error')
             lhs = PyccelSymbol('_', is_temp=True)
         else:
-            lhs = self._visit(self._context[-2].targets)
+            lhs = self._visit(assignment.targets)
             if len(lhs)==1:
                 lhs = lhs[0]
             else:

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -71,6 +71,11 @@ def array_int_1d_initialization_3():
     b = np.array(a)
     return np.sum(b), b[0], b[-1]
 
+def array_int_1d_initialization_4():
+    import numpy as np
+    b = np.array([i*2 for i in range(10)])
+    return b
+
 #==============================================================================
 # 2D ARRAYS OF INT-32 WITH C ORDERING
 #==============================================================================

--- a/tests/epyccel/modules/arrays.py
+++ b/tests/epyccel/modules/arrays.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring
+# pylint: disable=missing-function-docstring, missing-module-docstring, reimported
 import numpy as np
 
 from pyccel.decorators import template, stack_array, allow_negative_index

--- a/tests/epyccel/test_arrays.py
+++ b/tests/epyccel/test_arrays.py
@@ -346,6 +346,13 @@ def test_array_int_1d_initialization_3(language):
 
     assert f1() == f2()
 
+def test_array_int_1d_initialization_4(language):
+
+    f1 = arrays.array_int_1d_initialization_4
+    f2 = epyccel( f1 , language = language)
+
+    check_array_equal(f1(), f2())
+
 #==============================================================================
 # TEST: 2D ARRAYS OF INT-32 WITH C ORDERING
 #==============================================================================


### PR DESCRIPTION
Allow the use of a list comprehension to initialise an array. Fixes #2080 .
The type of the target that is created from the `FunctionalFor` is saved into the `FunctionalFor`. This extra parameter will also be useful when support for set comprehension and/or dictionary comprehension is added.