### PR TITLE
Correct error message formatting for invalid type annotation

### DIFF
--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -274,7 +274,7 @@ class SyntacticTypeAnnotation(PyccelAstNode):
 
     def __init__(self, dtype, order = None):
         if not isinstance(dtype, (str, DottedName, IndexedElement)):
-            raise ValueError("Syntactic datatypes should be strings not {type(dtype)}")
+            raise ValueError(f"Syntactic datatypes should be strings not {type(dtype)}")
         if not (order is None or isinstance(order, str)):
             raise ValueError("Order should be a string")
         self._dtype = dtype


### PR DESCRIPTION
# PR Summary
Small PR - Use f-string for error message in `SyntacticTypeAnnotation` to print the data type.

Before:
```
ValueError: Syntactic datatypes should be strings not {type(dtype)}
```
After:
```
ValueError: Syntactic datatypes should be strings not <class 'int'>
```


