### PR TITLE
Bump Anaconda windows version to avoid installation problems

### DIFF
--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - if: github.event_name == 'push'
       run: |
-        echo "version='3.10'" >> $GITHUB_ENV
+        echo "version='3.12'" >> $GITHUB_ENV
       shell: bash
     - id: dispatch-matrix
       if: github.event_name == 'workflow_dispatch'

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -11,7 +11,7 @@ from .github_api_interactions import GitHubAPIInteractions
 
 default_python_versions = {
         'anaconda_linux': '3.10',
-        'anaconda_windows': '3.10',
+        'anaconda_windows': '3.12',
         'coverage': '3.9',
         'docs': '3.10',
         'intel': '3.10',


### PR DESCRIPTION
Bump Anaconda windows version to 3.12 instead of 3.10 to avoid installation problems (see devel branch).