### PR TITLE
Allow saving an array result of a function to a slice

### DIFF
--- a/.dict_custom.txt
+++ b/.dict_custom.txt
@@ -123,3 +123,4 @@ gFTL
 STC's
 gFTL's
 CMake
+suboptimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ All notable changes to this project will be documented in this file.
 -   #2001 : Ensure all memory is correctly deallocated in the Python interface in a way that is compatible with all compilers.
 -   #2153 : Fix missing line information when an unknown class method is called.
 -   #2149 : Fix multi-line expressions in `if` conditions.
+-   #2181 : Allow saving an array result of a function to a slice but raise a warning about suboptimal performance.
 -   Lifted the restriction on ndarrays limiting them to rank<15.
 
 ### Changed

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3447,6 +3447,16 @@ class SemanticParser(BasicParser):
             else:
                 raise NotImplementedError("Cannot assign result of a function without a return")
 
+            if len(results) == 1 and results[0].var.rank > 1 and isinstance(lhs, IndexedElement):
+                temp = self.scope.get_new_name()
+                semantic_temp = self._assign_lhs_variable(temp, d_var, rhs, new_expressions)
+                new_expressions.append(Assign(semantic_temp, rhs))
+                rhs = semantic_temp
+                errors.report((f"Saving the result of the function {func.name} to a slice requires unnecessary "
+                               "data allocation and copies. This has a performance cost. Consider modifying "
+                               f"{func.name} so {lhs} can be passed as an argument whose contents are modified."),
+                        severity='warning', symbol=expr)
+
             # case of elemental function
             # if the input and args of func do not have the same shape,
             # then the lhs must be already declared

--- a/tests/pyccel/scripts/return_numpy_arrays.py
+++ b/tests/pyccel/scripts/return_numpy_arrays.py
@@ -24,6 +24,20 @@ e = f(1+2j, 3+4j)
 h,g = multi_returns()
 k = single_return() + 1
 
+def Mi(x: float, M0: 'float[:, :]') -> 'float[:, :]':
+    M1 = x * M0 + 1.
+    return M1
+
+def M_GEN(x: float) -> 'float[:, :, :]':
+    M = np.ones((4, 4), dtype = float)
+    M2 = np.empty((3, 4, 4), dtype = float)
+    for i in range(3):
+        M2[i] = Mi(x * i, M)
+    return M2
+
 if __name__ == '__main__':
     print(a, b, c, d, e, h, g, k)
     print(np.array([1,2,3,4]), np.array([1, 3]), np.array([1., 3.]), np.array([False, True]), np.array([1+2j, 3+4j]))
+
+    x = M_GEN(2.0)
+    print(x)

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -769,6 +769,7 @@ def test_return_numpy_arrays(language):
     types += [float]*5 # 5 floats for h
     types += [int]*5 # 5 ints for g
     types += [int]*4 # 4 ints for k
+    types += [float]*48 # 48 floats for x
     pyccel_test("scripts/return_numpy_arrays.py", language=language, output_dtype=types)
 
 #------------------------------------------------------------------------------

--- a/tests/warnings/semantic/UNNECESSARY_ALLOCATION_IN_FUNCTION.py
+++ b/tests/warnings/semantic/UNNECESSARY_ALLOCATION_IN_FUNCTION.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+def Mi(x: float, M0: 'float[:, :]') -> 'float[:, :]':
+    M1 = x * M0 + 1.    
+    return M1
+
+def M_GEN(x: float) -> 'float[:, :, :]':
+    M = np.ones((4, 4), dtype = float)
+    M2 = np.empty((3, 4, 4), dtype = float)
+    for i in range(3):
+        M2[i] = Mi(x * i, M)
+    return M2

--- a/tests/warnings/semantic/UNNECESSARY_ALLOCATION_IN_FUNCTION.py
+++ b/tests/warnings/semantic/UNNECESSARY_ALLOCATION_IN_FUNCTION.py
@@ -1,7 +1,8 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
 import numpy as np
 
 def Mi(x: float, M0: 'float[:, :]') -> 'float[:, :]':
-    M1 = x * M0 + 1.    
+    M1 = x * M0 + 1.
     return M1
 
 def M_GEN(x: float) -> 'float[:, :, :]':


### PR DESCRIPTION
Allow saving an array result of a function to a slice but raise a warning about suboptimal performance. Fixes #2181 