### PR TITLE
Fix Import regression

### DIFF
--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -587,7 +587,7 @@ class SemanticParser(BasicParser):
             found_from_import_name = True
 
         if imp is not None:
-            if found_from_import_name or imp.source == source:
+            if found_from_import_name or imp.source_module.name == source:
                 imp.define_target(target)
             else:
                 errors.report(IMPORTING_EXISTING_IDENTIFIED,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -587,7 +587,7 @@ class SemanticParser(BasicParser):
             found_from_import_name = True
 
         if imp is not None:
-            if found_from_import_name or imp.source_module.name == source:
+            if found_from_import_name or source in (imp.source, getattr(imp.source_module, 'name', '')):
                 imp.define_target(target)
             else:
                 errors.report(IMPORTING_EXISTING_IDENTIFIED,

--- a/tests/pyccel/scripts/runtest_import_mod_project_as.py
+++ b/tests/pyccel/scripts/runtest_import_mod_project_as.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+import import_syntax.user_mod as user_mod
+
+def fun(xi1 : 'double', xi2 : 'double', xi3 : 'double'):
+    return user_mod.user_func(xi1, xi2, xi3)
+
+if __name__ == '__main__':
+    print(fun(1.0,2.0,3.0))
+

--- a/tests/pyccel/scripts/runtest_import_mod_project_as.py
+++ b/tests/pyccel/scripts/runtest_import_mod_project_as.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
-import import_syntax.user_mod as user_mod
+import import_syntax.user_mod as user_mod # pylint: disable=consider-using-from-import
 
 def fun(xi1 : 'double', xi2 : 'double', xi3 : 'double'):
     return user_mod.user_func(xi1, xi2, xi3)

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -637,7 +637,8 @@ def test_import_syntax( test_file, language ):
 #------------------------------------------------------------------------------
 @pytest.mark.parametrize( "test_file", ["scripts/import_syntax/from_mod_import_as_user_func.py",
                                         "scripts/import_syntax/from_mod_import_as_user.py",
-                                        "scripts/import_syntax/collisions2.py"
+                                        "scripts/import_syntax/collisions2.py",
+                                        "scripts/runtest_import_mod_project_as.py",
                                         ] )
 @pytest.mark.parametrize( "language", (
         pytest.param("fortran", marks = pytest.mark.fortran),


### PR DESCRIPTION
Previously imports like `import a.b.c as d` were saved as `d` however this makes it difficult to reuse parsing when 2 files use `a.b.c` with different names. This was therefore changed so the key is now `a.b.c`. The case `import a.b.c as d` was correctly handled, but `import a.b.c as c` was not as it was previously a special case. The special case has now been corrected and a test is added. Fixes #2353 