### PR TITLE
Fix pr_tests when skipping

### DIFF
--- a/.github/workflows/anaconda_linux.yml
+++ b/.github/workflows/anaconda_linux.yml
@@ -127,7 +127,12 @@ jobs:
           retention-days: 1
           include-hidden-files: true
       - name: "Post completed"
-        if: always() && github.event_name != 'push'
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}
+        shell: bash -l {0}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'
         shell: bash -l {0}

--- a/.github/workflows/anaconda_windows.yml
+++ b/.github/workflows/anaconda_windows.yml
@@ -102,9 +102,12 @@ jobs:
         with:
           shell_cmd: 'bash -l -eo pipefail {0}'
       - name: "Post completed"
-        if: always() && github.event_name != 'push'
-        run: |
-          which python
-          python --version
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
+        run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }}
+        shell: bash -l -eo pipefail {0}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'
         shell: bash -l -eo pipefail {0}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -124,6 +124,12 @@ jobs:
           python compare/ci_tools/process_results.py compare/report.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip != 'true'
         run:
           python base/ci_tools/complete_check_run.py ${{ steps.doc_coverage.outcome }} ${{ steps.doc_format.outcome }}
+        shell: bash -l {0}
+      - name: "Post completed"
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'
+        shell: bash -l {0}

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -121,6 +121,10 @@ jobs:
           retention-days: 1
           include-hidden-files: true
       - name: "Post completed"
-        if: always() && github.event_name != 'push'
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }} ${{ steps.valgrind.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -125,6 +125,10 @@ jobs:
           retention-days: 3
           include-hidden-files: true
       - name: "Post completed"
-        if: always() && github.event_name != 'push'
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }} ${{ steps.valgrind.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -102,6 +102,10 @@ jobs:
         timeout-minutes: 20
         uses: ./.github/actions/pytest_parallel
       - name: "Post completed"
-        if: always() && github.event_name != 'push'
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/pickle.yml
+++ b/.github/workflows/pickle.yml
@@ -110,7 +110,11 @@ jobs:
         with:
           not_editable: "${{ matrix.editable_string == '-e' && 'False' || 'True' }}"
       - name: "Post completed"
-        if: always() && github.event_name != 'push'
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
         run: |
           python ci_tools/basic_json_check_output.py --statuses ${{ steps.installation.outcome }} ${{ steps.stc_check.outcome }} ${{ steps.gFTL_check.outcome}} --reasons "Installation failed." "STC was not found during installation." "gFTL was not found during installation."
           python ci_tools/complete_check_run.py ${{ steps.installation.outcome }} ${{ steps.stc_check.outcome }} ${{ steps.gFTL_check.outcome}}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/pickle_wheel.yml
+++ b/.github/workflows/pickle_wheel.yml
@@ -97,7 +97,11 @@ jobs:
         id: gFTL_check
         uses: ./.github/actions/check_for_gftl
       - name: "Post completed"
-        if: always() && github.event_name != 'push'
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
         run: |
           python ci_tools/basic_json_check_output.py --statuses ${{ steps.wheel_installation.outcome }} ${{ steps.stc_check.outcome }} ${{ steps.gFTL_check.outcome}} --reasons "Installation failed." "STC was not found during installation." "gFTL was not found during installation."
           python ci_tools/complete_check_run.py ${{ steps.wheel_installation.outcome }} ${{ steps.stc_check.outcome }} ${{ steps.gFTL_check.outcome}}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/pyccel_lint.yml
+++ b/.github/workflows/pyccel_lint.yml
@@ -88,6 +88,10 @@ jobs:
           cat $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.lint.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -89,6 +89,10 @@ jobs:
           python ci_tools/parse_pylint_output.py pylint_results.txt pull_diff.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.pylint.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -76,6 +76,10 @@ jobs:
         with:
           config: ./.typos.toml
       - name: "Post completed"
-        if: always() && github.event_name != 'pull_request'
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.spelling.outcome }} ${{ steps.manual_spelling.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,6 +105,10 @@ jobs:
         timeout-minutes: 20
         uses: ./.github/actions/pytest_parallel
       - name: "Post completed"
-        if: always() && github.event_name != 'push'
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.f_c_pytest.outcome }} ${{ steps.python_pytest.outcome }} ${{ steps.parallel.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/ci_tools/bot_tools/bot_funcs.py
+++ b/ci_tools/bot_tools/bot_funcs.py
@@ -50,6 +50,8 @@ tests_with_base = ('coverage', 'docs', 'pyccel_lint', 'pylint')
 pr_test_keys = ('linux', 'windows', 'macosx', 'coverage', 'docs', 'pylint',
                 'pyccel_lint', 'spelling', 'intel')
 
+pr_test_keys_to_trigger = ('linux', 'windows', 'macosx', 'coverage', 'intel')
+
 review_stage_labels = ["needs_initial_review", "Ready_for_review", "Ready_to_merge"]
 
 senior_reviewer = ['yguclu', 'EmilyBourne']
@@ -473,7 +475,7 @@ class Bot:
             return False
 
         if self.is_user_trusted(user):
-            states = self.run_tests(pr_test_keys)
+            states = self.run_tests(pr_test_keys_to_trigger)
 
             if 'failure' in states:
                 self.draft_due_to_failure()


### PR DESCRIPTION
Post success as the result of the test if it was skipped because it was a duplicate. Avoid running static analysis tests twice if `/bot run pr_tests` is used