### PR TITLE
Do not pass include flags to linker

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: [devel, main]
+    branches: [devel, main, issue-2273]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}
@@ -78,6 +78,11 @@ jobs:
         shell: bash
       - name: Coverage install
         uses: ./.github/actions/coverage_install
+      - name: Test ifx
+        run: |
+          pyccel c_arrays.py --verbose
+        shell: bash
+        working-directory: ./tests/pyccel/scripts
       - name: Fortran/C tests with pytest
         id: f_c_pytest
         timeout-minutes: 60

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
   push:
-    branches: [devel, main, issue-2273]
+    branches: [devel, main]
 
 env:
   COMMIT: ${{ inputs.ref || github.event.ref }}
@@ -78,11 +78,6 @@ jobs:
         shell: bash
       - name: Coverage install
         uses: ./.github/actions/coverage_install
-      - name: Test ifx
-        run: |
-          pyccel c_arrays.py --verbose
-        shell: bash
-        working-directory: ./tests/pyccel/scripts
       - name: Fortran/C tests with pytest
         id: f_c_pytest
         timeout-minutes: 60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ All notable changes to this project will be documented in this file.
 -   #1948 : Fix list comprehension does not work in C.
 -   #2245 : Fix internal error when an inhomogeneous tuple appears as an indexed element.
 -   #2258 : Fix missing errors for bad pointer handling in the case of containers with mutable elements.
+-   #2274 : Do not pass include flags to linker.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,8 +144,8 @@ All notable changes to this project will be documented in this file.
 -   #1948 : Fix list comprehension does not work in C.
 -   #2245 : Fix internal error when an inhomogeneous tuple appears as an indexed element.
 -   #2258 : Fix missing errors for bad pointer handling in the case of containers with mutable elements.
--   #2274 : Do not pass include flags to linker.
--   Always use the C compiler to build the C wrapper for NumPy arrays.
+-   #2274 : Do not pass include flags to linker (they are useless).
+-   #2274 : Always use the C compiler to build the C wrapper for NumPy arrays (fixes Intel failures).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ All notable changes to this project will be documented in this file.
 -   #2245 : Fix internal error when an inhomogeneous tuple appears as an indexed element.
 -   #2258 : Fix missing errors for bad pointer handling in the case of containers with mutable elements.
 -   #2274 : Do not pass include flags to linker.
+-   Always use the C compiler to build the C wrapper for NumPy arrays.
 
 ### Changed
 

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -497,7 +497,7 @@ class Compiler:
         sharedlib_modname = sharedlib_modname or compile_obj.python_module
         file_out = os.path.join(compile_obj.source_folder, sharedlib_modname+ext_suffix)
 
-        cmd = [exec_cmd, *flags, *includes, *libdirs_flags, *linker_libdirs_flags,
+        cmd = [exec_cmd, *flags, *libdirs_flags, *linker_libdirs_flags,
                 compile_obj.module_target, *m_code,
                 '-o', file_out, *libs_flags]
 

--- a/pyccel/codegen/python_wrapper.py
+++ b/pyccel/codegen/python_wrapper.py
@@ -167,8 +167,8 @@ def create_shared_library(codegen,
     #  Compile cwrapper_ndarrays from stdlib (if necessary)
     #--------------------------------------------------------
     start_compile_libs = time.time()
-    manage_dependencies(wrapper_codegen.get_additional_imports(), compiler, pyccel_dirpath, wrapper_compile_obj,
-            language, verbose)
+    manage_dependencies(wrapper_codegen.get_additional_imports(), compiler,
+            pyccel_dirpath, wrapper_compile_obj, 'c', verbose)
     timings['Dependency compilation'] = (time.time() - start_compile_libs)
 
     #---------------------------------------


### PR DESCRIPTION
Fix #2273 by removing `*includes` from the list of arguments to the linker in method `compile_shared_library` of class `Compiler`.

Further, in function `create_shared_library` of module `python_wrapper`, force the compiler language to C (rather than using the backend language) when building the C wrapper for NumPy arrays. This avoids failures with the Intel compilers.