### PR TITLE
Print deallocate in a more compact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ All notable changes to this project will be documented in this file.
 -   #2234 : Print all constant C variables with `const` specifier.
 -   #2249 : Improve installation docs and recommend virtual environment.
 -   #2242 : Change format of compiler info files.
+-   #2302 : Print the deallocation in a 1 line if statement.
 -   \[INTERNALS\] `FunctionDef` is annotated when it is called, or at the end of the `CodeBlock` if it is never called.
 -   \[INTERNALS\] `InlinedFunctionDef` is only annotated if it is called.
 -   \[INTERNALS\] Build `utilities.metaclasses.ArgumentSingleton` on the fly to ensure correct docstrings.

--- a/developer_docs/wrapper_stage.md
+++ b/developer_docs/wrapper_stage.md
@@ -90,9 +90,7 @@ module tmp
     implicit none
 
     if (initialised) then
-      if (allocated(x)) then
-        deallocate(x)
-      end if
+      if (allocated(x)) deallocate(x)
       initialised = .False._b4
     end if
 
@@ -319,9 +317,7 @@ is translated to the following Fortran code:
       Out_0001 = x + 3_i64
       return
     end if
-    if (allocated(Out_0001)) then
-      deallocate(Out_0001)
-    end if
+    if (allocated(Out_0001)) deallocate(Out_0001)
 
   end subroutine f
 ```

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -258,9 +258,7 @@ module cls_test
 
     if (.not. self%is_freed) then
       ! pass
-      if (allocated(self%param2)) then
-        deallocate(self%param2)
-      end if
+      if (allocated(self%param2)) deallocate(self%param2)
       self%is_freed = .True._b1
     end if
 
@@ -592,9 +590,7 @@ module cls_test
 
     if (.not. self%is_freed) then
       ! pass
-      if (allocated(self%param2)) then
-        deallocate(self%param2)
-      end if
+      if (allocated(self%param2)) deallocate(self%param2)
       self%is_freed = .True._b1
     end if
 

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -88,9 +88,7 @@ module boo
     !////////////////////////
     allocate(array_in_heap(0:2_i64))
     array_in_heap = [1_i64, 2_i64, 3_i64]
-    if (allocated(array_in_heap)) then
-      deallocate(array_in_heap)
-    end if
+    if (allocated(array_in_heap)) deallocate(array_in_heap)
 
   end subroutine fun1
   !........................................
@@ -190,12 +188,8 @@ module boo
     allocate(b(0:5_i64))
     b = [1_i64, 2_i64, 3_i64, 4_i64, 5_i64, 6_i64]
     print *, b(i - j)
-    if (allocated(a)) then
-      deallocate(a)
-    end if
-    if (allocated(b)) then
-      deallocate(b)
-    end if
+    if (allocated(a)) deallocate(a)
+    if (allocated(b)) deallocate(b)
 
   end subroutine fun1
   !........................................
@@ -302,12 +296,8 @@ module boo
     a = 1.0_f64
     allocate(Dummy_0001(0:4_i64))
     Dummy_0001 = square(a)
-    if (allocated(a)) then
-      deallocate(a)
-    end if
-    if (allocated(Dummy_0001)) then
-      deallocate(Dummy_0001)
-    end if
+    if (allocated(a)) deallocate(a)
+    if (allocated(Dummy_0001)) deallocate(Dummy_0001)
 
   end subroutine square_in_array
   !........................................
@@ -472,9 +462,7 @@ module boo
     end do
     pi = 3.14_f64
     print *, a, pi
-    if (allocated(a)) then
-      deallocate(a)
-    end if
+    if (allocated(a)) deallocate(a)
 
   end subroutine f
   !........................................

--- a/docs/function-pointers-as-arguments.md
+++ b/docs/function-pointers-as-arguments.md
@@ -309,9 +309,7 @@ program prog_prog_boo
   a = 1_i64
   b = 4_i64
   Dummy_0001 = func1(a, b, foo)
-  if (allocated(a)) then
-    deallocate(a)
-  end if
+  if (allocated(a)) deallocate(a)
 
 end program prog_prog_boo
 ```
@@ -414,9 +412,7 @@ program prog_prog_boo
   a = 1_i64
   b = 4_i64
   Dummy_0001 = func1(a, b, foo)
-  if (allocated(a)) then
-    deallocate(a)
-  end if
+  if (allocated(a))  deallocate(a)
 
 end program prog_prog_boo
 ```

--- a/docs/ndarrays.md
+++ b/docs/ndarrays.md
@@ -156,9 +156,7 @@ This limitation is due to the fact that the rank of Fortran allocatable objects 
             allocate(a(0:9_i64))
           end if
           a = 1.0_f64
-          if (allocated(a)) then
-            deallocate(a)
-          end if
+          if (allocated(a)) deallocate(a)
 
         end program prog_prog_ex
         ```
@@ -247,9 +245,7 @@ Some examples:
           allocate(a(0:3_i64))
           a = [1_i64, 3_i64, 4_i64, 5_i64]
           a(0_i64) = 0_i64
-          if (allocated(a)) then
-            deallocate(a)
-          end if
+          if (allocated(a)) deallocate(a)
 
         end program prog_prog_ex
         ```
@@ -312,9 +308,7 @@ Some examples:
           allocate(a(0:19_i64, 0:9_i64))
           a = 1.0_f64
           b(0:, 0:) => a(:4_i64, 2_i64:)
-          if (allocated(a)) then
-            deallocate(a)
-          end if
+          if (allocated(a)) deallocate(a)
 
         end program prog_prog_ex
         ```
@@ -398,9 +392,7 @@ Some examples:
           b(0:) => a(:, 1_i64)
           c = b(2_i64)
           write(stdout, '(I0)', advance="yes") c
-          if (allocated(a)) then
-            deallocate(a)
-          end if
+          if (allocated(a)) deallocate(a)
 
         end program prog_prog_ex
         ```
@@ -473,9 +465,7 @@ Some examples:
           a = [1_i64, 2_i64, 3_i64, 4_i64, 5_i64, 6_i64, 7_i64, 8_i64]
           b = a(5_i64)
           write(stdout, '(I0)', advance="yes") b
-          if (allocated(a)) then
-            deallocate(a)
-          end if
+          if (allocated(a)) deallocate(a)
 
         end program prog_prog_ex
         ```

--- a/docs/numpy-functions.md
+++ b/docs/numpy-functions.md
@@ -335,9 +335,7 @@ In Pyccel we try to support the NumPy functions which developers use the most.. 
           20_i64 - 1_i64), f64)), linspace_index = 0_i64,19_i64)]
       x(19_i64) = 10.0_f64
       print *, x
-      if (allocated(x)) then
-        deallocate(x)
-      end if
+      if (allocated(x)) deallocate(x)
 
     end program prog_prog_test
     ```

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2416,9 +2416,7 @@ class FCodePrinter(CodePrinter):
             return ''
         elif isinstance(class_type, (NumpyNDArrayType, HomogeneousTupleType, StringType)):
             var_code = self._print(var)
-            code  = 'if (allocated({})) then\n'.format(var_code)
-            code += '  deallocate({})\n'     .format(var_code)
-            code += 'end if\n'
+            code  = f'if (allocated({var_code})) deallocate({var_code})\n'
             return code
         else:
             errors.report(f"Deallocate not implemented for {class_type}",

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -231,11 +231,11 @@ iso_c_binding_shortcut_mapping = {
     'C_BOOL'                : 'b1'
 }
 
-inc_keyword = (r'do\b', r'if\b',
+inc_keyword = (r'do\b', r'if \(.*?\) then$',
                r'else\b', r'type\b\s*[^\(]',
                r'(elemental )?(pure )?(recursive )?((subroutine)|(function))\b',
                r'interface\b',r'module\b(?! *procedure)',r'program\b')
-inc_regex = re.compile('|'.join('({})'.format(i) for i in inc_keyword))
+inc_regex = re.compile('|'.join(f'({i})' for i in inc_keyword))
 
 end_keyword = ('do', 'if', 'type', 'function',
                'subroutine', 'interface','module','program')


### PR DESCRIPTION
The deallocation of arrays takes 3 lines which draws attention unnecessarily to the fact that it handles the case where the allocation occurred conditionally (e.g. in an if block). This PR changes the print to a 1 line form to neaten the code.