### PR TITLE
Change the order of the arguments of `FunctionDef`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Stop using ndarrays as an intermediate step to return arrays from Fortran code.
 -   \[INTERNALS\] Unify the strategy for handling additional imports in the printing stage for different languages.
 -   \[INTERNALS\] Make `Iterable` into a super-class instead of a storage class.
+-   \[INTERNALS\] Change the order of the constructor arguments of `FunctionDef`.
 
 ### Deprecated
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2162,7 +2162,7 @@ class FunctionDef(ScopedAstNode):
         name,
         arguments,
         body,
-        results = None,
+        results = (),
         *,
         global_vars=(),
         cls_name=None,
@@ -2215,8 +2215,6 @@ class FunctionDef(ScopedAstNode):
         assert not any(isinstance(b, FunctionDefResult) for b in body.body)
 
         # results
-        if results is None:
-            results = ()
         assert iterable(results) and all(isinstance(r, FunctionDefResult) for r in results)
 
         if cls_name:

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2212,7 +2212,6 @@ class FunctionDef(ScopedAstNode):
         if iterable(body):
             body = CodeBlock(body)
         assert isinstance(body,CodeBlock)
-        assert not any(isinstance(b, FunctionDefResult) for b in body.body)
 
         # results
         assert iterable(results) and all(isinstance(r, FunctionDefResult) for r in results)

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2047,11 +2047,11 @@ class FunctionDef(ScopedAstNode):
     arguments : iterable of FunctionDefArgument
         The arguments to the function.
 
-    results : iterable
-        The direct outputs of the function.
-
     body : iterable
         The body of the function.
+
+    results : iterable
+        The direct outputs of the function.
 
     global_vars : list of Symbols
         Variables which will not be passed into the function.
@@ -2161,8 +2161,9 @@ class FunctionDef(ScopedAstNode):
         self,
         name,
         arguments,
-        results,
         body,
+        results = None,
+        *,
         global_vars=(),
         cls_name=None,
         is_static=False,
@@ -2210,15 +2211,13 @@ class FunctionDef(ScopedAstNode):
 
         if iterable(body):
             body = CodeBlock(body)
-        elif not isinstance(body,CodeBlock):
-            raise TypeError('body must be an iterable or a CodeBlock')
+        assert isinstance(body,CodeBlock)
+        assert not any(isinstance(b, FunctionDefResult) for b in body.body)
 
         # results
-
-        if not iterable(results):
-            raise TypeError('results must be an iterable')
-        if not all(isinstance(r, FunctionDefResult) for r in results):
-            raise TypeError('results must be all be FunctionDefResults')
+        if results is None:
+            results = ()
+        assert iterable(results) and all(isinstance(r, FunctionDefResult) for r in results)
 
         if cls_name:
 
@@ -2527,28 +2526,28 @@ class FunctionDef(ScopedAstNode):
         args = (
         self._name,
         self._arguments,
-        self._results,
         self._body)
 
         kwargs = {
-        'global_vars':self._global_vars,
-        'cls_name':self._cls_name,
-        'is_static':self._is_static,
-        'imports':self._imports,
-        'decorators':self._decorators,
-        'headers':self._headers,
-        'is_recursive':self._is_recursive,
-        'is_pure':self._is_pure,
-        'is_elemental':self._is_elemental,
-        'is_private':self._is_private,
-        'is_header':self._is_header,
-        'functions':self._functions,
-        'is_external':self._is_external,
-        'is_imported':self._is_imported,
-        'is_semantic':self._is_semantic,
-        'interfaces':self._interfaces,
-        'docstring':self._docstring,
-        'scope':self._scope}
+            'results':self._results,
+            'global_vars':self._global_vars,
+            'cls_name':self._cls_name,
+            'is_static':self._is_static,
+            'imports':self._imports,
+            'decorators':self._decorators,
+            'headers':self._headers,
+            'is_recursive':self._is_recursive,
+            'is_pure':self._is_pure,
+            'is_elemental':self._is_elemental,
+            'is_private':self._is_private,
+            'is_header':self._is_header,
+            'functions':self._functions,
+            'is_external':self._is_external,
+            'is_imported':self._is_imported,
+            'is_semantic':self._is_semantic,
+            'interfaces':self._interfaces,
+            'docstring':self._docstring,
+            'scope':self._scope}
         return args, kwargs
 
     def __reduce_ex__(self, i):
@@ -3076,7 +3075,7 @@ class FunctionAddress(FunctionDef):
         memory_handling='stack',
         **kwargs
         ):
-        super().__init__(name, arguments, results, body=[], scope=None, **kwargs)
+        super().__init__(name, arguments, body=[], results=results, scope=None, **kwargs)
         if not isinstance(is_argument, bool):
             raise TypeError('Expecting a boolean for is_argument')
 

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -915,7 +915,7 @@ class PyModInitFunc(FunctionDef):
 
     def __init__(self, name, body, static_vars, scope):
         self._static_vars = static_vars
-        super().__init__(name, (), (), body, scope=scope)
+        super().__init__(name, (), body, scope=scope)
 
     @property
     def declarations(self):

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -510,8 +510,8 @@ class PyModule(Module):
         self._external_funcs = external_funcs
         self._declarations = declarations
         if import_func is None:
-            self._import_func = FunctionDef(f'{name}_import', (),
-                            (FunctionDefResult(Variable(CNativeInt(), '_', is_temp=True)),), ())
+            self._import_func = FunctionDef(f'{name}_import', (), (),
+                            (FunctionDefResult(Variable(CNativeInt(), '_', is_temp=True)),))
         else:
             self._import_func = import_func
         super().__init__(name, *args, init_func = init_func, **kwargs)

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 import pyccel.decorators as pyccel_decorators
 from pyccel.errors.errors import Errors, PyccelError
 
-from .core          import (AsName, Import, FunctionDef, FunctionCall,
+from .core          import (AsName, Import, FunctionCall,
                             Allocate, Duplicate, Assign, For, CodeBlock,
                             Concatenate, Module, PyccelFunctionDef)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -562,7 +562,8 @@ class FCodePrinter(CodePrinter):
                 imports_and_macros.append(complex_tool_import)
                 compare_func = FunctionDef('complex_comparison',
                                            [FunctionDefArgument(tmpVar_x), FunctionDefArgument(tmpVar_y)],
-                                           [FunctionDefResult(Variable(PythonNativeBool(), 'c'))], [])
+                                           [],
+                                           [FunctionDefResult(Variable(PythonNativeBool(), 'c'))])
                 lt_def = compare_func(tmpVar_x, tmpVar_y)
             else:
                 lt_def = PyccelAssociativeParenthesis(PyccelLt(tmpVar_x, tmpVar_y))

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -455,8 +455,8 @@ class CToPythonWrapper(Wrapper):
                         "which indicates which function should be called.")
 
         # Build the function
-        func = FunctionDef(name, [FunctionDefArgument(a) for a in args], [FunctionDefResult(type_indicator)],
-                            body, docstring=docstring, scope=func_scope)
+        func = FunctionDef(name, [FunctionDefArgument(a) for a in args], body,
+                            [FunctionDefResult(type_indicator)], docstring=docstring, scope=func_scope)
 
         return func, argument_type_flags
 

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -787,7 +787,7 @@ class CToPythonWrapper(Wrapper):
         result = func_scope.get_temporary_variable(CNativeInt())
         self.exit_scope()
         self._error_exit_code = Nil()
-        import_func = FunctionDef(func_name, (), (FunctionDefResult(result),), body, is_static=True, scope = func_scope)
+        import_func = FunctionDef(func_name, (), body, (FunctionDefResult(result),), is_static=True, scope = func_scope)
 
         return API_var, import_func
 
@@ -883,8 +883,8 @@ class CToPythonWrapper(Wrapper):
 
         self.exit_scope()
 
-        return PyFunctionDef(func_name, func_args, func_results,
-                             body, scope=func_scope, original_function = None)
+        return PyFunctionDef(func_name, func_args, body, func_results,
+                             scope=func_scope, original_function = None)
 
     def _get_class_initialiser(self, init_function, cls_dtype):
         """
@@ -980,7 +980,7 @@ class CToPythonWrapper(Wrapper):
             if not a.bound_argument:
                 self._python_object_map.pop(a)
 
-        function = PyFunctionDef(func_name, func_args, func_results, body, scope=func_scope,
+        function = PyFunctionDef(func_name, func_args, body, func_results, scope=func_scope,
                 docstring = init_function.docstring, original_function = original_func)
 
         self.scope.functions[func_name] = function
@@ -1046,7 +1046,7 @@ class CToPythonWrapper(Wrapper):
 
         self.exit_scope()
 
-        function = PyFunctionDef(func_name, [FunctionDefArgument(func_arg)], [], body, scope=func_scope,
+        function = PyFunctionDef(func_name, [FunctionDefArgument(func_arg)], body, [], scope=func_scope,
                 original_function = original_func)
 
         self.scope.functions[func_name] = function
@@ -1225,24 +1225,24 @@ class CToPythonWrapper(Wrapper):
         # Add external functions for functions wrapping array variables
         for v in expr.variable_wrappers:
             f = v.wrapper_function
-            external_funcs.append(FunctionDef(f.name, f.arguments, f.results, [], is_header = True, scope = Scope()))
+            external_funcs.append(FunctionDef(f.name, f.arguments, [], f.results, is_header = True, scope = Scope()))
 
         # Add external functions for normal functions
         for f in expr.funcs:
-            external_funcs.append(FunctionDef(f.name.lower(), f.arguments, f.results, [], is_header = True, scope = Scope()))
+            external_funcs.append(FunctionDef(f.name.lower(), f.arguments, [], f.results, is_header = True, scope = Scope()))
 
         for c in expr.classes:
             m = c.new_func
-            external_funcs.append(FunctionDef(m.name, m.arguments, m.results, [], is_header = True, scope = Scope()))
+            external_funcs.append(FunctionDef(m.name, m.arguments, [], m.results, is_header = True, scope = Scope()))
             for m in c.methods:
-                external_funcs.append(FunctionDef(m.name, m.arguments, m.results, [], is_header = True, scope = Scope()))
+                external_funcs.append(FunctionDef(m.name, m.arguments, [], m.results, is_header = True, scope = Scope()))
             for i in c.interfaces:
                 for f in i.functions:
-                    external_funcs.append(FunctionDef(f.name, f.arguments, f.results, [], is_header = True, scope = Scope()))
+                    external_funcs.append(FunctionDef(f.name, f.arguments, [], f.results, is_header = True, scope = Scope()))
             for a in c.attributes:
                 for f in (a.getter, a.setter):
                     if f:
-                        external_funcs.append(FunctionDef(f.name, f.arguments, f.results, [], is_header = True, scope = Scope()))
+                        external_funcs.append(FunctionDef(f.name, f.arguments, [], f.results, is_header = True, scope = Scope()))
         pymod.external_funcs = external_funcs
 
         return pymod
@@ -1326,8 +1326,8 @@ class CToPythonWrapper(Wrapper):
 
         interface_func = FunctionDef(func_name,
                                      [FunctionDefArgument(a) for a in func_args],
-                                     [FunctionDefResult(self.get_new_PyObject("result", is_temp=True))],
                                      body,
+                                     [FunctionDefResult(self.get_new_PyObject("result", is_temp=True))],
                                      scope=func_scope)
         for a in python_args:
             self._python_object_map.pop(a)
@@ -1467,7 +1467,7 @@ class CToPythonWrapper(Wrapper):
             if not a.bound_argument:
                 self._python_object_map.pop(a)
 
-        function = PyFunctionDef(func_name, func_args, func_results, body, scope=func_scope,
+        function = PyFunctionDef(func_name, func_args, body, func_results, scope=func_scope,
                 docstring = expr.docstring, original_function = original_func)
 
         self.scope.functions[func_name] = function
@@ -1712,7 +1712,7 @@ class CToPythonWrapper(Wrapper):
         self.exit_scope()
 
         args = [FunctionDefArgument(a) for a in getter_args]
-        getter = PyFunctionDef(getter_name, args, (FunctionDefResult(getter_result),), getter_body,
+        getter = PyFunctionDef(getter_name, args, getter_body, (FunctionDefResult(getter_result),),
                                 original_function = expr, scope = getter_scope)
 
         # ----------------------------------------------------------------------------------
@@ -1760,7 +1760,7 @@ class CToPythonWrapper(Wrapper):
         self.exit_scope()
 
         args = [FunctionDefArgument(a) for a in setter_args]
-        setter = PyFunctionDef(setter_name, args, setter_result, setter_body,
+        setter = PyFunctionDef(setter_name, args, setter_body, setter_result,
                                 original_function = expr, scope = setter_scope)
         self._error_exit_code = Nil()
         self._python_object_map.pop(new_set_val_arg)
@@ -1840,7 +1840,7 @@ class CToPythonWrapper(Wrapper):
         self.exit_scope()
 
         args = [FunctionDefArgument(a) for a in getter_args]
-        getter = PyFunctionDef(getter_name, args, (FunctionDefResult(getter_result),), getter_body,
+        getter = PyFunctionDef(getter_name, args, getter_body, (FunctionDefResult(getter_result),),
                                 original_function = expr.getter, scope = getter_scope)
 
         # ----------------------------------------------------------------------------------
@@ -1886,7 +1886,7 @@ class CToPythonWrapper(Wrapper):
             self.exit_scope()
 
             args = [FunctionDefArgument(a) for a in setter_args]
-            setter = PyFunctionDef(setter_name, args, setter_result, setter_body,
+            setter = PyFunctionDef(setter_name, args, setter_body, setter_result,
                                     original_function = expr, scope = setter_scope)
         else:
             setter = None

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1046,7 +1046,7 @@ class CToPythonWrapper(Wrapper):
 
         self.exit_scope()
 
-        function = PyFunctionDef(func_name, [FunctionDefArgument(func_arg)], body, [], scope=func_scope,
+        function = PyFunctionDef(func_name, [FunctionDefArgument(func_arg)], body, scope=func_scope,
                 original_function = original_func)
 
         self.scope.functions[func_name] = function

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -277,7 +277,7 @@ class FortranToCWrapper(Wrapper):
 
         self.exit_scope()
 
-        func = BindCFunctionDef(name, func_arguments, func_results, body, scope=func_scope, original_function = expr,
+        func = BindCFunctionDef(name, func_arguments, body, func_results, scope=func_scope, original_function = expr,
                 docstring = expr.docstring, result_pointer_map = expr.result_pointer_map)
 
         self.scope.functions[name] = func
@@ -541,7 +541,7 @@ class FortranToCWrapper(Wrapper):
         self._additional_exprs.clear()
         self.exit_scope()
 
-        getter = BindCFunctionDef(getter_name, (getter_arg,), (getter_result,), getter_body,
+        getter = BindCFunctionDef(getter_name, (getter_arg,), getter_body, (getter_result,),
                                 original_function = expr, scope = getter_scope)
 
         # ----------------------------------------------------------------------------------
@@ -579,7 +579,7 @@ class FortranToCWrapper(Wrapper):
             setter_body.append(Assign(attrib, set_val))
         self.exit_scope()
 
-        setter = BindCFunctionDef(setter_name, setter_args, (), setter_body,
+        setter = BindCFunctionDef(setter_name, setter_args, setter_body,
                                 original_function = expr, scope = setter_scope)
         return BindCClassProperty(lhs.cls_base.scope.get_python_name(expr.name),
                                   getter, setter, lhs.dtype)
@@ -623,7 +623,7 @@ class FortranToCWrapper(Wrapper):
         c_loc = CLocFunc(local_var, bind_var)
         body = [alloc, c_loc]
 
-        new_method = BindCFunctionDef(func_name, [], [result], body, original_function = None, scope = func_scope)
+        new_method = BindCFunctionDef(func_name, [], body, [result], original_function = None, scope = func_scope)
 
         methods = [self._wrap(m) for m in expr.methods]
         methods = [m for m in methods if not isinstance(m, EmptyNode)]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2392,7 +2392,7 @@ class SemanticParser(BasicParser):
             init_func_body = If(IfSection(PyccelNot(init_var),
                                 init_func_body+[Assign(init_var, LiteralTrue())]))
 
-            init_func = FunctionDef(init_func_name, [], [], [init_func_body],
+            init_func = FunctionDef(init_func_name, [], [init_func_body],
                     global_vars = variables, scope=init_scope)
             self.insert_function(init_func)
 
@@ -2416,7 +2416,7 @@ class SemanticParser(BasicParser):
                     import_free_calls+deallocs+[Assign(init_var, LiteralFalse())]))
                 # Ensure that the function is correctly defined within the namespaces
                 scope = self.create_new_function_scope(free_func_name)
-                free_func = FunctionDef(free_func_name, [], [], [free_func_body],
+                free_func = FunctionDef(free_func_name, [], [free_func_body],
                                     global_vars = variables, scope = scope)
                 self.exit_function_scope()
                 self.insert_function(free_func)
@@ -2456,7 +2456,7 @@ class SemanticParser(BasicParser):
 
                             args = [FunctionDefArgument(a) for a in args]
                             results = [FunctionDefResult(r) for r in results]
-                            func_defs.append(FunctionDef(v.name, args, results, [], is_external = is_external, is_header = True))
+                            func_defs.append(FunctionDef(v.name, args, [], results, is_external = is_external, is_header = True))
 
                         if len(func_defs) == 1:
                             F = func_defs[0]
@@ -4224,7 +4224,7 @@ class SemanticParser(BasicParser):
             # insert the FunctionDef into the scope
             # to handle the case of a recursive function
             # TODO improve in the case of an interface
-            recursive_func_obj = FunctionDef(name, arguments, results, [])
+            recursive_func_obj = FunctionDef(name, arguments, [], results)
             self.insert_function(recursive_func_obj)
 
             # Create a new list that store local variables for each FunctionDef to handle nested functions
@@ -4352,8 +4352,8 @@ class SemanticParser(BasicParser):
                 cls = FunctionDef
             func = cls(name,
                     arguments,
-                    results,
                     body,
+                    results,
                     **func_kwargs)
             if not is_recursive:
                 recursive_func_obj.invalidate_node()
@@ -4477,7 +4477,7 @@ class SemanticParser(BasicParser):
             argument = FunctionDefArgument(Variable(dtype, 'self', cls_base = cls), bound_argument = True)
             self.scope.insert_symbol('__init__')
             scope = self.create_new_function_scope('__init__')
-            init_func = FunctionDef('__init__', [argument], (), [], cls_name=cls.name, scope=scope)
+            init_func = FunctionDef('__init__', [argument], (), cls_name=cls.name, scope=scope)
             self.exit_function_scope()
             self.insert_function(init_func)
             cls.add_new_method(init_func)
@@ -4507,7 +4507,7 @@ class SemanticParser(BasicParser):
             argument = FunctionDefArgument(Variable(dtype, 'self', cls_base = cls), bound_argument = True)
             self.scope.insert_symbol('__del__')
             scope = self.create_new_function_scope('__del__')
-            del_method = FunctionDef('__del__', [argument], (), [Pass()], scope=scope)
+            del_method = FunctionDef('__del__', [argument], [Pass()], scope=scope)
             self.exit_function_scope()
             self.insert_function(del_method)
             cls.add_new_method(del_method)
@@ -4791,7 +4791,7 @@ class SemanticParser(BasicParser):
 
                 arguments = [FunctionDefArgument(self._visit(a)[0]) for a in syntactic_args]
                 results = [FunctionDefResult(self._visit(r)[0]) for r in syntactic_results]
-                interfaces.append(FunctionDef(f_name, arguments, results, []))
+                interfaces.append(FunctionDef(f_name, arguments, [], results))
 
             # TODO -> Said: must handle interface
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1007,8 +1007,8 @@ class SyntaxParser(BasicParser):
         func = cls(
                name,
                arguments,
-               results,
                body,
+               results,
                is_pure=is_pure,
                is_elemental=is_elemental,
                is_private=is_private,


### PR DESCRIPTION
In order to fix #337 the handling of function results must be changed. Specifically, the handling of the case where nothing is returned is non-trivial. It is therefore better to handle this with a default value, however adding a default value requires the order of the arguments of the `FunctionDef` class to be changed. This PR makes that change in preparation