### PR TITLE
Add C and Fortran support for set.intersection and set.intersection_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 -   #1753 : Add support for set method `union()`.
 -   #1754 : Add support for set method `update()`.
 -   #1744 : Add support for set method `intersection()`.
+-   #1745 : Add support for set method `intersection_update()`.
 -   #1884 : Add support for dict method `items()`.
 -   #1936 : Add missing C output for inline decorator example in documentation
 -   #1937 : Optimise `pyccel.ast.basic.PyccelAstNode.substitute` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to this project will be documented in this file.
 -   #1918 : Add support for set method `copy()`.
 -   #1753 : Add support for set method `union()`.
 -   #1754 : Add support for set method `update()`.
--   #1744 : Add Python support for set method `intersection()`.
+-   #1744 : Add support for set method `intersection()`.
 -   #1884 : Add support for dict method `items()`.
 -   #1936 : Add missing C output for inline decorator example in documentation
 -   #1937 : Optimise `pyccel.ast.basic.PyccelAstNode.substitute` method.

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -102,8 +102,8 @@ Python contains a limited number of builtin functions defined [here](https://doc
 | `difference` | No |
 | `difference_update` | No |
 | `discard` | Python-only |
-| `intersection` | Python-only |
-| `intersection_update` | No |
+| `intersection` | **Yes** |
+| `intersection_update` | **Yes** |
 | `isdisjoint` | No |
 | `issubset` | No |
 | `issuperset` | No |

--- a/pyccel/ast/builtin_methods/set_methods.py
+++ b/pyccel/ast/builtin_methods/set_methods.py
@@ -254,15 +254,6 @@ class SetIntersection(SetMethod):
     __slots__ = ('_other','_class_type', '_shape')
     name = 'intersection'
 
-    def __init__(self, set_obj, *others):
-        self._class_type = set_obj.class_type
-        element_type = self._class_type.element_type
-        for o in others:
-            if element_type != o.class_type.element_type:
-                raise TypeError(f"Argument fo type {o.type_class} cannot be used to build set of type {self._class_type}")
-        self._shape = (None,)*self.rank
-        super().__init__(set_obj, *others)
-
 #==============================================================================
 
 class SetIntersectionUpdate(SetMethod):
@@ -285,4 +276,8 @@ class SetIntersectionUpdate(SetMethod):
     _shape = None
 
     def __init__(self, set_obj, *others):
+        class_type = set_obj.class_type
+        for o in others:
+            if class_type != o.class_type:
+                raise TypeError(f"Only arguments of type {class_type} are supported for the functions intersection and .intersection_update")
         super().__init__(set_obj, *others)

--- a/pyccel/ast/builtin_methods/set_methods.py
+++ b/pyccel/ast/builtin_methods/set_methods.py
@@ -262,3 +262,27 @@ class SetIntersection(SetMethod):
                 raise TypeError(f"Argument fo type {o.type_class} cannot be used to build set of type {self._class_type}")
         self._shape = (None,)*self.rank
         super().__init__(set_obj, *others)
+
+#==============================================================================
+
+class SetIntersectionUpdate(SetMethod):
+    """
+    Represents a call to the .intersection_update() method.
+
+    Represents a call to the set method .intersection_update(). This method combines
+    two sets by including all elements which appear in all of the sets.
+
+    Parameters
+    ----------
+    set_obj : TypedAstNode
+        The set object which the method is called from.
+    *others : TypedAstNode
+        The sets which will be combined with this set.
+    """
+    __slots__ = ()
+    name = 'intersection_update'
+    _class_type = VoidType()
+    _shape = None
+
+    def __init__(self, set_obj, *others):
+        super().__init__(set_obj, *others)

--- a/pyccel/ast/class_defs.py
+++ b/pyccel/ast/class_defs.py
@@ -7,7 +7,8 @@ This module contains all types which define a python class which is automaticall
 """
 
 from pyccel.ast.builtin_methods.set_methods  import (SetAdd, SetClear, SetCopy, SetPop,
-                                                     SetDiscard, SetUpdate, SetUnion, SetIntersection)
+                                                     SetDiscard, SetUpdate, SetUnion,
+                                                     SetIntersection, SetIntersectionUpdate)
 from pyccel.ast.builtin_methods.list_methods import (ListAppend, ListInsert, ListPop,
                                                      ListClear, ListExtend, ListRemove,
                                                      ListCopy, ListSort)
@@ -167,9 +168,11 @@ SetClass = ClassDef('set',
             PyccelFunctionDef('remove', func_class = SetDiscard),
             PyccelFunctionDef('union', func_class = SetUnion),
             PyccelFunctionDef('intersection', func_class = SetIntersection),
+            PyccelFunctionDef('intersection_update', func_class = SetIntersectionUpdate),
             PyccelFunctionDef('update', func_class = SetUpdate),
             PyccelFunctionDef('__or__', func_class = SetUnion),
             PyccelFunctionDef('__and__', func_class = SetIntersection),
+            PyccelFunctionDef('__iand__', func_class = SetIntersectionUpdate),
             PyccelFunctionDef('__ior__', func_class = SetUpdate),
         ])
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2793,8 +2793,8 @@ class CCodePrinter(CodePrinter):
         var_type = self.get_c_type(class_type)
         self.add_import(Import('Set_extensions', AsName(VariableTypeAnnotation(class_type), var_type)))
         set_var = self._print(ObjectAddress(expr.set_variable))
-        args = ', '.join(self._print(ObjectAddress(a)) for a in expr.args)
-        return f'{var_type}_intersection_update({set_var}, {args});\n'
+        return ''.join(f'{var_type}_intersection_update({set_var}, {self._print(ObjectAddress(a))});\n' \
+                for a in expr.args)
 
     #=================== MACROS ==================
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2787,6 +2787,15 @@ class CCodePrinter(CodePrinter):
         args = ', '.join([str(len(expr.args)), *(self._print(ObjectAddress(a)) for a in expr.args)])
         return f'{var_type}_union({set_var}, {args})'
 
+    def _print_SetIntersectionUpdate(self, expr):
+        assign_base = expr.get_direct_user_nodes(lambda n: isinstance(n, Assign))
+        class_type = expr.set_variable.class_type
+        var_type = self.get_c_type(class_type)
+        self.add_import(Import('Set_extensions', AsName(VariableTypeAnnotation(class_type), var_type)))
+        set_var = self._print(ObjectAddress(expr.set_variable))
+        args = ', '.join(self._print(ObjectAddress(a)) for a in expr.args)
+        return f'{var_type}_intersection_update({set_var}, {args});\n'
+
     #=================== MACROS ==================
 
     def _print_MacroShape(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1363,6 +1363,15 @@ class FCodePrinter(CodePrinter):
             self._additional_code += code
             return result
 
+    def _print_SetIntersectionUpdate(self, expr):
+        var = expr.set_variable
+        expr_type = var.class_type
+        var_code = self._print(expr.set_variable)
+        type_name = self._print(expr_type)
+        self.add_import(self._build_gFTL_extension_module(expr_type))
+        return ''.join(f'call {type_name}_intersection_update({var_code}, {self._print(arg)})\n' \
+                for arg in expr.args)
+
     #========================== Numpy Elements ===============================#
 
     def _print_NumpySum(self, expr):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5449,7 +5449,10 @@ class SemanticParser(BasicParser):
         body = []
         lhs = self._assign_lhs_variable(syntactic_lhs, d_var, rhs, body)
         body.append(Assign(lhs, rhs, python_ast = expr.python_ast))
-        body += [SetIntersectionUpdate(lhs, s) for s in set_args]
+        try:
+            body += [SetIntersectionUpdate(lhs, s) for s in set_args]
+        except TypeError as e:
+            errors.report(e, symbol=expr, severity='error')
         if assign:
             return CodeBlock(body)
         else:

--- a/pyccel/stdlib/STC_Extensions/Set_extensions.h
+++ b/pyccel/stdlib/STC_Extensions/Set_extensions.h
@@ -38,6 +38,24 @@ static inline i_type _c_MEMB(_union)(i_type* self, int n, ...) {
     return union_result;
 }
 
+/**
+ * This function represents a call to the .intersection_update() method.
+ * @param self : The set instance to modify.
+ * @param other : The other set in which elements must be found.
+ */
+static inline void _c_MEMB(_intersection_update)(i_type* self, i_type* other) {
+    _c_MEMB(_iter) itr = _c_MEMB(_begin)(self);
+    while (itr.ref)
+    {
+        i_key val = (*itr.ref);
+        if (_c_MEMB(_contains)(other, val)) {
+            _c_MEMB(_next)(&itr);
+        } else {
+            itr = _c_MEMB(_erase_at)(self, itr);
+        }
+    }
+}
+
 #undef i_type
 #undef i_key
 #include <stc/priv/template2.h>

--- a/pyccel/stdlib/gFTL_functions/Set_extensions.inc
+++ b/pyccel/stdlib/gFTL_functions/Set_extensions.inc
@@ -33,9 +33,10 @@ contains
     last = this%end()
     do while (iter /= last)
       if (other_set % count(iter%of()) == 0) then
-        call this%erase(iter)
+        iter = this%erase(iter)
+      else
+        call iter%next()
       end if
-      call iter%next()
     end do
 
   end subroutine __IDENTITY(Set)_intersection_update

--- a/pyccel/stdlib/gFTL_functions/Set_extensions.inc
+++ b/pyccel/stdlib/gFTL_functions/Set_extensions.inc
@@ -22,4 +22,22 @@ contains
   
   end function __IDENTITY(Set)_pop
 
+  subroutine __IDENTITY(Set)_intersection_update(this, other_set)
+    class(Set), intent(inout) :: this
+    class(Set), intent(in) :: other_set
+
+    type(SetIterator) :: iter
+    type(SetIterator) :: last
+
+    iter = this%begin()
+    last = this%end()
+    do while (iter /= last)
+      if (other_set % count(iter%of()) == 0) then
+        call this%erase(iter)
+      end if
+      call iter%next()
+    end do
+
+  end subroutine __IDENTITY(Set)_intersection_update
+
 #include <set/tail.inc>

--- a/tests/epyccel/test_epyccel_sets.py
+++ b/tests/epyccel/test_epyccel_sets.py
@@ -438,33 +438,33 @@ def test_set_union_2_args(language):
     assert python_result[0] == pyccel_result[0]
     assert set(python_result[1:]) == set(pyccel_result[1:])
 
-def test_set_intersection_int(python_only_language):
+def test_set_intersection_int(language):
     def intersection_int():
         a = {1,2,3}
         b = {2,3,4}
         c = a.intersection(b)
         return len(c), c.pop(), c.pop()
 
-    epyccel_func = epyccel(intersection_int, language = python_only_language)
+    epyccel_func = epyccel(intersection_int, language = language)
     pyccel_result = epyccel_func()
     python_result = intersection_int()
     assert python_result[0] == pyccel_result[0]
     assert set(python_result[1:]) == set(pyccel_result[1:])
 
-def test_set_intersection_no_args(python_only_language):
+def test_set_intersection_no_args(language):
     def intersection_int():
         a = {1,2,3,4}
         c = a.intersection()
         a.add(5)
         return len(c), c.pop(), c.pop(), c.pop(), c.pop()
 
-    epyccel_func = epyccel(intersection_int, language = python_only_language)
+    epyccel_func = epyccel(intersection_int, language = language)
     pyccel_result = epyccel_func()
     python_result = intersection_int()
     assert python_result[0] == pyccel_result[0]
     assert set(python_result[1:]) == set(pyccel_result[1:])
 
-def test_set_intersection_2_args(python_only_language):
+def test_set_intersection_2_args(language):
     def intersection_int():
         a = {1,2,3,4}
         b = {5,6,7,2,1,3}
@@ -472,7 +472,7 @@ def test_set_intersection_2_args(python_only_language):
         d = a.intersection(b, c)
         return len(d), d.pop(), d.pop(), d.pop()
 
-    epyccel_func = epyccel(intersection_int, language = python_only_language)
+    epyccel_func = epyccel(intersection_int, language = language)
     pyccel_result = epyccel_func()
     python_result = intersection_int()
     assert python_result[0] == pyccel_result[0]
@@ -538,52 +538,26 @@ def test_set_union_operator(language):
     assert python_result[0] == pyccel_result[0]
     assert set(python_result[1:]) == set(pyccel_result[1:])
 
-def test_temporary_set_intersection(python_only_language):
+def test_temporary_set_intersection(language):
     def intersection_int():
         a = {1,2}
         b = {2}
         d = a.intersection(b).pop()
         return d
 
-    epyccel_func = epyccel(intersection_int, language = python_only_language)
+    epyccel_func = epyccel(intersection_int, language = language)
     pyccel_result = epyccel_func()
     python_result = intersection_int()
     assert python_result == pyccel_result
 
-def test_set_intersection_list(python_only_language):
-    def intersection_list():
-        a = {1.2, 2.3, 5.0}
-        b = [1.2, 5.0, 4.0]
-        d = a.intersection(b)
-        return len(d), d.pop(), d.pop()
-
-    epyccel_func = epyccel(intersection_list, language = python_only_language)
-    pyccel_result = epyccel_func()
-    python_result = intersection_list()
-    assert python_result[0] == pyccel_result[0]
-    assert set(python_result[1:]) == set(pyccel_result[1:])
-
-def test_set_intersection_tuple(python_only_language):
-    def intersection_tuple():
-        a = {True}
-        b = (False, True)
-        d = a.intersection(b)
-        return len(d), d.pop()
-
-    epyccel_func = epyccel(intersection_tuple, language = python_only_language)
-    pyccel_result = epyccel_func()
-    python_result = intersection_tuple()
-    assert python_result[0] == pyccel_result[0]
-    assert set(python_result[1:]) == set(pyccel_result[1:])
-
-def test_set_intersection_operator(python_only_language):
+def test_set_intersection_operator(language):
     def intersection_int():
         a = {1,2,3,4,8}
         b = {5,2,3,7,8}
         c = a & b
         return len(c), c.pop(), c.pop(), c.pop()
 
-    epyccel_func = epyccel(intersection_int, language = python_only_language)
+    epyccel_func = epyccel(intersection_int, language = language)
     pyccel_result = epyccel_func()
     python_result = intersection_int()
     assert python_result[0] == pyccel_result[0]
@@ -613,14 +587,14 @@ def test_set_contains(language):
     python_result = union_int()
     assert python_result == pyccel_result
 
-def test_set_intersection_augoperator(python_only_language):
+def test_set_intersection_augoperator(language):
     def intersection_int():
         a = {1,2,3,4}
         b = {2,3,4}
         a &= b
         return len(a), a.pop(), a.pop(), a.pop()
 
-    epyccel_func = epyccel(intersection_int, language = python_only_language)
+    epyccel_func = epyccel(intersection_int, language = language)
     pyccel_result = epyccel_func()
     python_result = intersection_int()
     assert python_result[0] == pyccel_result[0]

--- a/tests/epyccel/test_epyccel_sets.py
+++ b/tests/epyccel/test_epyccel_sets.py
@@ -563,6 +563,33 @@ def test_set_intersection_operator(language):
     assert python_result[0] == pyccel_result[0]
     assert set(python_result[1:]) == set(pyccel_result[1:])
 
+def test_set_intersection_update(language):
+    def intersection_int():
+        a = {1,2,3,4,8}
+        b = {5,2,3,7,8}
+        a.intersection_update(b)
+        return len(a), a.pop(), a.pop(), a.pop()
+
+    epyccel_func = epyccel(intersection_int, language = language)
+    pyccel_result = epyccel_func()
+    python_result = intersection_int()
+    assert python_result[0] == pyccel_result[0]
+    assert set(python_result[1:]) == set(pyccel_result[1:])
+
+def test_set_intersection_multiple_update(language):
+    def intersection_int():
+        a = {1,2,3,4,8}
+        b = {5,2,3,7,8}
+        c = {10,2,20}
+        a.intersection_update(b, c)
+        return len(a), a.pop()
+
+    epyccel_func = epyccel(intersection_int, language = language)
+    pyccel_result = epyccel_func()
+    python_result = intersection_int()
+    assert python_result[0] == pyccel_result[0]
+    assert set(python_result[1:]) == set(pyccel_result[1:])
+
 def test_set_union_augoperator(language):
     def union_int():
         a = {1,2,3,4}


### PR DESCRIPTION
Add C and Fortran support for set methods `intersection` and `intersection_update`. Fixes #1745 
Map `set.intersection` to `set.copy` and `set.intersection_update`. Activate existing tests and add tests for `intersection_update`. Remove tests for `intersection` taking lists or tuples as arguments. This can be added back later if it is requested