### PR TITLE
Fix Anaconda Windows CI

### DIFF
--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: [devel, main]
+    branches: [devel, main, devel_anaconda_fix]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - if: github.event_name == 'push'
       run: |
-        echo "version='3.12'" >> $GITHUB_ENV
+        echo "version=3.12" >> $GITHUB_ENV
       shell: bash
     - id: dispatch-matrix
       if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: [devel, main, devel_anaconda_fix]
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}


### PR DESCRIPTION
Fix Anaconda Windows CI by unquoting version (originally quoted for v 3.10 but failing due to quotes).