### PR TITLE
Complete deprecation of real as a type annotation

### DIFF
--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2339,7 +2339,10 @@ class SemanticParser(BasicParser):
                 class_type = NumpyNDArrayType(numpy_process_dtype(dtype), rank, order)
             elif isinstance(base, PyccelFunctionDef):
                 dtype_cls = base.cls_name
-                dtype = numpy_process_dtype(dtype_cls.static_type())
+                try:
+                    dtype = numpy_process_dtype(dtype_cls.static_type())
+                except AttributeError:
+                    errors.report(f"Unrecognised datatype {dtype_cls}", severity='fatal', symbol=expr)
                 class_type = NumpyNDArrayType(dtype, rank, order)
             return VariableTypeAnnotation(class_type)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3332,7 +3332,10 @@ class SemanticParser(BasicParser):
 
         if isinstance(visited_dtype, PyccelFunctionDef):
             dtype_cls = visited_dtype.cls_name
-            class_type = dtype_cls.static_type()
+            try:
+                class_type = dtype_cls.static_type()
+            except AttributeError:
+                errors.report(f"Unrecognised datatype {dtype_cls}", severity='fatal', symbol=expr)
             return UnionTypeAnnotation(VariableTypeAnnotation(class_type))
         elif isinstance(visited_dtype, VariableTypeAnnotation):
             if order and order != visited_dtype.class_type.order:

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3198,9 +3198,7 @@ class SemanticParser(BasicParser):
 
         if var is None and self._in_annotation:
             var = numpy_funcs.get(name, None)
-            if name == 'real':
-                var = numpy_funcs['float']
-            elif name == '*':
+            if name == '*':
                 return GenericType()
 
         if var is None and name in self._context_dict:

--- a/tests/epyccel/modules/generic_functions.py
+++ b/tests/epyccel/modules/generic_functions.py
@@ -29,15 +29,15 @@ def gen_7(x : T, y : T, z : R):
 
 
 
-@template('Z', types=['int', 'real'])
+@template('Z', types=['int', 'float'])
 def tmplt_head_1(x : 'Z', y : 'Z'):
     return x + y
 
-@template('O', types=['int', 'real'])
+@template('O', types=['int', 'float'])
 def local_override_1(x : 'O', y : 'O'):
     return x + y
 
-@template('Z', types=['int', 'real'])
+@template('Z', types=['int', 'float'])
 def tmplt_tmplt_1(x : 'Z', y : 'Z', z : R):
     return x + y + z
 

--- a/tests/errors/semantic/blocking/INTERFACE_WRONG_TYPES.py
+++ b/tests/errors/semantic/blocking/INTERFACE_WRONG_TYPES.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 from pyccel.decorators import template
 
-@template('a', types=['int', 'real'])
-@template('b', types=['int', 'real'])
+@template('a', types=['int', 'float'])
+@template('b', types=['int', 'float'])
 def multi_tmplt_1(x : 'a', y : 'a', z : 'b'):
     """Tests Interfaces"""
     return x + y + z

--- a/tests/errors/semantic/blocking/REAL_TYPE.py
+++ b/tests/errors/semantic/blocking/REAL_TYPE.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
 
 def f(a : 'real'):
     pass

--- a/tests/errors/semantic/blocking/REAL_TYPE.py
+++ b/tests/errors/semantic/blocking/REAL_TYPE.py
@@ -1,0 +1,3 @@
+
+def f(a : 'real'):
+    pass

--- a/tests/errors/semantic/blocking/TEMPLATE_WRONG_TYPE_CALL.py
+++ b/tests/errors/semantic/blocking/TEMPLATE_WRONG_TYPE_CALL.py
@@ -1,13 +1,13 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 from pyccel.decorators import template
 
-@template('z', types=['int', 'real'])
-@template('y', types=['int', 'real'])
+@template('z', types=['int', 'float'])
+@template('y', types=['int', 'float'])
 def multi_tmplt_1(x : 'z', y : 'z', z : 'y'):
     return x + y + z
 
 @template('z', types=['int'])
-@template('y', types=['int', 'real'])
+@template('y', types=['int', 'float'])
 def multi_tmplt_2(y : 'z', z : 'y'):
     return y + z
 

--- a/tests/errors/semantic/blocking/functions_in_uniontype.py
+++ b/tests/errors/semantic/blocking/functions_in_uniontype.py
@@ -1,4 +1,4 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 
-def f(g : '(int)(int)|(real)(real)', a : 'int|float'):
+def f(g : '(int)(int)|(float)(float)', a : 'int|float'):
     return g(a)

--- a/tests/errors/syntax_errors/TEMPLATE_WRONG_KEY.py
+++ b/tests/errors/syntax_errors/TEMPLATE_WRONG_KEY.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 from pyccel.decorators import template
 
-@template(name = 'O', test=['int', 'real']) # pylint: disable=unexpected-keyword-arg
+@template(name = 'O', test=['int', 'float']) # pylint: disable=unexpected-keyword-arg
 def tmplt_1(x : 'O', y : 'O'):
     return x + y
 

--- a/tests/errors/syntax_errors/TEMPLATE_WRONG_NUMBER_ARGS.py
+++ b/tests/errors/syntax_errors/TEMPLATE_WRONG_NUMBER_ARGS.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 from pyccel.decorators import template
 
-@template(name='O', types=['int', 'real'], test='int') # pylint: disable=unexpected-keyword-arg
+@template(name='O', types=['int', 'float'], test='int') # pylint: disable=unexpected-keyword-arg
 def tmplt_1(x : 'O', y : 'O'):
     return x + y
 


### PR DESCRIPTION
According to the CHANGELOG `real` was deprecated as a type annotation in #1813 . In reality this annotation was still working. This is now fixed and a clean error is raised for unrecognised type annotations. Fixes #2323 