### PR TITLE
Add the necessary pointer information to ensure errors are raised for multi-level containers

### DIFF
--- a/.github/actions/pytest_run/action.yml
+++ b/.github/actions/pytest_run/action.yml
@@ -63,7 +63,9 @@ runs:
       id: pytest_4
     - name: Test multi-file Fortran translations
       run: |
-        python -m pytest -rX ${FLAGS} -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" 2>&1 | tee s5_outfile.out
+        # Temporarily run warnings separately as lists of lists are used in errors and singleton means warning is only raised once
+        python -m pytest -rX ${FLAGS} -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" --ignore=warnings 2>&1 | tee s5_outfile.out
+        python -m pytest -rX ${FLAGS} -m "xdist_incompatible and not parallel and not (c or python) ${{ inputs.pytest_mark }}" warnings 2>&1 | tee -a s5_outfile.out
         pyccel-clean
       shell: ${{ inputs.shell_cmd }}
       working-directory: ./tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ All notable changes to this project will be documented in this file.
 -   #2098 : Fix using multiple list comprehensions.
 -   #1948 : Fix list comprehension does not work in C.
 -   #2245 : Fix internal error when an inhomogeneous tuple appears as an indexed element.
--   #2258 : Fix missing errors for bad pointer handling with multi-level containers.
+-   #2258 : Fix missing errors for bad pointer handling in the case of containers with mutable elements.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ All notable changes to this project will be documented in this file.
 -   #2098 : Fix using multiple list comprehensions.
 -   #1948 : Fix list comprehension does not work in C.
 -   #2245 : Fix internal error when an inhomogeneous tuple appears as an indexed element.
+-   #2258 : Fix missing errors for bad pointer handling with multi-level containers.
 
 ### Changed
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -822,10 +822,9 @@ class IndexedElement(TypedAstNode):
     @property
     def is_slice(self):
         """
-        Indicates whether the result is a slice of a container.
+        Indicates whether this instance represents a slice.
 
-        Indicates whether the result is a slice of a container or an element
-        of a container.
+        Indicates whether this instance represents a slice or an element.
         """
         return self._is_slice
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -819,6 +819,16 @@ class IndexedElement(TypedAstNode):
         """
         return self.base.allows_negative_indexes
 
+    @property
+    def is_slice(self):
+        """
+        Indicates whether the result is a slice of a container.
+
+        Indicates whether the result is a slice of a container or an element
+        of a container.
+        """
+        return self._is_slice
+
     def __hash__(self):
         return hash((self.base, self._indices))
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -1237,7 +1237,10 @@ class PythonCodePrinter(CodePrinter):
         cls_variable = expr.cls_variable
         cls_name = cls_variable.cls_base.name
         args = ', '.join(self._print(arg) for arg in expr.args[1:])
-        return f"{cls_variable} = {cls_name}({args})\n"
+        if expr.get_direct_user_nodes(lambda u: isinstance(u, CodeBlock)):
+            return f"{cls_variable} = {cls_name}({args})\n"
+        else:
+            return f"{cls_name}({args})"
 
     def _print_Del(self, expr):
         return ''.join(f'del {var.variable}\n' for var in expr.variables)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3922,16 +3922,6 @@ class SemanticParser(BasicParser):
                                   severity='fatal')
                 elif isinstance(r, (PythonList, PythonSet, PythonTuple, PythonDict)):
                     self._indicate_pointer_target(l, r, expr)
-                elif isinstance(r, (ListPop, DictPop, DictPopitem)) and \
-                        not isinstance(l.class_type, (StringType, FixedSizeNumericType)):
-                    class_obj = getattr(r, 'dict_obj', getattr(r, 'list_obj', None))
-                    class_obj = r.list_obj if isinstance(r, ListPop) else r.dict_obj
-                    for target, target_expr in self._pointer_targets[-1].get(class_obj, ()):
-                        # Create an expr describing 2 lines to show where the dependency comes from
-                        indicated_expr = CodeBlock([target_expr, expr])
-                        # Show the line number of the assignment for the returned object
-                        indicated_expr.set_current_ast(expr.python_ast)
-                        self._indicate_pointer_target(l, target, indicated_expr)
 
             new_expressions.append(new_expr)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1503,7 +1503,10 @@ class SemanticParser(BasicParser):
                 d_lhs['memory_handling'] = 'alias'
                 rhs.base.is_target = not rhs.base.is_alias
 
-            elif isinstance(rhs, (IndexedElement, ListPop, DictPop)):
+            elif isinstance(rhs, (ListPop, DictPop)):
+                d_lhs['memory_handling'] = 'alias'
+
+            elif isinstance(rhs, IndexedElement) and not rhs.is_slice:
                 d_lhs['memory_handling'] = 'alias'
 
     def _assign_lhs_variable(self, lhs, d_var, rhs, new_expressions, is_augassign = False,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1503,7 +1503,7 @@ class SemanticParser(BasicParser):
                 d_lhs['memory_handling'] = 'alias'
                 rhs.base.is_target = not rhs.base.is_alias
 
-            elif isinstance(rhs, (ListPop, DictPop)):
+            elif isinstance(rhs, (IndexedElement, ListPop, DictPop)):
                 d_lhs['memory_handling'] = 'alias'
 
     def _assign_lhs_variable(self, lhs, d_var, rhs, new_expressions, is_augassign = False,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1191,9 +1191,10 @@ class SemanticParser(BasicParser):
                             new_expr = DottedName(args[0].value, FunctionCall(func, args[1:]))
                         else:
                             new_expr = FunctionCall(func, args)
-                        new_expr.set_current_ast(expr.python_ast)
+                        new_expr.set_current_ast(expr.python_ast or self._current_ast_node)
                         pyccel_stage.set_stage('semantic')
-                        new_expr.set_current_user_node(expr.current_user_node)
+                        for u in expr.get_all_user_nodes():
+                            new_expr.set_current_user_node(u)
                         expr = new_expr
                     return getattr(self, annotation_method)(expr, args)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5433,7 +5433,7 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         expr : DottedName
-            The syntactic DottedName node that represent the call to `.extend()`.
+            The syntactic DottedName node that represents the call to `.extend()`.
 
         args : iterable[FunctionCallArgument]
             The semantic arguments passed to the function.
@@ -5488,7 +5488,7 @@ class SemanticParser(BasicParser):
             The syntactic FunctionCall describing the call to `cmath.sqrt`.
 
         func_call_args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            The semantic argument passed to the function.
 
         Returns
         -------
@@ -5545,7 +5545,7 @@ class SemanticParser(BasicParser):
             The syntactic FunctionCall describing the call to `cmath.sqrt`.
 
         func_call_args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            The semantic argument passed to the function.
 
         Returns
         -------
@@ -5595,7 +5595,7 @@ class SemanticParser(BasicParser):
             The syntactic FunctionCall describing the call to `cmath.polar`.
 
         func_call_args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            The semantic argument passed to the function.
 
         Returns
         -------
@@ -5632,7 +5632,7 @@ class SemanticParser(BasicParser):
             The syntactic FunctionCall describing the call to `cmath.rect`.
 
         func_call_args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            The 2 semantic arguments passed to the function.
 
         Returns
         -------
@@ -5662,7 +5662,7 @@ class SemanticParser(BasicParser):
             The syntactic FunctionCall describing the call to `cmath.phase`.
 
         func_call_args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            The semantic argument passed to the function.
 
         Returns
         -------
@@ -5792,7 +5792,7 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         expr : DottedName | AugAssign
-            The syntactic DottedName node that represent the call to `.update()`.
+            The syntactic DottedName node that represents the call to `.update()`.
 
         args : iterable[FunctionCallArgument]
             The semantic arguments passed to the function.
@@ -5852,7 +5852,7 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         expr : DottedName
-            The syntactic DottedName node that represent the call to `.union()`.
+            The syntactic DottedName node that represents the call to `.union()`.
 
         function_call_args : iterable[FunctionCallArgument]
             The semantic arguments passed to the function.
@@ -5907,7 +5907,7 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         expr : DottedName
-            The syntactic DottedName node that represent the call to `.intersection()`.
+            The syntactic DottedName node that represents the call to `.intersection()`.
 
         function_call_args : iterable[FunctionCallArgument]
             The semantic arguments passed to the function.
@@ -5954,10 +5954,10 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         expr : FunctionCall
-            The syntactic node that represent the call to `len()`.
+            The syntactic node that represents the call to `len()`.
 
         function_call_args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            The semantic argument passed to the function.
 
         Returns
         -------
@@ -5995,7 +5995,7 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         expr : FunctionCall
-            The syntactic node that represent the call to `PythonSetFunction`.
+            The syntactic node that represents the call to `PythonSetFunction`.
 
         function_call_args : iterable[FunctionCallArgument]
             The semantic arguments passed to the function.
@@ -6045,15 +6045,15 @@ class SemanticParser(BasicParser):
 
         The purpose of this `_build` method is to construct a literal boolean indicating
         whether or not the expression has the expected type.
-            The syntactic node that represent the call to `isinstance()`.
+        The syntactic node that represents the call to `isinstance()`.
 
         Parameters
         ----------
         expr : FunctionCall
-            The syntactic node that represent the call to `PythonSetFunction`.
+            The syntactic node that represents the call to `PythonSetFunction`.
 
         function_call_args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            The 2 semantic arguments passed to the function.
 
         Returns
         -------
@@ -6113,10 +6113,10 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         expr : DottedName
-            The syntactic DottedName node that represent the call to `.append()`.
+            The syntactic DottedName node that represents the call to `.append()`.
 
         args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            An iterable containing the 1 semantic argument passed to the function.
 
         Returns
         -------
@@ -6140,10 +6140,10 @@ class SemanticParser(BasicParser):
         Parameters
         ----------
         expr : DottedName
-            The syntactic DottedName node that represent the call to `.insert()`.
+            The syntactic DottedName node that represents the call to `.insert()`.
 
         args : iterable[FunctionCallArgument]
-            The semantic arguments passed to the function.
+            The 2 semantic arguments passed to the function.
 
         Returns
         -------

--- a/tests/epyccel/modules/list_user_defined_objs.py
+++ b/tests/epyccel/modules/list_user_defined_objs.py
@@ -13,4 +13,4 @@ def fn():
     lst = [a, b, c]
     lst.insert(0, d)
     lst.insert(1, e)
-    return lst
+    return len(lst)

--- a/tests/epyccel/modules/list_user_defined_objs1.py
+++ b/tests/epyccel/modules/list_user_defined_objs1.py
@@ -10,7 +10,7 @@ def fn():
     c = A(3)
     d = A(4)
     e = A(5)
-    lst = [a, b, c]
-    lst.append(d)
-    lst.append(e, e)
-    return lst
+    lst = [A(1), A(2), A(3)]
+    lst.append(A(4))
+    lst.append(A(5))
+    return len(lst)

--- a/tests/epyccel/modules/list_user_defined_objs1.py
+++ b/tests/epyccel/modules/list_user_defined_objs1.py
@@ -5,12 +5,7 @@ class A:
         self.x = x
 
 def fn():
-    a = A(1)
-    b = A(2)
-    c = A(3)
-    d = A(4)
-    e = A(5)
     lst = [A(1), A(2), A(3)]
     lst.append(A(4))
     lst.append(A(5))
-    return len(lst)
+    return lst

--- a/tests/epyccel/modules/list_user_defined_objs2.py
+++ b/tests/epyccel/modules/list_user_defined_objs2.py
@@ -13,4 +13,4 @@ def fn():
     lst = [a, b, c]
     lst2 = [d, e]
     lst.extend(lst2)
-    return lst
+    return len(lst)

--- a/tests/epyccel/modules/loops.py
+++ b/tests/epyccel/modules/loops.py
@@ -272,3 +272,14 @@ def for_expression():
         sum_e = ei
 
     return sum_e
+
+def for_lists_of_lists():
+    a = [[1,2], [3,4]]
+    b = [[5,6], [7,8]]
+    c = [0, 0]
+    for ai, bi in zip(a, b):
+        for i in range(2):
+            c[i] = ai[i] + bi[i]
+            bi[i] = -1
+
+    return c[0], c[1], b[0][0], b[0][1], b[1][0], b[1][1]

--- a/tests/epyccel/test_epyccel_lists.py
+++ b/tests/epyccel/test_epyccel_lists.py
@@ -242,7 +242,9 @@ def test_append_user_defined_objects(limited_language):
     modnew = epyccel(mod, language=limited_language)
     python_list = mod.fn()
     accelerated_list = modnew.fn()
-    assert python_list == accelerated_list
+    assert len(python_list) == len(accelerated_list)
+    for pi, ai in zip(python_list, accelerated_list):
+        assert pi.x == ai.x
 
 def test_insert_basic(limited_language):
     def f():

--- a/tests/epyccel/test_epyccel_lists.py
+++ b/tests/epyccel/test_epyccel_lists.py
@@ -75,7 +75,8 @@ def test_pop_list_of_ndarrays(limited_language) :
         array2 = array([[7, 8, 9], [10, 11, 12]])
         array3 = array([[13, 14, 15], [16, 17, 18]])
         a = [array1, array2, array3]
-        return a.pop()
+        r = array(a.pop())
+        return r
     epyc_last_element = epyccel(pop_last_element, language = limited_language)
     pyccel_result = epyc_last_element()
     python_result = pop_last_element()
@@ -230,20 +231,18 @@ def test_append_ndarrays(limited_language):
         a.append(array4)
         a.append(array5)
         a.append(array6)
-        return a
+        return len(a), a[0][0,0], a[-1][1,0]
 
     epyc_f = epyccel(f, language=limited_language)
-    assert np.array_equal(f(), epyc_f())
+    assert f() == epyc_f()
 
 def test_append_user_defined_objects(limited_language):
-    import modules.list_user_defined_objs2 as mod
+    import modules.list_user_defined_objs1 as mod
 
     modnew = epyccel(mod, language=limited_language)
     python_list = mod.fn()
     accelerated_list = modnew.fn()
-    assert len(python_list) == len(accelerated_list)
-    for python_elem, accelerated_elem in zip(python_list, accelerated_list):
-        assert python_elem.x == accelerated_elem.x
+    assert python_list == accelerated_list
 
 def test_insert_basic(limited_language):
     def f():
@@ -314,10 +313,10 @@ def test_insert_ndarrays(limited_language):
         a.insert(0, array4)
         a.insert(100, array5)
         a.insert(-3, array6)
-        return a
+        return len(a), a[0][0,1], a[-1][1,2]
 
     epyc_f = epyccel(f, language=limited_language)
-    assert np.array_equal(f(), epyc_f())
+    assert f() == epyc_f()
 
 def test_insert_multiple(limited_language):
     def f():
@@ -365,9 +364,7 @@ def test_insert_user_defined_objects(limited_language):
     modnew = epyccel(mod, language=limited_language)
     python_list = mod.fn()
     accelerated_list = modnew.fn()
-    assert len(python_list) == len(accelerated_list)
-    for python_elem, accelerated_elem in zip(python_list, accelerated_list):
-        assert python_elem.x == accelerated_elem.x
+    assert python_list == accelerated_list
 
 def test_clear_1(limited_language):
 
@@ -571,9 +568,7 @@ def test_extend_user_defined_objects(limited_language):
     modnew = epyccel(mod, language=limited_language)
     python_list = mod.fn()
     accelerated_list = modnew.fn()
-    assert len(python_list) == len(accelerated_list)
-    for python_elem, accelerated_elem in zip(python_list, accelerated_list):
-        assert python_elem.x == accelerated_elem.x
+    assert python_list == accelerated_list
 
 def test_remove_basic(limited_language):
     def f():

--- a/tests/epyccel/test_loops.py
+++ b/tests/epyccel/test_loops.py
@@ -251,3 +251,21 @@ def test_for_expression(language):
     f2 = epyccel( f1, language = language )
 
     assert f1() == f2()
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = [
+            pytest.mark.skip(reason="lists of lists not yet implemented in Fortran. See #2210"),
+            pytest.mark.fortran]
+        ),
+        pytest.param("c", marks = [
+            pytest.mark.skip(reason="lists of lists not yet implemented in C. See #2210"),
+            pytest.mark.c]
+        ),
+        pytest.param("python", marks = pytest.mark.python)
+    )
+)
+def test_for_lists_of_lists(language):
+    f1 = loops.for_lists_of_lists
+    f2 = epyccel( f1, language = language )
+
+    assert f1() == f2()

--- a/tests/errors/semantic/non_blocking/RETURN_LIST_ELEMENT.py
+++ b/tests/errors/semantic/non_blocking/RETURN_LIST_ELEMENT.py
@@ -1,0 +1,6 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+def f():
+    b = [[1,2,3], [4,5,6]]
+    c = b[0]
+    return c

--- a/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST.py
+++ b/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST.py
@@ -1,0 +1,6 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+def f():
+    a = [1, 2, 3]
+    b = [a]
+    return b

--- a/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST2.py
+++ b/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST2.py
@@ -1,0 +1,7 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+def f():
+    a = [1, 2, 3]
+    b = [[4,5,6]]
+    b.append(a)
+    return b

--- a/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST3.py
+++ b/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST3.py
@@ -1,0 +1,8 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+def f():
+    a = [1, 2, 3]
+    b = [7, 8, 9]
+    c = [[4,5,6]]
+    c.extend([a, b])
+    return c

--- a/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST4.py
+++ b/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST4.py
@@ -1,0 +1,7 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+def f():
+    a = [1, 2, 3]
+    b = [[4,5,6]]
+    b.insert(0, a)
+    return b

--- a/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST_ELEMENT.py
+++ b/tests/errors/semantic/non_blocking/RETURN_NON_OWNING_LIST_ELEMENT.py
@@ -1,0 +1,8 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+
+def f():
+    a = [1, 2, 3]
+    b = [a]
+    c = b.pop()
+    return c
+


### PR DESCRIPTION
Add the necessary pointer information in the semantic stage using `_indicate_pointer_target` to ensure errors are raised for multi-level containers (e.g. lists of lists) if a pointer is returned while its target goes out of scope. This is a first step towards #2210 .