### PR TITLE
Use older cmake command line syntax for compatibility

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ We recommend using GFortran/GCC and Open-MPI.
 
 Pyccel also depends on several Python3 packages, which are automatically downloaded by pip, the Python Package Installer, during the installation process. In addition to these, unit tests require additional packages which are installed as optional dependencies with pip, while building the documentation requires [Sphinx](http://www.sphinx-doc.org/).
 
-In order to install Pyccel from source, CMake is additionally required to build the gFTL dependence.
+In order to install Pyccel from source, CMake (>=3.13) is additionally required to build the gFTL dependence.
 
 ### Linux Debian-Ubuntu-Mint
 

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -41,7 +41,7 @@ class CustomBuildHook(BuildHookInterface):
         # Build gFTL for installation
         gFTL_folder = (Path(__file__).parent.parent / 'pyccel' / 'extensions' / 'gFTL').absolute()
         subprocess.run([shutil.which('cmake'), '-S', str(gFTL_folder), '-B', str(gFTL_folder / 'build'),
-                        '-DCMAKE_INSTALL_PREFIX={gFTL_folder / "install"}'], cwd = gFTL_folder, check=True)
+                        f'-DCMAKE_INSTALL_PREFIX={gFTL_folder / "install"}'], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--build', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--install', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
 

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -41,7 +41,7 @@ class CustomBuildHook(BuildHookInterface):
         # Build gFTL for installation
         gFTL_folder = (Path(__file__).parent.parent / 'pyccel' / 'extensions' / 'gFTL').absolute()
         subprocess.run([shutil.which('cmake'), '-S', str(gFTL_folder), '-B', str(gFTL_folder / 'build'),
-                        '--install-prefix', str(gFTL_folder / 'install')], cwd = gFTL_folder, check=True)
+                        '-DCMAKE_INSTALL_PREFIX={gFTL_folder / "install"}'], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--build', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--install', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
 


### PR DESCRIPTION
Use older cmake command line syntax for compatibility with older CMake versions (up to 3.13). This allows tests to run in https://github.com/pyccel/pyccel-cuda. Fixes #2135 