### PR TITLE
Fix string comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ All notable changes to this project will be documented in this file.
 -   #2149 : Fix multi-line expressions in `if` conditions.
 -   #2181 : Allow saving an array result of a function to a slice but raise a warning about suboptimal performance.
 -   #2190 : Fix missing error for list pointer assignment.
+-   #2195 : Fix string comparisons.
 -   Fixed returning strings from functions.
 -   Lifted the restriction on ndarrays limiting them to rank<15.
 

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -633,7 +633,7 @@ class HomogeneousContainerType(ContainerType):
     def __hash__(self):
         return hash((self.__class__, self.element_type))
 
-class StringType(HomogeneousContainerType, metaclass = Singleton):
+class StringType(PyccelType, metaclass = Singleton):
     """
     Class representing Python's native string type.
 
@@ -675,6 +675,17 @@ class StringType(HomogeneousContainerType, metaclass = Singleton):
         this is equal to 0.
         """
         return 1
+
+    @property
+    def order(self):
+        """
+        The data layout ordering in memory.
+
+        Indicates whether the data is stored in row-major ('C') or column-major
+        ('F') format. This is only relevant if rank > 1. When it is not relevant
+        this function returns None.
+        """
+        return None
 
     def __eq__(self, other):
         return isinstance(other, self.__class__)

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -641,9 +641,6 @@ class StringType(PyccelType, metaclass = Singleton):
     """
     __slots__ = ()
     _name = 'str'
-    _element_type = CharType()
-    _container_rank = 1
-    _order = None
 
     @property
     def datatype(self):
@@ -677,6 +674,16 @@ class StringType(PyccelType, metaclass = Singleton):
         return 1
 
     @property
+    def container_rank(self):
+        """
+        Number of dimensions of the container.
+
+        Number of dimensions of the object described by the container. This is
+        equal to the number of values required to index an element of this container.
+        """
+        return 1
+
+    @property
     def order(self):
         """
         The data layout ordering in memory.
@@ -686,6 +693,15 @@ class StringType(PyccelType, metaclass = Singleton):
         this function returns None.
         """
         return None
+
+    @property
+    def element_type(self):
+        """
+        The type of elements of the object.
+
+        The PyccelType describing an element of the container.
+        """
+        return CharType()
 
     def __eq__(self, other):
         return isinstance(other, self.__class__)

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -671,7 +671,7 @@ class HomogeneousContainerType(ContainerType):
     def __hash__(self):
         return hash((self.__class__, self.element_type))
 
-class StringType(PyccelType, metaclass = Singleton):
+class StringType(ContainerType, metaclass = Singleton):
     """
     Class representing Python's native string type.
 

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -23,6 +23,8 @@ from .literals              import Literal, LiteralInteger, LiteralFloat, Litera
 from .literals              import Nil, NilArgument, LiteralTrue, LiteralFalse
 from .literals              import convert_to_literal
 
+from .numpytypes            import NumpyNDArrayType
+
 errors = Errors()
 pyccel_stage = PyccelStage()
 
@@ -935,7 +937,7 @@ class PyccelComparisonOperator(PyccelBinaryOperator):
         """
         dtype = PythonNativeBool()
         possible_class_types = set(a.class_type for a in (arg1, arg2) \
-                        if isinstance(a.class_type, ContainerType))
+                        if isinstance(a.class_type, NumpyNDArrayType))
         if len(possible_class_types) == 0:
             class_type = dtype
         elif len(possible_class_types) == 1:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1039,14 +1039,24 @@ class CCodePrinter(CodePrinter):
         return ' || '.join(a for a in args)
 
     def _print_PyccelEq(self, expr):
-        lhs = self._print(expr.args[0])
-        rhs = self._print(expr.args[1])
-        return '{0} == {1}'.format(lhs, rhs)
+        lhs, rhs = expr.args
+        if isinstance(lhs.class_type, StringType) and isinstance(rhs.class_type, StringType):
+            lhs_code = self._print(CStrStr(lhs))
+            rhs_code = self._print(CStrStr(rhs))
+            return f'strcmp({lhs_code}, {rhs_code})'
+        else:
+            lhs_code = self._print(lhs)
+            rhs_code = self._print(rhs)
+            return f'{lhs_code} == {rhs_code}'
 
     def _print_PyccelNe(self, expr):
-        lhs = self._print(expr.args[0])
-        rhs = self._print(expr.args[1])
-        return '{0} != {1}'.format(lhs, rhs)
+        lhs, rhs = expr.args
+        lhs_code = self._print(lhs)
+        rhs_code = self._print(rhs)
+        if isinstance(lhs.class_type, StringType) and isinstance(rhs.class_type, StringType):
+            return f'!strcmp({lhs_code}, {rhs_code})'
+        else:
+            return f'{lhs_code} != {rhs_code}'
 
     def _print_PyccelLt(self, expr):
         lhs = self._print(expr.args[0])

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1043,7 +1043,7 @@ class CCodePrinter(CodePrinter):
         if isinstance(lhs.class_type, StringType) and isinstance(rhs.class_type, StringType):
             lhs_code = self._print(CStrStr(lhs))
             rhs_code = self._print(CStrStr(rhs))
-            return f'strcmp({lhs_code}, {rhs_code})'
+            return f'!strcmp({lhs_code}, {rhs_code})'
         else:
             lhs_code = self._print(lhs)
             rhs_code = self._print(rhs)
@@ -1051,11 +1051,13 @@ class CCodePrinter(CodePrinter):
 
     def _print_PyccelNe(self, expr):
         lhs, rhs = expr.args
-        lhs_code = self._print(lhs)
-        rhs_code = self._print(rhs)
         if isinstance(lhs.class_type, StringType) and isinstance(rhs.class_type, StringType):
-            return f'!strcmp({lhs_code}, {rhs_code})'
+            lhs_code = self._print(CStrStr(lhs))
+            rhs_code = self._print(CStrStr(rhs))
+            return f'strcmp({lhs_code}, {rhs_code})'
         else:
+            lhs_code = self._print(lhs)
+            rhs_code = self._print(rhs)
             return f'{lhs_code} != {rhs_code}'
 
     def _print_PyccelLt(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2267,7 +2267,7 @@ class FCodePrinter(CodePrinter):
                 return f'call {var_code} % reserve({size_code})\n'
             else:
                 return ''
-        elif isinstance(class_type, (HomogeneousContainerType, DictType)):
+        elif isinstance(class_type, (HomogeneousContainerType, DictType, StringType)):
             return ''
 
         else:

--- a/tests/epyccel/test_strings.py
+++ b/tests/epyccel/test_strings.py
@@ -25,4 +25,20 @@ def test_strings(test_func, language):
     pyccel_out = f2()
     print(python_out)
     print(pyccel_out)
-    assert python_out == pyccel_out
+    assert python_out == pyccel_out.strip()
+
+def test_string_compare(language):
+    def str_comp():
+        a = 'hello'
+        if a == 'world':
+            return 1
+        elif a != 'boo':
+            return 2
+        elif a == 'hello':
+            return 3
+        else:
+            return 4
+
+    f = epyccel( str_comp, language=language )
+
+    assert str_comp() == f()

--- a/tests/epyccel/test_strings.py
+++ b/tests/epyccel/test_strings.py
@@ -25,7 +25,7 @@ def test_strings(test_func, language):
     pyccel_out = f2()
     print(python_out)
     print(pyccel_out)
-    assert python_out == pyccel_out.strip()
+    assert python_out == pyccel_out
 
 def test_string_compare(language):
     def str_comp():


### PR DESCRIPTION
Fix string comparisons. Recurrent problems due to `StringType` inheritance are fixed by removing the inheritance of `ContainerType`. `CStrStr` is used with `strcmp` to implement comparison of strings in C. Fixes #2195.