### PR TITLE
Fix class scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ All notable changes to this project will be documented in this file.
 -   #2235 : Fix negative numbers in slice indices when translating to C.
 -   #2144 : Fix accidental imports due to modules making their contents public by default.
 -   #2312 : Fix rounding direction for negative integer elements in `np.linspace`.
+-   #2093 : Fix scoping issue preventing class methods from sharing a name with locals in another class method.
 
 ### Changed
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3351,6 +3351,7 @@ class ClassDef(ScopedAstNode):
 
         if not isinstance(attr, Variable):
             raise TypeError("Attributes must be Variables")
+        assert attr not in self._attributes
         attr.set_current_user_node(self)
         self._attributes += (attr,)
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2172,8 +2172,10 @@ class FunctionDef(ScopedAstNode):
 
         # Outside of semantic stage, if the scope is provided then the original name
         # of the function should be retrievable from the semantic name using scope.python_names
-        assert pyccel_stage == "syntactic" or scope is None or \
+        assert pyccel_stage != "semantic" or scope is None or \
                 name in scope.python_names
+        assert pyccel_stage != "semantic" or scope is None or \
+                scope.name == scope.python_names[name]
 
         if isinstance(name, str):
             name = PyccelSymbol(name)
@@ -3366,7 +3368,7 @@ class ClassDef(ScopedAstNode):
 
         if not isinstance(method, FunctionDef):
             raise TypeError("Method must be FunctionDef")
-        assert method.name in self.scope.python_names
+        assert pyccel_stage != "semantic" or method.name in self.scope.python_names
         method.set_current_user_node(self)
         self._methods += (method,)
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3366,6 +3366,7 @@ class ClassDef(ScopedAstNode):
 
         if not isinstance(method, FunctionDef):
             raise TypeError("Method must be FunctionDef")
+        assert method.name in self.scope.python_names
         method.set_current_user_node(self)
         self._methods += (method,)
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2170,6 +2170,11 @@ class FunctionDef(ScopedAstNode):
         docstring=None,
         scope=None):
 
+        # Outside of semantic stage, if the scope is provided then the original name
+        # of the function should be retrievable from the semantic name using scope.python_names
+        assert pyccel_stage == "syntactic" or scope is None or \
+                name in scope.python_names
+
         if isinstance(name, str):
             name = PyccelSymbol(name)
         elif isinstance(name, (tuple, list)):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -3368,7 +3368,7 @@ class ClassDef(ScopedAstNode):
 
         if not isinstance(method, FunctionDef):
             raise TypeError("Method must be FunctionDef")
-        assert pyccel_stage != "semantic" or method.name in self.scope.python_names
+        assert method.pyccel_staging != "semantic" or method.name in self.scope.python_names
         method.set_current_user_node(self)
         self._methods += (method,)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -773,7 +773,10 @@ class CCodePrinter(CodePrinter):
             class_scope = classDef.scope
             for method in classDef.methods:
                 if not method.is_inline:
+                    name = method.name
+                    py_name = method.scope.python_names.pop(name)
                     class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
+                    method.scope.python_names[method.name] = py_name
             for interface in classDef.interfaces:
                 for func in interface.functions:
                     if not func.is_inline:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -773,7 +773,6 @@ class CCodePrinter(CodePrinter):
             class_scope = classDef.scope
             for method in classDef.methods:
                 if not method.is_inline:
-                    name = method.name
                     class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
             for interface in classDef.interfaces:
                 for func in interface.functions:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -774,9 +774,7 @@ class CCodePrinter(CodePrinter):
             for method in classDef.methods:
                 if not method.is_inline:
                     name = method.name
-                    py_name = method.scope.python_names.pop(name)
                     class_scope.rename_function(method, f"{classDef.name}__{method.name.lstrip('__')}")
-                    method.scope.python_names[method.name] = py_name
             for interface in classDef.interfaces:
                 for func in interface.functions:
                     if not func.is_inline:

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -2746,7 +2746,7 @@ class FCodePrinter(CodePrinter):
                 methods += f'generic, public :: {i.name} => {names}\n'
                 methods += f'procedure :: {names}\n'
 
-
+        self.exit_scope()
 
         sig = 'type'
         if not(base is None):
@@ -2766,8 +2766,6 @@ class FCodePrinter(CodePrinter):
         methods = ''.join('\n'.join(['', sep, self._print(i), sep, '']) for i in cls_methods)
 
         self.set_current_class(None)
-
-        self.exit_scope()
 
         return decs, methods
 

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -404,7 +404,7 @@ class FortranToCWrapper(Wrapper):
 
         c_arg_var = Variable(BindCArrayType(rank, has_strides = False),
                         scope.get_new_name(), is_argument = True,
-                        shape = (LiteralInteger(2),))
+                        shape = (LiteralInteger(rank+1),))
 
         scope.insert_symbolic_alias(IndexedElement(c_arg_var, LiteralInteger(0)), bind_var)
         scope.insert_symbolic_alias(IndexedElement(c_arg_var, LiteralInteger(1)), shape_var)

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -232,7 +232,12 @@ class BasicParser(object):
 
     @property
     def current_function_name(self):
-        """Name of current function, if any."""
+        """
+        The name of the function currently being visited.
+
+        The name of the function currently being visited or None if we are not in
+        a function.
+        """
         return self._current_function_name[-1] if self._current_function_name else None
 
     @property

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -317,34 +317,6 @@ class BasicParser(object):
         else:
             raise TypeError('Expected a symbolic_function')
 
-    def create_new_function_scope(self, name, **kwargs):
-        """
-        Create a new Scope object for a Python function with the given name,
-        and attach any decorators' information to the scope. The new scope is
-        a child of the current one, and can be accessed from the dictionary of
-        its children using the function name as key.
-
-        Before returning control to the caller, the current scope (stored in
-        self._scope) is changed to the one just created, and the function's
-        name is stored in self._current_function_name.
-
-        Parameters
-        ----------
-        name : str
-            Function's name, used as a key to retrieve the new scope.
-
-        decorators : dict
-            Decorators attached to FunctionDef object at syntactic stage.
-
-        """
-        child = self.scope.new_child_scope(name, **kwargs)
-        child.insert_symbol(name)
-
-        self._scope = child
-        self._current_function_name.append(name)
-
-        return child
-
     def exit_function_scope(self):
         """ Exit the function scope and return to the encasing scope
         """

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -150,7 +150,7 @@ class BasicParser(object):
 
         # represent the scope of a function
         self._scope = Scope()
-        self._current_function = None
+        self._current_function_name = None
 
         # the following flags give us a status on the parsing stage
         self._syntax_done   = False
@@ -230,9 +230,14 @@ class BasicParser(object):
         return self._metavars
 
     @property
-    def current_function(self):
+    def current_function_name(self):
         """Name of current function, if any."""
-        return self._current_function
+        return self._current_function_name
+
+    @current_function_name.setter
+    def current_function_name(self, new_name):
+        """Name of current function, if any."""
+        self._current_function_name = new_name
 
     @property
     def syntax_done(self):
@@ -310,7 +315,7 @@ class BasicParser(object):
 
         Before returning control to the caller, the current scope (stored in
         self._scope) is changed to the one just created, and the function's
-        name is stored in self._current_function.
+        name is stored in self._current_function_name.
 
         Parameters
         ----------
@@ -324,9 +329,9 @@ class BasicParser(object):
         child = self.scope.new_child_scope(name, **kwargs)
 
         self._scope = child
-        if self._current_function:
-            name = DottedName(self._current_function, name)
-        self._current_function = name
+        if self._current_function_name:
+            name = DottedName(self._current_function_name, name)
+        self._current_function_name = name
 
         return child
 
@@ -335,16 +340,16 @@ class BasicParser(object):
         """
 
         self._scope = self._scope.parent_scope
-        if isinstance(self._current_function, DottedName):
+        if isinstance(self._current_function_name, DottedName):
 
-            name = self._current_function.name[:-1]
+            name = self._current_function_name.name[:-1]
             if len(name)>1:
                 name = DottedName(*name)
             else:
                 name = name[0]
         else:
             name = None
-        self._current_function = name
+        self._current_function_name = name
 
     def create_new_loop_scope(self):
         """ Create a new scope describing a loop
@@ -368,7 +373,7 @@ class BasicParser(object):
 
         Before returning control to the caller, the current scope (stored in
         self._scope) is changed to the one just created, and the function's
-        name is stored in self._current_function.
+        name is stored in self._current_function_name.
 
         Parameters
         ----------

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -280,7 +280,7 @@ class BasicParser(object):
     def blocking(self):
         return self._blocking
 
-    def insert_function(self, func):
+    def insert_function(self, func, scope = None):
         """
         Insert a function into the current scope.
 
@@ -296,7 +296,8 @@ class BasicParser(object):
         if isinstance(func, SympyFunction):
             self.insert_symbolic_function(func)
         elif isinstance(func, (FunctionDef, Interface, FunctionAddress)):
-            container = self.scope.functions
+            scope = scope or self.scope
+            container = scope.functions
             if func.pyccel_staging == 'syntactic':
                 container[self.scope.get_expected_name(func.name)] = func
             else:

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -150,7 +150,7 @@ class BasicParser(object):
 
         # represent the scope of a function
         self._scope = Scope()
-        self._current_function_name = None
+        self._current_function_name = []
 
         # the following flags give us a status on the parsing stage
         self._syntax_done   = False
@@ -232,12 +232,7 @@ class BasicParser(object):
     @property
     def current_function_name(self):
         """Name of current function, if any."""
-        return self._current_function_name
-
-    @current_function_name.setter
-    def current_function_name(self, new_name):
-        """Name of current function, if any."""
-        self._current_function_name = new_name
+        return self._current_function_name[-1] if self._current_function_name else None
 
     @property
     def syntax_done(self):
@@ -329,9 +324,7 @@ class BasicParser(object):
         child = self.scope.new_child_scope(name, **kwargs)
 
         self._scope = child
-        if self._current_function_name:
-            name = DottedName(self._current_function_name, name)
-        self._current_function_name = name
+        self._current_function_name.append(name)
 
         return child
 
@@ -340,16 +333,7 @@ class BasicParser(object):
         """
 
         self._scope = self._scope.parent_scope
-        if isinstance(self._current_function_name, DottedName):
-
-            name = self._current_function_name.name[:-1]
-            if len(name)>1:
-                name = DottedName(*name)
-            else:
-                name = name[0]
-        else:
-            name = None
-        self._current_function_name = name
+        self._current_function_name.pop()
 
     def create_new_loop_scope(self):
         """ Create a new scope describing a loop

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -338,6 +338,7 @@ class BasicParser(object):
 
         """
         child = self.scope.new_child_scope(name, **kwargs)
+        child.insert_symbol(name)
 
         self._scope = child
         self._current_function_name.append(name)

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -7,7 +7,7 @@
 """
 
 from pyccel.ast.bind_c    import BindCVariable
-from pyccel.ast.core      import ClassDef
+from pyccel.ast.core      import ClassDef, FunctionDef
 from pyccel.ast.datatypes import InhomogeneousTupleType
 from pyccel.ast.headers   import MacroFunction, MacroVariable
 from pyccel.ast.headers   import FunctionHeader, MethodHeader
@@ -871,10 +871,13 @@ class Scope(object):
         name : str
             The suggested name for the new function.
         """
+        assert isinstance(o, FunctionDef)
         newname = self.get_new_name(name)
         python_name = self._original_symbol.pop(o.name)
+        assert python_name == o.scope.python_names.pop(o.name)
         o.rename(newname)
         self._original_symbol[newname] = python_name
+        o.scope.python_names[newname] = python_name
 
     def collect_tuple_element(self, tuple_elem):
         """

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -904,6 +904,11 @@ class Scope(object):
         PyccelError
             An error is raised if the tuple element has not yet been added to the scope.
         """
+        if isinstance(tuple_elem, IndexedElement) and isinstance(tuple_elem.base, DottedVariable):
+            cls_scope = tuple_elem.base.lhs.cls_base.scope
+            if cls_scope is not self:
+                return cls_scope.collect_tuple_element(tuple_elem)
+
         if isinstance(tuple_elem, IndexedElement) and isinstance(tuple_elem.base.class_type, InhomogeneousTupleType) \
                 and not isinstance(tuple_elem.base, PyccelFunction):
             if isinstance(tuple_elem.base, DottedVariable):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3661,10 +3661,11 @@ class SemanticParser(BasicParser):
                 cls_def = semantic_lhs_var.lhs.cls_base
                 insert_scope = cls_def.scope
                 cls_def.add_new_attribute(semantic_lhs_var)
-                lhs = lhs.name
+                lhs_scope_name = lhs.name.name[-1]
             else:
                 insert_scope = self.scope
-                lhs = lhs.name
+                lhs_scope_name = lhs.name
+            lhs = lhs.name
 
             if semantic_lhs_var.class_type is TypeAlias():
                 pyccel_stage.set_stage('syntactic')
@@ -3685,7 +3686,7 @@ class SemanticParser(BasicParser):
                 return EmptyNode()
 
             try:
-                insert_scope.insert_variable(semantic_lhs_var, lhs)
+                insert_scope.insert_variable(semantic_lhs_var, lhs_scope_name)
             except RuntimeError as e:
                 errors.report(e, symbol=expr, severity='error')
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4687,14 +4687,14 @@ class SemanticParser(BasicParser):
             errors.report("Functions can only be declared in modules or inside other functions.",
                     symbol=expr, severity='error')
 
+        name = expr.scope.get_expected_name(expr.name)
         existing_semantic_funcs = []
         if not expr.is_semantic:
-            self.scope.functions.pop(self.scope.get_expected_name(expr.name), None)
+            self.scope.functions.pop(name, None)
         elif isinstance(expr, Interface):
             existing_semantic_funcs = [*expr.functions]
             expr                    = expr.syntactic_node
 
-        name               = self.scope.get_expected_name(expr.name)
         decorators         = expr.decorators
         new_semantic_funcs = []
         sub_funcs          = []
@@ -5100,11 +5100,13 @@ class SemanticParser(BasicParser):
                 scope.insert_variable(v)
                 attributes.append(v)
 
+        self.exit_class_scope()
+
         docstring = self._visit(expr.docstring) if expr.docstring else expr.docstring
 
         cls = ClassDef(name, attributes, [], superclasses=parent, scope=scope,
                 docstring = docstring, class_type = dtype)
-        self.scope.parent_scope.insert_class(cls)
+        self.scope.insert_class(cls)
 
         methods = expr.methods
         for method in methods:
@@ -5173,8 +5175,6 @@ class SemanticParser(BasicParser):
                         [del_method.body]+[Assign(deallocater, LiteralTrue())]))
         del_method.body = [condition]
         self._current_function = None
-
-        self.exit_class_scope()
 
         return EmptyNode()
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5123,6 +5123,8 @@ class SemanticParser(BasicParser):
             argument = FunctionDefArgument(Variable(dtype, 'self', cls_base = cls), bound_argument = True)
             self.scope.insert_symbol('__init__')
             scope = self.create_new_function_scope('__init__')
+            scope.insert_symbol('__init__')
+            cls_scope.insert_symbol('__init__')
             scope.insert_variable(argument.var)
             init_func = FunctionDef('__init__', [argument], (), cls_name=cls.name, scope=scope)
             self.exit_function_scope()

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -390,7 +390,6 @@ class SemanticParser(BasicParser):
         child.local_used_symbols[syntactic_name] = semantic_name
         child.python_names[semantic_name] = syntactic_name
 
-
         self._scope = child
         self._current_function_name.append(semantic_name)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4800,9 +4800,13 @@ class SemanticParser(BasicParser):
             if is_interface:
                 name, _ = self.scope.get_new_incremented_symbol(interface_name, tmpl_idx)
 
+            original_symbols = expr.scope.python_names.copy()
+            original_symbols[name] = expr.name
+            insertion_scope.python_names[name] = expr.name
+
             scope = self.create_new_function_scope(name, decorators = decorators,
                     used_symbols = expr.scope.local_used_symbols.copy(),
-                    original_symbols = expr.scope.python_names.copy(),
+                    original_symbols = original_symbols,
                     symbolic_aliases = expr.scope.symbolic_aliases)
 
             for n, v in zip(template_names, template_combinations[tmpl_idx]):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1420,12 +1420,10 @@ class SemanticParser(BasicParser):
             new_scope = new_scope.parent_scope
             if not new_scope.name is None:
                 scope_names.append(new_scope.name)
-        scope_names.reverse()
 
         # Use scope_names to find semantic scopes
-        while scope_names:
-            new_scope = new_scope.sons_scopes[scope_names[0]]
-            scope_names = scope_names[1:]
+        for n in scope_names[::-1]:
+            new_scope = new_scope.sons_scopes[n]
 
         # Set the Scope to the FunctionDef's parent Scope and annotate the old_func
         self._scope = new_scope

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1401,10 +1401,8 @@ class SemanticParser(BasicParser):
             cls_name = cls_base_syntactic[0].name
             cls_base = self.scope.find(cls_name, 'classes')
             cls_scope = cls_base.scope
-            key = 'classes'
             search_name = cls_name
         else:
-            key = 'functions'
             search_name = old_func.name
         # The function call might be in a completely different scope from the FunctionDef
         # Store the current scope and go to the parent scope of the FunctionDef
@@ -1412,7 +1410,7 @@ class SemanticParser(BasicParser):
         old_current_function = self._current_function
         old_current_function_name = self._current_function_name
         sc = self.scope
-        while search_name not in getattr(sc, key):
+        while search_name not in sc.local_used_symbols:
             sc = sc.parent_scope
 
         # Set the Scope to the FunctionDef's parent Scope and annotate the old_func

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3630,7 +3630,7 @@ class SemanticParser(BasicParser):
                 cls_def = semantic_lhs_var.lhs.cls_base
                 insert_scope = cls_def.scope
                 cls_def.add_new_attribute(semantic_lhs_var)
-                lhs = lhs.name.name[-1]
+                lhs = lhs.name
             else:
                 insert_scope = self.scope
                 lhs = lhs.name

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -355,6 +355,36 @@ class SemanticParser(BasicParser):
     #              Utility functions for scope handling
     #================================================================
 
+    def create_new_function_scope(self, syntactic_name, semantic_name, **kwargs):
+        """
+        Create a new Scope object for a Python function with the given name,
+        and attach any decorators' information to the scope. The new scope is
+        a child of the current one, and can be accessed from the dictionary of
+        its children using the function name as key.
+
+        Before returning control to the caller, the current scope (stored in
+        self._scope) is changed to the one just created, and the function's
+        name is stored in self._current_function_name.
+
+        Parameters
+        ----------
+        name : str
+            Function's name, used as a key to retrieve the new scope.
+
+        decorators : dict
+            Decorators attached to FunctionDef object at syntactic stage.
+
+        """
+        child = self.scope.new_child_scope(name, **kwargs)
+        child.local_used_symbols[syntactic_name] = semantic_name
+        child.python_names[semantic_name] = syntactic_name
+
+
+        self._scope = child
+        self._current_function_name.append(name)
+
+        return child
+
     def get_class_prefix(self, name):
         """
         Search for the class prefix of a dotted name in the current scope.

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5147,6 +5147,8 @@ class SemanticParser(BasicParser):
             self.scope.insert_symbol('__del__')
             scope = self.create_new_function_scope('__del__')
             scope.insert_variable(argument.var)
+            scope.insert_symbol('__del__')
+            cls_scope.insert_symbol('__del__')
             del_method = FunctionDef('__del__', [argument], [Pass()], scope=scope)
             self.exit_function_scope()
             self.insert_function(del_method, cls_scope)

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2701,7 +2701,6 @@ class SemanticParser(BasicParser):
                         func_defs = []
                         for v in headers:
                             scope = self.create_new_function_scope(name)
-                            scope.insert_symbol(name)
                             types = [self._visit(d).type_list[0] for d in v.dtypes]
                             args = [Variable(t.class_type, PyccelSymbol(f'anon_{i}'),
                                 shape = None, is_const = t.is_const, is_optional = False,
@@ -5123,7 +5122,6 @@ class SemanticParser(BasicParser):
             argument = FunctionDefArgument(Variable(dtype, 'self', cls_base = cls), bound_argument = True)
             self.scope.insert_symbol('__init__')
             scope = self.create_new_function_scope('__init__')
-            scope.insert_symbol('__init__')
             cls_scope.insert_symbol('__init__')
             scope.insert_variable(argument.var)
             init_func = FunctionDef('__init__', [argument], (), cls_name=cls.name, scope=scope)
@@ -5157,7 +5155,6 @@ class SemanticParser(BasicParser):
             self.scope.insert_symbol('__del__')
             scope = self.create_new_function_scope('__del__')
             scope.insert_variable(argument.var)
-            scope.insert_symbol('__del__')
             cls_scope.insert_symbol('__del__')
             del_method = FunctionDef('__del__', [argument], [Pass()], scope=scope)
             self.exit_function_scope()

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -706,17 +706,11 @@ class SemanticParser(BasicParser):
         """
         assert not isinstance(exceptions, Variable)
         for i in self._allocs[-1]:
-            if isinstance(i, DottedVariable):
-                if isinstance(i.lhs.class_type, CustomDataType) and self.current_function_name != '__del__':
-                    continue
             if i in exceptions:
                 continue
             self._pointer_targets[-1].pop(i, None)
         targets = {t[0]:t[1] for target_list in self._pointer_targets[-1].values() for t in target_list}
         for i in self._allocs[-1]:
-            if isinstance(i, DottedVariable):
-                if isinstance(i.lhs.class_type, CustomDataType) and self.current_function_name != '__del__':
-                    continue
             if i in exceptions:
                 continue
             if i in targets:
@@ -5231,8 +5225,6 @@ class SemanticParser(BasicParser):
                         [del_method.body]+[Assign(deallocater, LiteralTrue())]))
         del_method.body = [condition]
         del_name = self._current_function_name.pop()
-        if self._current_function and self._current_function[-1].name == del_name:
-            self._current_function.pop()
 
         return EmptyNode()
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -685,6 +685,7 @@ class SemanticParser(BasicParser):
         if self.current_function_name:
             func_name = self.current_function_name.name[-1] if isinstance(self.current_function_name, DottedName) else self.current_function_name
             current_func = self.scope.find(func_name, 'functions')
+            assert current_func == self._current_function[-1]
             arg_vars = {a.var:a for a in current_func.arguments}
 
             for p, t_list in self._pointer_targets[-1].items():
@@ -5154,7 +5155,7 @@ class SemanticParser(BasicParser):
             del_method = cls.get_method('__del__', expr)
 
         # Add destructors to __del__ method
-        self._current_function_name.append(del_method.name)
+        self.enter_function(del_method)
         attribute = []
         for attr in cls.attributes:
             if not attr.on_stack:
@@ -5171,7 +5172,7 @@ class SemanticParser(BasicParser):
         condition = If(IfSection(PyccelNot(deallocater),
                         [del_method.body]+[Assign(deallocater, LiteralTrue())]))
         del_method.body = [condition]
-        self._current_function_name.pop()
+        self.exit_function()
 
         return EmptyNode()
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1395,7 +1395,6 @@ class SemanticParser(BasicParser):
         func: FunctionDef|Interface
             The new annotated function.
         """
-        name = old_func.name
         cls_base_syntactic = old_func.get_direct_user_nodes(lambda p: isinstance(p, ClassDef))
         if cls_base_syntactic:
             cls_name = cls_base_syntactic[0].name

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4727,13 +4727,14 @@ class SemanticParser(BasicParser):
             errors.report("Functions can only be declared in modules or inside other functions.",
                     symbol=expr, severity='error')
 
-        name = expr.scope.get_expected_name(expr.name)
         existing_semantic_funcs = []
         if not expr.is_semantic:
+            name = expr.scope.get_expected_name(expr.name)
             self.scope.functions.pop(name, None)
         elif isinstance(expr, Interface):
             existing_semantic_funcs = [*expr.functions]
-            expr                    = expr.syntactic_node
+            expr = expr.syntactic_node
+            name = expr.scope.get_expected_name(expr.name)
 
         decorators         = expr.decorators
         new_semantic_funcs = []
@@ -4863,7 +4864,7 @@ class SemanticParser(BasicParser):
                 if not is_compatible:
                     self.exit_function_scope()
                     # remove the new created scope and the function name
-                    self.scope.sons_scopes.pop(name)
+                    self.scope.sons_scopes.pop(expr.name)
                     if is_interface:
                         self.scope.remove_symbol(name)
                     continue

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -683,9 +683,7 @@ class SemanticParser(BasicParser):
                         severity='error', symbol=targets[i])
 
         if self.current_function_name:
-            func_name = self.current_function_name.name[-1] if isinstance(self.current_function_name, DottedName) else self.current_function_name
-            current_func = self.scope.find(func_name, 'functions')
-            assert current_func == self._current_function[-1]
+            current_func = self._current_function[-1]
             arg_vars = {a.var:a for a in current_func.arguments}
 
             for p, t_list in self._pointer_targets[-1].items():

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5201,7 +5201,7 @@ class SemanticParser(BasicParser):
             del_method = cls.get_method('__del__', expr)
 
         # Add destructors to __del__ method
-        self.enter_function(del_method)
+        self._current_function_name.append(del_method.name)
         attribute = []
         for attr in cls.attributes:
             if not attr.on_stack:
@@ -5218,7 +5218,9 @@ class SemanticParser(BasicParser):
         condition = If(IfSection(PyccelNot(deallocater),
                         [del_method.body]+[Assign(deallocater, LiteralTrue())]))
         del_method.body = [condition]
-        self.exit_function()
+        del_name = self._current_function_name.pop()
+        if self._current_function and self._current_function[-1].name == del_name:
+            self._current_function.pop()
 
         return EmptyNode()
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -357,6 +357,8 @@ class SemanticParser(BasicParser):
 
     def create_new_function_scope(self, syntactic_name, semantic_name, **kwargs):
         """
+        Create a new Scope object for a Python function.
+
         Create a new Scope object for a Python function with the given name,
         and attach any decorators' information to the scope. The new scope is
         a child of the current one, and can be accessed from the dictionary of
@@ -368,12 +370,21 @@ class SemanticParser(BasicParser):
 
         Parameters
         ----------
-        name : str
-            Function's name, used as a key to retrieve the new scope.
+        syntactic_name : str
+            Function's original name in the translated code, used as a key to
+            retrieve the new scope.
 
-        decorators : dict
-            Decorators attached to FunctionDef object at syntactic stage.
+        semantic_name : str
+            The new name of the function by which it will be known in the target
+            language.
 
+        **kwargs : dict
+            Keyword arguments passed through to the new scope.
+
+        Returns
+        -------
+        Scope
+            The new scope for the function.
         """
         child = self.scope.new_child_scope(syntactic_name, **kwargs)
         child.local_used_symbols[syntactic_name] = semantic_name

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -176,6 +176,33 @@ class SyntaxParser(BasicParser):
 
         return ast
 
+    def create_new_function_scope(self, name, **kwargs):
+        """
+        Create a new Scope object for a Python function with the given name,
+        and attach any decorators' information to the scope. The new scope is
+        a child of the current one, and can be accessed from the dictionary of
+        its children using the function name as key.
+
+        Before returning control to the caller, the current scope (stored in
+        self._scope) is changed to the one just created, and the function's
+        name is stored in self._current_function_name.
+
+        Parameters
+        ----------
+        name : str
+            Function's name, used as a key to retrieve the new scope.
+
+        decorators : dict
+            Decorators attached to FunctionDef object at syntactic stage.
+
+        """
+        child = self.scope.new_child_scope(name, **kwargs)
+
+        self._scope = child
+        self._current_function_name.append(name)
+
+        return child
+
     def _treat_iterable(self, stmt):
         return (self._visit(i) for i in stmt)
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -836,9 +836,11 @@ class SyntaxParser(BasicParser):
 
         headers = self.scope.find(name, 'headers')
 
+        new_name = self.scope.get_expected_name(name)
+
         scope = self.create_new_function_scope(name,
-                used_symbols = {stmt.name: name},
-                original_symbols = {name: stmt.name})
+                used_symbols = {name: new_name},
+                original_symbols = {new_name: name})
 
         arguments    = self._visit(stmt.args)
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -178,6 +178,8 @@ class SyntaxParser(BasicParser):
 
     def create_new_function_scope(self, name, **kwargs):
         """
+        Create a new Scope object for a Python function.
+
         Create a new Scope object for a Python function with the given name,
         and attach any decorators' information to the scope. The new scope is
         a child of the current one, and can be accessed from the dictionary of
@@ -192,9 +194,13 @@ class SyntaxParser(BasicParser):
         name : str
             Function's name, used as a key to retrieve the new scope.
 
-        decorators : dict
-            Decorators attached to FunctionDef object at syntactic stage.
+        **kwargs : dict
+            Keyword arguments passed through to the new scope.
 
+        Returns
+        -------
+        Scope
+            The new scope for the function.
         """
         child = self.scope.new_child_scope(name, **kwargs)
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -836,7 +836,9 @@ class SyntaxParser(BasicParser):
 
         headers = self.scope.find(name, 'headers')
 
-        scope = self.create_new_function_scope(name)
+        scope = self.create_new_function_scope(name,
+                used_symbols = {stmt.name: name},
+                original_symbols = {name: stmt.name})
 
         arguments    = self._visit(stmt.args)
 

--- a/tests/epyccel/classes/class_property_name_conflict.py
+++ b/tests/epyccel/classes/class_property_name_conflict.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring, missing-class-docstring
+
+class A:
+    def __init__(self, x : float):
+        self._x = x
+
+    @property
+    def x(self):
+        return self._x
+
+    def translate(self, y : float):
+        x = self.x
+        return x + y

--- a/tests/epyccel/test_epyccel_classes.py
+++ b/tests/epyccel/test_epyccel_classes.py
@@ -471,3 +471,17 @@ def test_class_magic(language):
 
     for i in range(5):
         assert a_py[i] == a_l[i]
+
+def test_class_property_name_conflict(language):
+    import classes.class_property_name_conflict as mod
+    modnew = epyccel(mod, language = language)
+
+    a_py = mod.A(3.0)
+    a_l = modnew.A(3.0)
+
+    assert a_py.x == a_l.x
+
+    a_py.translate(4.5)
+    a_l.translate(4.5)
+
+    assert a_py.x == a_l.x


### PR DESCRIPTION
Fix class scoping. Methods should have the Module as `parent_scope` (used for name clashes), but the resulting function should be saved into the scope of the class. This can cause problems for retrieving the name of the function itself so the syntactic<->semantic mapping of the name of a function is added to the scope of that function in the `create_new_function_scope` in the semantic stage. Fixes #2093 

**Commit Summary**
- Add assertions to `FunctionDef` and `ClassDef` to ensure the scopes are well-formed
- Exit class scopes before visiting methods so they have the correct parent
- Correct size of homogeneous tuple in wrapper (not clear why this error became apparent in this PR)
- Rename `self._current_function`->`self._current_function_name`
- Use a list to store `Parser._current_function_name` to ensure history can be cleanly retrieved
- When a function is inserted into the scope, use it to update a new variable `self._current_function` (useful to avoid searching for the function in the scope, which is difficult for a class method where the scope is not readily available)
- Move `Parser._annotate_the_called_function_def` from `Parser` to children `SyntacticParser` and `SemanticParser` to allow a more complex implementation for `SemanticParser`
- Use 2 name arguments for `SemanticParser._annotate_the_called_function_def` to ensure correct handling of syntactic and semantic names
- Call correct scope from `collect_tuple_element` if the argument is a `DottedVariable`
- Remove unused code
- Use new `current_function_name` attribute to access `self._current_function_name` to avoid code duplication
- Change the arguments of `SemanticParser._annotate_the_called_function_def` to make the `function_call_args` argument compulsory. This reduces code duplication
- Insert functions into the correct scope
- Add a test (from the issue) with a class with an attribute whose name conflicts with a variable found in the other methods of the class