### PR TITLE
Fix missing spelling errors

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -65,6 +65,8 @@ jobs:
           python ci_tools/check_python_capitalisation.py $GITHUB_STEP_SUMMARY $FILES
       - name: Code spell check
         uses: crate-ci/typos@v1.29.10
+        with:
+          config: ./.typos.toml
       - name: "Post completed"
         if: always()
         run:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -356,7 +356,7 @@ class CCodePrinter(CodePrinter):
                     + 0.5*(i.source == 'STC_Extensions/Managed_memory'),
                  # Additionally sort by the source file
                  str(i.source),
-                 # Finally sort by type name for reproducability
+                 # Finally sort by type name for reproducibility
                  next(iter(i.target)).local_alias))
 
         non_stc_imports = [i for i in imports if i not in stc_imports]


### PR DESCRIPTION
Specify typos config file explicitly to ensure errors are parsed correctly. Fix 1 error flagged following this fix.