### PR TITLE
Fix documentation

### DIFF
--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -1,10 +1,8 @@
 """ A script to provide a hook which allows artifacts to be generated during installation of the package.
 """
-import os
 from pathlib import Path
 import shutil
 import subprocess
-import sys
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
@@ -20,9 +18,12 @@ class CustomBuildHook(BuildHookInterface):
     ----------
     *args : tuple
         See hatch docs.
-    **kwds : dict
+    **kwargs : dict
         See hatch docs.
     """
+
+    def __init__(self, *args, **kwargs): #pylint: disable=W0246
+        super().__init__(*args, **kwargs)
 
     def initialize(self, version, build_data):
         """

--- a/pyccel/ast/builtin_methods/set_methods.py
+++ b/pyccel/ast/builtin_methods/set_methods.py
@@ -278,9 +278,9 @@ class SetIntersection(SetMethod):
 
     Parameters
     ----------
-    set_obj : TypedAstNode
+    set_variable : TypedAstNode
         The set object which the method is called from.
-    *others : TypedAstNode
+    *args : TypedAstNode
         The iterables which will be combined (common elements) with this set.
     """
     __slots__ = ('_other','_class_type', '_shape')

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -2399,8 +2399,15 @@ class FunctionDef(ScopedAstNode):
 
     @property
     def is_external(self):
-        """ True if the function is exposed through a header file and coming
-        from a f77 module """
+        """
+        Indicates if the function is from an external library.
+
+        Indicates if the function is from an external library which has no
+        associated imports. Such functions must be declared locally to
+        satisfy the compiler. For example this method returns True if the
+        function is exposed through a pyi file and describes a method from
+        a f77 module.
+        """
         return self._is_external
 
     @is_external.setter

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -326,12 +326,17 @@ class NumpyInt(PythonInt):
     ----------
     arg : TypedAstNode
         The argument passed to the function.
+    base : TypedAstNode
+        The argument passed to the function to indicate the base in which
+        the integer is expressed.
     """
     __slots__ = ('_shape','_class_type')
     _static_type = numpy_precision_map[(PrimitiveIntegerType(), PythonInt._static_type.precision)]
     name = 'int'
 
     def __init__(self, arg=None, base=10):
+        if base != 10:
+            raise TypeError("numpy.int's base argument is not yet supported")
         self._shape = arg.shape
         rank  = arg.rank
         order = arg.order

--- a/pyccel/codegen/codegen.py
+++ b/pyccel/codegen/codegen.py
@@ -161,7 +161,17 @@ class Codegen:
         return self._language
 
     def get_printer_imports(self):
-        """return the imports of the current codeprinter"""
+        """
+        Get the objects that were imported by the current codeprinter.
+
+        Get the objects that were imported by the current codeprinter.
+        These imports may affect the necessary compiler commands.
+
+        Returns
+        -------
+        dict[str, Import]
+            A dictionary mapping the include strings to the import module.
+        """
         additional_imports = self._printer.get_additional_imports().copy()
         if self._parser.metavars['printer_imports']:
             for i in self._parser.metavars['printer_imports'].split(','):


### PR DESCRIPTION
For a few days since the last release our doc CI was not functioning correctly. During that time 5 bad docstrings slipped through the cracks. They are now flagged on the `release` branch. This PR fixes these docstrings.