### PR TITLE
Fix wrong type of Variable shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ All notable changes to this project will be documented in this file.
 -   #2078 : Fix translation of classes containing comments.
 -   #2041 : Include all type extension methods by default.
 -   #2082 : Allow the use of a list comprehension to initialise an array.
+-   #2094 : Fix slicing of array allocated in an if block.
 
 ### Changed
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -245,7 +245,7 @@ class Variable(TypedAstNode):
         Indicate that the exact shape is unknown, e.g. if the allocate is done in
         an If block.
         """
-        self._shape = [PyccelArrayShapeElement(self, LiteralInteger(i)) for i in range(self.rank)]
+        self._shape = tuple(PyccelArrayShapeElement(self, LiteralInteger(i)) for i in range(self.rank))
 
     def set_init_shape(self, shape):
         """

--- a/tests/epyccel/test_arrays_multiple_assignments.py
+++ b/tests/epyccel/test_arrays_multiple_assignments.py
@@ -168,6 +168,26 @@ def test_creation_in_if_heap(language):
     assert f(c) == g(c)
 
 #==============================================================================
+def test_creation_in_if_heap_shape(language):
+
+    def f(c : 'float'):
+        import numpy as np
+        if c > 0.5:
+            x = np.ones(2, dtype=int)
+        else:
+            x = np.ones(7, dtype=int)
+
+        y = x[1:-1]
+        return y.sum()
+
+    g = epyccel(f, language=language)
+
+    # Check result of pyccelized function
+    import numpy as np
+    c = np.random.random()
+    assert f(c) == g(c)
+
+#==============================================================================
 def test_Reassign_to_Target():
 
     def f():


### PR DESCRIPTION
Fix the type of the shape of a Variable following a call to `set_changeable_shape`. Fixes #2094 