### PR TITLE
Fix premature `stc/cspan` import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ All notable changes to this project will be documented in this file.
 -   Catch all internal errors arising in the syntactic, semantic, printing or code generation stages.
 -   #2206 : Fix returning an array of unknown literal size.
 -   #2112 : Improve floor division.
+-   #2220 : Fix premature `stc/cspan` import.
 
 ### Changed
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -257,6 +257,7 @@ c_imports = {n : Import(n, Module(n, (), ())) for n in
 
 import_header_guard_prefix = {
     'stc/common': '_TOOLS_COMMON',
+    'stc/cspan': '', # Included for import sorting
     'stc/hmap': '_TOOLS_DICT',
     'stc/hset': '_TOOLS_SET',
     'stc/vec': '_TOOLS_LIST'


### PR DESCRIPTION
Fix premature `stc/cspan` import. Fixes #2220 