### PR TITLE
Add `C` and `Fortran` support for the `list.clear()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Allow the use of magic methods to describe container methods.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
 -   \[DEVELOPER\] Added an environment variable to globally activate developer-mode for errors.
+-   #2256 Add C and Fortran support for list method `clear()`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 -   #1876 : Add C support for indexing lists.
 -   #1690 : Add C and Fortran support for list method `pop()`.
 -   #1695 : Add C and Fortran support for list method `reverse()`.
+-   #2256 : Add C and Fortran support for list method `clear()`.
 -   #1663 : Add C and Fortran support for sets as arguments.
 -   #1664 : Add C and Fortran support for returning sets from functions.
 -   #2023 : Add support for iterating over a `set`.
@@ -81,7 +82,6 @@ All notable changes to this project will be documented in this file.
 -   \[INTERNALS\] Allow the use of magic methods to describe container methods.
 -   \[DEVELOPER\] Added an improved traceback to the developer-mode errors for errors in function calls.
 -   \[DEVELOPER\] Added an environment variable to globally activate developer-mode for errors.
--   #2256 Add C and Fortran support for list method `clear()`.
 
 ### Fixed
 

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -79,7 +79,7 @@ Python contains a limited number of builtin functions defined [here](https://doc
 | Method | Supported |
 |----------|-----------|
 | **`append`** | **Yes** |
-| `clear` | Python-only |
+| **`clear`** | **Yes** |
 | `copy` | Python-only |
 | `count` | No |
 | `extend` | Python-only |

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2903,6 +2903,13 @@ class CCodePrinter(CodePrinter):
         else:
             return f'{c_type}_pull({list_obj})'
 
+    def _print_ListClear(self, expr):
+        target = expr.list_obj
+        class_type = target.class_type
+        c_type = self.get_c_type(class_type)
+        list_obj = self._print(ObjectAddress(expr.list_obj))
+        return f'{c_type}_clear({list_obj});\n'
+
     #================== Set methods ==================
 
     def _print_SetPop(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1412,6 +1412,10 @@ class FCodePrinter(CodePrinter):
             self._additional_code += code
             return lhs_code
 
+    def _print_ListClear(self, expr):
+        target = self._print(expr.list_obj)
+        return f'call {target} % clear()\n'
+
     #========================== Set Methods ================================#
 
     def _print_SetAdd(self, expr):

--- a/tests/epyccel/test_epyccel_lists.py
+++ b/tests/epyccel/test_epyccel_lists.py
@@ -369,26 +369,26 @@ def test_insert_user_defined_objects(limited_language):
     for python_elem, accelerated_elem in zip(python_list, accelerated_list):
         assert python_elem.x == accelerated_elem.x
 
-def test_clear_1(limited_language):
+def test_clear_1(language):
 
     def clear_1():
         a = [1, 2, 3]
         a.clear()
         return a
 
-    epyc_clear_1 = epyccel(clear_1, language = limited_language)
+    epyc_clear_1 = epyccel(clear_1, language = language)
     pyccel_result = epyc_clear_1()
     python_result = clear_1()
     assert python_result == pyccel_result
 
-def test_clear_2(limited_language):
+def test_clear_2(language):
 
     def clear_2():
-        a = []
+        a : 'list[int]' = []
         a.clear()
         return a
 
-    epyc_clear_2 = epyccel(clear_2, language = limited_language)
+    epyc_clear_2 = epyccel(clear_2, language = language)
     pyccel_result = epyc_clear_2()
     python_result = clear_2()
     assert python_result == pyccel_result


### PR DESCRIPTION
This PR adds `C` and `Fortran` printing for the `list.clear()` method and activates relevant tests.