### PR TITLE
Fix LAPACK installation on windows

### DIFF
--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -40,7 +40,7 @@ runs:
         #cd build
         #cmake --help
         #echo "cmake -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} .."
-        cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -B build -S .
+        cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER=gcc -D CMAKE_Fortran_COMPILER=gfortran -B build -S .
         echo "cmake done"
         cmake --build build -j 4 --target install
         ls ${Env:MINGW_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -38,6 +38,9 @@ runs:
         cd lapack-3.12.1
         $GCC_EXE=(Get-Command gcc).Path
         $GFORTRAN_EXE=(Get-Command gfortran).Path
+        gcc --version
+        gfortran --version
+        echo "${Env:GCC_EXE}  ${Env:GFORTRAN_EXE}"
         cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="${Env:GCC_EXE}" -D CMAKE_Fortran_COMPILER="${Env:GFORTRAN_EXE}" -B build -S .
         echo "cmake done"
         cmake --build build -j 4 --target install

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -39,7 +39,7 @@ runs:
         $GCC_EXE=((Get-Command gcc).Path -replace '\\', '/')
         $GFORTRAN_EXE=((Get-Command gfortran).Path -replace '\\', '/')
         echo "$GCC_EXE  $GFORTRAN_EXE  ${Env:MINGW_DIR}"
-        cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="$GCC_EXE" -D CMAKE_Fortran_COMPILER="$GFORTRAN_EXE" -B build -S .
+        cmake  -G "MinGW Makefiles" -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="$GCC_EXE" -D CMAKE_Fortran_COMPILER="$GFORTRAN_EXE" -B build -S .
         echo "cmake done"
         cmake --build build -j 4 --target install
         ls ${Env:MINGW_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -29,29 +29,54 @@ runs:
         $PYTHON_SITE_PATH="$PYTHON_PREFIX\lib\site-packages"
         echo "import os; os.add_dll_directory(r'$MINGW_DIR/lib'); os.add_dll_directory(r'$BIN_DIR')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
       shell: powershell
+    - name: Restore cached Lapack
+      id: cache-lapack-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          C:/mingw64/lib/cmake/lapack-3.12.0/lapack-targets.cmake
+          C:/mingw64/lib/cmake/lapack-3.12.0/lapack-targets-release.cmake
+          C:/mingw64/lib/pkgconfig/lapack.pc
+          C:/mingw64/lib/cmake/lapack-3.12.0/lapack-config.cmake
+          C:/mingw64/lib/cmake/lapack-3.12.0/lapack-config-version.cmake
+          C:/mingw64/lib/pkgconfig/blas.pc
+          C:/mingw64/lib/libblas.a
+          C:/mingw64/lib/liblapack.a
+          C:/mingw64/lib/libblas.dll
+          C:/mingw64/lib/liblapack.dll
+        key: ${{ runner.os }}-gcc-lapack-v1
+        restore-keys: |
+          ${{ runner.os }}-gcc-lapack-
     - name: Install Lapack
+      if: steps.cache-lapack-restore.outputs.cache-hit != 'true'
       run: |
-        #
-        # Download x64 BLAS and LAPACK DLLs from https://icl.cs.utk.edu/lapack-for-windows/lapack/
+        # Download and build BLAS and LAPACK from https://github.com/Reference-LAPACK/lapack
         curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
         tar -xf v3.12.1.tar.gz
         cd lapack-3.12.1
         $GCC_EXE=((Get-Command gcc).Path -replace '\\', '/')
         $GFORTRAN_EXE=((Get-Command gfortran).Path -replace '\\', '/')
-        echo "$GCC_EXE  $GFORTRAN_EXE  ${Env:MINGW_DIR}"
-        cmake  -G "MinGW Makefiles" -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="$GCC_EXE" -D CMAKE_Fortran_COMPILER="$GFORTRAN_EXE" -B build -S .
-        echo "cmake done"
+        cmake  -G "MinGW Makefiles" -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="$GCC_EXE" -D CMAKE_Fortran_COMPILER="$GFORTRAN_EXE" -D BUILD_SHARED_LIBS=ON -B build -S .
         cmake --build build -j 4 --target install
-        ls ${Env:MINGW_DIR}
         ls ${Env:MINGW_DIR}/lib
-        #
-        # Microsoft C runtime library: generate static libmsvcr140.a from vcruntime140.dll
-        #cd ${Env:LIBRARY_DIR}
-        #cp $Env:SystemRoot\\SysWOW64\\vcruntime140.dll .
-        #gendef vcruntime140.dll
-        #dlltool -d vcruntime140.def -l libmsvcr140.a -D vcruntime140.dll
         echo "BLAS/LAPACK installed"
       shell: powershell
+    - name: Save Lapack Cache
+      id: cache-lapack-save
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          C:/mingw64/lib/cmake/lapack-3.12.0/lapack-targets.cmake
+          C:/mingw64/lib/cmake/lapack-3.12.0/lapack-targets-release.cmake
+          C:/mingw64/lib/pkgconfig/lapack.pc
+          C:/mingw64/lib/cmake/lapack-3.12.0/lapack-config.cmake
+          C:/mingw64/lib/cmake/lapack-3.12.0/lapack-config-version.cmake
+          C:/mingw64/lib/pkgconfig/blas.pc
+          C:/mingw64/lib/libblas.a
+          C:/mingw64/lib/liblapack.a
+          C:/mingw64/lib/libblas.dll
+          C:/mingw64/lib/liblapack.dll
+        key: ${{ steps.cache-lapack-restore.outputs.cache-primary-key }}
     - name: Install MS MPI runtime and SDK
       run: |
         #

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -36,11 +36,11 @@ runs:
         curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
         tar -xf v3.12.1.tar.gz
         cd lapack-3.12.1
-        New-Item -Name "build" -ItemType "Directory"
-        cd build
-        cmake --help
-        echo "cmake -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} .."
-        cmake -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} ..
+        #New-Item -Name "build" -ItemType "Directory"
+        #cd build
+        #cmake --help
+        #echo "cmake -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} .."
+        cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -B build -S .
         echo "cmake done"
         cmake --build build -j 4 --target install
         ls ${Env:MINGW_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -44,7 +44,7 @@ runs:
           C:/mingw64/bin/libblas.dll
           C:/mingw64/lib/liblapack.dll.a
           C:/mingw64/bin/liblapack.dll
-        key: ${{ runner.os }}-gcc-lapack-v1
+        key: ${{ runner.os }}-gcc-lapack-v3.12.1
         restore-keys: |
           ${{ runner.os }}-gcc-lapack-
     - name: Install Lapack

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -21,28 +21,29 @@ runs:
         echo $EXE
         $BIN_DIR=(Split-Path -Parent ${EXE}) # Find folder containing c compiler
         $MINGW_DIR=(Split-Path -Parent ${BIN_DIR}) # Find the enclosing mingw directory
-        $LIBRARY_DIR="$MINGW_DIR/lib"
-        echo $LIBRARY_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "LIBRARY_DIR=${LIBRARY_DIR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo $LIBRARY_ROOT | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "LIBRARY_ROOT=${LIBRARY_ROOT}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
         # Add DLL paths for python imports
         $PYTHON_PREFIX=(python -c "import sys; print(sys.prefix)")
         $PYTHON_SITE_PATH="$PYTHON_PREFIX\lib\site-packages"
-        echo "import os; os.add_dll_directory(r'$LIBRARY_DIR'); os.add_dll_directory(r'$BIN_DIR')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
+        echo "import os; os.add_dll_directory(r'$LIBRARY_ROOT/lib'); os.add_dll_directory(r'$BIN_DIR')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
       shell: powershell
     - name: Install Lapack
       run: |
         #
         # Download x64 BLAS and LAPACK DLLs from https://icl.cs.utk.edu/lapack-for-windows/lapack/
-        $WEB_ADDRESS="https://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.7.0/Dynamic-MINGW/Win64"
-        curl $WEB_ADDRESS/libblas.dll -o ${Env:LIBRARY_DIR}\\libblas.dll
-        curl $WEB_ADDRESS/liblapack.dll -o ${Env:LIBRARY_DIR}\\liblapack.dll
+        wget https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz
+        tar -xf v3.12.1.tar.gz
+        cd lapack-3.12.1
+        cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:LIBRARY_DIR} .
+        cmake --build build -j --target install
         #
         # Microsoft C runtime library: generate static libmsvcr140.a from vcruntime140.dll
-        cd ${Env:LIBRARY_DIR}
-        cp $Env:SystemRoot\\SysWOW64\\vcruntime140.dll .
-        gendef vcruntime140.dll
-        dlltool -d vcruntime140.def -l libmsvcr140.a -D vcruntime140.dll
+        #cd ${Env:LIBRARY_DIR}
+        #cp $Env:SystemRoot\\SysWOW64\\vcruntime140.dll .
+        #gendef vcruntime140.dll
+        #dlltool -d vcruntime140.def -l libmsvcr140.a -D vcruntime140.dll
         echo "BLAS/LAPACK installed"
       shell: powershell
     - name: Install MS MPI runtime and SDK

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -21,13 +21,13 @@ runs:
         echo $EXE
         $BIN_DIR=(Split-Path -Parent ${EXE}) # Find folder containing c compiler
         $MINGW_DIR=(Split-Path -Parent ${BIN_DIR}) # Find the enclosing mingw directory
-        echo $LIBRARY_ROOT | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "LIBRARY_ROOT=${LIBRARY_ROOT}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo $MINGW_DIR | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "MINGW_DIR=${MINGW_DIR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
         # Add DLL paths for python imports
         $PYTHON_PREFIX=(python -c "import sys; print(sys.prefix)")
         $PYTHON_SITE_PATH="$PYTHON_PREFIX\lib\site-packages"
-        echo "import os; os.add_dll_directory(r'$LIBRARY_ROOT/lib'); os.add_dll_directory(r'$BIN_DIR')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
+        echo "import os; os.add_dll_directory(r'$MINGW_DIR/lib'); os.add_dll_directory(r'$BIN_DIR')" | Out-File -FilePath $PYTHON_SITE_PATH\\dll_path.pth -Encoding ascii
       shell: powershell
     - name: Install Lapack
       run: |
@@ -36,12 +36,12 @@ runs:
         curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
         tar -xf v3.12.1.tar.gz
         cd lapack-3.12.1
-        echo "cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:LIBRARY_ROOT} ."
-        cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:LIBRARY_ROOT} .
+        echo "cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} ."
+        cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} .
         echo "cmake done"
         cmake --build build -j 4 --target install
-        ls ${Env:LIBRARY_ROOT}
-        ls ${Env:LIBRARY_ROOT}/lib
+        ls ${Env:MINGW_DIR}
+        ls ${Env:MINGW_DIR}/lib
         #
         # Microsoft C runtime library: generate static libmsvcr140.a from vcruntime140.dll
         #cd ${Env:LIBRARY_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -33,16 +33,13 @@ runs:
       run: |
         #
         # Download x64 BLAS and LAPACK DLLs from https://icl.cs.utk.edu/lapack-for-windows/lapack/
-        ls
         curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
-        ls
         tar -xf v3.12.1.tar.gz
-        ls
         cd lapack-3.12.1
-        cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:LIBRARY_DIR} .
+        cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:LIBRARY_ROOT} .
         cmake --build build -j --target install
-        ls ${Env:LIBRARY_DIR}
-        ls ${Env:LIBRARY_DIR}/lib
+        ls ${Env:LIBRARY_ROOT}
+        ls ${Env:LIBRARY_ROOT}/lib
         #
         # Microsoft C runtime library: generate static libmsvcr140.a from vcruntime140.dll
         #cd ${Env:LIBRARY_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -36,8 +36,11 @@ runs:
         curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
         tar -xf v3.12.1.tar.gz
         cd lapack-3.12.1
-        echo "cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} ."
-        cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} .
+        New-Item -Name "build" -ItemType "Directory"
+        cd build
+        cmake --help
+        echo "cmake -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} .."
+        cmake -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} ..
         echo "cmake done"
         cmake --build build -j 4 --target install
         ls ${Env:MINGW_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -36,11 +36,9 @@ runs:
         curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
         tar -xf v3.12.1.tar.gz
         cd lapack-3.12.1
-        #New-Item -Name "build" -ItemType "Directory"
-        #cd build
-        #cmake --help
-        #echo "cmake -DCMAKE_INSTALL_PREFIX=${Env:MINGW_DIR} .."
-        cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER=gcc -D CMAKE_Fortran_COMPILER=gfortran -B build -S .
+        $GCC_EXE=(Get-Command gcc).Path
+        $GFORTRAN_EXE=(Get-Command gfortran).Path
+        cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="${Env:GCC_EXE}" -D CMAKE_Fortran_COMPILER="${Env:GFORTRAN_EXE}" -B build -S .
         echo "cmake done"
         cmake --build build -j 4 --target install
         ls ${Env:MINGW_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -40,8 +40,8 @@ runs:
         $GFORTRAN_EXE=(Get-Command gfortran).Path
         gcc --version
         gfortran --version
-        echo "${Env:GCC_EXE}  ${Env:GFORTRAN_EXE}"
-        cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="${Env:GCC_EXE}" -D CMAKE_Fortran_COMPILER="${Env:GFORTRAN_EXE}" -B build -S .
+        echo "$GCC_EXE  $GFORTRAN_EXE  ${Env:MINGW_DIR}"
+        cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="$GCC_EXE" -D CMAKE_Fortran_COMPILER="$GFORTRAN_EXE" -B build -S .
         echo "cmake done"
         cmake --build build -j 4 --target install
         ls ${Env:MINGW_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -34,7 +34,7 @@ runs:
         #
         # Download x64 BLAS and LAPACK DLLs from https://icl.cs.utk.edu/lapack-for-windows/lapack/
         ls
-        wget https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz
+        curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
         ls
         tar -xf v3.12.1.tar.gz
         ls

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -33,11 +33,16 @@ runs:
       run: |
         #
         # Download x64 BLAS and LAPACK DLLs from https://icl.cs.utk.edu/lapack-for-windows/lapack/
+        ls
         wget https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz
+        ls
         tar -xf v3.12.1.tar.gz
+        ls
         cd lapack-3.12.1
         cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:LIBRARY_DIR} .
         cmake --build build -j --target install
+        ls ${Env:LIBRARY_DIR}
+        ls ${Env:LIBRARY_DIR}/lib
         #
         # Microsoft C runtime library: generate static libmsvcr140.a from vcruntime140.dll
         #cd ${Env:LIBRARY_DIR}

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -36,10 +36,8 @@ runs:
         curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
         tar -xf v3.12.1.tar.gz
         cd lapack-3.12.1
-        $GCC_EXE=(Get-Command gcc).Path
-        $GFORTRAN_EXE=(Get-Command gfortran).Path
-        gcc --version
-        gfortran --version
+        $GCC_EXE=((Get-Command gcc).Path -replace '\\', '/')
+        $GFORTRAN_EXE=((Get-Command gfortran).Path -replace '\\', '/')
         echo "$GCC_EXE  $GFORTRAN_EXE  ${Env:MINGW_DIR}"
         cmake -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="$GCC_EXE" -D CMAKE_Fortran_COMPILER="$GFORTRAN_EXE" -B build -S .
         echo "cmake done"

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -36,8 +36,10 @@ runs:
         curl https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.1.tar.gz -o v3.12.1.tar.gz
         tar -xf v3.12.1.tar.gz
         cd lapack-3.12.1
+        echo "cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:LIBRARY_ROOT} ."
         cmake -B build -DCMAKE_INSTALL_PREFIX=${Env:LIBRARY_ROOT} .
-        cmake --build build -j --target install
+        echo "cmake done"
+        cmake --build build -j 4 --target install
         ls ${Env:LIBRARY_ROOT}
         ls ${Env:LIBRARY_ROOT}/lib
         #

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -40,10 +40,10 @@ runs:
           C:/mingw64/lib/cmake/lapack-3.12.0/lapack-config.cmake
           C:/mingw64/lib/cmake/lapack-3.12.0/lapack-config-version.cmake
           C:/mingw64/lib/pkgconfig/blas.pc
-          C:/mingw64/lib/libblas.a
-          C:/mingw64/lib/liblapack.a
-          C:/mingw64/lib/libblas.dll
-          C:/mingw64/lib/liblapack.dll
+          C:/mingw64/lib/libblas.dll.a
+          C:/mingw64/bin/libblas.dll
+          C:/mingw64/lib/liblapack.dll.a
+          C:/mingw64/bin/liblapack.dll
         key: ${{ runner.os }}-gcc-lapack-v1
         restore-keys: |
           ${{ runner.os }}-gcc-lapack-
@@ -72,10 +72,10 @@ runs:
           C:/mingw64/lib/cmake/lapack-3.12.0/lapack-config.cmake
           C:/mingw64/lib/cmake/lapack-3.12.0/lapack-config-version.cmake
           C:/mingw64/lib/pkgconfig/blas.pc
-          C:/mingw64/lib/libblas.a
-          C:/mingw64/lib/liblapack.a
-          C:/mingw64/lib/libblas.dll
-          C:/mingw64/lib/liblapack.dll
+          C:/mingw64/lib/libblas.dll.a
+          C:/mingw64/bin/libblas.dll
+          C:/mingw64/lib/liblapack.dll.a
+          C:/mingw64/bin/liblapack.dll
         key: ${{ steps.cache-lapack-restore.outputs.cache-primary-key }}
     - name: Install MS MPI runtime and SDK
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,12 +62,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ needs.Python_version_picker.outputs.python_version }}
-      #- name: "Setup"
-      #  if: github.event_name != 'push'
-      #  id: token
-      #  run: |
-      #    pip install jwt requests
-      #    python ci_tools/setup_check_run.py windows
+      - name: "Setup"
+        if: github.event_name != 'push'
+        id: token
+        run: |
+          pip install jwt requests
+          python ci_tools/setup_check_run.py windows
       # Uncomment to examine DLL requirements with 'objdump -x FILE'
       #- name: Install mingw tools
       #  uses: msys2/setup-msys2@v2
@@ -78,10 +78,6 @@ jobs:
             python -m pip install --upgrade pip
             python -m pip install .[test]
         shell: bash
-      - name: Test external first
-        run: |
-          pytest test_external_functions.py -vxs
-        working-directory: ./tests/epyccel
       - name: Fortran/C tests with pytest
         id: f_c_pytest
         timeout-minutes: 60
@@ -94,7 +90,7 @@ jobs:
         id: parallel
         timeout-minutes: 20
         uses: ./.github/actions/pytest_parallel
-      #- name: "Post completed"
-      #  if: always() && github.event_name != 'push'
-      #  run:
-      #    python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push'
+        run:
+          python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,12 +62,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ needs.Python_version_picker.outputs.python_version }}
-      - name: "Setup"
-        if: github.event_name != 'push'
-        id: token
-        run: |
-          pip install jwt requests
-          python ci_tools/setup_check_run.py windows
+      #- name: "Setup"
+      #  if: github.event_name != 'push'
+      #  id: token
+      #  run: |
+      #    pip install jwt requests
+      #    python ci_tools/setup_check_run.py windows
       # Uncomment to examine DLL requirements with 'objdump -x FILE'
       #- name: Install mingw tools
       #  uses: msys2/setup-msys2@v2
@@ -94,7 +94,7 @@ jobs:
         id: parallel
         timeout-minutes: 20
         uses: ./.github/actions/pytest_parallel
-      - name: "Post completed"
-        if: always() && github.event_name != 'push'
-        run:
-          python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}
+      #- name: "Post completed"
+      #  if: always() && github.event_name != 'push'
+      #  run:
+      #    python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,6 +78,10 @@ jobs:
             python -m pip install --upgrade pip
             python -m pip install .[test]
         shell: bash
+      - name: Test external first
+        run: |
+          pytest test_external_functions.py -vxs
+        working-directory: ./tests/epyccel
       - name: Fortran/C tests with pytest
         id: f_c_pytest
         timeout-minutes: 60

--- a/tests/epyccel/test_external_functions.py
+++ b/tests/epyccel/test_external_functions.py
@@ -8,7 +8,6 @@ from pyccel import epyccel
 
 # ==============================================================================
 @pytest.mark.fortran
-@pytest.mark.skipif( sys.platform == 'win32', reason="Compilation problem. On execution Windows raises: error while loading shared libraries: libblas.dll: cannot open shared object file: No such file or directory" )
 def test_dnrm2_1():
     blas_dnrm2 = epyccel( mod.blas_dnrm2, language = 'fortran' )
 
@@ -25,7 +24,6 @@ def test_dnrm2_1():
 
 # ==============================================================================
 @pytest.mark.fortran
-@pytest.mark.skipif( sys.platform == 'win32', reason="Compilation problem. On execution Windows raises: error while loading shared libraries: libblas.dll: cannot open shared object file: No such file or directory" )
 def test_dasum_1():
     blas_dasum = epyccel( mod.blas_dasum, language = 'fortran' )
 
@@ -42,7 +40,6 @@ def test_dasum_1():
 
 # ==============================================================================
 @pytest.mark.fortran
-@pytest.mark.skipif( sys.platform == 'win32', reason="Compilation problem. On execution Windows raises: error while loading shared libraries: libblas.dll: cannot open shared object file: No such file or directory" )
 def test_ddot_1():
     blas_ddot = epyccel( mod.blas_ddot, language = 'fortran' )
 
@@ -60,7 +57,6 @@ def test_ddot_1():
 
 # ==============================================================================
 @pytest.mark.fortran
-@pytest.mark.skipif( sys.platform == 'win32', reason="Compilation problem. On execution Windows raises: error while loading shared libraries: libblas.dll: cannot open shared object file: No such file or directory" )
 def test_ddot_2():
     blas_ddot = epyccel( mod.blas_ddot_in_func, language = 'fortran' )
 
@@ -78,7 +74,6 @@ def test_ddot_2():
 
 # ==============================================================================
 @pytest.mark.fortran
-@pytest.mark.skipif( sys.platform == 'win32', reason="Compilation problem. On execution Windows raises: error while loading shared libraries: libblas.dll: cannot open shared object file: No such file or directory" )
 def test_idamax_1():
     blas_idamax = epyccel( mod.blas_idamax, language = 'fortran' )
 


### PR DESCRIPTION
The Windows CI is failing as the University of Tennessee has changed the permissions on its website. It is therefore no longer possible to download the compiled dll files from this site.

This PR changes the installation process to collect LAPACK from the GitHub reference repository. It is compiled with CMake and the result is cached to avoid recompiling every time we use a Windows runner. This new installation fixes #1091 