### PR TITLE
Add support for @property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project will be documented in this file.
 -   #1980 : Extend The C support for min and max to more than two variables
 -   #2081 : Add support for multi operator expressions
 -   Add support for inhomogeneous tuple annotations.
+-   #1834 : Add support for `@property` decorator.
 -   \[INTERNALS\] Add abstract class `SetMethod` to handle calls to various set methods.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[INTERNALS\] Add a `__call__` method to `FunctionDef` to create `FunctionCall` instances.

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -190,7 +190,7 @@ MyClass Object created!
 
 ## Class properties
 
-Pyccel now supports class properties (as getters only).
+Pyccel now supports class properties (to retrieve a constant value only).
 
 ### - Python Example
 

--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -608,10 +608,8 @@ class BindCClassProperty(PyccelAstNode):
     __slots__ = ('_getter', '_setter', '_python_name', '_docstring', '_class_type')
     _attribute_nodes = ('_getter', '_setter')
     def __init__(self, python_name, getter, setter, class_type, docstring = None):
-        if not isinstance(getter, BindCFunctionDef):
-            raise TypeError("Getter should be a BindCFunctionDef")
-        if not isinstance(setter, BindCFunctionDef):
-            raise TypeError("Setter should be a BindCFunctionDef")
+        assert isinstance(getter, BindCFunctionDef)
+        assert isinstance(setter, BindCFunctionDef) or setter is None
         self._python_name = python_name
         self._getter = getter
         self._setter = setter

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -843,10 +843,8 @@ class PyGetSetDefElement(PyccelAstNode):
     _attribute_nodes = ('_getter', '_setter', '_docstring')
     __slots__ = ('_python_name', '_getter', '_setter', '_docstring')
     def __init__(self, python_name, getter, setter, docstring):
-        if not isinstance(getter, PyFunctionDef):
-            raise TypeError("Getter should be a PyFunctionDef")
-        if not isinstance(setter, PyFunctionDef):
-            raise TypeError("Setter should be a PyFunctionDef")
+        assert isinstance(getter, PyFunctionDef)
+        assert isinstance(setter, PyFunctionDef) or setter is None
         self._python_name = python_name
         self._getter = getter
         self._setter = setter

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -285,7 +285,7 @@ class CWrapperCodePrinter(CCodePrinter):
                     "};\n")
             sig_methods = c.methods + (c.new_func,) + tuple(f for i in c.interfaces for f in i.functions) + \
                           tuple(i.interface_func for i in c.interfaces) + \
-                          tuple(getset for p in c.properties for getset in (p.getter, p.setter))
+                          tuple(getset for p in c.properties for getset in (p.getter, p.setter) if getset)
             function_signatures += '\n'+''.join(self.function_signature(f)+';\n' for f in sig_methods)
             macro_defs += f'#define {type_name} (*(PyTypeObject*){API_var.name}[{i}])\n'
 
@@ -393,7 +393,7 @@ class CWrapperCodePrinter(CCodePrinter):
 
         original_scope = expr.original_class.scope
         getters = tuple(p.getter for p in expr.properties)
-        setters = tuple(p.setter for p in expr.properties)
+        setters = tuple(p.setter for p in expr.properties if p.setter)
         print_methods = expr.methods + (expr.new_func,) + expr.interfaces + \
                          getters + setters
         functions = '\n'.join(self._print(f) for f in print_methods)
@@ -417,13 +417,13 @@ class CWrapperCodePrinter(CCodePrinter):
                                                     if f.docstring else '""'
             funcs[py_name] = (f.name, docstring)
 
-        property_definitions = ''.join(('{\n'
-                                        f'"{p.python_name}",\n'
-                                        f'(getter) {p.getter.name},\n'
-                                        f'(setter) {p.setter.name},\n'
-                                        f'{self._print(p.docstring)},\n'
-                                        'NULL\n'
-                                        '},\n') for p in expr.properties)
+        property_definitions = ''.join(''.join(('{\n',
+                                        f'"{p.python_name}",\n',
+                                        f'(getter) {p.getter.name},\n',
+                                        f'(setter) {p.setter.name},\n' if p.setter else '',
+                                        f'{self._print(p.docstring)},\n',
+                                        'NULL\n',
+                                        '},\n')) for p in expr.properties)
         property_definitions += '{ NULL }\n'
 
         method_def_funcs = ''.join(('{\n'

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -420,7 +420,7 @@ class CWrapperCodePrinter(CCodePrinter):
         property_definitions = ''.join(''.join(('{\n',
                                         f'"{p.python_name}",\n',
                                         f'(getter) {p.getter.name},\n',
-                                        f'(setter) {p.setter.name},\n' if p.setter else '',
+                                        f'(setter) {p.setter.name},\n' if p.setter else '(setter) NULL,\n',
                                         f'{self._print(p.docstring)},\n',
                                         'NULL\n',
                                         '},\n')) for p in expr.properties)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3735,7 +3735,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_BindCClassDef(self, expr):
         funcs = [expr.new_func, *expr.methods, *[f for i in expr.interfaces for f in i.functions],
-                 *[a.getter for a in expr.attributes], *[a.setter for a in expr.attributes]]
+                 *[a.getter for a in expr.attributes], *[a.setter for a in expr.attributes if a.setter]]
         sep = f'\n{self._print(SeparatorComment(40))}\n'
         return '', sep.join(self._print(f) for f in funcs)
 

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1213,7 +1213,6 @@ class CToPythonWrapper(Wrapper):
         -------
         PyModule
             The module which can be called from Python.
-
         """
         pymod = self._wrap_Module(expr)
 

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1477,8 +1477,8 @@ class CToPythonWrapper(Wrapper):
         if 'property' in original_func.decorators:
             python_name = original_func.scope.get_python_name(original_func.name)
             docstring = LiteralString(
-                            '\n'.join(original_func.docstring.comments) or
-                            f"The attribute {python_name}")
+                            '\n'.join(original_func.docstring.comments)
+                            if original_func.docstring else f"The attribute {python_name}")
             return PyGetSetDefElement(python_name, function, None, docstring)
         else:
             return function

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1894,8 +1894,10 @@ class CToPythonWrapper(Wrapper):
 
         self._error_exit_code = Nil()
 
-        return PyGetSetDefElement(expr.python_name, getter, setter,
-                                LiteralString(f"The attribute {expr.python_name}"))
+        docstring = LiteralString(
+                        '\n'.join(expr.docstring.comments)
+                        if expr.docstring else f"The attribute {expr.python_name}")
+        return PyGetSetDefElement(expr.python_name, getter, setter, docstring)
 
     def _wrap_ClassDef(self, expr):
         """

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -638,7 +638,7 @@ class FortranToCWrapper(Wrapper):
                     symbol=expr)
 
         properties_getters = [BindCClassProperty(expr.scope.get_python_name(m.original_function.name),
-                                                 m, None, expr.class_type)
+                                                 m, None, expr.class_type, m.original_function.docstring)
                                 for m in methods if 'property' in m.original_function.decorators]
         methods = [m for m in methods if m not in properties_getters
                         if 'property' not in m.original_function.decorators]

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -637,10 +637,16 @@ class FortranToCWrapper(Wrapper):
                     severity='warning',
                     symbol=expr)
 
+        properties_getters = [BindCClassProperty(expr.scope.get_python_name(m.original_function.name),
+                                                 m, None, expr.class_type)
+                                for m in methods if 'property' in m.original_function.decorators]
+        methods = [m for m in methods if m not in properties_getters
+                        if 'property' not in m.original_function.decorators]
+
         # Pseudo-self variable is useful for pre-defined attributes which are not DottedVariables
         pseudo_self = Variable(expr.class_type, 'self', cls_base = expr)
         properties = [self._wrap(v if isinstance(v, DottedVariable) else v.clone(v.name, new_class = DottedVariable, lhs=pseudo_self)) \
                         for v in expr.attributes if not v.is_private and not isinstance(v.class_type, TupleType)]
         return BindCClassDef(expr, new_func = new_method, methods = methods,
-                             interfaces = interfaces, attributes = properties,
+                             interfaces = interfaces, attributes = properties_getters + properties,
                              docstring = expr.docstring, class_type = expr.class_type)

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -289,6 +289,8 @@ pgfortran_info.update(python_info)
 nvc_info.update(python_info)
 nvfort_info.update(python_info)
 
+gcc_info['python']['flags'].append('-Wno-incompatible-pointer-types')
+
 available_compilers = {('GNU', 'c') : gcc_info,
                        ('GNU', 'fortran') : gfort_info,
                        ('intel', 'c') : icc_info,

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -290,6 +290,7 @@ nvc_info.update(python_info)
 nvfort_info.update(python_info)
 
 gcc_info['python']['flags'].append('-Wno-incompatible-pointer-types')
+gcc_info['python']['flags'].append('-Wno-discarded-qualifiers')
 
 available_compilers = {('GNU', 'c') : gcc_info,
                        ('GNU', 'fortran') : gfort_info,

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -290,7 +290,6 @@ nvc_info.update(python_info)
 nvfort_info.update(python_info)
 
 gcc_info['python']['flags'].append('-Wno-incompatible-pointer-types')
-gcc_info['python']['flags'].append('-Wno-discarded-qualifiers')
 
 available_compilers = {('GNU', 'c') : gcc_info,
                        ('GNU', 'fortran') : gfort_info,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4026,7 +4026,7 @@ class SemanticParser(BasicParser):
         if cls_name:
             bound_class = self.scope.find(cls_name, 'classes', raise_if_missing = True)
 
-        not_used = [d for d in decorators if d not in def_decorators.__all__]
+        not_used = [d for d in decorators if d not in (*def_decorators.__all__, 'property')]
         if len(not_used) >= 1:
             errors.report(UNUSED_DECORATORS, symbol=', '.join(not_used), severity='warning')
 

--- a/tests/epyccel/classes/classes_5.py
+++ b/tests/epyccel/classes/classes_5.py
@@ -1,0 +1,21 @@
+# pylint: disable=missing-class-docstring, missing-function-docstring, missing-module-docstring
+# coding: utf-8
+
+class Point(object):
+    def __init__(self, x : 'float[:]'):
+        self._X = 10
+        self._x = x
+
+    def __del__(self):
+        pass
+
+    def translate(self, a : 'float[:]'):
+        self._x[:]   =  self._x + a
+
+    @property
+    def x(self):
+        return self._x
+
+    @property
+    def X(self):
+        return self._X

--- a/tests/epyccel/test_docstrings.py
+++ b/tests/epyccel/test_docstrings.py
@@ -63,6 +63,9 @@ def test_class_docstring(language):
 
 def test_property_docstring(language):
     class A:
+        """
+        Class containing x
+        """
         def __init__(self : 'A', x : int):
             self._x = x
 
@@ -75,5 +78,7 @@ def test_property_docstring(language):
 
     B = epyccel(A, language=language)
 
+    python_doc, pyccel_doc = pad_docstrings(A.__doc__, B.__doc__)
+    assert python_doc == pyccel_doc
     python_doc, pyccel_doc = pad_docstrings(A.x.__doc__, B.x.__doc__)
     assert python_doc == pyccel_doc

--- a/tests/epyccel/test_docstrings.py
+++ b/tests/epyccel/test_docstrings.py
@@ -60,3 +60,20 @@ def test_class_docstring(language):
 
     python_doc, pyccel_doc = pad_docstrings(A.__doc__, B.__doc__)
     assert python_doc == pyccel_doc
+
+def test_property_docstring(language):
+    class A:
+        def __init__(self : 'A', x : int):
+            self._x = x
+
+        @property
+        def x(self):
+            """
+            This is a property it cannot be set.
+            """
+            return self._x
+
+    B = epyccel(A, language=language)
+
+    python_doc, pyccel_doc = pad_docstrings(A.x.__doc__, B.x.__doc__)
+    assert python_doc == pyccel_doc

--- a/tests/epyccel/test_docstrings.py
+++ b/tests/epyccel/test_docstrings.py
@@ -62,11 +62,11 @@ def test_class_docstring(language):
     assert python_doc == pyccel_doc
 
 def test_property_docstring(language):
-    class A:
+    class MyA:
         """
         Class containing x
         """
-        def __init__(self : 'A', x : int):
+        def __init__(self : 'MyA', x : int):
             self._x = x
 
         @property
@@ -76,9 +76,11 @@ def test_property_docstring(language):
             """
             return self._x
 
-    B = epyccel(A, language=language)
+    B = epyccel(MyA, language=language)
 
-    python_doc, pyccel_doc = pad_docstrings(A.__doc__, B.__doc__)
+    print(MyA.__doc__, B.__doc__)
+
+    python_doc, pyccel_doc = pad_docstrings(MyA.__doc__, B.__doc__)
     assert python_doc == pyccel_doc
-    python_doc, pyccel_doc = pad_docstrings(A.x.__doc__, B.x.__doc__)
+    python_doc, pyccel_doc = pad_docstrings(MyA.x.__doc__, B.x.__doc__)
     assert python_doc == pyccel_doc

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -172,6 +172,28 @@ def test_classes_4(language):
 
     p1_py = mod.Point()
 
+def test_classes_5(language):
+    import classes.classes_5 as mod
+    modnew = epyccel(mod, language = language)
+
+    x1 = np.array([0.,0.,0.])
+    x2 = np.array([0.,0.,0.])
+    a = np.array([1.,1.,1.])
+
+    p1_py = mod.Point(x1)
+    p1_l  = modnew.Point(x2)
+
+    assert np.allclose(p1_py.x, p1_l.x, rtol=RTOL, atol=ATOL)
+
+    p1_py.translate(a)
+    p1_l.translate(a)
+
+    assert np.allclose(p1_py.x, p1_l.x, rtol=RTOL, atol=ATOL)
+    assert np.allclose(x1, x2, rtol=RTOL, atol=ATOL)
+
+    with pytest.raises(AttributeError):
+        p1_l.x = 4.0
+
 def test_classes_6(language):
     import classes.classes_6 as mod
     modnew = epyccel(mod, language = language)


### PR DESCRIPTION
The semantic handling and the printing of methods using the `@property` decorator was already working, however official support for the decorator was missing due to the missing wrapper support. This PR adds the wrapping and removes the warning about this decorator. Fixes #1834 

**Commit Summary**
- Add documentation
- Prefer assertions for errors that only affect developers
- Allow the setter of a property to be missing (it is then saved as `None`)
- Add wrapping of a class property. The arguments of such functions are slightly different to those of a basic function.
- Add `-Wno-incompatible-pointer-types` to Python flags to remove unavoidable warnings
- Add tests