### PR TITLE
Add C and Fortran support for list method `insert`

### DIFF
--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -84,7 +84,7 @@ Python contains a limited number of builtin functions defined [here](https://doc
 | `count` | No |
 | `extend` | Python-only |
 | `index` | No |
-| `insert` | Python-only |
+| **`insert`** | **Yes** |
 | `max` | No |
 | `min` | No |
 | **`pop`** | **Yes** |

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2903,6 +2903,15 @@ class CCodePrinter(CodePrinter):
         else:
             return f'{c_type}_pull({list_obj})'
 
+    def _print_ListInsert(self, expr):
+        target = expr.list_obj
+        class_type = target.class_type
+        c_type = self.get_c_type(class_type)
+        idx = self._print(expr.args[0])
+        value = self._print(expr.args[1])
+        list_obj = self._print(ObjectAddress(expr.list_obj))
+        return f'{c_type}_insert({list_obj}, {idx}, {value});\n'
+
     #================== Set methods ==================
 
     def _print_SetPop(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1412,6 +1412,14 @@ class FCodePrinter(CodePrinter):
             self._additional_code += code
             return lhs_code
 
+    def _print_ListInsert(self, expr):
+        target = self._print(expr.list_obj)
+        type_name = self._print(expr.list_obj.class_type)
+        self.add_import(self._build_gFTL_extension_module(expr.list_obj.class_type))
+        idx = self._print(expr.args[0])
+        value = self._print(expr.args[1])
+        return f'call {type_name}_insert({target}, {idx}, {value})\n'
+
     #========================== Set Methods ================================#
 
     def _print_SetAdd(self, expr):

--- a/pyccel/stdlib/STC_Extensions/List_extensions.h
+++ b/pyccel/stdlib/STC_Extensions/List_extensions.h
@@ -43,7 +43,26 @@ static inline i_key _c_MEMB(_max)(const Self* self) {
     }
     return max_val;
 }
+
 #endif
+
+// Function to insert value before position idx
+static inline void _c_MEMB(_insert)(Self* self, intptr_t idx, i_key value) {
+    size_t n = _c_MEMB(_size)(self);
+
+    if (idx < 0) idx += (intptr_t)n;
+    if (idx < 0) idx = 0;
+
+    if ((size_t)idx >= n) {
+        _c_MEMB(_push_back)(self, value);
+    }
+    else {
+        _c_MEMB(_insert_at)(self,
+            _c_MEMB(_advance)(_c_MEMB(_begin)(self), idx),
+            value);
+    }
+}
+
 #undef i_type
 #undef i_key
 #undef i_use_cmp

--- a/pyccel/stdlib/gFTL_functions/Vector_extensions.inc
+++ b/pyccel/stdlib/gFTL_functions/Vector_extensions.inc
@@ -56,4 +56,28 @@ contains
     end do
 
   end function __IDENTITY(Vector)_max
+
+  subroutine __IDENTITY(Vector)_insert(my_vector, idx, value)
+    class(Vector), intent(inout)              :: my_vector
+    integer(kind=GFTL_SIZE_KIND), intent(in)  :: idx
+    __T_declare_dummy__, intent(in)           :: value
+  
+    integer :: n, pos, i
+  
+    n = my_vector%size()
+    pos = idx
+  
+    if (pos < 0) pos = pos + n
+    if (pos < 0) pos = 0
+    if (pos > n) pos = n
+  
+    call my_vector%resize(n + 1)
+  
+    do i = n + 1, pos + 1, -1
+       call my_vector%set(i, my_vector%of(i - 1))
+    end do
+  
+    call my_vector%set(pos + 1, value)
+  end subroutine __IDENTITY(Vector)_insert
+
 #include <vector/tail.inc>

--- a/tests/epyccel/test_epyccel_lists.py
+++ b/tests/epyccel/test_epyccel_lists.py
@@ -254,7 +254,7 @@ def test_insert_basic(limited_language):
     epyc_f = epyccel(f, language=limited_language)
     assert f() == epyc_f()
 
-def test_insert_booleans(limited_language):
+def test_insert_booleans(language):
     def f():
         a = [True, False, True]
         a.insert(0, True)
@@ -266,10 +266,10 @@ def test_insert_booleans(limited_language):
         a.insert(-25, False)
         return a
 
-    epyc_f = epyccel(f, language=limited_language)
+    epyc_f = epyccel(f, language=language)
     assert f() == epyc_f()
 
-def test_insert_complex(limited_language):
+def test_insert_complex(language):
     def f():
         a = [2j, 3 + 6j, 0 + 0j]
         a.insert(0, 9j)
@@ -281,10 +281,10 @@ def test_insert_complex(limited_language):
         a.insert(-25, 0 - 0j)
         return a
 
-    epyc_f = epyccel(f, language=limited_language)
+    epyc_f = epyccel(f, language=language)
     assert f() == epyc_f()
 
-def test_insert_float(limited_language):
+def test_insert_float(language):
     def f():
         a = [0.0, 3.6 , 0.5]
         a.insert(0, 6.4)
@@ -296,7 +296,7 @@ def test_insert_float(limited_language):
         a.insert(-25, 2.5)
         return a
 
-    epyc_f = epyccel(f, language=limited_language)
+    epyc_f = epyccel(f, language=language)
     assert f() == epyc_f()
 
 def test_insert_ndarrays(limited_language):
@@ -319,7 +319,7 @@ def test_insert_ndarrays(limited_language):
     epyc_f = epyccel(f, language=limited_language)
     assert np.array_equal(f(), epyc_f())
 
-def test_insert_multiple(limited_language):
+def test_insert_multiple(language):
     def f():
         a = [1, 2, 3]
         a.insert(4, 4)
@@ -327,7 +327,7 @@ def test_insert_multiple(limited_language):
         a.insert(1, 6)
         return a
 
-    epyc_f = epyccel(f, language=limited_language)
+    epyc_f = epyccel(f, language=language)
     assert f() == epyc_f()
 
 def test_insert_list(limited_language):
@@ -339,14 +339,14 @@ def test_insert_list(limited_language):
     epyc_f = epyccel(f, language=limited_language)
     assert f() == epyc_f()
 
-def test_insert_range(limited_language):
+def test_insert_range(language):
     def f():
         a = [1, 2, 3]
         for i in range(4, 1000):
             a.insert(i - 1 ,i)
         return a
 
-    epyc_f = epyccel(f, language=limited_language)
+    epyc_f = epyccel(f, language=language)
     assert f() == epyc_f()
 
 def test_insert_range_list(limited_language):


### PR DESCRIPTION
This PR adds C and Fortran printers for list method `insert` and activates the relevant tests