### PR TITLE
Fix underflow errors on devel

### DIFF
--- a/tests/epyccel/test_epyccel_expressions.py
+++ b/tests/epyccel/test_epyccel_expressions.py
@@ -125,8 +125,8 @@ def test_tuple_assign(language):
     assert f(2,4) == tup_assign(2,4)
     assert f(-2,4) == tup_assign(-2,4)
     assert f(4,100) == tup_assign(4,100)
-    x = randint(min_int, max_int//2)
-    y = randint(min_int, max_int//2)
+    x = randint(min_int//2, max_int//2)
+    y = randint(min_int//2, max_int//2)
     assert f(x,y) == tup_assign(x,y)
 
 def test_tuple_assign2(language):
@@ -138,8 +138,8 @@ def test_tuple_assign2(language):
     assert f(2,4) == tup_assign(2,4)
     assert f(-2,4) == tup_assign(-2,4)
     assert f(4,100) == tup_assign(4,100)
-    x = randint(min_int, max_int//2)
-    y = randint(min_int, max_int//2)
+    x = randint(min_int//2, max_int//2)
+    y = randint(min_int//2, max_int//2)
     assert f(x,y) == tup_assign(x,y)
 
 def test_tuple_assign3(language):


### PR DESCRIPTION
Windows tests are sometimes failing due to underflow errors. This is fixed by limiting the range of integers used in the test to a range that returns valid results. This was already fixed for overflow errors but `min_int` is a negative number not a small value as for `min_float`.