### PR TITLE
Remove unused class `FuncAddressDeclare`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Remove unused functions `Errors.unset_target`, and `Errors.reset_target`.
 -   \[INTERNALS\] Remove unused classes `SymbolicAssign` and `SymbolicPrint`.
 -   \[INTERNALS\] Remove `ast.bind_c.BindCFunctionDefResult` (replaced by `ast.bind_c.BindCArrayType` and `ast.bind_c.BindCResultVariable`).
+-   \[INTERNALS\] Remove unused class `ast.core.FuncAddressDeclare`.
 
 ## \[1.12.1\] - 2024-10-01
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -66,7 +66,6 @@ __all__ = (
     'ErrorExit',
     'Exit',
     'For',
-    'FuncAddressDeclare',
     'FunctionAddress',
     'FunctionCall',
     'FunctionCallArgument',
@@ -3002,13 +3001,11 @@ class FunctionAddress(FunctionDef):
 
     Examples
     --------
-    >>> from pyccel.ast.core import Variable, FunctionAddress, FuncAddressDeclare, FunctionDef
+    >>> from pyccel.ast.core import Variable, FunctionAddress, FunctionDef
     >>> x = Variable(PythonNativeFloat(), 'x')
     >>> y = Variable(PythonNativeFloat(), 'y')
     >>> # a function definition can have a FunctionAddress as an argument
     >>> FunctionDef('g', [FunctionAddress('f', [x], [y])], [], [])
-    >>> # we can also Declare a FunctionAddress
-    >>> FuncAddressDeclare(FunctionAddress('f', [x], [y]))
     """
     __slots__ = ('_is_optional','_is_kwonly','_is_argument', '_memory_handling')
 
@@ -3753,85 +3750,6 @@ class Import(PyccelAstNode):
 
 
 # TODO: Should Declare have an optional init value for each var?
-
-class FuncAddressDeclare(PyccelAstNode):
-    """
-    Represents a FunctionAddress declaration in the code.
-
-    Represents a FunctionAddress declaration in the code.
-
-    Parameters
-    ----------
-    variable : FunctionAddress
-        An instance of FunctionAddress.
-    intent : str, optional
-        One among {'in', 'out', 'inout'}.
-    value : TypedAstNode
-        Variable value.
-    static : bool
-        True for a static declaration of an array.
-
-    Examples
-    --------
-    >>> from pyccel.ast.core import Variable, FunctionAddress, FuncAddressDeclare
-    >>> x = Variable(PythonNativeFloat(), 'x')
-    >>> y = Variable(PythonNativeFloat(), 'y')
-    >>> FuncAddressDeclare(FunctionAddress('f', [x], [y]))
-    """
-    __slots__ = ('_variable','_intent','_value','_static')
-    _attribute_nodes = ('_variable', '_value')
-
-    def __init__(
-        self,
-        variable,
-        intent=None,
-        value=None,
-        static=False,
-        ):
-
-        if not isinstance(variable, FunctionAddress):
-            raise TypeError(f'variable must be of type FunctionAddress, given {variable}')
-
-        if intent:
-            if not intent in ['in', 'out', 'inout']:
-                raise ValueError("intent must be one among {'in', 'out', 'inout'}")
-
-        if not isinstance(static, bool):
-            raise TypeError('Expecting a boolean for static attribute')
-
-        self._variable  = variable
-        self._intent    = intent
-        self._value     = value
-        self._static    = static
-        super().__init__()
-
-    @property
-    def results(self):
-        return self._variable.results
-
-    @property
-    def arguments(self):
-        return self._variable.arguments
-
-    @property
-    def name(self):
-        return self._variable.name
-
-    @property
-    def variable(self):
-        return self._variable
-
-    @property
-    def intent(self):
-        return self._intent
-
-    @property
-    def value(self):
-        return self._value
-
-    @property
-    def static(self):
-        return self._static
 
 # ARA : issue-999 add is_external for external function exported through header files
 class Declare(PyccelAstNode):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -24,7 +24,7 @@ from pyccel.ast.builtins  import PythonList, PythonTuple, PythonSet, PythonDict,
 from pyccel.ast.builtin_methods.dict_methods  import DictItems, DictKeys
 
 from pyccel.ast.core      import Declare, For, CodeBlock, ClassDef
-from pyccel.ast.core      import FuncAddressDeclare, FunctionCall, FunctionCallArgument
+from pyccel.ast.core      import FunctionCall, FunctionCallArgument
 from pyccel.ast.core      import Deallocate
 from pyccel.ast.core      import FunctionAddress
 from pyccel.ast.core      import Assign, Import, AugAssign, AliasAssign
@@ -2165,7 +2165,7 @@ class CCodePrinter(CodePrinter):
 
         body  = self._print(expr.body)
         decs = [Declare(i, value=(Nil() if i.is_alias and isinstance(i.class_type, (VoidType, BindCPointer)) else None))
-                if isinstance(i, Variable) else FuncAddressDeclare(i) for i in expr.local_vars]
+                for i in expr.local_vars]
 
         if len(results) == 1 :
             res = results[0]

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1503,25 +1503,6 @@ class CCodePrinter(CodePrinter):
         else:
             return dtype
 
-    def _print_FuncAddressDeclare(self, expr):
-        args = list(expr.arguments)
-        if len(expr.results) == 1:
-            ret_type = self.get_declare_type(expr.results[0])
-        elif len(expr.results) > 1:
-            ret_type = self._print(datatype('int'))
-            args += [a.clone(name = a.name, memory_handling='alias') for a in expr.results]
-        else:
-            ret_type = self._print(datatype('void'))
-        name = expr.name
-        if not args:
-            arg_code = 'void'
-        else:
-            # TODO: extract informations needed for printing in case of function argument which itself has a function argument
-            arg_code = ', '.join('{}'.format(self._print_FuncAddressDeclare(i))
-                        if isinstance(i, FunctionAddress) else f'{self.get_declare_type(i)} {i}'
-                        for i in args)
-        return f'{ret_type} (*{name})({arg_code});\n'
-
     def _print_Declare(self, expr):
         var = expr.variable
         if isinstance(var.class_type, InhomogeneousTupleType):


### PR DESCRIPTION
Remove unused class `FuncAddressDeclare` which does not seem to be required. Fixes #2203