### PR TITLE
Stop modifying variables to add `Final` annotation

### DIFF
--- a/.github/workflows/pyccel_lint.yml
+++ b/.github/workflows/pyccel_lint.yml
@@ -89,7 +89,7 @@ jobs:
           cat $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
-        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip != 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.lint.outcome }}
       - name: "Post completed"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -90,7 +90,7 @@ jobs:
           python ci_tools/parse_pylint_output.py pylint_results.txt pull_diff.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"
-        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip == 'true'
+        if: always() && github.event_name != 'pull_request' && steps.duplicate_check.outputs.should_skip != 'true'
         run:
           python ci_tools/complete_check_run.py ${{ steps.pylint.outcome }}
       - name: "Post completed"

--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,4 @@ Contributors
 * Joao Antonio Gomes
 * Nandini Raja
 * Brijesh Thummar
+* Max Lindqvist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,7 @@ All notable changes to this project will be documented in this file.
 -   #1668 : Fix handling of `is not None` check to ensure it is always checked before accessing the variable.
 -   #802 : Add if blocks in Python output to ensure support for implementations that differ for different types.
 -   Fix casting of arrays in Python translation.
--   #2167 : Do not automatically treat variables as input-only.
+-   #2167 : Stop modifying variables to add `Final` annotation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,7 @@ All notable changes to this project will be documented in this file.
 -   #1668 : Fix handling of `is not None` check to ensure it is always checked before accessing the variable.
 -   #802 : Add if blocks in Python output to ensure support for implementations that differ for different types.
 -   Fix casting of arrays in Python translation.
--   #2167 : Fix error in INTENT in/inout
+-   #2167 : Do not automatically set variables to intent in.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,7 @@ All notable changes to this project will be documented in this file.
 -   #1668 : Fix handling of `is not None` check to ensure it is always checked before accessing the variable.
 -   #802 : Add if blocks in Python output to ensure support for implementations that differ for different types.
 -   Fix casting of arrays in Python translation.
--   #2167 : Do not automatically set variables to intent in.
+-   #2167 : Do not automatically treat variables as input-only.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ All notable changes to this project will be documented in this file.
 -   #1668 : Fix handling of `is not None` check to ensure it is always checked before accessing the variable.
 -   #802 : Add if blocks in Python output to ensure support for implementations that differ for different types.
 -   Fix casting of arrays in Python translation.
+-   #2167 : Fix error in INTENT in/inout
 
 ### Changed
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5152,9 +5152,9 @@ class SemanticParser(BasicParser):
                                                                  if isinstance(a, DottedVariable) else [a])]
 
             # ... computing inout arguments
-            # for a in arguments:
-            #     if a.var not in all_assigned and expr.name not in ('__del__', '__init__'):
-            #         a.make_const()
+            for a in arguments:
+                if a.var not in all_assigned and expr.name not in ('__del__', '__init__'):
+                    a.make_const()
             # ...
             # Raise an error if one of the return arguments is an alias.
             pointer_targets = self._pointer_targets.pop()

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5151,11 +5151,6 @@ class SemanticParser(BasicParser):
                 all_assigned = [v for a in all_assigned for v in (a.get_attribute_nodes(Variable) \
                                                                  if isinstance(a, DottedVariable) else [a])]
 
-            # ... computing inout arguments
-            for a in arguments:
-                if a.var not in all_assigned and expr.name not in ('__del__', '__init__'):
-                    a.make_const()
-            # ...
             # Raise an error if one of the return arguments is an alias.
             pointer_targets = self._pointer_targets.pop()
             result_pointer_map = {}

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5152,9 +5152,9 @@ class SemanticParser(BasicParser):
                                                                  if isinstance(a, DottedVariable) else [a])]
 
             # ... computing inout arguments
-            for a in arguments:
-                if a.var not in all_assigned and expr.name not in ('__del__', '__init__'):
-                    a.make_const()
+            # for a in arguments:
+            #     if a.var not in all_assigned and expr.name not in ('__del__', '__init__'):
+            #         a.make_const()
             # ...
             # Raise an error if one of the return arguments is an alias.
             pointer_targets = self._pointer_targets.pop()

--- a/tests/codegen/fcode/scripts/macros.py
+++ b/tests/codegen/fcode/scripts/macros.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring, undefined-variable
+# pylint: disable=missing-function-docstring, missing-module-docstring
 from numpy import zeros
 
 # .....................................
@@ -15,11 +15,9 @@ def f1(n):
     x = zeros(n, 'int')
     __f(x)
 
-# TODO not working yet, x is intent(inout)
-#      but it is not inferred as inout
 #$ header function f2(int [:])
 def f2(x):
-    __f(x)
+    __f(x) # pylint: disable=undefined-variable
 # .....................................
 
 # .....................................

--- a/tests/codegen/fcode/scripts/macros.py
+++ b/tests/codegen/fcode/scripts/macros.py
@@ -19,9 +19,8 @@ def f1(n):
 #      but it is not inferred as inout
 #$ header function f2(int [:])
 def f2(x):
-   __f(x)
+    __f(x)
 # .....................................
-
 
 # .....................................
 #           2d case

--- a/tests/codegen/fcode/scripts/macros.py
+++ b/tests/codegen/fcode/scripts/macros.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring
+# pylint: disable=missing-function-docstring, missing-module-docstring, undefined-variable
 from numpy import zeros
 
 # .....................................

--- a/tests/codegen/fcode/scripts/macros.py
+++ b/tests/codegen/fcode/scripts/macros.py
@@ -17,9 +17,9 @@ def f1(n):
 
 # TODO not working yet, x is intent(inout)
 #      but it is not inferred as inout
-##$ header function f2(int [:])
-#def f2(x):
-#    __f(x)
+#$ header function f2(int [:])
+def f2(x):
+   __f(x)
 # .....................................
 
 

--- a/tests/epyccel/modules/highorder_functions.py
+++ b/tests/epyccel/modules/highorder_functions.py
@@ -130,7 +130,7 @@ def euler (dydt: '()(float, const float[:], float[:])',
         dydt ( t[i], y[i,:], y[i+1,:] )
         y[i+1,:] = y[i,:] + dt * y[i+1,:]
 
-def predator_prey_deriv ( t: 'float', rf: 'float[:]', out: 'float[:]' ):
+def predator_prey_deriv ( t: 'float', rf: 'const float[:]', out: 'float[:]' ):
 
     r = rf[0]
     f = rf[1]


### PR DESCRIPTION
Closes #2167 

I removed the block of code that attempted to determine which function arguments were modified and should be marked as `inout`. If the user manually marks an argument with `const`, then it will still be `intent:in`, but otherwise `intent:inout` is always used.
