### PR TITLE
Support sets as arguments in Fortran

### DIFF
--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -60,6 +60,10 @@ class DictMethod(PyccelFunction):
         """
         return self._dict_obj
 
+    @property
+    def modified_args(self):
+        return (self._dict_obj,)
+
 #==============================================================================
 class DictPop(DictMethod):
     """
@@ -189,6 +193,10 @@ class DictGet(DictMethod):
         """
         return self._args[1]
 
+    @property
+    def modified_args(self):
+        return ()
+
 #==============================================================================
 class DictSetDefault(DictMethod):
     """
@@ -289,6 +297,10 @@ class DictCopy(DictMethod):
         self._shape = dict_obj.shape
         super().__init__(dict_obj)
 
+    @property
+    def modified_args(self):
+        return ()
+
 #==============================================================================
 class DictItems(Iterable):
     """
@@ -334,6 +346,10 @@ class DictItems(Iterable):
         """
         item = DictPopitem(self._dict_obj)
         return [IndexedElement(item, 0), IndexedElement(item, 1)]
+
+    @property
+    def modified_args(self):
+        return ()
 
 #==============================================================================
 class DictKeys(Iterable):
@@ -381,6 +397,10 @@ class DictKeys(Iterable):
         """
         item = DictPopitem(self._dict_obj)
         return [IndexedElement(item, 0)]
+
+    @property
+    def modified_args(self):
+        return ()
 
 #==============================================================================
 class DictGetItem(DictMethod):

--- a/pyccel/ast/builtin_methods/list_methods.py
+++ b/pyccel/ast/builtin_methods/list_methods.py
@@ -294,6 +294,10 @@ class ListCopy(ListMethod) :
         self._class_type = list_obj.class_type
         super().__init__(list_obj)
 
+    @property
+    def modified_args(self):
+        return ()
+
 #==============================================================================
 class ListSort(ListMethod) :
     """

--- a/pyccel/ast/builtin_methods/list_methods.py
+++ b/pyccel/ast/builtin_methods/list_methods.py
@@ -56,6 +56,10 @@ class ListMethod(PyccelFunction):
         """
         return self._list_obj
 
+    @property
+    def modified_args(self):
+        return (self._list_obj,)
+
 #==============================================================================
 class ListAppend(ListMethod):
     """

--- a/pyccel/ast/builtin_methods/set_methods.py
+++ b/pyccel/ast/builtin_methods/set_methods.py
@@ -57,6 +57,10 @@ class SetMethod(PyccelFunction):
         """
         return self._set_variable
 
+    @property
+    def modified_args(self):
+        return (self._set_variable,)
+
 #==============================================================================
 class SetAdd(SetMethod) :
     """
@@ -125,6 +129,10 @@ class SetCopy(SetMethod):
         self._shape = set_variable._shape
         self._class_type = set_variable._class_type
         super().__init__(set_variable)
+
+    @property
+    def modified_args(self):
+        return ()
 
 #==============================================================================
 class SetPop(SetMethod):
@@ -236,6 +244,10 @@ class SetUnion(SetMethod):
         self._shape = (None,)*self._class_type.rank
         super().__init__(set_obj, *others)
 
+    @property
+    def modified_args(self):
+        return ()
+
 #==============================================================================
 
 class SetIntersection(SetMethod):
@@ -255,6 +267,10 @@ class SetIntersection(SetMethod):
     """
     __slots__ = ('_other','_class_type', '_shape')
     name = 'intersection'
+
+    @property
+    def modified_args(self):
+        return ()
 
 #==============================================================================
 

--- a/pyccel/ast/builtin_methods/set_methods.py
+++ b/pyccel/ast/builtin_methods/set_methods.py
@@ -325,3 +325,7 @@ class SetIsDisjoint(SetMethod):
         if set_obj.class_type != other_set_obj.class_type:
             raise TypeError("Is disjoint can only be used to compare sets of the same type.")
         super().__init__(set_obj, other_set_obj)
+
+    @property
+    def modified_args(self):
+        return ()

--- a/pyccel/ast/internals.py
+++ b/pyccel/ast/internals.py
@@ -67,6 +67,15 @@ class PyccelFunction(TypedAstNode):
         """
         return False
 
+    @property
+    def modified_args(self):
+        """
+        Return an iterable of all the arguments which may be modified by this function.
+
+        Return an iterable of all the arguments which may be modified by this function.
+        This is notably useful in order to determine the constness of arguments.
+        """
+        return ()
 
 class PyccelArraySize(PyccelFunction):
     """

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -2514,17 +2514,28 @@ class CToPythonWrapper(Wrapper):
         assert not bound_argument
 
         size_var = self.scope.get_temporary_variable(PythonNativeInt(), self.scope.get_new_name(f'{orig_var.name}_size'))
+        body = [Assign(size_var, PySet_Size(collect_arg))]
 
         if is_bind_c_argument:
-            raise errors.report("Fortran set interface is not yet implemented", severity='fatal', symbol=orig_var)
+            element_type = orig_var.class_type.element_type
+            #raise errors.report("Fortran set interface is not yet implemented", severity='fatal', symbol=orig_var)
+            arr_var = Variable(NumpyNDArrayType(element_type, 1, None), self.scope.get_expected_name(orig_var.name),
+                                shape = (size_var,), memory_handling = 'heap')
+            self.scope.insert_variable(arr_var, orig_var.name)
+            arg_var = Variable(BindCArrayType(1, False), self.scope.get_new_name(orig_var.name),
+                        shape = (LiteralInteger(2),))
+            data = DottedVariable(VoidType(), 'data', lhs=arr_var)
+            self.scope.insert_symbolic_alias(IndexedElement(arg_var, LiteralInteger(0)), data)
+            self.scope.insert_symbolic_alias(IndexedElement(arg_var, LiteralInteger(1)), size_var)
+            arg_vars = [arg_var]
+            body.append(Allocate(arr_var, shape = (size_var,), status='unallocated'))
         else:
             arg_var = orig_var.clone(self.scope.get_expected_name(orig_var.name), is_argument = False,
                                     memory_handling='heap', new_class = Variable)
             self._wrapping_arrays = True
             self.scope.insert_variable(arg_var, orig_var.name)
             arg_vars = [arg_var]
-            body = [Assign(arg_var, PythonSet())]
-            insert_func = SetAdd
+            body.append(Assign(arg_var, PythonSet()))
 
         idx = self.scope.get_temporary_variable(CNativeInt())
         indexed_orig_var = self.scope.get_temporary_variable(orig_var.class_type.element_type)
@@ -2532,33 +2543,40 @@ class CToPythonWrapper(Wrapper):
 
         iter_obj = self.scope.get_temporary_variable(PyccelPyObject(), 'iter', memory_handling='alias')
 
-        body += [Assign(size_var, PySet_Size(collect_arg)),
-                 AliasAssign(iter_obj, PySet_GetIter(collect_arg))]
+        body.append(AliasAssign(iter_obj, PySet_GetIter(collect_arg)))
 
         for_scope = self.scope.create_new_loop_scope()
         self.scope = for_scope
         for_body = [AliasAssign(indexed_collect_arg, PyIter_Next(iter_obj))]
         for_body += self._extract_FunctionDefArgument(indexed_orig_var, indexed_collect_arg,
                                     bound_argument, is_bind_c_argument, arg_var = indexed_orig_var)['body']
-        for_body.append(insert_func(arg_var, indexed_orig_var))
+        if is_bind_c_argument:
+            for_body.append(Assign(IndexedElement(arr_var, idx), indexed_orig_var))
+        else:
+            for_body.append(SetAdd(arg_var, indexed_orig_var))
         self.exit_scope()
 
         body.append(For((idx,), PythonRange(size_var), for_body, scope = for_scope))
 
         clean_up = []
         if not orig_var.is_const:
-            element_extraction = self._extract_FunctionDefResult(IndexedElement(orig_var, idx),
-                                            is_bind_c_argument, None)
-            elem_set = PySet_Add(collect_arg, element_extraction['py_result'])
-            for_body = [*element_extraction['body'],
-                    If(IfSection(PyccelEq(elem_set, PyccelUnarySub(LiteralInteger(1))),
-                                             [Return(self._error_exit_code)]))]
+            if is_bind_c_argument:
+                errors.report("Sets should be passed as constant arguments when translating to languages other than c." +
+                              "Any changes to the set will not be reflected in the calling code.",
+                              severity='warning', symbol=orig_var)
+            else:
+                element_extraction = self._extract_FunctionDefResult(IndexedElement(orig_var, idx),
+                                                is_bind_c_argument, None)
+                elem_set = PySet_Add(collect_arg, element_extraction['py_result'])
+                for_body = [*element_extraction['body'],
+                        If(IfSection(PyccelEq(elem_set, PyccelUnarySub(LiteralInteger(1))),
+                                                 [Return(self._error_exit_code)]))]
 
-            loop_iterator = VariableIterator(arg_var)
-            loop_iterator.set_loop_counter(idx)
-            clean_up = [If(IfSection(PyccelEq(PySet_Clear(collect_arg), PyccelUnarySub(LiteralInteger(1))),
-                                             [Return(self._error_exit_code)])),
-                    For((element_extraction['c_results'][0],), loop_iterator, for_body, for_scope)]
+                loop_iterator = VariableIterator(arg_var)
+                loop_iterator.set_loop_counter(idx)
+                clean_up = [If(IfSection(PyccelEq(PySet_Clear(collect_arg), PyccelUnarySub(LiteralInteger(1))),
+                                                 [Return(self._error_exit_code)])),
+                        For((element_extraction['c_results'][0],), loop_iterator, for_body, for_scope)]
 
         return {'body': body, 'args': arg_vars, 'clean_up': clean_up}
 

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -15,6 +15,7 @@ from pyccel.ast.bind_c import BindCArrayVariable, BindCClassDef, DeallocatePoint
 from pyccel.ast.bind_c import BindCClassProperty, c_malloc, BindCSizeOf
 from pyccel.ast.bind_c import BindCVariable, BindCArrayType, C_NULL_CHAR
 from pyccel.ast.builtins import VariableIterator, PythonRange
+from pyccel.ast.builtin_methods.set_methods import SetAdd
 from pyccel.ast.core import Assign, FunctionCallArgument
 from pyccel.ast.core import Allocate, EmptyNode, FunctionAddress
 from pyccel.ast.core import If, IfSection, Import, Interface, FunctionDefArgument
@@ -396,6 +397,50 @@ class FortranToCWrapper(Wrapper):
         shape_var = scope.get_temporary_variable(PythonNativeInt(), name=f'{name}_size', is_argument = True)
 
         body = [C_F_Pointer(bind_var, arg_var, (shape_var,))]
+
+        c_arg_var = Variable(BindCArrayType(rank, has_strides = False),
+                        scope.get_new_name(), is_argument = True,
+                        shape = (LiteralInteger(2),))
+
+        scope.insert_symbolic_alias(IndexedElement(c_arg_var, LiteralInteger(0)), bind_var)
+        scope.insert_symbolic_alias(IndexedElement(c_arg_var, LiteralInteger(1)), shape_var)
+
+        return {'c_arg': BindCVariable(c_arg_var, var), 'f_arg': arg_var, 'body': body}
+
+    def _extract_HomogeneousSetType_FunctionDefArgument(self, var, func):
+        name = var.name
+        scope = self.scope
+        scope.insert_symbol(name)
+        collisionless_name = scope.get_expected_name(name)
+        rank = var.rank
+        element_type = var.class_type.element_type
+        bind_var = Variable(BindCPointer(), scope.get_new_name(f'bound_{name}'),
+                            is_argument = True, is_optional = False, memory_handling='alias')
+        arg_var = var.clone(collisionless_name, is_argument = False, is_optional = False,
+                            allows_negative_indexes=False, new_class = Variable)
+        scope.insert_variable(arg_var)
+        scope.insert_variable(bind_var)
+
+        shape_var = scope.get_temporary_variable(PythonNativeInt(), name=f'{name}_size', is_argument = True)
+        local_var = Variable(NumpyNDArrayType(element_type, 1, None), scope.get_new_name(name),
+                            shape = (shape_var,), memory_handling='alias')
+        scope.insert_variable(local_var)
+
+        for_scope = scope.create_new_loop_scope()
+        iterator = PythonRange(LiteralInteger(1), PyccelAdd(shape_var, LiteralInteger(1)))
+        idx = Variable(PythonNativeInt(), self.scope.get_new_name())
+        iterator.set_loop_counter(idx)
+        self.scope.insert_variable(idx)
+
+        # Default Fortran arrays retrieved from C_F_Pointer are 1-indexed
+        # Lists are 1-indexed but Pyccel adds the shift during printing so they are
+        # treated as 0-indexed here
+        for_body = [SetAdd(arg_var, IndexedElement(local_var, idx))]
+
+        body = [C_F_Pointer(bind_var, local_var, (shape_var,)),
+                Allocate(arg_var, shape = (shape_var,), status = 'unallocated',
+                    alloc_type = 'reserve'),
+                For((idx,), iterator, for_body, scope = for_scope)]
 
         c_arg_var = Variable(BindCArrayType(rank, has_strides = False),
                         scope.get_new_name(), is_argument = True,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4621,6 +4621,7 @@ class SemanticParser(BasicParser):
             # Find all nodes which can modify variables
             assigns = body.get_attribute_nodes((Assign, AliasAssign), excluded_nodes = (FunctionCall,))
             calls   = body.get_attribute_nodes(FunctionCall)
+            builtin_func_calls = body.get_attribute_nodes(PyccelFunction)
             builtin_calls = body.get_attribute_nodes((Allocate, Deallocate))
 
             # Collect the modified objects
@@ -4628,6 +4629,7 @@ class SemanticParser(BasicParser):
             modified_args = [call_arg.value for f in calls
                                 for call_arg, func_arg in zip(f.args, f.funcdef.arguments) if func_arg.inout]
             modified_args += [f.variable for f in builtin_calls]
+            modified_args += [v for f in builtin_func_calls for v in f.modified_args]
             # Collect modified variables
             all_assigned = [v for a in (lhs_assigns + modified_args) for v in
                             (a.get_attribute_nodes(Variable) if not isinstance(a, Variable) else [a])]

--- a/tests/epyccel/test_epyccel_sets.py
+++ b/tests/epyccel/test_epyccel_sets.py
@@ -350,12 +350,12 @@ def test_set_copy_from_arg1(python_only_language):
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-def test_set_copy_from_arg2(stc_language):
+def test_set_copy_from_arg2(language):
     def copy_from_arg2(a : 'set[float]'):
         b = set(a)
         return b
     a = {2.5, 1.4, 9.2}
-    epyc_copy_from_arg = epyccel(copy_from_arg2, language = stc_language)
+    epyc_copy_from_arg = epyccel(copy_from_arg2, language = language)
     pyccel_result = epyc_copy_from_arg(a)
     python_result = copy_from_arg2(a)
     assert isinstance(python_result, type(pyccel_result))
@@ -703,14 +703,14 @@ def test_set_iter_prod(language):
     assert python_result == pyccel_result
     assert isinstance(python_result, type(pyccel_result))
 
-def test_set_const_arg(stc_language):
+def test_set_const_arg(language):
     @template('T', ['int', 'float', 'complex'])
     def set_arg(arg : 'const set[T]', my_sum : 'T'):
         for ai in arg:
             my_sum += ai
         return my_sum
 
-    epyccel_func = epyccel(set_arg, language = stc_language)
+    epyccel_func = epyccel(set_arg, language = language)
     int_arg = {1,2,3,4,5,6,7}
     float_arg = {1.5, 2.5, 3.5, 4.5, 6.7}
     complex_arg = {1+0j,4j,2.5+2j}
@@ -757,35 +757,14 @@ def test_set_min_max(language):
     assert python_result == pyccel_result
     assert isinstance(python_result, type(pyccel_result))
 
-def test_set_is_disjoint(stc_language):
+def test_set_is_disjoint(language):
     def set_is_disjoint(a : set[int], b : set[int]):
         return a.isdisjoint(b)
 
-    epyccel_func = epyccel(set_is_disjoint, language = stc_language)
+    epyccel_func = epyccel(set_is_disjoint, language = language)
     example_set1 = {1,2,3,4}
     example_set2 = {5,6,7,8}
     example_set3 = {7,8,2}
     assert set_is_disjoint(example_set1, example_set2) == epyccel_func(example_set1, example_set2)
     assert set_is_disjoint(example_set1, example_set3) == epyccel_func(example_set1, example_set3)
     assert set_is_disjoint(example_set3, example_set2) == epyccel_func(example_set3, example_set2)
-
-def test_set_is_disjoint_fortran():
-    def set_is_disjoint1():
-        a = {1,2,3,4}
-        b = {5,6,7,8}
-        return a.isdisjoint(b)
-    def set_is_disjoint2():
-        a = {1,2,3,4}
-        b = {7,8,2}
-        return a.isdisjoint(b)
-    def set_is_disjoint3():
-        a = {7,8,2}
-        b = {5,6,7,8}
-        return a.isdisjoint(b)
-
-    epyccel_func1 = epyccel(set_is_disjoint1, language = 'fortran')
-    epyccel_func2 = epyccel(set_is_disjoint2, language = 'fortran')
-    epyccel_func3 = epyccel(set_is_disjoint3, language = 'fortran')
-    assert set_is_disjoint1() == epyccel_func1()
-    assert set_is_disjoint2() == epyccel_func2()
-    assert set_is_disjoint3() == epyccel_func3()


### PR DESCRIPTION
Support sets as arguments in Fortran. Fixes #1662

**Commit Summary**
- Add a `modified_args` property to `PyccelFunction` so it is possible to indicate if a `PyccelFunction` modifies one or more of the arguments passed to it. This is important to determine constness.
- Add the wrapper for sets as arguments in Fortran
- Activate existing tests