### PR TITLE
Allow language to be set using a capitalised name (Fortran, C, Python)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ All notable changes to this project will be documented in this file.
 -   Fix casting of arrays in Python translation.
 -   #2167 : Stop modifying variables to add `Final` annotation.
 -   #2216 : Ensure compilation dependencies added by Pyccel are indicated for compilation of files which import the module.
+-   #???? : Allow language to set using a capitalised name (Fortran, C, Python).
 
 ### Changed
 

--- a/pyccel/commands/console.py
+++ b/pyccel/commands/console.py
@@ -80,7 +80,7 @@ def pyccel(files=None, mpi=None, openmp=None, openacc=None, output_dir=None, com
     # ... backend compiler options
     group = parser.add_argument_group('Backend compiler options')
 
-    group.add_argument('--language', choices=('fortran', 'c', 'python'), help='Generated language')
+    group.add_argument('--language', choices=('fortran', 'c', 'python'), help='Generated language', type=str.lower)
 
     group.add_argument('--compiler', help='Compiler family or json file containing a compiler description {GNU,intel,PGI,nvidia}')
 

--- a/pyccel/naming/__init__.py
+++ b/pyccel/naming/__init__.py
@@ -11,6 +11,11 @@ from .fortrannameclashchecker import FortranNameClashChecker
 from .cnameclashchecker import CNameClashChecker
 from .pythonnameclashchecker import PythonNameClashChecker
 
-name_clash_checkers = {'fortran':FortranNameClashChecker(),
+name_clash_checkers = {
+        'fortran':FortranNameClashChecker(),
         'c':CNameClashChecker(),
-        'python':PythonNameClashChecker()}
+        'python':PythonNameClashChecker(),
+        'Fortran':FortranNameClashChecker(),
+        'C':CNameClashChecker(),
+        'Python':PythonNameClashChecker()
+        }

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -24,6 +24,19 @@ def test_func_no_args_1(language):
     with pytest.raises(TypeError):
         c_gift(unexpected_arg)
 
+def test_func_with_capitalised_language(language):
+    '''test function with return value but no args'''
+    def free_gift():
+        gift = 10
+        return gift
+
+    c_gift = epyccel(free_gift, language=language.capitalize())
+    assert c_gift() == free_gift()
+    assert isinstance(c_gift(), type(free_gift()))
+    unexpected_arg = 0
+    with pytest.raises(TypeError):
+        c_gift(unexpected_arg)
+
 def test_func_no_args_2(language):
     '''test function with negative return value but no args'''
     def p_lose():

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -534,6 +534,13 @@ def test_folder_imports(language):
 def test_funcs(language):
     pyccel_test("scripts/runtest_funcs.py", language = language)
 
+@pytest.mark.xdist_incompatible
+def test_capitalised_language(language):
+    test_file = get_abs_path("scripts/runtest_funcs.py")
+    cwd = os.path.dirname(test_file)
+    output_folder = "__pyccel__" + os.environ.get('PYTEST_XDIST_WORKER', '')
+    compile_pyccel(cwd, test_file, f'--language={language.capitalize()} --output={output_folder}')
+
 #------------------------------------------------------------------------------
 # Enumerate not supported in c
 def test_inout_func(language):


### PR DESCRIPTION
Allow language to be set using a capitalised name (Fortran, C, Python) via both Pyccel's command line tool and `epyccel`.