### PR TITLE
Provide context clues to epyccel to access constants and modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ All notable changes to this project will be documented in this file.
 -   #337 : Add support for returning tuples from functions.
 -   #2194 : Add support for strings as arguments.
 -   #2192 : Add support for the floor division assignment operator.
--   #2279 : Allow literals (including Type hints) and recognised modules to be deduced from a function's context.
+-   #2279 : Allow scalar literals (including Type hints) and recognised modules to be deduced from a function's context.
 -   \[INTERNALS\] Add abstract class `SetMethod` to handle calls to various set methods.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[INTERNALS\] Add a `__call__` method to `FunctionDef` to create `FunctionCall` instances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ All notable changes to this project will be documented in this file.
 -   #337 : Add support for returning tuples from functions.
 -   #2194 : Add support for strings as arguments.
 -   #2192 : Add support for the floor division assignment operator.
+-   #2279 : Allow literals (including Type hints) and recognised modules to be deduced from a function's context.
 -   \[INTERNALS\] Add abstract class `SetMethod` to handle calls to various set methods.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[INTERNALS\] Add a `__call__` method to `FunctionDef` to create `FunctionCall` instances.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -399,7 +399,7 @@ from mod import f
 f_fast = epyccel(f)
 ```
 In practice `epyccel` copies the contents of `f` into a temporary Python file in the `__epyccel__` directory.
-As a result it is important that all imports are written inside the function when using `epyccel`.
+Although some basic information (scalar literals, type hints, imports of supported libraries) can be deduced from the context, it is important that all other objects are defined inside the function when using `epyccel`.
 Once the file has been copied, `epyccel` calls the `pyccel` command to generate a Python C extension module that contains a single pyccelised function.
 Then finally, it imports this function and returns it to the caller.
 

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -238,7 +238,8 @@ class LiteralComplex(Literal):
         Extract the Python value from the input argument.
 
         Extract the Python value from the input argument which can either
-        be a literal or a Python variable.
+        be a literal or a Python variable. The input argument represents
+        either the real or the imaginary part of the complex literal.
 
         Parameters
         ----------

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -4,6 +4,7 @@
 #------------------------------------------------------------------------------------------#
 """ This module contains all literal types
 """
+import numpy as np
 from pyccel.utilities.metaclasses import Singleton
 
 from .basic     import TypedAstNode, PyccelAstNode
@@ -138,7 +139,7 @@ class LiteralInteger(Literal):
 
     def __init__(self, value, dtype = PythonNativeInt()):
         assert value >= 0
-        if not isinstance(value, int):
+        if not isinstance(value, (int, np.integer)):
             raise TypeError("A LiteralInteger can only be created with an integer")
         self._value = value
         self._class_type = dtype
@@ -174,7 +175,7 @@ class LiteralFloat(Literal):
     __slots__   = ('_value', '_class_type')
 
     def __init__(self, value, dtype = PythonNativeFloat()):
-        if not isinstance(value, (int, float, LiteralFloat)):
+        if not isinstance(value, (int, float, LiteralFloat, np.integer, np.floating)):
             raise TypeError("A LiteralFloat can only be created with an integer or a float")
         if isinstance(value, LiteralFloat):
             self._value = value.python_value

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -141,7 +141,7 @@ class LiteralInteger(Literal):
         assert value >= 0
         if not isinstance(value, (int, np.integer)):
             raise TypeError("A LiteralInteger can only be created with an integer")
-        self._value = value
+        self._value = int(value)
         self._class_type = dtype
         super().__init__()
 
@@ -179,10 +179,8 @@ class LiteralFloat(Literal):
             raise TypeError("A LiteralFloat can only be created with an integer or a float")
         if isinstance(value, LiteralFloat):
             self._value = value.python_value
-        elif isinstance(value, (int, np.integer)):
-            self._value = float(value)
         else:
-            self._value = value
+            self._value = float(value)
         self._class_type = dtype
         super().__init__()
 
@@ -253,9 +251,9 @@ class LiteralComplex(Literal):
             The Python value of the argument.
         """
         if isinstance(arg, Literal):
-            return arg.python_value
-        elif isinstance(arg, (int, float)):
-            return arg
+            return float(arg.python_value)
+        elif isinstance(arg, (int, float, np.integer, np.floating)):
+            return float(arg)
         else:
             raise TypeError(f"LiteralComplex argument must be an int/float/LiteralInt/LiteralFloat not a {type(arg)}")
 

--- a/pyccel/ast/literals.py
+++ b/pyccel/ast/literals.py
@@ -179,8 +179,10 @@ class LiteralFloat(Literal):
             raise TypeError("A LiteralFloat can only be created with an integer or a float")
         if isinstance(value, LiteralFloat):
             self._value = value.python_value
-        else:
+        elif isinstance(value, (int, np.integer)):
             self._value = float(value)
+        else:
+            self._value = value
         self._class_type = dtype
         super().__init__()
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -610,7 +610,7 @@ def process_dtype(dtype):
 
     Parameters
     ----------
-    dtype : PythonType, PyccelFunctionDef, LiteralString, str
+    dtype : PythonType, PyccelFunctionDef, LiteralString, str, VariableTypeAnnotation
         The actual dtype passed to the NumPy function.
 
     Returns

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -38,7 +38,7 @@ from .numpytypes     import NumpyNumericType, NumpyInt8Type, NumpyInt16Type, Num
 from .numpytypes     import NumpyFloat32Type, NumpyFloat64Type, NumpyFloat128Type, NumpyNDArrayType
 from .numpytypes     import NumpyComplex64Type, NumpyComplex128Type, NumpyComplex256Type, numpy_precision_map
 from .operators      import broadcast, PyccelMinus, PyccelDiv, PyccelMul, PyccelAdd
-from .type_annotations import typenames_to_dtypes as dtype_registry
+from .type_annotations import VariableTypeAnnotation, typenames_to_dtypes as dtype_registry
 from .variable       import Variable, Constant, IndexedElement
 
 errors = Errors()
@@ -625,6 +625,8 @@ def process_dtype(dtype):
     TypeError: In the case of unrecognized argument type.
     TypeError: In the case of passed string argument not recognized as valid dtype.
     """
+    if isinstance(dtype, VariableTypeAnnotation):
+        dtype = dtype.class_type
 
     if isinstance(dtype, PythonType):
         if dtype.arg.rank > 0:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -58,7 +58,8 @@ def execute_pyccel(fname, *,
                    accelerators    = (),
                    output_name     = None,
                    compiler_export_file = None,
-                   conda_warnings  = 'basic'):
+                   conda_warnings  = 'basic',
+                   context_dict    = None):
     """
     Run Pyccel on the provided code.
 
@@ -113,6 +114,9 @@ def execute_pyccel(fname, *,
         Name of the JSON file to which compiler information is exported. Default is None.
     conda_warnings : str, optional
         Specify the level of Conda warnings to display (choices: off, basic, verbose), Default is 'basic'.
+    context_dict : dict, optional
+        A dictionary containing any variables that are available in the calling context.
+        This can allow certain constants to be defined outside of the function passed to epyccel.
     """
     start = time.time()
     timers = {}
@@ -209,7 +213,7 @@ def execute_pyccel(fname, *,
     timers["Initialisation"] = start_syntax-start
     # Parse Python file
     try:
-        parser = Parser(pymod_filepath)
+        parser = Parser(pymod_filepath, context_dict = context_dict)
         parser.parse(verbose=verbose)
     except NotImplementedError as error:
         msg = str(error)

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -114,7 +114,7 @@ def execute_pyccel(fname, *,
         Name of the JSON file to which compiler information is exported. Default is None.
     conda_warnings : str, optional
         Specify the level of Conda warnings to display (choices: off, basic, verbose), Default is 'basic'.
-    context_dict : dict, optional
+    context_dict : dict[str, object], optional
         A dictionary containing any variables that are available in the calling context.
         This can allow certain constants to be defined outside of the function passed to epyccel.
     """

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -92,8 +92,15 @@ def get_source_code_and_context(func_or_class):
         # globals, the only way to get a clean version is to reprint the signature)
         sig = inspect.signature(m)
         prototype_idx = prototypes[m_name]
+
         method_prototype = lines[prototype_idx]
         indent = len(method_prototype) - len(method_prototype.lstrip())
+
+        # Handle multi-line prototypes
+        end_of_prototype_idx = next(i for i, l in enumerate(lines[prototype_idx:]) if l.strip().endswith(':'))
+        if end_of_prototype_idx > prototype_idx:
+            lines = lines[:prototype_idx+1] + lines[end_of_prototype_idx+1:]
+
         method_prototype = ' '*indent + f'def {m_name}{sig}:\n'
 
         # TypeVar in a signature appear as +T, -T or ~T but the associated variable

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -135,8 +135,6 @@ def get_source_code_and_context(func_or_class):
         # Save the updated prototype
         lines[prototype_idx] = method_prototype
 
-    print(''.join(lines))
-
     return ''.join(lines), context_dict
 
 #==============================================================================

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -212,6 +212,7 @@ def epyccel_seq(function_or_module, *,
         code = get_source_function(pyfunc)
 
         module_name, module_lock = get_unique_name('mod', epyccel_dirpath)
+        context_dict.update(function_or_module.__globals__)
 
     elif isinstance(function_or_module, ModuleType):
         pymod = function_or_module
@@ -337,7 +338,6 @@ def epyccel( python_function_or_module, **kwargs ):
     # This can allow certain constants to be defined outside of the function passed to epyccel.
     context = inspect.stack()
     context_dict = context[1].frame.f_locals.copy()
-    context_dict.update(context[1].frame.f_globals)
 
     comm  = kwargs.pop('comm', None)
     root  = kwargs.pop('root', 0)

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -215,7 +215,7 @@ def epyccel_seq(function_class_or_module, *,
 
     Parameters
     ----------
-    function_class_or_module : function | module | str
+    function_class_or_module : function | class | module | str
         Python function or module to be accelerated.
         If a string is passed then it is assumed to be the code from a module which
         should be accelerated. The module must be capable of running as a standalone
@@ -364,7 +364,7 @@ def epyccel_seq(function_class_or_module, *,
             if not isinstance(loader, ExtensionFileLoader):
                 raise ImportError('Could not load shared library')
 
-        # If Python object was function, extract it from module
+        # If Python object was a function or a class, extract it from module
         if isinstance(function_class_or_module, (FunctionType, type)):
             func = getattr(package, function_class_or_module.__name__)
         else:
@@ -376,7 +376,7 @@ def epyccel_seq(function_class_or_module, *,
     return package, func
 
 #==============================================================================
-def epyccel( python_function_or_module, **kwargs ):
+def epyccel( python_function_class_or_module, **kwargs ):
     """
     Accelerate Python function or module using Pyccel in "embedded" mode.
 
@@ -386,7 +386,7 @@ def epyccel( python_function_or_module, **kwargs ):
 
     Parameters
     ----------
-    python_function_or_module : function | module | str
+    python_function_class_or_module : function | class | module | str
         Python function or module to be accelerated.
         If a string is passed then it is assumed to be the code from a module which
         should be accelerated..
@@ -411,7 +411,7 @@ def epyccel( python_function_or_module, **kwargs ):
     >>> one_f = epyccel(one, language='fortran')
     >>> one_c = epyccel(one, language='c')
     """
-    assert isinstance( python_function_or_module, (FunctionType, type, ModuleType, str) )
+    assert isinstance( python_function_class_or_module, (FunctionType, type, ModuleType, str) )
 
     comm  = kwargs.pop('comm', None)
     root  = kwargs.pop('root', 0)
@@ -441,10 +441,10 @@ def epyccel( python_function_or_module, **kwargs ):
         # Master process calls epyccel
         if comm.rank == root:
             try:
-                mod, fun = epyccel_seq( python_function_or_module, **kwargs )
+                mod, fun = epyccel_seq( python_function_class_or_module, **kwargs )
                 mod_path = os.path.abspath(mod.__file__)
                 mod_name = mod.__name__
-                fun_name = python_function_or_module.__name__ if fun else None
+                fun_name = python_function_class_or_module.__name__ if fun else None
                 success  = True
             # error handling carried out after broadcast to prevent deadlocks
             except PyccelError as e:
@@ -487,7 +487,7 @@ def epyccel( python_function_or_module, **kwargs ):
     # Serial version
     else:
         try:
-            mod, fun = epyccel_seq( python_function_or_module, **kwargs )
+            mod, fun = epyccel_seq( python_function_class_or_module, **kwargs )
         except PyccelError as e:
             raise type(e)(str(e)) from None
 

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -68,6 +68,15 @@ def get_source_code_and_context(func_or_class):
     leading_spaces = len(unindented_line) - len(unindented_line.lstrip())
     lines = [l[leading_spaces:] for l in lines]
 
+    # Strip trailing comments (e.g. pylint disable)
+    new_lines = []
+    for l in lines:
+        comment = l.rfind('#')
+        if "'" not in l[comment:] and "'" not in l[comment:]:
+            l = l[:comment] + '\n'
+        new_lines.append(l)
+    lines = new_lines
+
     # Search for methods
     methods = [(func_or_class.__name__, func_or_class)] if isinstance(func_or_class, FunctionType) else \
                 inspect.getmembers(func_or_class, predicate=inspect.isfunction)
@@ -121,6 +130,8 @@ def get_source_code_and_context(func_or_class):
 
         # Save the updated prototype
         lines[prototype_idx] = method_prototype
+
+    print(''.join(lines))
 
     return ''.join(lines), context_dict
 

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -222,7 +222,7 @@ def epyccel_seq(function_or_module, *,
         context_dict.update(inspect.getclosurevars(function_or_module).nonlocals)
 
         # Extract TypeVars to context
-        for arg, p in inspect.signature(pyfunc).parameters.items():
+        for p in inspect.signature(pyfunc).parameters.values():
             annot = p.annotation
             if isinstance(annot, TypeVar):
                 name = annot.__name__

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -72,7 +72,7 @@ def get_source_code_and_context(func_or_class):
     methods = [(func_or_class.__name__, func_or_class)] if isinstance(func_or_class, FunctionType) else \
                 inspect.getmembers(func_or_class, predicate=inspect.isfunction)
 
-    func_name_regex = re.compile('^\s*def\s+([a-zA-Z0-9_]+)\s*\(')
+    func_name_regex = re.compile(r'^\s*def\s+([a-zA-Z0-9_]+)\s*\(')
     func_match = [re.match(func_name_regex, l) for l in lines]
     prototypes = {m[1]: i for i, m in enumerate(func_match) if m}
 

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -338,7 +338,7 @@ def epyccel( python_function_or_module, **kwargs ):
     context = inspect.stack()
     context_dict = {}
     for f in reversed(context[1:]):
-        context_dict.update({k: v for k,v in f.frame.f_locals.items()})
+        context_dict.update(f.frame.f_locals)
 
     comm  = kwargs.pop('comm', None)
     root  = kwargs.pop('root', 0)

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -58,10 +58,15 @@ def get_source_function(func):
 
     lines, _ = inspect.getsourcelines(func)
     # remove indentation if the first line is indented
-    decl, body = lines[0], lines[1:]
-    leading_spaces = len(decl) - len(decl.lstrip())
+    unindented_line = lines[0]
+    leading_spaces = len(unindented_line) - len(unindented_line.lstrip())
+    lines = [l[leading_spaces:] for l in lines]
+    prototype_idx = next(i for i,l in enumerate(lines) if l.startswith('def '))
 
-    return f'def {name}{sig}:\n' + ''.join(a[leading_spaces:] for a in body)
+    decorators = lines[:prototype_idx]
+    body = lines[prototype_idx+1:]
+
+    return ''.join(decorators) + f'def {name}{sig}:\n' + ''.join(body)
 
 #==============================================================================
 def get_unique_name(prefix, path):

--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -336,9 +336,8 @@ def epyccel( python_function_or_module, **kwargs ):
     # Retrieve the information about the variables that are available in the calling context.
     # This can allow certain constants to be defined outside of the function passed to epyccel.
     context = inspect.stack()
-    context_dict = {}
-    for f in reversed(context[1:]):
-        context_dict.update(f.frame.f_locals)
+    context_dict = context[1].frame.f_locals.copy()
+    context_dict.update(context[1].frame.f_globals)
 
     comm  = kwargs.pop('comm', None)
     root  = kwargs.pop('root', 0)

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -166,6 +166,17 @@ class Parser(object):
         return parser.ast
 
     def annotate(self, **settings):
+        """
+        Annotate the AST collected from the syntactic stage.
+
+        Use the semantic parser to annotate the AST collected from
+        the syntactic stage.
+
+        Parameters
+        ----------
+        settings : dict
+            Additional keyword arguments for BasicParser.
+        """
 
         # If the semantic parser already exists, do nothing
         if self._semantic_parser:

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -174,7 +174,7 @@ class Parser(object):
 
         Parameters
         ----------
-        settings : dict
+        **settings : dict
             Additional keyword arguments for BasicParser.
         """
 

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -176,6 +176,11 @@ class Parser(object):
         ----------
         **settings : dict
             Additional keyword arguments for BasicParser.
+
+        Returns
+        -------
+        SemanticParser
+            The semantic parser that was used to annotate the AST.
         """
 
         # If the semantic parser already exists, do nothing

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -27,11 +27,15 @@ class Parser(object):
     filename : str
         The name of the file being translated.
 
+    context_dict : dict, optional
+        A dictionary containing any variables that are available in the calling context.
+        This can allow certain constants to be defined outside of the function passed to epyccel.
+
     **kwargs : dict
         Any keyword arguments for BasicParser.
     """
 
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, context_dict = None, **kwargs):
 
         self._filename = filename
         self._kwargs   = kwargs
@@ -47,6 +51,8 @@ class Parser(object):
         self._syntax_parser   = None
         self._semantic_parser = None
         self._compile_obj     = None
+
+        self._context_dict = context_dict
 
         self._input_folder = os.path.dirname(filename)
 
@@ -171,8 +177,9 @@ class Parser(object):
 
         # Create a new semantic parser and store it in object
         parser = SemanticParser(self._syntax_parser,
-                                d_parsers=self.d_parsers,
-                                parents=self.parents,
+                                d_parsers = self.d_parsers,
+                                parents = self.parents,
+                                context_dict = self._context_dict,
                                 **settings)
         self._semantic_parser = parser
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -9,9 +9,13 @@ See the developer docs for more details
 
 from itertools import chain, product
 import os
-from types import ModuleType, UnionType
+from types import ModuleType
+import sys
 import typing
 import warnings
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
 
 from sympy.utilities.iterables import iterable as sympy_iterable
 
@@ -2950,7 +2954,7 @@ class SemanticParser(BasicParser):
             env_var = self._context_dict[name]
             if env_var in original_type_to_pyccel_type:
                 var = VariableTypeAnnotation(original_type_to_pyccel_type[env_var])
-            elif isinstance(env_var, UnionType):
+            elif sys.version_info >= (3, 10) and isinstance(env_var, UnionType):
                 python_types = typing.get_args(env_var)
                 if all(t in original_type_to_pyccel_type for t in python_types):
                     var = UnionTypeAnnotation(*[VariableTypeAnnotation(original_type_to_pyccel_type[t]) for t in python_types])

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2949,7 +2949,7 @@ class SemanticParser(BasicParser):
         if var is None and self._context_dict and name in self._context_dict:
             env_var = self._context_dict[name]
             if env_var in original_type_to_pyccel_type:
-                var = PyccelFunctionDef(env_var.__name__, original_type_to_pyccel_type[env_var])
+                var = VariableTypeAnnotation(original_type_to_pyccel_type[env_var])
             elif isinstance(env_var, UnionType):
                 python_types = typing.get_args(env_var)
                 if all(t in original_type_to_pyccel_type for t in python_types):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3492,6 +3492,12 @@ class SemanticParser(BasicParser):
                 name = _get_name(func.name)
                 args = macro.apply(args)
 
+            if func is None and name in self._context_dict:
+                env_var = self._context_dict[name]
+                func = builtin_functions_dict.get(env_var.__name__, None)
+                if func is not None:
+                    func = PyccelFunctionDef(env_var.__name__, func)
+
             if func is None:
                 return errors.report(UNDEFINED_FUNCTION, symbol=name,
                         bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -14,9 +14,6 @@ import sys
 import typing
 import warnings
 
-if sys.version_info >= (3, 10):
-    from types import UnionType
-
 from sympy.utilities.iterables import iterable as sympy_iterable
 
 from sympy import Sum as Summation
@@ -160,6 +157,9 @@ from pyccel.parser.syntax.headers import types_meta
 from pyccel.utilities.stage import PyccelStage
 
 import pyccel.decorators as def_decorators
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
 #==============================================================================
 
 errors = Errors()

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -225,6 +225,10 @@ class SemanticParser(BasicParser):
     d_parsers : list
         A list of parsers describing files imported by this file.
 
+    context_dict : dict, optional
+        A dictionary describing any variables in the context where the translated
+        objected was defined.
+
     **kwargs : dict
         Additional keyword arguments for BasicParser.
     """
@@ -274,7 +278,7 @@ class SemanticParser(BasicParser):
         self._pointer_targets = []
 
         # provides information about the calling context to collect constants
-        self._context_dict = context_dict
+        self._context_dict = context_dict or {}
 
         #
         self._code = parser._code
@@ -2950,7 +2954,7 @@ class SemanticParser(BasicParser):
             elif name == '*':
                 return GenericType()
 
-        if var is None and self._context_dict and name in self._context_dict:
+        if var is None and name in self._context_dict:
             env_var = self._context_dict[name]
             if env_var in original_type_to_pyccel_type:
                 var = VariableTypeAnnotation(original_type_to_pyccel_type[env_var])

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2954,7 +2954,7 @@ class SemanticParser(BasicParser):
             env_var = self._context_dict[name]
             if env_var in original_type_to_pyccel_type:
                 var = VariableTypeAnnotation(original_type_to_pyccel_type[env_var])
-            elif sys.version_info >= (3, 10) and isinstance(env_var, UnionType):
+            elif sys.version_info >= (3, 10) and isinstance(env_var, UnionType): # pylint:disable=possibly-used-before-assignment
                 python_types = typing.get_args(env_var)
                 if all(t in original_type_to_pyccel_type for t in python_types):
                     var = UnionTypeAnnotation(*[VariableTypeAnnotation(original_type_to_pyccel_type[t]) for t in python_types])

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -11,6 +11,14 @@ ATOL = 1e-15
 def modnew(language):
     return epyccel(mod, language = language)
 
+def test_empty_class(language):
+    class A:
+        pass
+
+    epyc_A = epyccel(A, language = language)
+
+    assert isinstance(epyc_A, type)
+
 def test_class_import(language):
     class A:
         def __init__(self : 'A'):

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -1,8 +1,10 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 import sys
+from typing import TypeVar
 import numpy as np
 import pytest
 from pyccel import epyccel
+from pyccel.errors.errors import PyccelError
 
 def test_numpy_context(language):
     def f():
@@ -25,7 +27,7 @@ def test_literal_context(language):
 def test_type_alias_context(language):
     T = int
 
-    def f(a : T):
+    def f(a : T) -> T:
         return 2*a
 
     epyc_f = epyccel(f, language=language)
@@ -44,3 +46,31 @@ def test_type_union_context(language):
     assert isinstance(f(2), type(epyc_f(2)))
     assert f(3.5) == epyc_f(3.5)
     assert isinstance(f(2.3), type(epyc_f(2.3)))
+
+def test_type_enclosing_context(language):
+    def get_func(b : bool):
+        T = int if b else float
+
+        def f(a : T):
+            return 2*a
+
+        return f
+
+    epyc_f = epyccel(get_func(True), language=language)
+    py_f = get_func(True)
+    assert py_f(3) == epyc_f(3)
+    assert isinstance(py_f(2), type(epyc_f(2)))
+    epyc_f = epyccel(get_func(False), language=language)
+    py_f = get_func(False)
+    assert py_f(3.5) == epyc_f(3.5)
+    assert isinstance(py_f(2.3), type(epyc_f(2.3)))
+
+def test_bad_type_var_context(language):
+    T = TypeVar('T', int, float)
+    S = TypeVar('T', int, float)
+
+    def f(a : T, b : S) -> T:
+        return 2*a
+
+    with pytest.raises(PyccelError):
+        epyc_f = epyccel(f, language=language)

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -1,0 +1,42 @@
+import numpy as np
+from pyccel import epyccel
+
+def test_numpy_context(language):
+    def f():
+        a = np.ones(5)
+        return a.sum()
+
+    epyc_f = epyccel(f, language=language)
+    assert f() == epyc_f()
+
+def test_literal_context(language):
+    a = 4
+    b = np.float32(4.5)
+    def f():
+        return a + b
+
+    epyc_f = epyccel(f, language=language)
+    assert f() == epyc_f()
+    assert isinstance(f(), type(epyc_f()))
+
+def test_type_alias_context(language):
+    T = int
+
+    def f(a : T):
+        return 2*a
+
+    epyc_f = epyccel(f, language=language)
+    assert f(3) == epyc_f(3)
+    assert isinstance(f(2), type(epyc_f(2)))
+
+def test_type_union_context(language):
+    T = int | float
+
+    def f(a : T):
+        return 2*a
+
+    epyc_f = epyccel(f, language=language)
+    assert f(3) == epyc_f(3)
+    assert isinstance(f(2), type(epyc_f(2)))
+    assert f(3.5) == epyc_f(3.5)
+    assert isinstance(f(2.3), type(epyc_f(2.3)))

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -99,3 +99,12 @@ def test_class_context(language):
     epyc_a += 5
     assert a.times(1) == epyc_a.times(1)
     assert isinstance(a.times(1), type(epyc_a.times(1)))
+
+def test_numpy_cast_context(language):
+    T = int
+    def f():
+        a = np.ones(5, dtype=T)
+        return a.sum()
+
+    epyc_f = epyccel(f, language=language)
+    assert f() == epyc_f()

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -1,5 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
+import sys
 import numpy as np
+import pytest
 from pyccel import epyccel
 
 def test_numpy_context(language):

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
 import numpy as np
 from pyccel import epyccel
 
@@ -29,6 +30,7 @@ def test_type_alias_context(language):
     assert f(3) == epyc_f(3)
     assert isinstance(f(2), type(epyc_f(2)))
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Union of types implemented in Python 3.10")
 def test_type_union_context(language):
     T = int | float
 

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring
+# pylint: disable=missing-function-docstring, missing-class-docstring, missing-module-docstring
 import sys
 from typing import TypeVar
 import numpy as np
@@ -92,7 +92,7 @@ def test_class_context(language):
     epyc_A = epyccel(A, language=language)
 
     a = A(3)
-    epyc_a = A(3)
+    epyc_a = epyc_A(3)
     assert a.times(2) == epyc_a.times(2)
     assert isinstance(a.times(2), type(epyc_a.times(2)))
     a += 5

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -73,4 +73,4 @@ def test_bad_type_var_context(language):
         return 2*a
 
     with pytest.raises(PyccelError):
-        epyc_f = epyccel(f, language=language)
+        epyccel(f, language=language)

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -74,3 +74,28 @@ def test_bad_type_var_context(language):
 
     with pytest.raises(PyccelError):
         epyccel(f, language=language)
+
+def test_class_context(language):
+    T = int
+    T2 = float
+    class A:
+        def __init__(self, x : T):
+            self._x : T2 = T2(x)
+
+        def times(self, y : T):
+            return self._x * y
+
+        def __iadd__(self, y : T):
+            self._x += y
+            return self
+
+    epyc_A = epyccel(A, language=language)
+
+    a = A(3)
+    epyc_a = A(3)
+    assert a.times(2) == epyc_a.times(2)
+    assert isinstance(a.times(2), type(epyc_a.times(2)))
+    a += 5
+    epyc_a += 5
+    assert a.times(1) == epyc_a.times(1)
+    assert isinstance(a.times(1), type(epyc_a.times(1)))

--- a/tests/epyccel/test_epyccel_context_clues.py
+++ b/tests/epyccel/test_epyccel_context_clues.py
@@ -32,7 +32,7 @@ def test_type_alias_context(language):
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Union of types implemented in Python 3.10")
 def test_type_union_context(language):
-    T = int | float
+    T = int | float #pylint: disable=unsupported-binary-operation
 
     def f(a : T):
         return 2*a


### PR DESCRIPTION
Use `inspect` to provide context clues to epyccel. This gives Pyccel access to the calling context. This is used to insert constants (literal scalars or TypeAliases) and known modules. This will allow us to deprecate the `@template` decorator and stop writing `from numpy import np` in almost all test functions despite the module being available at the top of the file.

**Commit Summary**
- Allow NumPy literals to be used to create `Literal` instances
- Allow a `VariableTypeAnnotation` to be passed to `process_dtype`
- Ensure `Literal` objects contain pure Python literals of the correct type
- Add `context_dict` argument to functions to allow context information to be provided to the semantic parser
- Use evaluated function signature when printing functions in epyccel to ensure types are known
- Rename `function_or_module` in `epyccel` and `epyccel_seq` to reflect the fact that these methods handle classes too
- Use `context_dict` to insert literals, recognised imports and type hints
- Add tests