### PR TITLE
Fix returning an array of unknown literal size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ All notable changes to this project will be documented in this file.
 -   #2181 : Allow saving an array result of a function to a slice but raise a warning about suboptimal performance.
 -   #2190 : Fix missing error for list pointer assignment.
 -   Lifted the restriction on ndarrays limiting them to rank<15.
+-   #2206 : Fix returning an array of unknown literal size.
 
 ### Changed
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -246,6 +246,7 @@ class Variable(TypedAstNode):
         an If block.
         """
         self._shape = tuple(PyccelArrayShapeElement(self, LiteralInteger(i)) for i in range(self.rank))
+        self._alloc_shape = tuple(PyccelArrayShapeElement(self, LiteralInteger(i)) for i in range(self.rank))
 
     def set_init_shape(self, shape):
         """

--- a/tests/epyccel/test_epyccel_return_arrays.py
+++ b/tests/epyccel/test_epyccel_return_arrays.py
@@ -905,3 +905,17 @@ def test_annotated_return(language):
     assert pyth_out.dtype is pycc_out.dtype
     assert pyth_out.flags.c_contiguous == pycc_out.flags.c_contiguous
     assert pyth_out.flags.f_contiguous == pycc_out.flags.f_contiguous
+
+def test_unknown_size_array(language):
+    def unknown_size(b : bool):
+        from numpy import ones, zeros
+        if b:
+            a = ones(3)
+        else:
+            a = zeros(4)
+        return a
+
+    epyccel_func = epyccel(unknown_size, language=language)
+
+    assert np.array_equal(epyccel_func(True), unknown_size(True))
+    assert np.array_equal(epyccel_func(False), unknown_size(False))


### PR DESCRIPTION
Fix returning an array of unknown literal size. This was broken due to a correct shape but incorrect `alloc_shape`. Fixes #2206 