### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ All notable changes to this project will be documented in this file.
 -   #2181 : Allow saving an array result of a function to a slice but raise a warning about suboptimal performance.
 -   #2190 : Fix missing error for list pointer assignment.
 -   Lifted the restriction on ndarrays limiting them to rank<15.
+-   Catch all internal errors arising in the syntactic, semantic, printing or codegen stages.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ All notable changes to this project will be documented in this file.
 -   #2181 : Allow saving an array result of a function to a slice but raise a warning about suboptimal performance.
 -   #2190 : Fix missing error for list pointer assignment.
 -   Lifted the restriction on ndarrays limiting them to rank<15.
--   Catch all internal errors arising in the syntactic, semantic, printing or codegen stages.
+-   Catch all internal errors arising in the syntactic, semantic, printing or code generation stages.
 
 ### Changed
 

--- a/developer_docs/overview.md
+++ b/developer_docs/overview.md
@@ -84,6 +84,8 @@ Pyccel tries to fail cleanly and raise readable errors for users. This is manage
 
 If the error prevents further translation (e.g. the type of an object is now unknown) then the severity should be indicated as `'fatal'`.
 
+This error handling can make it easier to debug developments. Pyccel therefore includes a developer mode which ensures that all errors include a traceback.
+
 ## Getting Help
 
 While discussions within the associated GitHub issue are often sufficient, should you require more help you can join our [Pyccel Discord Server](https://discord.gg/2Q6hwjfFVb).

--- a/developer_docs/tips_and_tricks.md
+++ b/developer_docs/tips_and_tricks.md
@@ -7,5 +7,6 @@
 -   When trying to find a bug where the generated code gives different results to the original Python code, a good first step is usually to generate the corresponding code and try to find where the implementation differs
 -   When there is a problem in the compile stage the first step must **always** be to run `pyccel` with the `--verbose` flag and test the generated compile commands manually. It is impossible to fix the compile problem without knowing what the correct command should be
 -   When you have broken previously working code, comparing the difference in the generated code before and after your changes should help you target which of your changes caused the problems
+-   Sometimes the traceback provided by Pyccel in developer-mode is too short to find the problem. If this is the case, the length of the traceback can be changed temporarily in `pyccel.errors.errors.Errors.report` (the default traceback length is 5).
 
 _Please feel free to add any tips or tricks you find to this non-exhaustive list_

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -107,7 +107,7 @@ class CodePrinter:
 
     def _print(self, expr):
         """
-        Print the AST node in the printer language
+        Print the AST node in the printer language.
 
         The printing is done by finding the appropriate function _print_X
         for the object expr. X is the type of the object expr. If this function

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -127,7 +127,7 @@ class CodePrinter:
                     obj = getattr(self, print_method)(expr)
                 except (PyccelError, NotImplementedError) as err:
                     raise err
-                except Exception as err:
+                except Exception as err: #pylint: disable=broad-exception-caught
                     if ErrorsMode().value == 'user':
                         errors.report(PYCCEL_INTERNAL_ERROR,
                                 symbol = self._current_ast_node, severity='fatal')

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -106,13 +106,25 @@ class CodePrinter:
         self._scope = self._scope.parent_scope
 
     def _print(self, expr):
-        """Print the AST node in the printer language
+        """
+        Print the AST node in the printer language
 
         The printing is done by finding the appropriate function _print_X
         for the object expr. X is the type of the object expr. If this function
         does not exist then the method resolution order is used to search for
         other compatible _print_X functions. If none are found then an error is
-        raised
+        raised.
+
+        Parameters
+        ----------
+        expr : PyccelAstNode
+            The expression that should be printed.
+
+        Returns
+        -------
+        str
+            A string containing code in the printer language which is equivalent
+            to the expression.
         """
 
         current_ast = self._current_ast_node

--- a/pyccel/codegen/printing/codeprinter.py
+++ b/pyccel/codegen/printing/codeprinter.py
@@ -10,7 +10,7 @@ from pyccel.ast.basic import PyccelAstNode
 from pyccel.ast.core      import Module, ModuleHeader, Program
 from pyccel.ast.internals import PyccelSymbol
 
-from pyccel.errors.errors     import Errors, ErrorsMode
+from pyccel.errors.errors     import Errors, ErrorsMode, PyccelError
 from pyccel.errors.messages   import PYCCEL_RESTRICTION_TODO, PYCCEL_INTERNAL_ERROR
 
 # TODO: add examples
@@ -125,6 +125,8 @@ class CodePrinter:
             if hasattr(self, print_method):
                 try:
                     obj = getattr(self, print_method)(expr)
+                except (PyccelError, NotImplementedError) as err:
+                    raise err
                 except Exception as err:
                     if ErrorsMode().value == 'user':
                         errors.report(PYCCEL_INTERNAL_ERROR,

--- a/pyccel/codegen/wrapper/wrapper.py
+++ b/pyccel/codegen/wrapper/wrapper.py
@@ -8,8 +8,8 @@ Module describing the base code-wrapping class : Wrapper.
 """
 
 from pyccel.parser.scope      import Scope
-from pyccel.errors.errors     import Errors
-from pyccel.errors.messages   import PYCCEL_RESTRICTION_TODO
+from pyccel.errors.errors     import Errors, ErrorsMode
+from pyccel.errors.messages   import PYCCEL_RESTRICTION_TODO, PYCCEL_INTERNAL_ERROR
 
 __all__ = ["Wrapper"]
 
@@ -29,6 +29,7 @@ class Wrapper:
 
     def __init__(self):
         self._scope = None
+        self._current_ast_node = None
 
     @property
     def scope(self):
@@ -96,11 +97,24 @@ class Wrapper:
             The AST which describes the object that lets you
             access the expression.
         """
+        current_ast = self._current_ast_node
+        if getattr(expr,'python_ast', None) is not None:
+            self._current_ast_node = expr.python_ast
+
         classes = type(expr).mro()
         for cls in classes:
             wrap_method = '_wrap_' + cls.__name__
             if hasattr(self, wrap_method):
-                return getattr(self, wrap_method)(expr)
+                try:
+                    obj = getattr(self, wrap_method)(expr)
+                except Exception as err:
+                    if ErrorsMode().value == 'user':
+                        errors.report(PYCCEL_INTERNAL_ERROR,
+                                symbol = self._current_ast_node, severity='fatal')
+                    else:
+                        raise err
+                self._current_ast_node = current_ast
+                return obj
 
         return self._wrap_not_supported(expr)
 

--- a/pyccel/codegen/wrapper/wrapper.py
+++ b/pyccel/codegen/wrapper/wrapper.py
@@ -8,7 +8,7 @@ Module describing the base code-wrapping class : Wrapper.
 """
 
 from pyccel.parser.scope      import Scope
-from pyccel.errors.errors     import Errors, ErrorsMode
+from pyccel.errors.errors     import Errors, ErrorsMode, PyccelError
 from pyccel.errors.messages   import PYCCEL_RESTRICTION_TODO, PYCCEL_INTERNAL_ERROR
 
 __all__ = ["Wrapper"]
@@ -107,6 +107,8 @@ class Wrapper:
             if hasattr(self, wrap_method):
                 try:
                     obj = getattr(self, wrap_method)(expr)
+                except (PyccelError, NotImplementedError) as err:
+                    raise err
                 except Exception as err:
                     if ErrorsMode().value == 'user':
                         errors.report(PYCCEL_INTERNAL_ERROR,

--- a/pyccel/codegen/wrapper/wrapper.py
+++ b/pyccel/codegen/wrapper/wrapper.py
@@ -109,7 +109,7 @@ class Wrapper:
                     obj = getattr(self, wrap_method)(expr)
                 except (PyccelError, NotImplementedError) as err:
                     raise err
-                except Exception as err:
+                except Exception as err: #pylint: disable=broad-exception-caught
                     if ErrorsMode().value == 'user':
                         errors.report(PYCCEL_INTERNAL_ERROR,
                                 symbol = self._current_ast_node, severity='fatal')

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -111,6 +111,8 @@ PYCCEL_RESTRICTION_LIST_COMPREHENSION_LIMITS = 'Pyccel cannot handle this list c
 PYCCEL_RESTRICTION_INHOMOG_LIST = 'Inhomogeneous lists are not supported by Pyccel. Please use a tuple'
 PYCCEL_RESTRICTION_INHOMOG_SET = 'Inhomogeneous Sets are not supported by Pyccel'
 
+PYCCEL_INTERNAL_ERROR = '[INTERNAL ERROR] Pyccel has raised an internal error. Please check that your code executes correctly without raising any errors in Python. If this is the case then please create an issue at https://github.com/pyccel/pyccel/issues and provide a small example of your problem. Do not forget to specify your target language.'
+
 # Fortran limitation
 FORTRAN_ALLOCATABLE_IN_EXPRESSION = 'An allocatable function cannot be used in an expression'
 FORTRAN_RANDINT_ALLOCATABLE_IN_EXPRESSION = "Numpy's randint function does not have a fortran equivalent. It can be expressed as '(high-low)*rand(size)+low' using numpy's rand, however allocatable function cannot be used in an expression"

--- a/pyccel/errors/messages.py
+++ b/pyccel/errors/messages.py
@@ -111,7 +111,7 @@ PYCCEL_RESTRICTION_LIST_COMPREHENSION_LIMITS = 'Pyccel cannot handle this list c
 PYCCEL_RESTRICTION_INHOMOG_LIST = 'Inhomogeneous lists are not supported by Pyccel. Please use a tuple'
 PYCCEL_RESTRICTION_INHOMOG_SET = 'Inhomogeneous Sets are not supported by Pyccel'
 
-PYCCEL_INTERNAL_ERROR = '[INTERNAL ERROR] Pyccel has raised an internal error. Please check that your code executes correctly without raising any errors in Python. If this is the case then please create an issue at https://github.com/pyccel/pyccel/issues and provide a small example of your problem. Do not forget to specify your target language.'
+PYCCEL_INTERNAL_ERROR = '[INTERNAL ERROR] Pyccel has raised an internal error. Please check that your code executes correctly without raising any errors in Python. If this is the case then please create an issue at https://github.com/pyccel/pyccel/issues and include the traceback generated when running pyccel with the --developer-mode flag (or epyccel with developer_mode=True). If possible please provide a small example of your problem.'
 
 # Fortran limitation
 FORTRAN_ALLOCATABLE_IN_EXPRESSION = 'An allocatable function cannot be used in an expression'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -122,7 +122,7 @@ from pyccel.ast.variable import Variable
 from pyccel.ast.variable import IndexedElement, AnnotatedPyccelSymbol
 from pyccel.ast.variable import DottedName, DottedVariable
 
-from pyccel.errors.errors import Errors
+from pyccel.errors.errors import Errors, ErrorsMode
 from pyccel.errors.errors import PyccelSemanticError
 
 from pyccel.errors.messages import (PYCCEL_RESTRICTION_TODO, UNDERSCORE_NOT_A_THROWAWAY,
@@ -139,7 +139,8 @@ from pyccel.errors.messages import (PYCCEL_RESTRICTION_TODO, UNDERSCORE_NOT_A_TH
         PYCCEL_RESTRICTION_LIST_COMPREHENSION_LIMITS, PYCCEL_RESTRICTION_LIST_COMPREHENSION_SIZE,
         UNUSED_DECORATORS, UNSUPPORTED_POINTER_RETURN_VALUE, PYCCEL_RESTRICTION_OPTIONAL_NONE,
         PYCCEL_RESTRICTION_PRIMITIVE_IMMUTABLE, PYCCEL_RESTRICTION_IS_ISNOT,
-        FOUND_DUPLICATED_IMPORT, UNDEFINED_WITH_ACCESS, MACRO_MISSING_HEADER_OR_FUNC)
+        FOUND_DUPLICATED_IMPORT, UNDEFINED_WITH_ACCESS, MACRO_MISSING_HEADER_OR_FUNC,
+        PYCCEL_INTERNAL_ERROR)
 
 from pyccel.parser.base      import BasicParser
 from pyccel.parser.syntactic import SyntaxParser
@@ -2304,12 +2305,19 @@ class SemanticParser(BasicParser):
         classes = type(expr).__mro__
         for cls in classes:
             annotation_method = '_visit_' + cls.__name__
-            if hasattr(self, annotation_method):
-                obj = getattr(self, annotation_method)(expr)
-                if isinstance(obj, PyccelAstNode) and self.current_ast_node:
-                    obj.set_current_ast(self.current_ast_node)
-                self._current_ast_node = current_ast
-                return obj
+            try:
+                if hasattr(self, annotation_method):
+                    obj = getattr(self, annotation_method)(expr)
+                    if isinstance(obj, PyccelAstNode) and self.current_ast_node:
+                        obj.set_current_ast(self.current_ast_node)
+                    self._current_ast_node = current_ast
+                    return obj
+            except Exception as err:
+                if ErrorsMode().value == 'user':
+                    errors.report(PYCCEL_INTERNAL_ERROR,
+                            symbol = self._current_ast_node, severity='fatal')
+                else:
+                    raise err
 
         # Unknown object, we raise an error.
         return errors.report(PYCCEL_RESTRICTION_TODO, symbol=type(expr),

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2313,7 +2313,7 @@ class SemanticParser(BasicParser):
                     return obj
             except (PyccelError, NotImplementedError) as err:
                 raise err
-            except Exception as err:
+            except Exception as err: #pylint: disable=broad-exception-caught
                 if ErrorsMode().value == 'user':
                     errors.report(PYCCEL_INTERNAL_ERROR,
                             symbol = self._current_ast_node, severity='fatal')

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -122,8 +122,7 @@ from pyccel.ast.variable import Variable
 from pyccel.ast.variable import IndexedElement, AnnotatedPyccelSymbol
 from pyccel.ast.variable import DottedName, DottedVariable
 
-from pyccel.errors.errors import Errors, ErrorsMode
-from pyccel.errors.errors import PyccelSemanticError
+from pyccel.errors.errors import Errors, ErrorsMode, PyccelError, PyccelSemanticError
 
 from pyccel.errors.messages import (PYCCEL_RESTRICTION_TODO, UNDERSCORE_NOT_A_THROWAWAY,
         UNDEFINED_VARIABLE, IMPORTING_EXISTING_IDENTIFIED, INDEXED_TUPLE, LIST_OF_TUPLES,
@@ -2312,6 +2311,8 @@ class SemanticParser(BasicParser):
                         obj.set_current_ast(self.current_ast_node)
                     self._current_ast_node = current_ast
                     return obj
+            except (PyccelError, NotImplementedError) as err:
+                raise err
             except Exception as err:
                 if ErrorsMode().value == 'user':
                     errors.report(PYCCEL_INTERNAL_ERROR,

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -332,7 +332,7 @@ class SyntaxParser(BasicParser):
                     result.set_current_ast(stmt)
             except (PyccelError, NotImplementedError) as err:
                 raise err
-            except Exception as err:
+            except Exception as err: #pylint: disable=broad-exception-caught
                 if ErrorsMode().value == 'user':
                     errors.report(PYCCEL_INTERNAL_ERROR,
                             symbol = self._context[-1], severity='fatal')

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -76,7 +76,7 @@ from pyccel.parser.syntax.openacc import parse as acc_parse
 
 from pyccel.utilities.stage import PyccelStage
 
-from pyccel.errors.errors import Errors, ErrorsMode
+from pyccel.errors.errors import Errors, ErrorsMode, PyccelError
 
 # TODO - remove import * and only import what we need
 from pyccel.errors.messages import *
@@ -330,6 +330,8 @@ class SyntaxParser(BasicParser):
                 result = getattr(self, syntax_method)(stmt)
                 if isinstance(result, PyccelAstNode) and result.python_ast is None and isinstance(stmt, ast.AST):
                     result.set_current_ast(stmt)
+            except (PyccelError, NotImplementedError) as err:
+                raise err
             except Exception as err:
                 if ErrorsMode().value == 'user':
                     errors.report(PYCCEL_INTERNAL_ERROR,

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -76,7 +76,7 @@ from pyccel.parser.syntax.openacc import parse as acc_parse
 
 from pyccel.utilities.stage import PyccelStage
 
-from pyccel.errors.errors import Errors
+from pyccel.errors.errors import Errors, ErrorsMode
 
 # TODO - remove import * and only import what we need
 from pyccel.errors.messages import *
@@ -326,9 +326,16 @@ class SyntaxParser(BasicParser):
         syntax_method = '_visit_' + cls.__name__
         if hasattr(self, syntax_method):
             self._context.append(stmt)
-            result = getattr(self, syntax_method)(stmt)
-            if isinstance(result, PyccelAstNode) and result.python_ast is None and isinstance(stmt, ast.AST):
-                result.set_current_ast(stmt)
+            try:
+                result = getattr(self, syntax_method)(stmt)
+                if isinstance(result, PyccelAstNode) and result.python_ast is None and isinstance(stmt, ast.AST):
+                    result.set_current_ast(stmt)
+            except Exception as err:
+                if ErrorsMode().value == 'user':
+                    errors.report(PYCCEL_INTERNAL_ERROR,
+                            symbol = self._context[-1], severity='fatal')
+                else:
+                    raise err
             self._context.pop()
             return result
 

--- a/tests/errors/semantic/blocking/INTERNAL_ERROR.py
+++ b/tests/errors/semantic/blocking/INTERNAL_ERROR.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+a = 3 + 'non-valid Python expression'
+


### PR DESCRIPTION
Add a `try`/`except` block in `SyntacticParser._visit`, `SemanticParser._visit`, `CodegenPrinter._print`, and `Wrapper._wrap` to catch any internal errors. Use context information to try to provide an accurate line number. Internal errors arise due to bugs in Pyccel, but also if user code does not execute properly. Tracebacks should be avoided in both these cases, but especially in the latter. The behaviour seen on the `devel` branch can be recovered using the `--developer-mode` flag.

It is extremely difficult to test this kind of error as bugs that would lead to this error should generally be fixed. Nonetheless a test is added for the semantic stage using code that does not execute correctly in Python.