### PR TITLE
Add Fortran support for `dict.clear`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 -   #1881 : Add Python support for dict method `copy()`.
--   #1880 : Add Python and C support for dict method `clear()`.
+-   #1880 : Add support for dict method `clear()`.
 -   #1720 : Add support for `Ellipsis` as the only index for an array.
 -   #1787 : Ensure STC is installed with Pyccel.
 -   #1656 : Ensure gFTL is installed with Pyccel.

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -120,7 +120,7 @@ Python contains a limited number of builtin functions defined [here](https://doc
 
 | Method | Supported |
 |----------|-----------|
-| `clear` | Python and C |
+| `clear` | **Yes** |
 | `copy` | Python-only |
 | `get` | Python-only |
 | `items` | **Yes** |

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1444,6 +1444,12 @@ class FCodePrinter(CodePrinter):
         success = self.scope.get_temporary_variable(PythonNativeInt())
         return f'{success} = {var} % erase_value({val})\n'
 
+   #========================== Dict Methods ================================#
+
+    def _print_DictClear(self, expr):
+        var = self._print(expr.dict_obj)
+        return f'call {var} % clear()\n'
+
     #========================== Numpy Elements ===============================#
 
     def _print_NumpySum(self, expr):

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -229,12 +229,12 @@ def test_dict_ptr(python_only_language):
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_dict_clear(stc_language):
+def test_dict_clear(language):
     def dict_clear():
         a = {1:1.0, 2:2.0}
         a.clear()
         return len(a)
-    epyc_dict_clear = epyccel(dict_clear, language = stc_language)
+    epyc_dict_clear = epyccel(dict_clear, language = language)
     pyccel_result = epyc_dict_clear()
     python_result = dict_clear()
     assert python_result == pyccel_result


### PR DESCRIPTION
Add Fortran support for dict method `clear()`. Fixes #2046

**Commit Summary**
- Implement Fortran support for the `dict.clear()` method.
- Activate `dict.clear()` tests for Fortran.