### PR TITLE
Fix Intel compilation

### DIFF
--- a/ci_tools/bot_messages/show_tests.txt
+++ b/ci_tools/bot_messages/show_tests.txt
@@ -2,6 +2,7 @@ The following is a list of keywords which can be used to run tests. Tests in bol
 - **linux** : Runs the unit tests on a Linux system.
 - **windows** : Runs the unit tests on a Windows system.
 - **macosx** : Runs the unit tests on a MacOS X system.
+- **intel** : Runs the unit tests on a linux system using the intel compiler.
 - **coverage** : Runs the unit tests on a Linux system and checks the coverage of the tests.
 - **docs** : Checks if the documentation follows the numpydoc format.
 - **pylint** : Runs pylint on files which are too big to be handled by codacy.
@@ -13,6 +14,5 @@ The following is a list of keywords which can be used to run tests. Tests in bol
 - wheel : Checks that files have been correctly generated and packaged into the wheel.
 - anaconda_linux : Runs the unit tests on a linux system using anaconda for python.
 - anaconda_windows : Runs the unit tests on a windows system using anaconda for python.
-- intel : Runs the unit tests on a linux system using the intel compiler.
 
 These tests can be run with the command `/bot run X` (multiple tests can be specified separated by spaces), or with `try V X` to test on Python version V.

--- a/ci_tools/bot_messages/show_tests.txt
+++ b/ci_tools/bot_messages/show_tests.txt
@@ -2,7 +2,7 @@ The following is a list of keywords which can be used to run tests. Tests in bol
 - **linux** : Runs the unit tests on a Linux system.
 - **windows** : Runs the unit tests on a Windows system.
 - **macosx** : Runs the unit tests on a MacOS X system.
-- **intel** : Runs the unit tests on a linux system using the intel compiler.
+- **intel** : Runs the unit tests on a Linux system using the Intel compiler.
 - **coverage** : Runs the unit tests on a Linux system and checks the coverage of the tests.
 - **docs** : Checks if the documentation follows the numpydoc format.
 - **pylint** : Runs pylint on files which are too big to be handled by codacy.

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -48,7 +48,7 @@ test_dependencies = {'coverage':['linux']}
 tests_with_base = ('coverage', 'docs', 'pyccel_lint', 'pylint')
 
 pr_test_keys = ('linux', 'windows', 'macosx', 'coverage', 'docs', 'pylint',
-                'pyccel_lint', 'spelling')
+                'pyccel_lint', 'spelling', 'intel')
 
 review_stage_labels = ["needs_initial_review", "Ready_for_review", "Ready_to_merge"]
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3116,9 +3116,6 @@ class ClassDef(ScopedAstNode):
     methods : iterable
         Class methods.
 
-    options : list, tuple
-        A list of options ('public', 'private', 'abstract').
-
     imports : list, tuple
         A list of required imports.
 
@@ -3154,7 +3151,7 @@ class ClassDef(ScopedAstNode):
     >>> ClassDef('Point', attributes, methods)
     ClassDef(Point, (x, y), (FunctionDef(translate, (x, y, a, b), (z, t), [y := a + x], [], [], None, False, function),), [public])
     """
-    __slots__ = ('_name','_attributes','_methods','_options', '_class_type',
+    __slots__ = ('_name','_attributes','_methods', '_class_type',
                  '_imports','_superclasses','_interfaces', '_docstring')
     _attribute_nodes = ('_attributes', '_methods', '_imports', '_interfaces', '_docstring')
 
@@ -3163,7 +3160,6 @@ class ClassDef(ScopedAstNode):
         name,
         attributes=(),
         methods=(),
-        options=('public',),
         imports=(),
         superclasses=(),
         interfaces=(),
@@ -3189,11 +3185,6 @@ class ClassDef(ScopedAstNode):
 
         if not iterable(methods):
             raise TypeError('methods must be an iterable')
-
-        # options
-
-        if not iterable(options):
-            raise TypeError('options must be an iterable')
 
         # imports
 
@@ -3252,7 +3243,6 @@ class ClassDef(ScopedAstNode):
         self._name = name
         self._attributes = attributes
         self._methods = methods
-        self._options = options
         self._imports = imports
         self._superclasses  = superclasses
         self._interfaces = interfaces
@@ -3292,10 +3282,6 @@ class ClassDef(ScopedAstNode):
     @property
     def methods(self):
         return self._methods
-
-    @property
-    def options(self):
-        return self._options
 
     @property
     def imports(self):
@@ -3530,10 +3516,7 @@ class ClassDef(ScopedAstNode):
 
     @property
     def hide(self):
-        if 'hide' in self.options:
-            return True
-        else:
-            return self.is_iterable or self.is_with_construct
+        return self.is_iterable or self.is_with_construct
 
     @property
     def is_unused(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3516,6 +3516,12 @@ class ClassDef(ScopedAstNode):
 
     @property
     def hide(self):
+        """
+        Indicate whether the class should be hidden.
+
+        Indicate whether the class should be hidden. A hidden class does
+        not appear in the printed code.
+        """
         return self.is_iterable or self.is_with_construct
 
     @property

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2748,9 +2748,7 @@ class FCodePrinter(CodePrinter):
 
 
 
-        options = ', '.join(i for i in expr.options)
-
-        sig = 'type, {0}'.format(options)
+        sig = 'type'
         if not(base is None):
             sig = '{0}, extends({1})'.format(sig, base)
 


### PR DESCRIPTION
The `options` parameter of the `ClassDef` class was unused. However its default parameter (`public`) was conflicting with the global public declaration of module elements. This parameter has been removed. This fixes the `intel` CI workflow, which is added to the PR tests to prevent future regressions.