### PR TITLE
Improve type checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ All notable changes to this project will be documented in this file.
 -   #2097 : Fix printing of an empty list.
 -   #2235 : Fix negative numbers in slice indices when translating to C.
 -   #2144 : Fix accidental imports due to modules making their contents public by default.
+-   #2125 : Fix missing type check for argument of known type in a function with arguments whose type can be one of several types.
 
 ### Changed
 
@@ -177,6 +178,7 @@ All notable changes to this project will be documented in this file.
 -   #2249 : Improve installation docs and recommend virtual environment.
 -   #2242 : Change format of compiler info files.
 -   #2302 : Print the deallocation in a 1 line if statement.
+-   #2125 : Add information about received data type to type errors when calling a function with the wrong type.
 -   \[INTERNALS\] `FunctionDef` is annotated when it is called, or at the end of the `CodeBlock` if it is never called.
 -   \[INTERNALS\] `InlinedFunctionDef` is only annotated if it is called.
 -   \[INTERNALS\] Build `utilities.metaclasses.ArgumentSingleton` on the fly to ensure correct docstrings.

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -1050,6 +1050,8 @@ class PyArgumentError(PyccelAstNode):
     _attribute_nodes = ('_args',)
 
     def __init__(self, error_type, error_msg : str, **kwargs):
+        assert isinstance(error_type, Variable)
+        assert isinstance(error_msg, str)
         args = []
         # Find all expressions of the style '{type(var_name)}' in the error message
         type_indicators = re.findall(r'{type\([a-zA-Z0-9_]+\)}', error_msg)

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -56,6 +56,7 @@ __all__ = (
     'PyModule',
     'PyArgKeywords',
     'PyArg_ParseTupleNode',
+    'PyArgumentError',
     'PyBuildValueNode',
     'PyCapsule_New',
     'PyCapsule_Import',

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -9,6 +9,7 @@ between Python code and C code (using Python/C Api and cwrapper.c).
 This file contains classes but also many FunctionDef/Variable instances representing
 objects defined in Python.h.
 """
+import re
 
 from pyccel.utilities.metaclasses import Singleton
 
@@ -1028,6 +1029,69 @@ class PyTuple_Pack(PyccelFunction):
     __slots__ = ()
     _class_type = PyccelPyObject()
     _shape = None
+
+class PyArgumentError(PyccelAstNode):
+    """
+    Class to display errors related to arguments.
+
+    Class to display errors related to arguments. This class helps
+    format the arguments to display the type of the received argument.
+
+    Parameters
+    ----------
+    error_type : Variable
+        A Variable containing the error type to be raised. E.g. PyTypeError.
+    error_msg : str
+        The message to be displayed containing f-string style type indicators.
+    **kwargs : dict[str, Variable]
+        The arguments whose types will be printed.
+    """
+    __slots__ = ('_error_type', '_error_msg', '_args')
+    _attribute_nodes = ('_args',)
+
+    def __init__(self, error_type, error_msg : str, **kwargs):
+        args = []
+        # Find all expressions of the style '{type(var_name)}' in the error message
+        type_indicators = re.findall(r'{type\([a-zA-Z0-9_]+\)}', error_msg)
+        # Save the error message, replacing type indicators with the format string
+        self._error_msg = re.sub(r'{type\([a-zA-Z0-9_]+\)}', '%V', error_msg)
+        # Find the relevant arguments for each type indicator
+        for t in type_indicators:
+            var_name = t.removeprefix('{type(').removesuffix(')}')
+            args.append(ObjectAddress(kwargs[var_name]))
+
+        self._args = tuple(args)
+        self._error_type = error_type
+        super().__init__()
+
+    @property
+    def error_type(self):
+        """
+        The error type that should be raised.
+
+        The error type that should be raised.
+        """
+        return self._error_type
+
+    @property
+    def error_msg(self):
+        """
+        The error message that should be formatted.
+
+        The error message that should be formatted.
+        """
+        return self._error_msg
+
+    @property
+    def args(self):
+        """
+        The arguments whose types are printed in the error message.
+
+        The arguments whose types are printed in the error message.
+        These arguments are displayed in the order they appear in
+        the error message.
+        """
+        return self._args
 
 #-------------------------------------------------------------------
 #                      Python.h Constants

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -607,3 +607,8 @@ class CWrapperCodePrinter(CCodePrinter):
             return f'PyList_SetSlice({list_code}, 0, PY_SSIZE_T_MAX, NULL)'
         else:
             return f'PyList_Clear({list_code})'
+
+    def _print_PyArgumentError(self, expr):
+        args = ', '.join([f'"{self._print(expr.error_msg)}"'] + \
+                         [f'PyObject_Str((PyObject*)Py_TYPE({self._print(a)}))' for a in expr.args])
+        return f'PyErr_SetObject({self._print(expr.error_type)}, PyUnicode_FromFormat({args}));\n'

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -37,7 +37,7 @@ from pyccel.ast.cwrapper      import PyTuple_Size, PyTuple_Check, PyTuple_New
 from pyccel.ast.cwrapper      import PyTuple_GetItem, PyTuple_SetItem
 from pyccel.ast.cwrapper      import PySet_New, PySet_Add, PyList_Check, PyList_Size
 from pyccel.ast.cwrapper      import PySet_Size, PySet_Check, PyObject_GetIter, PySet_Clear
-from pyccel.ast.cwrapper      import PyIter_Next, PyList_Clear
+from pyccel.ast.cwrapper      import PyIter_Next, PyList_Clear, PyArgumentError
 from pyccel.ast.cwrapper      import PyDict_New, PyDict_SetItem
 from pyccel.ast.cwrapper      import PyUnicode_AsUTF8, PyUnicode_Check, PyUnicode_GetLength
 from pyccel.ast.c_concepts    import ObjectAddress, PointerCast, CStackArray, CNativeInt
@@ -391,8 +391,9 @@ class CToPythonWrapper(Wrapper):
 
         if raise_error and not isinstance(arg.class_type, NumpyNDArrayType):
             # No error code required for arrays as the error is raised inside pyarray_check
-            message = LiteralString(f"Expected an argument of type {arg.class_type} for argument {arg.name}")
-            python_error = PyErr_SetString(PyTypeError, CStrStr(message))
+            python_error = PyArgumentError(PyTypeError,
+                                f"Expected an argument of type {arg.class_type} for argument {arg.name}. Received {{type(arg)}}",
+                                arg = py_obj)
             error_code = (python_error,)
 
         return type_check_condition, error_code

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -486,7 +486,8 @@ class CToPythonWrapper(Wrapper):
                     check_func_call, _ = self._get_type_check_condition(py_arg, type_to_example_arg[t], False, body)
                     if_blocks.append(IfSection(check_func_call, [AugAssign(type_indicator, '+', LiteralInteger(index*step))]))
                 body.append(If(*if_blocks, IfSection(LiteralTrue(),
-                            [PyErr_SetString(PyTypeError, CStrStr(LiteralString(f"Unexpected type for argument {interface_args[0].name}"))),
+                            [PyArgumentError(PyTypeError, f"Unexpected type for argument {interface_args[0].name}. Received {{type(arg)}}",
+                                arg = py_arg),
                              Return(PyccelUnarySub(LiteralInteger(1)))])))
             else:
                 check_func_call, err_body = self._get_type_check_condition(py_arg, type_to_example_arg.popitem()[1], True, body)

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -489,7 +489,7 @@ class CToPythonWrapper(Wrapper):
                             [PyArgumentError(PyTypeError, f"Unexpected type for argument {interface_args[0].name}. Received {{type(arg)}}",
                                 arg = py_arg),
                              Return(PyccelUnarySub(LiteralInteger(1)))])))
-            else:
+            elif not orig_funcs[0].arguments[i].has_default:
                 check_func_call, err_body = self._get_type_check_condition(py_arg, type_to_example_arg.popitem()[1], True, body)
                 err_body = err_body + (Return(PyccelUnarySub(LiteralInteger(1))), )
                 if_sec = IfSection(PyccelNot(check_func_call), err_body)

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -376,9 +376,11 @@ def test_wrong_argument_type(language):
     def f(integer_arg : int):
         return integer_arg + 1
     epyc_f = epyccel(f, language=language)
+    test_arg = 3.5
     with pytest.raises(TypeError) as err:
-        epyc_f(3.5)
+        epyc_f(test_arg)
     assert 'integer_arg' in str(err.value)
+    assert str(type(test_arg)) in str(err.value)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
@@ -391,9 +393,11 @@ def test_wrong_known_argument_type_in_interface(language):
     def f(a : T, integer_arg : int):
         return a + 1
     epyc_f = epyccel(f, language=language)
+    test_arg = 4.5
     with pytest.raises(TypeError) as err:
-        epyc_f(3.5, 4.5)
+        epyc_f(3.5, test_arg)
     assert 'integer_arg' in str(err.value)
+    assert str(type(test_arg)) in str(err.value)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),
@@ -406,9 +410,11 @@ def test_wrong_unknown_argument_type_in_interface(language):
     def f(templated_arg : T, b : int):
         return templated_arg + 1
     epyc_f = epyccel(f, language=language)
+    test_arg = 3.5+1j
     with pytest.raises(TypeError) as err:
-        epyc_f(3.5+1j, 4.5)
+        epyc_f(test_arg, 4.5)
     assert 'templated_arg' in str(err.value)
+    assert str(type(test_arg)) in str(err.value)
 
 @pytest.mark.parametrize( 'language', (
         pytest.param("fortran", marks = pytest.mark.fortran),

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 # coding: utf-8
 import sys
+from typing import TypeVar
 
 import pytest
 import numpy as np
@@ -365,6 +366,63 @@ def test_return_annotation(language):
 
     f = epyccel(get_2, language=language)
     assert f() == get_2()
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+    )
+)
+def test_wrong_argument_type(language):
+    def f(integer_arg : int):
+        return integer_arg + 1
+    epyc_f = epyccel(f, language=language)
+    with pytest.raises(TypeError) as err:
+        epyc_f(3.5)
+    assert 'integer_arg' in str(err.value)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+    )
+)
+def test_wrong_known_argument_type_in_interface(language):
+    T = TypeVar('T', int, float)
+
+    def f(a : T, integer_arg : int):
+        return a + 1
+    epyc_f = epyccel(f, language=language)
+    with pytest.raises(TypeError) as err:
+        epyc_f(3.5, 4.5)
+    assert 'integer_arg' in str(err.value)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+    )
+)
+def test_wrong_unknown_argument_type_in_interface(language):
+    T = TypeVar('T', int, float)
+
+    def f(templated_arg : T, b : int):
+        return templated_arg + 1
+    epyc_f = epyccel(f, language=language)
+    with pytest.raises(TypeError) as err:
+        epyc_f(3.5+1j, 4.5)
+    assert 'templated_arg' in str(err.value)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+    )
+)
+def test_wrong_argument_combination_in_interface(language):
+    T = TypeVar('T', int, float)
+
+    def f(a : T, b : T):
+        return a + 1
+    epyc_f = epyccel(f, language=language)
+    with pytest.raises(TypeError):
+        epyc_f(3.5, 4)
 
 ##==============================================================================
 ## CLEAN UP GENERATED FILES AFTER RUNNING TESTS

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -404,6 +404,23 @@ def test_wrong_known_argument_type_in_interface(language):
         pytest.param("c", marks = pytest.mark.c),
     )
 )
+def test_wrong_known_argument_type_in_interface_with_default(language):
+    T = TypeVar('T', int, float)
+
+    def f(a : T, integer_arg : int = 5):
+        return a + 1
+    epyc_f = epyccel(f, language=language)
+    test_arg = 4.5
+    with pytest.raises(TypeError) as err:
+        epyc_f(3.5, test_arg)
+    assert 'integer_arg' in str(err.value)
+    assert str(type(test_arg)) in str(err.value)
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+    )
+)
 def test_wrong_unknown_argument_type_in_interface(language):
     T = TypeVar('T', int, float)
 


### PR DESCRIPTION
Improve type checks by:
- Displaying the received type when it does not match expectations
- Displaying a more verbose error message where possible when the wrong types are passed to an `Interface`
- Fixing missing type check for argument of fixed type in an `Interface`. Fixes #2125 

**Commit Summary**
- Add `PyArgumentError` to set the error message with a message containing the type of an object passed from Python
- Use `PyArgumentError` to add more detail to error messages
- Add missing type check
- Add an extra if block to raise recognised errors from `Interface`s instead of always showing the error "Unexpected type combination"
- Add tests which check that the raised error contains the name of the problematic variable and the received type.