### PR TITLE
Correct base for workflows triggered without inputs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ env:
   GITHUB_CHECK_RUN_ID: ${{ inputs.check_run_id }}
   PR_REPO: ${{ inputs.pr_repo || github.repository }}
   PYTHON_VERSION: ${{ inputs.python_version || '3.10' }}
+  BASE: ${{ inputs.base || github.event.pull_request.base.ref }}
 
 jobs:
 
@@ -53,7 +54,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.base }}
+          ref: ${{ env.BASE }}
           path: base
           submodules: true
       - uses: actions/checkout@v4
@@ -109,9 +110,9 @@ jobs:
         run: |
           cd compare
           git fetch
-          git checkout ${{ inputs.base }} # Make sure there is a local copy in case of a branch
+          git checkout ${{ env.BASE }} # Make sure there is a local copy in case of a branch
           git checkout ${{ env.COMMIT }}
-          git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
+          git diff ${{ env.BASE }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
           python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
           export PYTHONPATH=ci_tools

--- a/.github/workflows/pyccel_lint.yml
+++ b/.github/workflows/pyccel_lint.yml
@@ -32,6 +32,7 @@ env:
   GITHUB_CHECK_RUN_ID: ${{ inputs.check_run_id }}
   PR_REPO: ${{ inputs.pr_repo || github.repository }}
   PYTHON_VERSION: ${{ inputs.python_version || '3.11' }}
+  BASE: ${{ inputs.base || github.event.pull_request.base.ref }}
 
 jobs:
   Pyccel-Linter:
@@ -78,7 +79,7 @@ jobs:
       - name: Collect diff information
         if: steps.duplicate_check.outputs.should_skip != 'true'
         run: |
-          git diff ${{ inputs.base }} --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
+          git diff ${{ env.BASE }} --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
         shell: bash
       - name: Lint
         if: steps.duplicate_check.outputs.should_skip != 'true'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -32,6 +32,7 @@ env:
   GITHUB_CHECK_RUN_ID: ${{ inputs.check_run_id }}
   PR_REPO: ${{ inputs.pr_repo || github.repository }}
   PYTHON_VERSION: ${{ inputs.python_version || '3.9' }}
+  BASE: ${{ inputs.base || github.event.pull_request.base.ref }}
 
 jobs:
   Linter:
@@ -74,7 +75,7 @@ jobs:
       - name: Run Pylint
         if: steps.duplicate_check.outputs.should_skip != 'true'
         run: |
-          check_files=$(git diff ${{ inputs.base }}..HEAD --name-only --diff-filter=AM | grep "\.py$" || true)
+          check_files=$(git diff ${{ env.BASE }}..HEAD --name-only --diff-filter=AM | grep "\.py$" || true)
           if [ -z ${check_files} ]
           then
             touch pylint_results.txt
@@ -86,7 +87,7 @@ jobs:
         if: steps.duplicate_check.outputs.should_skip != 'true'
         id: pylint
         run: |
-          git diff ${{ inputs.base }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
+          git diff ${{ env.BASE }}..HEAD --no-indent-heuristic --unified=0 --output=pull_diff.txt --no-color
           python ci_tools/parse_pylint_output.py pylint_results.txt pull_diff.txt $GITHUB_STEP_SUMMARY
         shell: bash
       - name: "Post completed"


### PR DESCRIPTION
Correct base for workflows triggered without inputs. Base is an input (usually devel) but is not provided when the workflow is triggered by taking it out of draft. This leads to an empty diff so no errors are reported.