### PR TITLE
Fix annotation of variables that are returned in a function whose result type is annotated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ All notable changes to this project will be documented in this file.
 -   #2220 : Fix premature `stc/cspan` import.
 -   #2214 : Fix returning a local variable from an inline function.
 -   #1321 : Fix use of tuples returned from functions in a non-assign statement.
+-   #2229 : Fix annotation of variables that are returned in a function whose result type is annotated.
 
 ### Changed
 

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -313,6 +313,10 @@ class SyntacticTypeAnnotation(PyccelAstNode):
         else:
             return False
 
+    def __str__(self):
+        order_str = f'(order={self.order})' if self.order else ''
+        return f'{self.dtype}{order_str}'
+
 #==============================================================================
 
 typenames_to_dtypes = { 'float'   : PythonNativeFloat(),

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2896,7 +2896,7 @@ class SemanticParser(BasicParser):
 
     def _visit_AnnotatedPyccelSymbol(self, expr):
         # Check if the variable already exists
-        var = self.scope.find(expr, 'variables', local_only = True)
+        var = self.scope.find(expr.name, 'variables', local_only = True)
         if var is not None:
             errors.report("Variable has been declared multiple times",
                     symbol=expr, severity='error')

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -358,6 +358,14 @@ def test_union_type(language):
     assert np.isclose(f(y), square(y), rtol=RTOL, atol=ATOL)
     assert isinstance(f(y), type(square(y)))
 
+def test_return_annotation(language):
+    def get_2() -> int:
+        my_var : int = 2
+        return my_var
+
+    f = epyccel(get_2, language=language)
+    assert f() == get_2()
+
 ##==============================================================================
 ## CLEAN UP GENERATED FILES AFTER RUNNING TESTS
 ##==============================================================================


### PR DESCRIPTION
Fix annotation of variables that are returned in a function whose result type is annotated. Fixes #2229 