### PR TITLE
Add C and Fortran support for dict.popitem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 -   #1895 : Add Python support for dict initialisation with `{}`.
 -   #1895 : Add Python support for dict initialisation with `dict()`.
 -   #1881 : Add Python support for dict method `copy()`.
--   #1887 : Add Python support for dict method `popitem()`.
 -   #1888 : Add Python support for dict method `setdefault()`.
 -   #1885 : Add Python and C support for dict method `get()`.
 -   #1844 : Add line numbers and code to errors from built-in function calls.
@@ -57,6 +56,7 @@ All notable changes to this project will be documented in this file.
 -   #1884 : Add support for dict method `items()`.
 -   #1884 : Add support for dict method `keys()`.
 -   #1886 : Add support for dict method `pop()`.
+-   #1887 : Add support for dict method `popitem()`.
 -   #1936 : Add missing C output for inline decorator example in documentation
 -   #1937 : Optimise `pyccel.ast.basic.PyccelAstNode.substitute` method.
 -   #1544 : Add support for `typing.TypeAlias`.

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -126,7 +126,7 @@ Python contains a limited number of builtin functions defined [here](https://doc
 | **`items`** | **Yes** |
 | **`keys`** | **Yes** |
 | **`pop`** | **Yes** |
-| `popitem` | Python-only |
+| **`popitem`** | **Yes** |
 | `reversed` | No |
 | `setdefault` | Python-only |
 | `update` | No |

--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -144,6 +144,13 @@ class DictPopitem(DictMethod):
         super().__init__(dict_obj)
 
     def __iter__(self):
+        """
+        Iterate over a popitem to get an example of a key and a value.
+
+        Iterate over a popitem to get an example of a key and a value. This
+        is particularly useful in the semantic stage in order to create the
+        variables representing the key and value objects.
+        """
         return iter((IndexedElement(self, 0), IndexedElement(self, 1)))
 
 #==============================================================================

--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -143,6 +143,9 @@ class DictPopitem(DictMethod):
         self._class_type = InhomogeneousTupleType(dict_type.key_type, dict_type.value_type)
         super().__init__(dict_obj)
 
+    def __iter__(self):
+        return iter((IndexedElement(self, 0), IndexedElement(self, 1)))
+
 #==============================================================================
 class DictGet(DictMethod):
     """

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -21,7 +21,7 @@ from pyccel.ast.builtins  import PythonPrint, PythonType, VariableIterator
 
 from pyccel.ast.builtins  import PythonList, PythonTuple, PythonSet, PythonDict, PythonLen
 
-from pyccel.ast.builtin_methods.dict_methods  import DictItems, DictKeys
+from pyccel.ast.builtin_methods.dict_methods  import DictItems, DictKeys, DictPopitem
 
 from pyccel.ast.core      import Declare, For, CodeBlock, ClassDef
 from pyccel.ast.core      import FunctionCall, FunctionCallArgument
@@ -2473,7 +2473,7 @@ class CCodePrinter(CodePrinter):
     def _print_Assign(self, expr):
         lhs = expr.lhs
         rhs = expr.rhs
-        if isinstance(rhs, FunctionCall) and isinstance(rhs.class_type, InhomogeneousTupleType):
+        if isinstance(rhs, (FunctionCall, DictPopitem)) and isinstance(rhs.class_type, InhomogeneousTupleType):
             self._temporary_args = [ObjectAddress(a) for a in lhs]
             code = self._print(rhs)
             self._temporary_args = []
@@ -3043,6 +3043,24 @@ class CCodePrinter(CodePrinter):
             pop_expr = f"{c_type}_pop({dict_var}, {key})"
 
         return pop_expr
+
+    def _print_DictPopitem(self, expr):
+        dict_obj = expr.dict_obj
+        class_type = dict_obj.class_type
+        c_type = self.get_c_type(class_type)
+
+        dict_obj_code = self._print(ObjectAddress(dict_obj))
+
+        assigns = expr.get_direct_user_nodes(lambda u: isinstance(u, Assign))
+        assert len(assigns) == 1
+        lhs = assigns[0].lhs
+
+        key, value = self._temporary_args
+
+        key_code = self._print(key)
+        value_code = self._print(value)
+
+        return f'{c_type}_popitem({dict_obj_code}, {key_code}, {value_code});\n'
 
     def _print_DictGetItem(self, expr):
         dict_obj = expr.dict_obj

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -3051,10 +3051,6 @@ class CCodePrinter(CodePrinter):
 
         dict_obj_code = self._print(ObjectAddress(dict_obj))
 
-        assigns = expr.get_direct_user_nodes(lambda u: isinstance(u, Assign))
-        assert len(assigns) == 1
-        lhs = assigns[0].lhs
-
         key, value = self._temporary_args
 
         key_code = self._print(key)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -26,7 +26,7 @@ from pyccel.ast.builtins import PythonInt, PythonType, PythonPrint, PythonRange
 from pyccel.ast.builtins import PythonTuple, DtypePrecisionToCastFunction
 from pyccel.ast.builtins import PythonBool, PythonList, PythonSet, VariableIterator
 
-from pyccel.ast.builtin_methods.dict_methods import DictItems, DictKeys
+from pyccel.ast.builtin_methods.dict_methods import DictItems, DictKeys, DictPopitem
 
 from pyccel.ast.builtin_methods.list_methods import ListPop
 
@@ -1546,6 +1546,23 @@ class FCodePrinter(CodePrinter):
         else:
             return f'{type_name}_pop({dict_obj_code}, {key})'
 
+    def _print_DictPopitem(self, expr):
+        dict_obj = expr.dict_obj
+        class_type = dict_obj.class_type
+
+        dict_obj_code = self._print(dict_obj)
+
+        type_name = self._print(class_type)
+        self.add_import(self._build_gFTL_extension_module(class_type))
+
+        assigns = expr.get_direct_user_nodes(lambda u: isinstance(u, Assign))
+        assert len(assigns) == 1
+        lhs = assigns[0].lhs
+
+        key, value = lhs
+
+        return f'call {type_name}_popitem({dict_obj_code}, {key}, {value})\n'
+
     #========================== String Methods ===============================#
 
     def _print_PythonStr(self, expr):
@@ -2221,7 +2238,7 @@ class FCodePrinter(CodePrinter):
         lhs = expr.lhs
         rhs = expr.rhs
 
-        if isinstance(rhs, (FunctionCall, SetUnion, ListPop)):
+        if isinstance(rhs, (FunctionCall, SetUnion, ListPop, DictPopitem)):
             return self._print(rhs)
 
         lhs_code = self._print(lhs)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1561,7 +1561,10 @@ class FCodePrinter(CodePrinter):
 
         key, value = lhs
 
-        return f'call {type_name}_popitem({dict_obj_code}, {key}, {value})\n'
+        key_code = self._print(key)
+        value_code = self._print(value)
+
+        return f'call {type_name}_popitem({dict_obj_code}, {key_code}, {value_code})\n'
 
     #========================== String Methods ===============================#
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -935,7 +935,11 @@ class PythonCodePrinter(CodePrinter):
         dict_obj = self._print(expr.dict_obj)
         method_args = ', '.join(self._print(a) for a in expr.args)
 
-        return f"{dict_obj}.{method_name}({method_args})\n"
+        code = f"{dict_obj}.{method_name}({method_args})"
+        if isinstance(expr.class_type, VoidType):
+            return f'{code}\n'
+        else:
+            return code
 
     def _print_DictPop(self, expr):
         dict_obj = self._print(expr.dict_obj)

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -11,7 +11,7 @@ from pyccel.ast.core      import ClassDef
 from pyccel.ast.datatypes import InhomogeneousTupleType
 from pyccel.ast.headers   import MacroFunction, MacroVariable
 from pyccel.ast.headers   import FunctionHeader, MethodHeader
-from pyccel.ast.internals import PyccelSymbol
+from pyccel.ast.internals import PyccelSymbol, PyccelFunction
 from pyccel.ast.variable  import Variable, DottedName, AnnotatedPyccelSymbol
 from pyccel.ast.variable  import IndexedElement, DottedVariable
 
@@ -892,7 +892,8 @@ class Scope(object):
         PyccelError
             An error is raised if the tuple element has not yet been added to the scope.
         """
-        if isinstance(tuple_elem, IndexedElement) and isinstance(tuple_elem.base.class_type, InhomogeneousTupleType):
+        if isinstance(tuple_elem, IndexedElement) and isinstance(tuple_elem.base.class_type, InhomogeneousTupleType) \
+                and not isinstance(tuple_elem.base, PyccelFunction):
             if isinstance(tuple_elem.base, DottedVariable):
                 class_var = tuple_elem.base.lhs
                 base = tuple_elem.base.clone(tuple_elem.base.name, Variable)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3829,6 +3829,15 @@ class SemanticParser(BasicParser):
                     new_expressions.append(Assign(rhs_var, rhs))
                     rhs = rhs_var
                 lhs = PythonTuple(*new_lhs)
+            elif isinstance(rhs, PyccelFunction):
+                assert isinstance(rhs.class_type, InhomogeneousTupleType)
+                r_iter = [self.scope.collect_tuple_element(v) for v in rhs]
+                new_lhs = []
+                for i,(l,r) in enumerate(zip(lhs, r_iter)):
+                    d = self._infer_type(r)
+                    new_lhs.append( self._assign_lhs_variable(l, d, r, new_expressions,
+                                                    arr_in_multirets=r.rank>0 ) )
+                lhs = PythonTuple(*new_lhs)
             else:
                 if isinstance(rhs.class_type, InhomogeneousTupleType):
                     r_iter = [self.scope.collect_tuple_element(v) for v in rhs]

--- a/pyccel/stdlib/STC_Extensions/Dict_extensions.h
+++ b/pyccel/stdlib/STC_Extensions/Dict_extensions.h
@@ -30,5 +30,19 @@ static inline i_val _c_MEMB(_pop_with_default)(Self* self, i_keyraw rkey, i_valr
     return _c_MEMB(_pop)(self, rkey);
 }
 
+/**
+ * Remove and returns a (key, value) pair from the dictionary.
+ *
+ * @param[inout] self : A pointer to the dictionary instance.
+ * @param[out] key : A key.
+ * @param[out] val : The associated value.
+ */
+static inline void _c_MEMB(_popitem)(Self* self, i_key* key, i_val* val) {
+    _m_iter iter = _c_MEMB(_begin)(self);
+    *key = iter.ref->first;
+    *val = iter.ref->second;
+    _c_MEMB(_erase_at)(self, iter);
+}
+
 #include <stc/priv/template2.h>
 #undef _i_is_map

--- a/pyccel/stdlib/gFTL_functions/Map_extensions.inc
+++ b/pyccel/stdlib/gFTL_functions/Map_extensions.inc
@@ -48,14 +48,13 @@ contains
     __T_declare_dummy__, intent(out) :: value
 
     type (__map_iterator) :: iter
-    type (__map_iterator) :: new_iter
 
     iter =  my_map % begin()
 
     key = iter % first()
     value = iter % second()
 
-    new_iter = my_map % erase( iter )
+    iter = my_map % erase( iter )
 
   end subroutine __IDENTITY(Map)_popitem
 

--- a/pyccel/stdlib/gFTL_functions/Map_extensions.inc
+++ b/pyccel/stdlib/gFTL_functions/Map_extensions.inc
@@ -42,5 +42,22 @@ contains
 
   end function __IDENTITY(Map)_pop_with_default
 
+  subroutine __IDENTITY(Map)_popitem(my_map, key, value)
+    class(Map), intent(inout) :: my_map
+    __Key_declare_dummy__, intent(out) :: key
+    __T_declare_dummy__, intent(out) :: value
+
+    type (__map_iterator) :: iter
+    type (__map_iterator) :: new_iter
+
+    iter =  my_map%begin()
+
+    key = iter % first()
+    value = iter % second()
+
+    new_iter = my_map % erase( iter )
+
+  end subroutine __IDENTITY(Map)_popitem
+
 #include <map/tail.inc>
 

--- a/pyccel/stdlib/gFTL_functions/Map_extensions.inc
+++ b/pyccel/stdlib/gFTL_functions/Map_extensions.inc
@@ -50,7 +50,7 @@ contains
     type (__map_iterator) :: iter
     type (__map_iterator) :: new_iter
 
-    iter =  my_map%begin()
+    iter =  my_map % begin()
 
     key = iter % first()
     value = iter % second()

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -184,6 +184,17 @@ def test_pop_item_key(python_only_language):
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
+def test_pop_item_unpacking(python_only_language):
+    def pop_item():
+        a = {1:1.0, 2:2.0}
+        b, c = a.popitem()
+        return b, c
+    epyc_default_element = epyccel(pop_item, language = python_only_language)
+    pyccel_result = epyc_default_element()
+    python_result = pop_item()
+    assert isinstance(python_result, type(pyccel_result))
+    assert python_result == pyccel_result
+
 def test_get_element(python_only_language):
     def get_element():
         a = {1:1.0, 2:2.0}

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -141,59 +141,62 @@ def test_pop_non_literal_str_keys(stc_language):
     assert isinstance(python_result, type(pyccel_result))
     assert python_result == pyccel_result
 
-@pytest.mark.skip("Returning tuples is not yet implemented. See #337")
-def test_pop_item(python_only_language):
+def test_pop_item(language):
     def pop_item():
         a = {1:1.0, 2:2.0}
         return a.popitem()
-    epyc_default_element = epyccel(pop_item, language = python_only_language)
-    pyccel_result = epyc_default_element()
-    python_result = pop_item()
-    assert isinstance(python_result, type(pyccel_result))
-    assert python_result == pyccel_result
 
-def test_pop_item_elements(python_only_language):
+    original_dict = {1:1.0, 2:2.0}
+    epyc_default_element = epyccel(pop_item, language = language)
+    pyccel_result = epyc_default_element()
+    assert pyccel_result[0] in original_dict
+    assert pyccel_result[1] == original_dict[pyccel_result[0]]
+
+def test_pop_item_elements(language):
     def pop_item():
         a = {1:1.0, 2:2.0}
         b = a.popitem()
         return b[0], b[1]
-    epyc_default_element = epyccel(pop_item, language = python_only_language)
-    pyccel_result = epyc_default_element()
-    python_result = pop_item()
-    assert isinstance(python_result, type(pyccel_result))
-    assert python_result == pyccel_result
 
-def test_pop_item_str_keys(python_only_language):
+    original_dict = {1:1.0, 2:2.0}
+    epyc_default_element = epyccel(pop_item, language = language)
+    pyccel_result = epyc_default_element()
+    assert pyccel_result[0] in original_dict
+    assert pyccel_result[1] == original_dict[pyccel_result[0]]
+
+def test_pop_item_str_keys(stc_language):
     def pop_item_str_keys():
         a = {'a':1, 'b':2}
         b = a.popitem()
         return b[0], b[1]
-    epyc_default_element = epyccel(pop_item_str_keys, language = python_only_language)
-    pyccel_result = epyc_default_element()
-    python_result = pop_item_str_keys()
-    assert isinstance(python_result, type(pyccel_result))
-    assert python_result == pyccel_result
 
-def test_pop_item_key(python_only_language):
+    original_dict = {'a':1, 'b':2}
+    epyc_default_element = epyccel(pop_item_str_keys, language = stc_language)
+    pyccel_result = epyc_default_element()
+    assert pyccel_result[0] in original_dict
+    assert pyccel_result[1] == original_dict[pyccel_result[0]]
+
+def test_pop_item_key(language):
     def pop_item():
         a = {1:1.0, 2:2.0}
         return a.popitem()[0]
-    epyc_default_element = epyccel(pop_item, language = python_only_language)
-    pyccel_result = epyc_default_element()
-    python_result = pop_item()
-    assert isinstance(python_result, type(pyccel_result))
-    assert python_result == pyccel_result
 
-def test_pop_item_unpacking(python_only_language):
+    original_dict = {1:1.0, 2:2.0}
+    epyc_default_element = epyccel(pop_item, language = language)
+    pyccel_result = epyc_default_element()
+    assert pyccel_result in original_dict
+
+def test_pop_item_unpacking(language):
     def pop_item():
         a = {1:1.0, 2:2.0}
         b, c = a.popitem()
         return b, c
-    epyc_default_element = epyccel(pop_item, language = python_only_language)
+
+    original_dict = {1:1.0, 2:2.0}
+    epyc_default_element = epyccel(pop_item, language = language)
     pyccel_result = epyc_default_element()
-    python_result = pop_item()
-    assert isinstance(python_result, type(pyccel_result))
-    assert python_result == pyccel_result
+    assert pyccel_result[0] in original_dict
+    assert pyccel_result[1] == original_dict[pyccel_result[0]]
 
 def test_get_element(python_only_language):
     def get_element():

--- a/tests/epyccel/test_epyccel_dicts.py
+++ b/tests/epyccel/test_epyccel_dicts.py
@@ -186,6 +186,16 @@ def test_pop_item_key(language):
     pyccel_result = epyc_default_element()
     assert pyccel_result in original_dict
 
+def test_pop_item_expression(language):
+    def pop_item():
+        a = {1:1.0, 2:2.0}
+        return a.popitem()[0] + 4
+
+    possible_results = {5, 6}
+    epyc_default_element = epyccel(pop_item, language = language)
+    pyccel_result = epyc_default_element()
+    assert pyccel_result in possible_results
+
 def test_pop_item_unpacking(language):
     def pop_item():
         a = {1:1.0, 2:2.0}


### PR DESCRIPTION
Add C and Fortran support for dict.popitem. Fixes #2054. Fixes #2053 
Fix semantic stage to allow `a, b = c.popitem()` syntax.
Add extra tests.