### PR TITLE
Improve compiler documentation

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -6,7 +6,7 @@ Pyccel provides default compiler settings for 4 different compiler families:
 -   **Intel** : `icx` / `ifx`
 -   **NVIDIA** : `nvc` / `nvfort`
 
-**Warning** : The **GNU** compiler is currently the only compiler which is tested regularly
+**Warning** : The **NVIDIA** compiler is not currently tested regularly
 
 ## Specifying a compiler
 
@@ -22,9 +22,9 @@ epyccel(my_func, compiler='intel')
 
 It is also possible to change the default compiler family by setting the environment variable `PYCCEL_DEFAULT_COMPILER`.
 
-## User-defined compiler
+## Using an unsupported compiler or custom compiler flags
 
-The user can also define their own compiler in a JSON file. To use this definition, the location of the JSON file must be passed to the _compiler_ argument. The JSON file must define the following:
+Pyccel's compiler settings are described internally by a dictionary. This makes it easy for a user to define their own compiler settings. This is done via a JSON file. The location of the JSON file is passed to the _compiler_ argument of pyccel/epyccel. The JSON file must define the following:
 
 -   `exec` : The name of the executable
 -   `mpi_exec` : The name of the MPI executable
@@ -45,12 +45,12 @@ In addition, for each accelerator (`mpi`/`openmp`/`openacc`/`python`) that you w
 -   `libdirs` : A list of library directories necessary for compiling \[optional\]
 -   `includes` : A list of include directories necessary for compiling \[optional\]
 
-Python is considered to be an accelerator and must additionally specify shared\_suffix.
+Python is considered to be an accelerator and must additionally specify `shared_suffix`.
 
 The default compilers can provide examples compatible with your system once Pyccel has been executed at least. To export the JSON file describing your setup, use the `--export-compile-info` flag and provide a target file name.
 E.g.
 ```shell
-pyccel --compiler=PGI --language=c --export-compile-info=icc.json
+pyccel --compiler=intel --language=c --export-compile-info=icc.json
 ```
 ## Utilising Pyccel within Anaconda Environment
 While Anaconda is a popular way to install Python as it simplifies package management, it can introduce challenges when working with compilers.

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -52,6 +52,11 @@ E.g.
 ```shell
 pyccel --compiler=intel --language=c --export-compile-info=icc.json
 ```
+once this file has been modified it can then be used with:
+```shell
+pyccel --compiler=icc.json --language=c <file_to_translate>
+```
+
 ## Utilising Pyccel within Anaconda Environment
 While Anaconda is a popular way to install Python as it simplifies package management, it can introduce challenges when working with compilers.
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -24,7 +24,7 @@ It is also possible to change the default compiler family by setting the environ
 
 ## Using an unsupported compiler or custom compiler flags
 
-Pyccel's compiler settings are described internally by a dictionary. This makes it easy for a user to define their own compiler settings. This is done via a JSON file. The location of the JSON file is passed to the _compiler_ argument of pyccel/epyccel. The JSON file must define the following:
+Pyccel's compiler settings are described internally by a dictionary. This makes it easy for a user to define their own compiler settings. This is done via a JSON file. The location of the JSON file is passed to the _compiler_ argument of the Pyccel command line tool or `epyccel`. The JSON file must define the following:
 
 -   `exec` : The name of the executable
 -   `mpi_exec` : The name of the MPI executable

--- a/pyccel/commands/console.py
+++ b/pyccel/commands/console.py
@@ -82,7 +82,7 @@ def pyccel(files=None, mpi=None, openmp=None, openacc=None, output_dir=None, com
 
     group.add_argument('--language', choices=('fortran', 'c', 'python'), help='Generated language')
 
-    group.add_argument('--compiler', help='Compiler family or json file containing a compiler description {GNU,intel,PGI}')
+    group.add_argument('--compiler', help='Compiler family or json file containing a compiler description {GNU,intel,PGI,nvidia}')
 
     group.add_argument('--flags', type=str, \
                        help='Compiler flags.')


### PR DESCRIPTION
Improve compiler documentation to make section about unsupported compilers more obvious. Fixes #2224 