### PR TITLE
Fix incorrect memory handling for temporary variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ All notable changes to this project will be documented in this file.
 -   #2214 : Fix returning a local variable from an inline function.
 -   #1321 : Fix use of tuples returned from functions in a non-assign statement.
 -   #2229 : Fix annotation of variables that are returned in a function whose result type is annotated.
+-   #2238 : Fix incorrect memory handling for temporary variable.
 
 ### Changed
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -765,13 +765,11 @@ class CCodePrinter(CodePrinter):
 
             lhs = self._print(lhs_var)
             if not isinstance(arg_var, Variable):
-                if arg_var.rank:
-                    tmp = self.scope.get_temporary_variable(arg_var.class_type, shape = arg_var.shape,
-                            memory_handling='alias')
-                    prefix += self._print(AliasAssign(tmp, arg_var))
-                else:
-                    tmp = self.scope.get_temporary_variable(arg_var.class_type, shape = arg_var.shape)
-                    prefix += self._print(Assign(tmp, arg_var))
+                # This handles slice arguments
+                assert arg_var.rank
+                tmp = self.scope.get_temporary_variable(arg_var.class_type, shape = arg_var.shape,
+                        memory_handling='alias')
+                prefix += self._print(AliasAssign(tmp, arg_var))
                 arg_var = tmp
             arg = self._print(arg_var)
             c_type = self.get_c_type(class_type)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -2454,6 +2454,21 @@ def test_sum_property(language):
     x = randint(99, size=10)
     assert f1(x) == sum_call(x)
 
+def test_sum_slice_in_if(language):
+    def sum_call(x : 'int[:]'):
+        from numpy import sum as np_sum
+        s = x.shape[0]
+        if s < 3:
+            return 0
+        else:
+            n = 1
+            m = s -1
+            return np_sum(x[n:m])
+
+    f1 = epyccel(sum_call, language = language, fflags='-Werror=uninitialized')
+    x = randint(99, size=10)
+    assert f1(x) == sum_call(x)
+
 def test_min_int(language):
     def min_call(x : 'int[:]'):
         from numpy import amin


### PR DESCRIPTION
Fix incorrect memory handling for temporary variable. A temporary variable created in the codegen stage was incorrectly assumed to be a scalar. Correcting this assumption fixes #2236.