### PR TITLE
Avoid the need for secrets in review_bot workflow

### DIFF
--- a/.github/workflows/review_bot.yml
+++ b/.github/workflows/review_bot.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           python -m pip install requests
       - name: "Generate token"
+        if: github.repository == 'pyccel/pyccel'
         id: token
         uses: ./.github/actions/generate_bot_token
         with:

--- a/ci_tools/bot_comment_react.py
+++ b/ci_tools/bot_comment_react.py
@@ -82,5 +82,9 @@ if __name__ == '__main__':
 
         bot.indicate_trust(command_words[2])
 
+    elif command_words == ['approved', 'pr', 'fork']:
+        print(event['comment']['user']['login'])
+        bot.mark_as_ready(following_review = True)
+
     else:
         bot.show_commands()

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -497,25 +497,6 @@ class Bot:
         self.mark_as_draft()
         self._GAI.create_comment(self._pr_id, message_from_file('set_draft_failing.txt'))
 
-    def draft_due_to_changes_requested(self, author, reviewer):
-        """
-        Mark the pull request as a draft following requested changes.
-
-        Mark the pull request specified in the constructor as a draft.
-        This function should be called when a review is left on a pull
-        request by a user (non-bot) requesting changes.
-
-        Parameters
-        ----------
-        author : str
-            The login id of the author of the pull request.
-
-        reviewer : str
-            The login id of the reviewer of the pull request.
-        """
-        self.mark_as_draft()
-        self._GAI.create_comment(self._pr_id, message_from_file('set_draft_changes.txt').format(author=author, reviewer=reviewer))
-
     def request_mark_as_ready(self, user):
         """
         Remove the draft status from the pull request.


### PR DESCRIPTION
Avoid the need for secrets in review_bot workflow. This should stop bot actions failing on forks. It needs testing in my fork https://github.com/EmilyBourne/pyccel I need help for this as I cannot create a fork of my fork