### PR TITLE
Specify the libdirs for a shared Python library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ All notable changes to this project will be documented in this file.
 -   #2214 : Fix returning a local variable from an inline function.
 -   #1321 : Fix use of tuples returned from functions in a non-assign statement.
 -   #2229 : Fix annotation of variables that are returned in a function whose result type is annotated.
+-   #2239 : Fix missing library directory for Python shared library.
 
 ### Changed
 

--- a/pyccel/compilers/default_compilers.py
+++ b/pyccel/compilers/default_compilers.py
@@ -263,6 +263,7 @@ else:
                 possible_shared_lib = preferred_lib
 
         python_info['python']['dependencies'] = (possible_shared_lib[0],)
+        python_info['python']['libdirs'] = (os.path.dirname(possible_shared_lib[0]),)
     elif possible_static_lib:
         if len(possible_static_lib)>1:
             preferred_lib = [l for l in possible_static_lib if l.endswith('.a')]


### PR DESCRIPTION
Specify the libdirs for a shared Python library. This ensures that the library will be found during execution if the compilation succeeds.