### PR TITLE
Stop using STC deprecated methods

### DIFF
--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -537,7 +537,7 @@ class CCodePrinter(CodePrinter):
             c_type = self.get_c_type(lhs.class_type)
             loop_scope = self.scope.create_new_loop_scope()
             iter_var_name = loop_scope.get_new_name()
-            code_init += f'c_each({iter_var_name}, {c_type}, {lhs_code}) {{\n'
+            code_init += f'for (c_each({iter_var_name}, {c_type}, {lhs_code})) {{\n'
             code_init += f'*({iter_var_name}.ref) = {fill_val};\n'
             code_init += '}\n'
         return code_init
@@ -792,7 +792,7 @@ class CCodePrinter(CodePrinter):
             self._additional_code = tmp_additional_code
 
             return prefix + (f'{lhs} = {start};\n'
-                    f'c_each({iter_var_name}, {c_type}, {arg}) {{\n'
+                    f'for (c_each({iter_var_name}, {c_type}, {arg})) {{\n'
                     f'{body}'
                      '}\n')
         else:
@@ -2533,7 +2533,7 @@ class CCodePrinter(CodePrinter):
             counter = Variable(IteratorType(iterable_type), indices[0].name)
             c_type = self.get_c_type(iterable_type)
             iterable_code = self._print(var)
-            for_code = f'c_each ({self._print(counter)}, {c_type}, {iterable_code})'
+            for_code = f'for (c_each ({self._print(counter)}, {c_type}, {iterable_code}))'
             tmp_ref = DottedVariable(VoidType(), 'ref', memory_handling='alias', lhs = counter)
             if isinstance(iterable, DictItems):
                 assigns = [Assign(expr.target[0], DottedVariable(VoidType(), 'first', lhs = tmp_ref)),

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -537,7 +537,7 @@ class CCodePrinter(CodePrinter):
             c_type = self.get_c_type(lhs.class_type)
             loop_scope = self.scope.create_new_loop_scope()
             iter_var_name = loop_scope.get_new_name()
-            code_init += f'c_foreach({iter_var_name}, {c_type}, {lhs_code}) {{\n'
+            code_init += f'c_each({iter_var_name}, {c_type}, {lhs_code}) {{\n'
             code_init += f'*({iter_var_name}.ref) = {fill_val};\n'
             code_init += '}\n'
         return code_init
@@ -676,7 +676,7 @@ class CCodePrinter(CodePrinter):
         """
         Generate the initialization of an STC container in C.
 
-        This method generates and prints the C code for initializing a container using the STC `c_init()` method.
+        This method generates and prints the C code for initializing a container using the STC `c_make()` method.
 
         Parameters
         ----------
@@ -708,7 +708,7 @@ class CCodePrinter(CodePrinter):
                 args = [self._print(a) for a in expr.args]
             keyraw = '{' + ', '.join(args) + '}'
         container_name = self._print(assignment_var)
-        init = f'{container_name} = c_init({dtype}, {keyraw});\n'
+        init = f'{container_name} = c_make({dtype}, {keyraw});\n'
         return init
 
     def rename_imported_methods(self, expr):
@@ -792,7 +792,7 @@ class CCodePrinter(CodePrinter):
             self._additional_code = tmp_additional_code
 
             return prefix + (f'{lhs} = {start};\n'
-                    f'c_foreach({iter_var_name}, {c_type}, {arg}) {{\n'
+                    f'c_each({iter_var_name}, {c_type}, {arg}) {{\n'
                     f'{body}'
                      '}\n')
         else:
@@ -2533,7 +2533,7 @@ class CCodePrinter(CodePrinter):
             counter = Variable(IteratorType(iterable_type), indices[0].name)
             c_type = self.get_c_type(iterable_type)
             iterable_code = self._print(var)
-            for_code = f'c_foreach ({self._print(counter)}, {c_type}, {iterable_code})'
+            for_code = f'c_each ({self._print(counter)}, {c_type}, {iterable_code})'
             tmp_ref = DottedVariable(VoidType(), 'ref', memory_handling='alias', lhs = counter)
             if isinstance(iterable, DictItems):
                 assigns = [Assign(expr.target[0], DottedVariable(VoidType(), 'first', lhs = tmp_ref)),


### PR DESCRIPTION
Stop using deprecated methods:
- `c_init`->`c_make`
- `c_foreach`->`for (c_each(...))`