### PR TITLE
Add wrapping support for arithmetic magic methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ All notable changes to this project will be documented in this file.
 -   #1583 : Allow inhomogeneous tuples in classes.
 -   #738 : Add support for homogeneous tuples with scalar elements as arguments.
 -   Add a warning about containers in lists.
--   #2016 : Add support for translating arithmetic magic methods (methods cannot yet be used from Python).
+-   #2016 : Add support for translating arithmetic magic methods.
 -   #1980 : Extend The C support for min and max to more than two variables
 -   #2081 : Add support for multi operator expressions
 -   #2061 : Add C support for string declarations.

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -2,6 +2,15 @@
 
 Pyccel strives to provide robust support for object-oriented programming concepts commonly used by developers. In Pyccel, classes are a fundamental building block for creating structured and reusable code. This documentation outlines key features and considerations when working with classes in Pyccel.
 
+## Contents
+
+1. [Constructor Method](#constructor-method)
+2. [Destructor Method](#destructor-method)
+3. [Class Methods](#class-methods)
+4. [Class Properties](#class-properties)
+5. [Magic Methods](#magic-methods)
+6. [Limitations](#limitations)
+
 ## Constructor Method
 
 -   The Constructor Method, `__init__`, is used to initialise the object's attributes.
@@ -188,7 +197,7 @@ MyClass Object created!
 ==158858== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
 ```
 
-## Class properties
+## Class Properties
 
 Pyccel now supports class properties (to retrieve a constant value only).
 
@@ -415,7 +424,7 @@ int main()
   call obj % free()
 ```
 
-## Magic methods
+## Magic Methods
 
 Pyccel supports a subset of magic methods that are listed here:
 

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -415,6 +415,42 @@ int main()
   call obj % free()
 ```
 
+## Magic methods
+
+Pyccel supports a subset of magic methods that are listed here:
+
+-   `__add__`
+-   `__sub__`
+-   `__mul__`
+-   `__truediv__`
+-   `__pow__`
+-   `__lshift__`
+-   `__rshift__`
+-   `__and__`
+-   `__or__`
+-   `__iadd__`
+-   `__isub__`
+-   `__imul__`
+-   `__itruediv__`
+-   `__ipow__`
+-   `__ilshift__`
+-   `__irshift__`
+-   `__iand__`
+-   `__ior__`
+
+Additionally the following methods are supported in the translation but are lacking the wrapper support that would allow them to be called from Python code:
+
+-   `__radd__`
+-   `__rsub__`
+-   `__rmul__`
+-   `__rtruediv__`
+-   `__rpow__`
+-   `__rlshift__`
+-   `__rrshift__`
+-   `__rand__`
+-   `__ror__`
+-   `__contains__`
+
 ## Limitations
 
-It's important to note that Pyccel does not support class inheritance, magic methods or static class variables. For our first implementation, the focus of Pyccel is primarily on core class functionality and memory management.
+It's important to note that Pyccel does not support class inheritance, or static class variables. For our first implementation, the focus of Pyccel is primarily on core class functionality and memory management.

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -13,7 +13,7 @@ from pyccel.utilities.stage   import PyccelStage
 
 from .basic     import PyccelAstNode, TypedAstNode, iterable, ScopedAstNode
 
-from .bitwise_operators import PyccelBitOr, PyccelBitAnd
+from .bitwise_operators import PyccelBitOr, PyccelBitAnd, PyccelLShift, PyccelRShift
 
 from .builtins  import PythonBool, PythonTuple
 
@@ -750,6 +750,8 @@ class AugAssign(Assign):
             '%' : PyccelMod,
             '|' : PyccelBitOr,
             '&' : PyccelBitAnd,
+            '<<': PyccelLShift,
+            '>>': PyccelRShift,
         }
 
     def __init__(

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -718,7 +718,8 @@ class PyClassDef(ClassDef):
         wrapped.
     """
     __slots__ = ('_original_class', '_struct_name', '_type_name', '_type_object',
-                 '_new_func', '_properties')
+                 '_new_func', '_properties', '_number_magic_methods')
+    _attribute_nodes = ClassDef._attribute_nodes + ('_number_magic_methods',)
 
     def __init__(self, original_class, struct_name, type_name, scope, **kwargs):
         self._original_class = original_class
@@ -727,6 +728,7 @@ class PyClassDef(ClassDef):
         self._type_object = Variable(PyccelPyClassType(), type_name)
         self._new_func = None
         self._properties = ()
+        self._number_magic_methods = ()
         variables = [Variable(VoidType(), 'instance', memory_handling='alias'),
                      Variable(PyccelPyObject(), 'referenced_objects', memory_handling='alias'),
                      Variable(PythonNativeBool(), 'is_alias')]
@@ -818,6 +820,33 @@ class PyClassDef(ClassDef):
         Get all wrapped class properties.
         """
         return self._properties
+
+    def add_new_magic_number_method(self, method):
+        """
+        Add a new magic number method to the current class.
+
+        Add a new magic method to the current ClassDef describing
+        a number method.
+
+        Parameters
+        ----------
+        method : FunctionDef
+            The Method that will be added.
+        """
+
+        if not isinstance(method, PyFunctionDef):
+            raise TypeError("Method must be FunctionDef")
+        method.set_current_user_node(self)
+        self._number_magic_methods += (method,)
+
+    @property
+    def number_magic_methods(self):
+        """
+        Get the magic methods describing number methods.
+
+        Get the magic methods describing number methods such as __add__.
+        """
+        return self._number_magic_methods
 
 #-------------------------------------------------------------------
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -21,6 +21,8 @@ from pyccel.ast.variable   import DottedName, Variable
 from pyccel.ast.utilities  import builtin_import_registry as pyccel_builtin_import_registry
 from pyccel.ast.utilities  import decorators_mod
 
+from pyccel.parser.semantic import magic_method_map
+
 from pyccel.codegen.printing.codeprinter import CodePrinter
 
 from pyccel.errors.errors import Errors
@@ -299,11 +301,12 @@ class PythonCodePrinter(CodePrinter):
 
         body = ''.join([docstring, functions, interfaces, imports, body])
 
-        code = ('def {name}({args}):\n'
-                '{body}\n').format(
-                        name=name,
-                        args=args,
-                        body=body)
+        # Put back return removed in semantic stage
+        if name.startswith('__i') and ('__'+name[3:]) in magic_method_map.values():
+            body += f'    return {expr.arguments[0].name}\n'
+
+        code = (f'def {name}({args}):\n'
+                f'{body}\n')
         decorators = expr.decorators.copy()
         if decorators:
             if decorators['template']:

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -73,6 +73,15 @@ magic_binary_funcs = ('__add__',
                       '__rshift__',
                       '__and__',
                       '__or__',
+                      '__iadd__',
+                      '__isub__',
+                      '__imul__',
+                      '__itruediv__',
+                      '__ipow__',
+                      '__ilshift__',
+                      '__irshift__',
+                      '__iand__',
+                      '__ior__',
                       )
 
 class CToPythonWrapper(Wrapper):
@@ -2026,6 +2035,8 @@ class CToPythonWrapper(Wrapper):
                 wrapped_class.add_new_method(self._get_class_destructor(f, orig_cls_dtype, wrapped_class.scope))
             elif python_name == '__init__':
                 wrapped_class.add_new_method(self._get_class_initialiser(f, orig_cls_dtype))
+            elif python_name in magic_binary_funcs:
+                wrapped_class.add_new_magic_number_method(self._wrap(f))
             elif 'property' in f.decorators:
                 wrapped_class.add_property(self._wrap(f))
             else:

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -64,6 +64,17 @@ errors = Errors()
 cwrapper_ndarray_imports = [Import('cwrapper_ndarrays', Module('cwrapper_ndarrays', (), ())),
                             Import('ndarrays', Module('ndarrays', (), ()))]
 
+magic_binary_funcs = ('__add__',
+                      '__sub__',
+                      '__mul__',
+                      '__truediv__',
+                      '__pow__',
+                      '__lshift__',
+                      '__rshift__',
+                      '__and__',
+                      '__or__',
+                      )
+
 class CToPythonWrapper(Wrapper):
     """
     Class for creating a wrapper exposing C code to Python.
@@ -1409,7 +1420,7 @@ class CToPythonWrapper(Wrapper):
 
     def _wrap_FunctionDef(self, expr):
         """
-        Build a `PyFunctionDef` form a `FunctionDef`.
+        Build a `PyFunctionDef` from a `FunctionDef`.
 
         Create a `PyFunctionDef` which wraps a C-compatible `FunctionDef`.
         The `PyFunctionDef` should take three arguments (`self`, `args`,
@@ -1431,6 +1442,7 @@ class CToPythonWrapper(Wrapper):
         func_name = self.scope.get_new_name(expr.name+'_wrapper')
         func_scope = self.scope.new_child_scope(func_name)
         self.scope = func_scope
+        original_func_name = original_func.scope.get_python_name(original_func.name)
 
         possible_class_base = expr.get_user_nodes((ClassDef,))
         if possible_class_base:
@@ -1477,7 +1489,7 @@ class CToPythonWrapper(Wrapper):
             func_args = [FunctionDefArgument(a) for a in func_args]
             body = []
         else:
-            if in_interface:
+            if in_interface or original_func_name in magic_binary_funcs:
                 func_args = [FunctionDefArgument(a) for a in self._get_python_argument_variables(python_args)]
                 body = []
             else:

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1511,7 +1511,12 @@ class CToPythonWrapper(Wrapper):
 
         # Get the code required to wrap the C-compatible results into Python objects
         # This function creates variables so it must be called before extracting them from the scope.
-        if len(python_results) == 0:
+        if original_func_name in magic_binary_funcs and original_func_name.startswith('__i'):
+            res = func_args[0].var.clone(self.scope.get_new_name(func_args[0].var.name), is_argument=False)
+            wrapped_results = {'c_results': [], 'py_result': res, 'body': []}
+            body.append(AliasAssign(res, func_args[0].var))
+            body.append(Py_INCREF(res))
+        elif len(python_results) == 0:
             wrapped_results = {'c_results': [], 'py_result': Py_None, 'body': []}
         elif len(python_results) == 1:
             wrapped_results = self._extract_FunctionDefResult(original_func.results[0].var, is_bind_c_function_def, expr)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -444,6 +444,10 @@ class SyntaxParser(BasicParser):
             return AugAssign(lhs, '|', rhs)
         elif isinstance(stmt.op, ast.BitAnd):
             return AugAssign(lhs, '&', rhs)
+        elif isinstance(stmt.op, ast.LShift):
+            return AugAssign(lhs, '<<', rhs)
+        elif isinstance(stmt.op, ast.RShift):
+            return AugAssign(lhs, '>>', rhs)
         else:
             return errors.report(PYCCEL_RESTRICTION_TODO, symbol = stmt,
                     severity='error')

--- a/tests/epyccel/classes/class_magic.py
+++ b/tests/epyccel/classes/class_magic.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-class-docstring,  missing-function-docstring, missing-module-docstring
+
 class A:
     def __init__(self, x : int):
         self.x = x

--- a/tests/epyccel/classes/class_magic.py
+++ b/tests/epyccel/classes/class_magic.py
@@ -7,10 +7,55 @@ class A:
     def __add__(self, other : int):
         return A(self.x+other)
 
+    def __sub__(self, other : int):
+        return A(self.x-other)
+
     def __mul__(self, other : int):
         return A(self.x*other)
+
+    def __truediv__(self, other : int):
+        return A(int(self.x/other))
+
+    def __lshift__(self, other : int):
+        return A(self.x << other)
+
+    def __rshift__(self, other : int):
+        return A(self.x >> other)
+
+    def __and__(self, other : int):
+        return A(self.x & other)
+
+    def __or__(self, other : int):
+        return A(self.x | other)
 
     def __iadd__(self, other : int):
         self.x += other
         return self
 
+    def __isub__(self, other : int):
+        self.x -= other
+        return self
+
+    def __imul__(self, other : int):
+        self.x *= other
+        return self
+
+    def __itruediv__(self, other : int):
+        self.x = int(self.x / other)
+        return self
+
+    def __ilshift__(self, other : int):
+        self.x <<= other
+        return self
+
+    def __irshift__(self, other : int):
+        self.x >>= other
+        return self
+
+    def __iand__(self, other : int):
+        self.x &= other
+        return self
+
+    def __ior__(self, other : int):
+        self.x |= other
+        return self

--- a/tests/epyccel/classes/class_magic.py
+++ b/tests/epyccel/classes/class_magic.py
@@ -1,0 +1,14 @@
+class A:
+    def __init__(self, x : int):
+        self.x = x
+
+    def __add__(self, other : int):
+        return A(self.x+other)
+
+    def __mul__(self, other : int):
+        return A(self.x*other)
+
+    def __iadd__(self, other : int):
+        self.x += other
+        return self
+

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -346,3 +346,30 @@ def test_ptr_in_class(language):
     y[0] = -3
 
     assert np.array_equal(a_py.x, a_l.x)
+
+def test_class_magic(language):
+    import classes.class_magic as mod
+    modnew = epyccel(mod, language = language)
+
+    a_py = mod.A(4)
+    a_l = modnew.A(4)
+
+    assert a_py.x == a_l.x
+
+    left_add_py = a_py + 5
+    left_add_l = a_l + 5
+
+    assert isinstance(left_add_l, modnew.A)
+    assert left_add_py.x == left_add_l.x
+
+    left_mul_py = a_py * 2
+    left_mul_l = a_l * 2
+
+    assert isinstance(left_mul_l, modnew.A)
+    assert left_mul_py.x == left_mul_l.x
+
+    a_py += 6
+    a_l += 6
+
+    assert a_py.x == a_l.x
+

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -362,14 +362,85 @@ def test_class_magic(language):
     assert isinstance(left_add_l, modnew.A)
     assert left_add_py.x == left_add_l.x
 
+    left_sub_py = a_py - 2
+    left_sub_l = a_l - 2
+
+    assert isinstance(left_sub_l, modnew.A)
+    assert left_sub_py.x == left_sub_l.x
+
     left_mul_py = a_py * 2
     left_mul_l = a_l * 2
 
     assert isinstance(left_mul_l, modnew.A)
     assert left_mul_py.x == left_mul_l.x
 
+    left_truediv_py = a_py / 2
+    left_truediv_l = a_l / 2
+
+    assert isinstance(left_truediv_l, modnew.A)
+    assert left_truediv_py.x == left_truediv_l.x
+
+    left_lshift_py = a_py << 2
+    left_lshift_l = a_l << 2
+
+    assert isinstance(left_lshift_l, modnew.A)
+    assert left_lshift_py.x == left_lshift_l.x
+
+    left_rshift_py = a_py >> 2
+    left_rshift_l = a_l >> 2
+
+    assert isinstance(left_rshift_l, modnew.A)
+    assert left_rshift_py.x == left_rshift_l.x
+
+    left_and_py = a_py & 2
+    left_and_l = a_l & 2
+
+    assert isinstance(left_and_l, modnew.A)
+    assert left_and_py.x == left_and_l.x
+
+    left_or_py = a_py | 2
+    left_or_l = a_l | 2
+
+    assert isinstance(left_or_l, modnew.A)
+    assert left_or_py.x == left_or_l.x
+
     a_py += 6
     a_l += 6
+
+    assert a_py.x == a_l.x
+
+    a_py -= 6
+    a_l -= 6
+
+    assert a_py.x == a_l.x
+
+    a_py *= 6
+    a_l *= 6
+
+    assert a_py.x == a_l.x
+
+    a_py /= 2
+    a_l /= 2
+
+    assert a_py.x == a_l.x
+
+    a_py <<= 1
+    a_l <<= 1
+
+    assert a_py.x == a_l.x
+
+    a_py >>= 2
+    a_l >>= 2
+
+    assert a_py.x == a_l.x
+
+    a_py &= 7
+    a_l &= 7
+
+    assert a_py.x == a_l.x
+
+    a_py |= 6
+    a_l |= 6
 
     assert a_py.x == a_l.x
 


### PR DESCRIPTION
Add wrapping support for arithmetic magic methods to allow them to be called from Python. Fixes #2024 