### PR TITLE
Fix type hinting bug for renamed class attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ All notable changes to this project will be documented in this file.
 -   #2082 : Allow the use of a list comprehension to initialise an array.
 -   #2094 : Fix slicing of array allocated in an if block.
 -   #2085 : Fix calling class methods before they are defined.
+-   #2111 : Fix declaration of class attributes with name conflicts using type annotations.
 
 ### Changed
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3279,10 +3279,11 @@ class SemanticParser(BasicParser):
                 cls_def = semantic_lhs_var.lhs.cls_base
                 insert_scope = cls_def.scope
                 cls_def.add_new_attribute(semantic_lhs_var)
+                lhs = lhs.name.name[-1]
             else:
                 insert_scope = self.scope
+                lhs = lhs.name
 
-            lhs = lhs.name
             if semantic_lhs_var.class_type is TypeAlias():
                 if not isinstance(rhs, SyntacticTypeAnnotation):
                     pyccel_stage.set_stage('syntactic')
@@ -3293,7 +3294,7 @@ class SemanticParser(BasicParser):
                 return EmptyNode()
 
             try:
-                insert_scope.insert_variable(semantic_lhs_var)
+                insert_scope.insert_variable(semantic_lhs_var, lhs)
             except RuntimeError as e:
                 errors.report(e, symbol=expr, severity='error')
 

--- a/tests/epyccel/classes/classes_7.py
+++ b/tests/epyccel/classes/classes_7.py
@@ -2,7 +2,7 @@
 
 class A:
     def __init__(self : 'A', x : int):
-        self.data = x
+        self.data : int = x
 
     def update(self : 'A', x : int):
         self.data = x

--- a/tests/epyccel/classes/classes_7.py
+++ b/tests/epyccel/classes/classes_7.py
@@ -2,10 +2,10 @@
 
 class A:
     def __init__(self : 'A', x : int):
-        self.x = x
+        self.data = x
 
     def update(self : 'A', x : int):
-        self.x = x
+        self.data = x
 
 def get_A():
     return A(4)
@@ -15,15 +15,6 @@ def get_A_int():
 
 def get_x_from_A(a : 'A' = None):
     if a is not None:
-        return a.x
+        return a.data
     else:
         return 5
-
-if __name__ == '__main__':
-    print(get_A().x)
-    print(get_x_from_A())
-    print(get_x_from_A(get_A()))
-    x = get_A()
-    x.update(10)
-    print(get_x_from_A(x))
-    x, p = get_A_int()

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -210,6 +210,21 @@ def test_classes_6(language):
     assert p_py.get_attributes(3) == p_l.get_attributes(3)
     assert p_py.get_attributes(4.5) == p_l.get_attributes(4.5)
 
+def test_classes_7(language):
+    import classes.classes_7 as mod
+    modnew = epyccel(mod, language = language)
+
+    p_py = mod.get_A()
+    p_l  = modnew.get_A()
+
+    assert mod.get_x_from_A() == modnew.get_x_from_A()
+    assert mod.get_x_from_A(p_py) == modnew.get_x_from_A(p_l)
+
+    p_py.update(10)
+    p_l.update(10)
+
+    assert mod.get_x_from_A(p_py) == modnew.get_x_from_A(p_l)
+
 def test_classes_8(language):
     import classes.classes_8 as mod
     modnew = epyccel(mod, language = language)


### PR DESCRIPTION
Fix declaration of class attributes with name conflicts using type annotations. Fixes #2111 .
 The attribute created via the type annotation was not passing the original Python name to the scope which lead to it not being found later. As a result a second (unnecessary but identical) variable was created.