### PR TITLE
Fix GCC-15 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@ All notable changes to this project will be documented in this file.
 -   #1814 : Fix class method visitation order to correctly access the global scope from methods.
 -   #1668 : Fix handling of `is not None` check to ensure it is always checked before accessing the variable.
 -   #802 : Add if blocks in Python output to ensure support for implementations that differ for different types.
--   #2286 : Fix warnings due to non-existant include directories.
+-   #2286 : Fix warnings due to non-existent include directories.
 -   Fix casting of arrays in Python translation.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ All notable changes to this project will be documented in this file.
 -   #1814 : Fix class method visitation order to correctly access the global scope from methods.
 -   #1668 : Fix handling of `is not None` check to ensure it is always checked before accessing the variable.
 -   #802 : Add if blocks in Python output to ensure support for implementations that differ for different types.
+-   #2286 : Fix warnings due to non-existant include directories.
 -   Fix casting of arrays in Python translation.
 
 ### Changed

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -384,6 +384,16 @@ class PyccelNot(PyccelUnaryOperator):
     _precedence = 6
     _class_type = PythonNativeBool()
 
+    def __new__(cls, arg):
+        if isinstance(arg, PyccelEq):
+            arg1, arg2 = arg.args
+            return PyccelNe(arg1, arg2)
+        elif isinstance(arg, PyccelNe):
+            arg1, arg2 = arg.args
+            return PyccelEq(arg1, arg2)
+        else:
+            return super().__new__(cls)
+
     def _set_type(self):
         """
         Set the type of the result of the operator.

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -356,7 +356,7 @@ def execute_pyccel(fname, *,
         if parser.compile_obj:
             deps[mod_base] = parser.compile_obj
         elif mod_base not in deps:
-            compile_libs = parser.metavars.get('libraries', '').split(',')
+            compile_libs = [l for l in parser.metavars.get('libraries', '').split(',') if l]
             if not parser.metavars.get('ignore_at_import',False):
                 deps[mod_base] = CompileObj(mod_base,
                                     folder          = mod_folder,

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -303,7 +303,7 @@ def execute_pyccel(fname, *,
     compile_libs = [*libs, parser.metavars['libraries']] \
                     if 'libraries' in parser.metavars else libs
     compile_libs.extend(l for son in parser.sons if son.metavars.get('ignore_at_import',False) \
-                        for l in parser.metavars.get('libraries', '').split(',') if l)
+                        for l in son.metavars.get('libraries', '').split(',') if l)
     mod_obj = CompileObj(file_name = fname,
             folder       = pyccel_dirpath,
             flags        = fflags,

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -302,6 +302,8 @@ def execute_pyccel(fname, *,
 
     compile_libs = [*libs, parser.metavars['libraries']] \
                     if 'libraries' in parser.metavars else libs
+    compile_libs.extend(son.metavars['libraries'] for son in parser.sons \
+                        if son.metavars.get('ignore_at_import',False))
     mod_obj = CompileObj(file_name = fname,
             folder       = pyccel_dirpath,
             flags        = fflags,
@@ -355,7 +357,6 @@ def execute_pyccel(fname, *,
             deps[mod_base] = parser.compile_obj
         elif mod_base not in deps:
             compile_libs = (parser.metavars['libraries'],) if 'libraries' in parser.metavars else ()
-            assert not parser.metavars.get('ignore_at_import',False) or len(compile_libs) == 0
             if not parser.metavars.get('ignore_at_import',False):
                 deps[mod_base] = CompileObj(mod_base,
                                     folder          = mod_folder,

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -355,12 +355,12 @@ def execute_pyccel(fname, *,
             deps[mod_base] = parser.compile_obj
         elif mod_base not in deps:
             compile_libs = (parser.metavars['libraries'],) if 'libraries' in parser.metavars else ()
-            no_target = parser.metavars.get('no_target',False) or \
-                    parser.metavars.get('ignore_at_import',False)
-            deps[mod_base] = CompileObj(mod_base,
-                                folder          = mod_folder,
-                                libs            = compile_libs,
-                                has_target_file = not no_target)
+            assert not parser.metavars.get('ignore_at_import',False) or len(compile_libs) == 0
+            if not parser.metavars.get('ignore_at_import',False):
+                deps[mod_base] = CompileObj(mod_base,
+                                    folder          = mod_folder,
+                                    libs            = compile_libs,
+                                    has_target_file = parser.metavars.get('no_target',False))
 
         # Proceed recursively
         for son in parser.sons:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -300,39 +300,58 @@ def execute_pyccel(fname, *,
             print_timers(start, timers)
         return
 
-    compile_libs = [*libs, parser.metavars['libraries']] \
-                    if 'libraries' in parser.metavars else libs
-
-    deps = dict()
     # ...
-    # Determine all .o files and all folders needed by executable
-    def get_module_dependencies(parser, deps):
+    def get_module_and_compile_dependencies(parser, compile_libs = None, deps = None):
+        """
+        Get the module (.o files) and compilation dependencies.
+
+        Determine all additional .o files, include folders and libraries required
+        to generate the shared library or executable.
+
+        Parameters
+        ----------
+        parser : Parser
+            The parser whose dependencies should be appended.
+        compile_libs : list[str]
+            The libraries (-lX) that should be used for the compilation.
+        deps : dict[str, CompileObj]
+            A dictionary describing the modules on which this code depends.
+            The key is the name of the file containing the module. The value
+            is the CompileObj describing the .o file.
+        """
         filename = parser.filename
         mod_folder = os.path.join(os.path.dirname(filename), '__pyccel__' + os.environ.get('PYTEST_XDIST_WORKER', ''))
         mod_base = os.path.basename(filename)
 
-        # Stop conditions
-        if parser.metavars.get('module_name', None) == 'omp_lib':
-            return
+        if compile_libs is None:
+            assert deps is None
+            compile_libs = []
+            deps = {}
+        else:
+            # Stop conditions
+            if parser.metavars.get('module_name', None) == 'omp_lib':
+                return
 
-        if parser.compile_obj:
-            deps[filename] = parser.compile_obj
-        elif filename not in deps:
-            dep_compile_libs = [l for l in parser.metavars.get('libraries', '').split(',') if l]
-            if not parser.metavars.get('ignore_at_import', False):
-                deps[filename] = CompileObj(mod_base,
-                                    folder          = mod_folder,
-                                    libs            = dep_compile_libs,
-                                    has_target_file = not parser.metavars.get('no_target', False))
-            else:
-                compile_libs.extend(dep_compile_libs)
+            if parser.compile_obj:
+                deps[filename] = parser.compile_obj
+            elif filename not in deps:
+                dep_compile_libs = [l for l in parser.metavars.get('libraries', '').split(',') if l]
+                if not parser.metavars.get('ignore_at_import', False):
+                    deps[filename] = CompileObj(mod_base,
+                                        folder          = mod_folder,
+                                        libs            = dep_compile_libs,
+                                        has_target_file = not parser.metavars.get('no_target', False))
+                else:
+                    compile_libs.extend(dep_compile_libs)
 
         # Proceed recursively
         for son in parser.sons:
-            get_module_dependencies(son, deps)
+            get_module_and_compile_dependencies(son, compile_libs, deps)
 
-    for son in parser.sons:
-        get_module_dependencies(son, deps)
+        return compile_libs, deps
+
+    compile_libs, deps = get_module_and_compile_dependencies(parser)
+    compile_libs.extend(libs)
 
     mod_obj = CompileObj(file_name = fname,
             folder       = pyccel_dirpath,

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -361,7 +361,7 @@ def execute_pyccel(fname, *,
                 deps[mod_base] = CompileObj(mod_base,
                                     folder          = mod_folder,
                                     libs            = compile_libs,
-                                    has_target_file = parser.metavars.get('no_target',False))
+                                    has_target_file = not parser.metavars.get('no_target',False))
 
         # Proceed recursively
         for son in parser.sons:

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -302,8 +302,8 @@ def execute_pyccel(fname, *,
 
     compile_libs = [*libs, parser.metavars['libraries']] \
                     if 'libraries' in parser.metavars else libs
-    compile_libs.extend(son.metavars['libraries'] for son in parser.sons \
-                        if son.metavars.get('ignore_at_import',False))
+    compile_libs.extend(l for son in parser.sons if son.metavars.get('ignore_at_import',False) \
+                        for l in parser.metavars.get('libraries', '').split(',') if l)
     mod_obj = CompileObj(file_name = fname,
             folder       = pyccel_dirpath,
             flags        = fflags,
@@ -356,7 +356,7 @@ def execute_pyccel(fname, *,
         if parser.compile_obj:
             deps[mod_base] = parser.compile_obj
         elif mod_base not in deps:
-            compile_libs = (parser.metavars['libraries'],) if 'libraries' in parser.metavars else ()
+            compile_libs = parser.metavars.get('libraries', '').split(',')
             if not parser.metavars.get('ignore_at_import',False):
                 deps[mod_base] = CompileObj(mod_base,
                                     folder          = mod_folder,

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -18,7 +18,7 @@ from pyccel.errors.errors          import PyccelSyntaxError, PyccelSemanticError
 from pyccel.errors.messages        import PYCCEL_RESTRICTION_TODO
 from pyccel.parser.parser          import Parser
 from pyccel.codegen.codegen        import Codegen
-from pyccel.codegen.utilities      import manage_dependencies
+from pyccel.codegen.utilities      import manage_dependencies, get_module_and_compile_dependencies
 from pyccel.codegen.python_wrapper import create_shared_library
 from pyccel.naming                 import name_clash_checkers
 from pyccel.utilities.stage        import PyccelStage
@@ -299,56 +299,6 @@ def execute_pyccel(fname, *,
         if show_timings:
             print_timers(start, timers)
         return
-
-    # ...
-    def get_module_and_compile_dependencies(parser, compile_libs = None, deps = None):
-        """
-        Get the module (.o files) and compilation dependencies.
-
-        Determine all additional .o files, include folders and libraries required
-        to generate the shared library or executable.
-
-        Parameters
-        ----------
-        parser : Parser
-            The parser whose dependencies should be appended.
-        compile_libs : list[str]
-            The libraries (-lX) that should be used for the compilation.
-        deps : dict[str, CompileObj]
-            A dictionary describing the modules on which this code depends.
-            The key is the name of the file containing the module. The value
-            is the CompileObj describing the .o file.
-        """
-        filename = parser.filename
-        mod_folder = os.path.join(os.path.dirname(filename), '__pyccel__' + os.environ.get('PYTEST_XDIST_WORKER', ''))
-        mod_base = os.path.basename(filename)
-
-        if compile_libs is None:
-            assert deps is None
-            compile_libs = []
-            deps = {}
-        else:
-            # Stop conditions
-            if parser.metavars.get('module_name', None) == 'omp_lib':
-                return
-
-            if parser.compile_obj:
-                deps[filename] = parser.compile_obj
-            elif filename not in deps:
-                dep_compile_libs = [l for l in parser.metavars.get('libraries', '').split(',') if l]
-                if not parser.metavars.get('ignore_at_import', False):
-                    deps[filename] = CompileObj(mod_base,
-                                        folder          = mod_folder,
-                                        libs            = dep_compile_libs,
-                                        has_target_file = not parser.metavars.get('no_target', False))
-                else:
-                    compile_libs.extend(dep_compile_libs)
-
-        # Proceed recursively
-        for son in parser.sons:
-            get_module_and_compile_dependencies(son, compile_libs, deps)
-
-        return compile_libs, deps
 
     compile_libs, deps = get_module_and_compile_dependencies(parser)
     compile_libs.extend(libs)

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -319,11 +319,11 @@ def execute_pyccel(fname, *,
             deps[filename] = parser.compile_obj
         elif filename not in deps:
             dep_compile_libs = [l for l in parser.metavars.get('libraries', '').split(',') if l]
-            if not parser.metavars.get('ignore_at_import',False):
+            if not parser.metavars.get('ignore_at_import', False):
                 deps[filename] = CompileObj(mod_base,
                                     folder          = mod_folder,
                                     libs            = dep_compile_libs,
-                                    has_target_file = not parser.metavars.get('no_target',False))
+                                    has_target_file = not parser.metavars.get('no_target', False))
             else:
                 compile_libs.extend(dep_compile_libs)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2599,14 +2599,20 @@ class CCodePrinter(CodePrinter):
         return ' ^ '.join(self._print(a) for a in expr.args)
 
     def _print_PyccelBitOr(self, expr):
+        args = [f'({self._print(a)})' if isinstance(a, PyccelOperator) and \
+                                        not isinstance(a, PyccelAssociativeParenthesis) \
+                    else self._print(a) for a in expr.args]
         if expr.dtype is PythonNativeBool():
-            return ' || '.join(self._print(a) for a in expr.args)
-        return ' | '.join(self._print(a) for a in expr.args)
+            return ' || '.join(args)
+        return ' | '.join(args)
 
     def _print_PyccelBitAnd(self, expr):
+        args = [f'({self._print(a)})' if isinstance(a, PyccelOperator) and \
+                                        not isinstance(a, PyccelAssociativeParenthesis) \
+                    else self._print(a) for a in expr.args]
         if expr.dtype is PythonNativeBool():
-            return ' && '.join(self._print(a) for a in expr.args)
-        return ' & '.join(self._print(a) for a in expr.args)
+            return ' && '.join(args)
+        return ' & '.join(args)
 
     def _print_PyccelInvert(self, expr):
         return '~{}'.format(self._print(expr.args[0]))

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1171,13 +1171,13 @@ class CCodePrinter(CodePrinter):
 
     def _print_PyccelAnd(self, expr):
         args = [f'({self._print(a)})' if isinstance(a, PyccelOperator) and \
-                                        not isinstance(arg, PyccelAssociativeParenthesis) \
+                                        not isinstance(a, PyccelAssociativeParenthesis) \
                     else self._print(a) for a in expr.args]
         return ' && '.join(a for a in args)
 
     def _print_PyccelOr(self, expr):
         args = [f'({self._print(a)})' if isinstance(a, PyccelOperator) and \
-                                        not isinstance(arg, PyccelAssociativeParenthesis) \
+                                        not isinstance(a, PyccelAssociativeParenthesis) \
                     else self._print(a) for a in expr.args]
         return ' || '.join(a for a in args)
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1170,11 +1170,11 @@ class CCodePrinter(CodePrinter):
         return '0'
 
     def _print_PyccelAnd(self, expr):
-        args = [self._print(a) for a in expr.args]
+        args = [f'(self._print(a)})' if isinstance(a, PyccelOperator) else self._print(a) for a in expr.args]
         return ' && '.join(a for a in args)
 
     def _print_PyccelOr(self, expr):
-        args = [self._print(a) for a in expr.args]
+        args = [f'(self._print(a)})' if isinstance(a, PyccelOperator) else self._print(a) for a in expr.args]
         return ' || '.join(a for a in args)
 
     def _print_PyccelEq(self, expr):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1173,13 +1173,13 @@ class CCodePrinter(CodePrinter):
         args = [f'({self._print(a)})' if isinstance(a, PyccelOperator) and \
                                         not isinstance(a, PyccelAssociativeParenthesis) \
                     else self._print(a) for a in expr.args]
-        return ' && '.join(a for a in args)
+        return ' && '.join(args)
 
     def _print_PyccelOr(self, expr):
         args = [f'({self._print(a)})' if isinstance(a, PyccelOperator) and \
                                         not isinstance(a, PyccelAssociativeParenthesis) \
                     else self._print(a) for a in expr.args]
-        return ' || '.join(a for a in args)
+        return ' || '.join(args)
 
     def _print_PyccelEq(self, expr):
         lhs, rhs = expr.args

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -437,7 +437,7 @@ def get_module_and_compile_dependencies(parser, compile_libs = None, deps = None
     else:
         # Stop conditions
         if parser.metavars.get('module_name', None) == 'omp_lib':
-            return
+            return compile_libs, deps
 
         if parser.compile_obj:
             deps[filename] = parser.compile_obj

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -408,13 +408,13 @@ def get_module_and_compile_dependencies(parser, compile_libs = None, deps = None
         The parser whose dependencies should be appended.
     compile_libs : list[str], optional
         The libraries (-lX) that should be used for the compilation.
-        This arguments is used internally but should not be provided
+        This argument is used internally but should not be provided
         from an external call to this function.
     deps : dict[str, CompileObj], optional
         A dictionary describing the modules on which this code depends.
         The key is the name of the file containing the module. The value
         is the CompileObj describing the .o file.
-        This arguments is used internally but should not be provided
+        This argument is used internally but should not be provided
         from an external call to this function.
 
     Returns

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -321,6 +321,7 @@ def recompile_object(compile_obj,
                 language=language,
                 verbose=verbose)
 
+#==============================================================================
 def manage_dependencies(pyccel_imports, compiler, pyccel_dirpath, mod_obj, language, verbose, convert_only = False):
     """
     Manage dependencies of the code to be compiled.
@@ -393,3 +394,65 @@ def manage_dependencies(pyccel_imports, compiler, pyccel_dirpath, mod_obj, langu
                              verbose  = verbose)
             mod_obj.add_dependencies(d)
 
+#==============================================================================
+def get_module_and_compile_dependencies(parser, compile_libs = None, deps = None):
+    """
+    Get the module (.o files) and compilation dependencies.
+
+    Determine all additional .o files, include folders and libraries required
+    to generate the shared library or executable.
+
+    Parameters
+    ----------
+    parser : Parser
+        The parser whose dependencies should be appended.
+    compile_libs : list[str], optional
+        The libraries (-lX) that should be used for the compilation.
+        This arguments is used internally but should not be provided
+        from an external call to this function.
+    deps : dict[str, CompileObj], optional
+        A dictionary describing the modules on which this code depends.
+        The key is the name of the file containing the module. The value
+        is the CompileObj describing the .o file.
+        This arguments is used internally but should not be provided
+        from an external call to this function.
+
+    Returns
+    -------
+    compile_libs : list[str], optional
+        The libraries (-lX) that should be used for the compilation.
+    deps : dict[str, CompileObj], optional
+        A dictionary describing the modules on which this code depends.
+        The key is the name of the file containing the module. The value
+        is the CompileObj describing the .o file.
+    """
+    filename = parser.filename
+    mod_folder = os.path.join(os.path.dirname(filename), '__pyccel__' + os.environ.get('PYTEST_XDIST_WORKER', ''))
+    mod_base = os.path.basename(filename)
+
+    if compile_libs is None:
+        assert deps is None
+        compile_libs = []
+        deps = {}
+    else:
+        # Stop conditions
+        if parser.metavars.get('module_name', None) == 'omp_lib':
+            return
+
+        if parser.compile_obj:
+            deps[filename] = parser.compile_obj
+        elif filename not in deps:
+            dep_compile_libs = [l for l in parser.metavars.get('libraries', '').split(',') if l]
+            if not parser.metavars.get('ignore_at_import', False):
+                deps[filename] = CompileObj(mod_base,
+                                    folder          = mod_folder,
+                                    libs            = dep_compile_libs,
+                                    has_target_file = not parser.metavars.get('no_target', False))
+            else:
+                compile_libs.extend(dep_compile_libs)
+
+    # Proceed recursively
+    for son in parser.sons:
+        get_module_and_compile_dependencies(son, compile_libs, deps)
+
+    return compile_libs, deps


### PR DESCRIPTION
Fix several warnings seen in the MacOS runner (which uses GCC-15, a more recent compiler than other runners).
- `!(a == b)` is simplified to `a != b`
- `!(a != b)` is simplified to `a == b`
- Added parentheses to remove warnings about ambiguity when printing `PyccelAnd`, `PyccelOr`, `PyccelNot`, `PyccelBitAnd`, `PyccelBitOr`
- Use `ignore_at_import` metavar to decide if a compile object is needed (prevents unused include directories. Fixes #2286)