### PR TITLE
Add support for bitwise operators with NumPy arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ All notable changes to this project will be documented in this file.
 -   Generate stub files to allow double compilation to potentially be bypassed.
 -   Added `context_dict` argument to `epyccel` for passing non-global `typing.TypeVar` objects.
 -   #2293 : Add `pyccel-test` command to run unit tests. Improve docs.
+-   Added support for bitwise operators with NumPy arrays.
 -   \[INTERNALS\] Add abstract class `SetMethod` to handle calls to various set methods.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[INTERNALS\] Add a `__call__` method to `FunctionDef` to create `FunctionCall` instances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,9 +88,9 @@ All notable changes to this project will be documented in this file.
 -   #2132 : Add support for `typing.TypeVar` to replace `@template`.
 -   #2253 : Add multiple levels of verbosity.
 -   Generate stub files to allow double compilation to potentially be bypassed.
--   Added `context_dict` argument to `epyccel` for passing non-global `typing.TypeVar` objects.
+-   Add `context_dict` argument to `epyccel` for passing non-global `typing.TypeVar` objects.
 -   #2293 : Add `pyccel-test` command to run unit tests. Improve docs.
--   Added support for bitwise operators with NumPy arrays.
+-   #2358 : Add support for bitwise operators with NumPy arrays.
 -   \[INTERNALS\] Add abstract class `SetMethod` to handle calls to various set methods.
 -   \[INTERNALS\] Added `container_rank` property to `ast.datatypes.PyccelType` objects.
 -   \[INTERNALS\] Add a `__call__` method to `FunctionDef` to create `FunctionCall` instances.

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -123,12 +123,12 @@ class PyccelBitOperator(PyccelBinaryOperator):
         DataType
             The  datatype of the result of the operation.
         """
-        try:
-            class_type = arg1.class_type + arg2.class_type
-        except NotImplementedError as err:
-            raise TypeError(f'Cannot determine the type of {arg1} {self.op} {arg2}') from err # pylint: disable=no-member
-
-        assert isinstance(getattr(class_type, 'primitive_type', None), (PrimitiveBooleanType, PrimitiveIntegerType))
+        class_type = arg1.class_type + arg2.class_type
+        if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
+            if class_type.rank:
+                class_type = class_type.switch_basic_type(NumpyInt8Type())
+            else:
+                class_type = class_type.switch_basic_type(PythonNativeInt())
 
         cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
         self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]
@@ -163,41 +163,6 @@ class PyccelRShift(PyccelBitOperator):
     _precedence = 11
     op = ">>"
 
-    def _calculate_type(self, arg1, arg2):
-        """
-        Get the type of the result of the function.
-
-        If one argument is a string then all arguments must be strings.
-
-        If the arguments are numeric then the datatype
-        matches the broadest type.
-        e.g.
-            1 + 2j -> PyccelAdd(LiteralInteger, LiteralComplex) -> complex
-
-        Parameters
-        ----------
-        arg1 : TypedAstNode
-            The first argument passed to the operator.
-        arg2 : TypedAstNode
-            The second argument passed to the operator.
-
-        Returns
-        -------
-        DataType
-            The  datatype of the result of the operation.
-        """
-        class_type = arg1.class_type + arg2.class_type
-        if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
-            if class_type.rank:
-                class_type = class_type.switch_basic_type(NumpyInt8Type())
-            else:
-                class_type = class_type.switch_basic_type(PythonNativeInt())
-
-        cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
-        self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]
-
-        return class_type
-
 #==============================================================================
 
 class PyccelLShift(PyccelBitOperator):
@@ -222,41 +187,6 @@ class PyccelLShift(PyccelBitOperator):
     __slots__ = ()
     _precedence = 11
     op = "<<"
-
-    def _calculate_type(self, arg1, arg2):
-        """
-        Get the type of the result of the function.
-
-        If one argument is a string then all arguments must be strings.
-
-        If the arguments are numeric then the datatype
-        matches the broadest type.
-        e.g.
-            1 + 2j -> PyccelAdd(LiteralInteger, LiteralComplex) -> complex
-
-        Parameters
-        ----------
-        arg1 : TypedAstNode
-            The first argument passed to the operator.
-        arg2 : TypedAstNode
-            The second argument passed to the operator.
-
-        Returns
-        -------
-        DataType
-            The  datatype of the result of the operation.
-        """
-        class_type = arg1.class_type + arg2.class_type
-        if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
-            if class_type.rank:
-                class_type = class_type.switch_basic_type(NumpyInt8Type())
-            else:
-                class_type = class_type.switch_basic_type(PythonNativeInt())
-
-        cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
-        self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]
-
-        return class_type
 
 #==============================================================================
 

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -92,6 +92,7 @@ class PyccelBitOperator(PyccelBinaryOperator):
     arg2 : TypedAstNode
         The second argument passed to the operator.
     """
+    __slots__ = ()
 
     def __init__(self, arg1, arg2):
         super().__init__(arg1, arg2)

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -63,12 +63,12 @@ class PyccelInvert(PyccelUnaryOperator):
         DataType
             The  datatype of the result of the operation.
         """
-        dtype = PythonNativeInt()
+        class_type = arg.class_type.switch_dtype(PythonNativeInt())
         assert isinstance(getattr(arg.dtype, 'primitive_type', None), (PrimitiveBooleanType, PrimitiveIntegerType))
 
         cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
-        self._args = (cast(arg) if arg.dtype is not dtype else arg,)
-        return dtype
+        self._args = (cast(arg) if arg.dtype is not class_type else arg,)
+        return class_type
 
     def __repr__(self):
         return f'~{repr(self.args[0])}'

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -64,7 +64,7 @@ class PyccelInvert(PyccelUnaryOperator):
         DataType
             The  datatype of the result of the operation.
         """
-        if arg.class_type.shape:
+        if arg.class_type.rank:
             class_type = arg.class_type
         else:
             class_type = arg.class_type.switch_basic_type(PythonNativeInt())
@@ -187,7 +187,7 @@ class PyccelRShift(PyccelBitOperator):
         """
         class_type = arg1.class_type + arg2.class_type
         if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
-            if class_type.shape:
+            if class_type.rank:
                 class_type = class_type.switch_basic_type(NumpyInt8Type())
             else:
                 class_type = class_type.switch_basic_type(PythonNativeInt())
@@ -247,7 +247,7 @@ class PyccelLShift(PyccelBitOperator):
         """
         class_type = arg1.class_type + arg2.class_type
         if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
-            if class_type.shape:
+            if class_type.rank:
                 class_type = class_type.switch_basic_type(NumpyInt8Type())
             else:
                 class_type = class_type.switch_basic_type(PythonNativeInt())

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -63,7 +63,7 @@ class PyccelInvert(PyccelUnaryOperator):
         DataType
             The  datatype of the result of the operation.
         """
-        class_type = arg.class_type.switch_dtype(PythonNativeInt())
+        class_type = arg.class_type.switch_basic_type(PythonNativeInt())
         assert isinstance(getattr(arg.dtype, 'primitive_type', None), (PrimitiveBooleanType, PrimitiveIntegerType))
 
         cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
@@ -159,6 +159,38 @@ class PyccelRShift(PyccelBitOperator):
     _precedence = 11
     op = ">>"
 
+    def _calculate_type(self, arg1, arg2):
+        """
+        Get the type of the result of the function.
+
+        If one argument is a string then all arguments must be strings.
+
+        If the arguments are numeric then the datatype
+        matches the broadest type.
+        e.g.
+            1 + 2j -> PyccelAdd(LiteralInteger, LiteralComplex) -> complex
+
+        Parameters
+        ----------
+        arg1 : TypedAstNode
+            The first argument passed to the operator.
+        arg2 : TypedAstNode
+            The second argument passed to the operator.
+
+        Returns
+        -------
+        DataType
+            The  datatype of the result of the operation.
+        """
+        class_type = arg1.class_type + arg2.class_type
+        if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
+            class_type = class_type.switch_basic_type(PythonNativeInt())
+
+        cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
+        self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]
+
+        return class_type
+
 #==============================================================================
 
 class PyccelLShift(PyccelBitOperator):
@@ -183,6 +215,38 @@ class PyccelLShift(PyccelBitOperator):
     __slots__ = ()
     _precedence = 11
     op = "<<"
+
+    def _calculate_type(self, arg1, arg2):
+        """
+        Get the type of the result of the function.
+
+        If one argument is a string then all arguments must be strings.
+
+        If the arguments are numeric then the datatype
+        matches the broadest type.
+        e.g.
+            1 + 2j -> PyccelAdd(LiteralInteger, LiteralComplex) -> complex
+
+        Parameters
+        ----------
+        arg1 : TypedAstNode
+            The first argument passed to the operator.
+        arg2 : TypedAstNode
+            The second argument passed to the operator.
+
+        Returns
+        -------
+        DataType
+            The  datatype of the result of the operation.
+        """
+        class_type = arg1.class_type + arg2.class_type
+        if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
+            class_type = class_type.switch_basic_type(PythonNativeInt())
+
+        cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
+        self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]
+
+        return class_type
 
 #==============================================================================
 

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -11,7 +11,7 @@ They also have specific rules to determine the datatype, rank, shape
 from .builtins     import PythonInt
 from .datatypes    import PrimitiveBooleanType, PrimitiveIntegerType
 from .datatypes    import PythonNativeBool, PythonNativeInt
-from .operators    import PyccelUnaryOperator, PyccelOperator
+from .operators    import PyccelUnaryOperator, PyccelBinaryOperator
 
 __all__ = (
     'PyccelBitComparisonOperator',
@@ -74,7 +74,7 @@ class PyccelInvert(PyccelUnaryOperator):
 
 #==============================================================================
 
-class PyccelBitOperator(PyccelOperator):
+class PyccelBitOperator(PyccelBinaryOperator):
     """
     Abstract superclass representing a Python bitwise operator with two arguments.
 
@@ -87,7 +87,6 @@ class PyccelBitOperator(PyccelOperator):
     arg2 : TypedAstNode
         The second argument passed to the operator.
     """
-    _shape = None
     __slots__ = ('_class_type',)
 
     def __init__(self, arg1, arg2):
@@ -129,14 +128,6 @@ class PyccelBitOperator(PyccelOperator):
         self._args = [PythonInt(a) if a.dtype is PythonNativeBool() else a for a in (arg1, arg2)]
 
         return class_type
-
-    def _set_shape(self):
-        """
-        Set the shape of the resulting object.
-
-        Set the shape of the resulting object. For a PyccelBitOperator,
-        the shape is a class attribute so nothing needs to be done.
-        """
 
     def __repr__(self):
         return f'{self.args[0]} {self.op} {self.args[1]}' # pylint: disable=no-member

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -125,10 +125,8 @@ class PyccelBitOperator(PyccelBinaryOperator):
         """
         class_type = arg1.class_type + arg2.class_type
         if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
-            if class_type.rank:
-                class_type = class_type.switch_basic_type(NumpyInt8Type())
-            else:
-                class_type = class_type.switch_basic_type(PythonNativeInt())
+            assert class_type.rank > 0
+            class_type = class_type.switch_basic_type(NumpyInt8Type())
 
         cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
         self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -8,7 +8,7 @@ These operators all have a precision as detailed here:
 https://docs.python.org/3/reference/expressions.html#operator-precedence
 They also have specific rules to determine the datatype, rank, shape
 """
-from .builtins     import PythonInt
+from .builtins     import DtypePrecisionToCastFunction
 from .datatypes    import PrimitiveBooleanType, PrimitiveIntegerType
 from .datatypes    import PythonNativeBool, PythonNativeInt
 from .operators    import PyccelUnaryOperator, PyccelBinaryOperator
@@ -66,7 +66,8 @@ class PyccelInvert(PyccelUnaryOperator):
         dtype = PythonNativeInt()
         assert isinstance(getattr(arg.dtype, 'primitive_type', None), (PrimitiveBooleanType, PrimitiveIntegerType))
 
-        self._args      = (PythonInt(arg) if arg.dtype is PythonNativeBool() else arg,)
+        cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
+        self._args = (cast(arg) if arg.dtype is not dtype else arg,)
         return dtype
 
     def __repr__(self):
@@ -125,7 +126,8 @@ class PyccelBitOperator(PyccelBinaryOperator):
 
         assert isinstance(getattr(class_type, 'primitive_type', None), (PrimitiveBooleanType, PrimitiveIntegerType))
 
-        self._args = [PythonInt(a) if a.dtype is PythonNativeBool() else a for a in (arg1, arg2)]
+        cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
+        self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]
 
         return class_type
 
@@ -229,9 +231,9 @@ class PyccelBitComparisonOperator(PyccelBitOperator):
 
         primitive_type = class_type.primitive_type
         assert isinstance(primitive_type, (PrimitiveBooleanType, PrimitiveIntegerType))
+        cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
 
-        if isinstance(primitive_type, PrimitiveIntegerType):
-            self._args = [PythonInt(a) if a.dtype is PythonNativeBool() else a for a in (arg1, arg2)]
+        self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]
 
         return class_type
 

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -12,6 +12,7 @@ from .builtins     import DtypePrecisionToCastFunction
 from .datatypes    import PrimitiveBooleanType, PrimitiveIntegerType
 from .datatypes    import PythonNativeBool, PythonNativeInt
 from .operators    import PyccelUnaryOperator, PyccelBinaryOperator
+from .numpytypes   import NumpyInt8Type
 
 __all__ = (
     'PyccelBitComparisonOperator',
@@ -63,7 +64,10 @@ class PyccelInvert(PyccelUnaryOperator):
         DataType
             The  datatype of the result of the operation.
         """
-        class_type = arg.class_type.switch_basic_type(PythonNativeInt())
+        if arg.class_type.shape:
+            class_type = arg.class_type
+        else:
+            class_type = arg.class_type.switch_basic_type(PythonNativeInt())
         assert isinstance(getattr(arg.dtype, 'primitive_type', None), (PrimitiveBooleanType, PrimitiveIntegerType))
 
         cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
@@ -88,7 +92,6 @@ class PyccelBitOperator(PyccelBinaryOperator):
     arg2 : TypedAstNode
         The second argument passed to the operator.
     """
-    __slots__ = ('_class_type',)
 
     def __init__(self, arg1, arg2):
         super().__init__(arg1, arg2)
@@ -184,7 +187,10 @@ class PyccelRShift(PyccelBitOperator):
         """
         class_type = arg1.class_type + arg2.class_type
         if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
-            class_type = class_type.switch_basic_type(PythonNativeInt())
+            if class_type.shape:
+                class_type = class_type.switch_basic_type(NumpyInt8Type())
+            else:
+                class_type = class_type.switch_basic_type(PythonNativeInt())
 
         cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
         self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]
@@ -241,7 +247,10 @@ class PyccelLShift(PyccelBitOperator):
         """
         class_type = arg1.class_type + arg2.class_type
         if isinstance(getattr(class_type, 'primitive_type', None), PrimitiveBooleanType):
-            class_type = class_type.switch_basic_type(PythonNativeInt())
+            if class_type.shape:
+                class_type = class_type.switch_basic_type(NumpyInt8Type())
+            else:
+                class_type = class_type.switch_basic_type(PythonNativeInt())
 
         cast = DtypePrecisionToCastFunction[getattr(class_type, 'element_type', class_type)]
         self._args = [cast(a) if a.dtype is not class_type else a for a in (arg1, arg2)]

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -2759,6 +2759,7 @@ class NumpyNDArray(PyccelFunction):
 #==============================================================================
 
 DtypePrecisionToCastFunction.update({
+    PythonNativeBool()    : NumpyBool,
     NumpyInt8Type()       : NumpyInt8,
     NumpyInt16Type()      : NumpyInt16,
     NumpyInt32Type()      : NumpyInt32,

--- a/pyccel/ast/numpytypes.py
+++ b/pyccel/ast/numpytypes.py
@@ -321,7 +321,6 @@ class NumpyNDArrayType(HomogeneousContainerType, metaclass = ArgumentSingleton):
     @lru_cache
     def __and__(self, other):
         elem_type = self.element_type
-        assert isinstance(elem_type, PythonNativeBool)
         out_type = NumpyNDArrayType(elem_type, self.rank, self.order)
         if isinstance(other, FixedSizeNumericType):
             out_type.switch_basic_type(elem_type and other)

--- a/pyccel/ast/numpytypes.py
+++ b/pyccel/ast/numpytypes.py
@@ -321,10 +321,14 @@ class NumpyNDArrayType(HomogeneousContainerType, metaclass = ArgumentSingleton):
     @lru_cache
     def __and__(self, other):
         elem_type = self.element_type
+        assert isinstance(elem_type, PythonNativeBool)
+        out_type = NumpyNDArrayType(elem_type, self.rank, self.order)
         if isinstance(other, FixedSizeNumericType):
-            return NumpyNDArrayType(elem_type and other)
+            out_type.switch_basic_type(elem_type and other)
+            return out_type
         elif isinstance(other, NumpyNDArrayType):
-            return NumpyNDArrayType(elem_type+other.element_type)
+            out_type.switch_basic_type(elem_type and other.element_type)
+            return out_type
         else:
             return NotImplemented
 

--- a/pyccel/ast/numpytypes.py
+++ b/pyccel/ast/numpytypes.py
@@ -322,9 +322,9 @@ class NumpyNDArrayType(HomogeneousContainerType, metaclass = ArgumentSingleton):
     def __and__(self, other):
         elem_type = self.element_type
         if isinstance(other, FixedSizeNumericType):
-            return self.switch_basic_type(elem_type and other)
+            return self.switch_basic_type(elem_type & other)
         elif isinstance(other, NumpyNDArrayType):
-            return self.switch_basic_type(elem_type and other.element_type)
+            return self.switch_basic_type(elem_type & other.element_type)
         else:
             return NotImplemented
 

--- a/pyccel/ast/numpytypes.py
+++ b/pyccel/ast/numpytypes.py
@@ -321,13 +321,10 @@ class NumpyNDArrayType(HomogeneousContainerType, metaclass = ArgumentSingleton):
     @lru_cache
     def __and__(self, other):
         elem_type = self.element_type
-        out_type = NumpyNDArrayType(elem_type, self.rank, self.order)
         if isinstance(other, FixedSizeNumericType):
-            out_type.switch_basic_type(elem_type and other)
-            return out_type
+            return self.switch_basic_type(elem_type and other)
         elif isinstance(other, NumpyNDArrayType):
-            out_type.switch_basic_type(elem_type and other.element_type)
-            return out_type
+            return self.switch_basic_type(elem_type and other.element_type)
         else:
             return NotImplemented
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2516,7 +2516,11 @@ class CCodePrinter(CodePrinter):
         return ' & '.join(args)
 
     def _print_PyccelInvert(self, expr):
-        return '~{}'.format(self._print(expr.args[0]))
+        arg = self._print(expr.args[0])
+        if expr.dtype is PythonNativeBool():
+            return f'!{arg}'
+        else:
+            return f'~{arg}'
 
     def _print_PyccelAssociativeParenthesis(self, expr):
         return '({})'.format(self._print(expr.args[0]))

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3086,25 +3086,30 @@ class FCodePrinter(CodePrinter):
         return code
 
     def _print_PyccelRShift(self, expr):
-        return 'RSHIFT({}, {})'.format(self._print(expr.args[0]), self._print(expr.args[1]))
+        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        return f'RSHIFT({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelLShift(self, expr):
-        return 'LSHIFT({}, {})'.format(self._print(expr.args[0]), self._print(expr.args[1]))
+        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        return f'LSHIFT({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelBitXor(self, expr):
         if isinstance(expr.dtype.primitive_type, PrimitiveBooleanType):
             return ' .neqv. '.join(self._print(a) for a in expr.args)
-        return 'IEOR({}, {})'.format(self._print(expr.args[0]), self._print(expr.args[1]))
+        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        return f'IEOR({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelBitOr(self, expr):
         if isinstance(expr.dtype.primitive_type, PrimitiveBooleanType):
             return ' .or. '.join(self._print(a) for a in expr.args)
-        return 'IOR({}, {})'.format(self._print(expr.args[0]), self._print(expr.args[1]))
+        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        return f'IOR({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelBitAnd(self, expr):
         if isinstance(expr.dtype.primitive_type, PrimitiveBooleanType):
             return ' .and. '.join(self._print(a) for a in expr.args)
-        return 'IAND({}, {})'.format(self._print(expr.args[0]), self._print(expr.args[1]))
+        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        return f'IAND({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelInvert(self, expr):
         return 'NOT({})'.format(self._print(expr.args[0]))

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3086,29 +3086,29 @@ class FCodePrinter(CodePrinter):
         return code
 
     def _print_PyccelRShift(self, expr):
-        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        arg0, arg1 = expr.args
         return f'RSHIFT({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelLShift(self, expr):
-        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        arg0, arg1 = expr.args
         return f'LSHIFT({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelBitXor(self, expr):
         if isinstance(expr.dtype.primitive_type, PrimitiveBooleanType):
             return ' .neqv. '.join(self._print(a) for a in expr.args)
-        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        arg0, arg1 = expr.args
         return f'IEOR({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelBitOr(self, expr):
         if isinstance(expr.dtype.primitive_type, PrimitiveBooleanType):
             return ' .or. '.join(self._print(a) for a in expr.args)
-        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        arg0, arg1 = expr.args
         return f'IOR({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelBitAnd(self, expr):
         if isinstance(expr.dtype.primitive_type, PrimitiveBooleanType):
             return ' .and. '.join(self._print(a) for a in expr.args)
-        arg0, arg1 = self._apply_cast(expr.dtype, *expr.args)
+        arg0, arg1 = expr.args
         return f'IAND({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelInvert(self, expr):

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3112,7 +3112,11 @@ class FCodePrinter(CodePrinter):
         return f'IAND({self._print(arg0)}, {self._print(arg1)})'
 
     def _print_PyccelInvert(self, expr):
-        return 'NOT({})'.format(self._print(expr.args[0]))
+        arg = self._print(expr.args[0])
+        if expr.dtype is PythonNativeBool():
+            return f'.not. ({arg})'
+        else:
+            return f'NOT({arg})'
 
     def _print_PyccelAssociativeParenthesis(self, expr):
         return '({})'.format(self._print(expr.args[0]))

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -24,7 +24,7 @@ from pyccel.ast.low_level_tools import UnpackManagedMemory
 from pyccel.ast.numpyext   import numpy_target_swap, numpy_linalg_mod, numpy_random_mod
 from pyccel.ast.numpyext   import NumpyArray, NumpyNonZero, NumpyResultType
 from pyccel.ast.numpyext   import process_dtype as numpy_process_dtype
-from pyccel.ast.numpyext   import NumpyNDArray
+from pyccel.ast.numpyext   import NumpyNDArray, NumpyBool
 from pyccel.ast.numpytypes import NumpyNumericType, NumpyNDArrayType
 from pyccel.ast.type_annotations import VariableTypeAnnotation, SyntacticTypeAnnotation
 from pyccel.ast.typingext  import TypingTypeVar, TypingFinal
@@ -179,6 +179,8 @@ class PythonCodePrinter(CodePrinter):
             cls = expr
         else:
             cls = type(expr)
+        if cls is NumpyBool:
+            return 'bool'
         type_name = expr.name
         name = self._aliases.get(cls, type_name)
         if name == type_name and cls not in (PythonBool, PythonInt, PythonFloat, PythonComplex):

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -12,6 +12,10 @@ IT2 = TypeVar('IT2', *int_types)
 def test_numpy_bit_and(language):
     def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
         return a & b
+    def g(a : 'IT[:,:,:]', b : 'IT2'):
+        return a & b
+    def h(a : 'IT', b : 'IT2[:,:,:]'):
+        return a & b
 
     for t_x in int_types:
         for t_y in int_types:
@@ -19,14 +23,32 @@ def test_numpy_bit_and(language):
             y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
+            epyc_g = epyccel(g, language=language)
+            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
+            y = randint(2 if t_y is bool else 127, dtype = t_y)
+
+            z2 = g(x,y)
+            epyc_z2 = epyc_g(x,y)
+            assert np.array_equal(epyc_z2, z2)
+            assert z2.dtype is epyc_z2.dtype
+
+            z3 = h(y,x)
+            epyc_z3 = epyc_h(y,x)
+            assert np.array_equal(epyc_z3, z3)
+            assert z3.dtype is epyc_z3.dtype
+
 def test_numpy_bit_or(language):
     def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a | b
+    def g(a : 'IT[:,:,:]', b : 'IT2'):
+        return a | b
+    def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a | b
 
     for t_x in int_types:
@@ -35,14 +57,32 @@ def test_numpy_bit_or(language):
             y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
+            epyc_g = epyccel(g, language=language)
+            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
+            y = randint(2 if t_y is bool else 127, dtype = t_y)
+
+            z2 = g(x,y)
+            epyc_z2 = epyc_g(x,y)
+            assert np.array_equal(epyc_z2, z2)
+            assert z2.dtype is epyc_z2.dtype
+
+            z3 = h(y,x)
+            epyc_z3 = epyc_h(y,x)
+            assert np.array_equal(epyc_z3, z3)
+            assert z3.dtype is epyc_z3.dtype
+
 def test_numpy_bit_xor(language):
     def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a ^ b
+    def g(a : 'IT[:,:,:]', b : 'IT2'):
+        return a ^ b
+    def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a ^ b
 
     for t_x in int_types:
@@ -51,14 +91,32 @@ def test_numpy_bit_xor(language):
             y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
+            epyc_g = epyccel(g, language=language)
+            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
+            y = randint(2 if t_y is bool else 127, dtype = t_y)
+
+            z2 = g(x,y)
+            epyc_z2 = epyc_g(x,y)
+            assert np.array_equal(epyc_z2, z2)
+            assert z2.dtype is epyc_z2.dtype
+
+            z3 = h(y,x)
+            epyc_z3 = epyc_h(y,x)
+            assert np.array_equal(epyc_z3, z3)
+            assert z3.dtype is epyc_z3.dtype
+
 def test_numpy_bit_lshift(language):
     def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a << b
+    def g(a : 'IT[:,:,:]', b : 'IT2'):
+        return a << b
+    def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a << b
 
     for t_x in int_types:
@@ -67,14 +125,35 @@ def test_numpy_bit_lshift(language):
             y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
+            epyc_g = epyccel(g, language=language)
+            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
+            y = randint(2 if t_y is bool else 5, dtype = t_y)
+
+            z2 = g(x,y)
+            epyc_z2 = epyc_g(x,y)
+            assert np.array_equal(epyc_z2, z2)
+            assert z2.dtype is epyc_z2.dtype
+
+            x = randint(2 if t_x is bool else 32, dtype = t_x)
+            y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
+
+            z3 = h(x,y)
+            epyc_z3 = epyc_h(x,y)
+            assert np.array_equal(epyc_z3, z3)
+            assert z3.dtype is epyc_z3.dtype
+
 def test_numpy_bit_rshift(language):
     def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a >> b
+    def g(a : 'IT[:,:,:]', b : 'IT2'):
+        return a >> b
+    def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a >> b
 
     for t_x in int_types:
@@ -83,11 +162,28 @@ def test_numpy_bit_rshift(language):
             y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
+            epyc_g = epyccel(g, language=language)
+            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
+
+            y = randint(2 if t_y is bool else 5, dtype = t_y)
+
+            z2 = g(x,y)
+            epyc_z2 = epyc_g(x,y)
+            assert np.array_equal(epyc_z2, z2)
+            assert z2.dtype is epyc_z2.dtype
+
+            x = randint(2 if t_x is bool else 32, dtype = t_x)
+            y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
+
+            z3 = h(x,y)
+            epyc_z3 = epyc_h(x,y)
+            assert np.array_equal(epyc_z3, z3)
+            assert z3.dtype is epyc_z3.dtype
 
 def test_numpy_bit_invert(language):
     def f(a : 'IT[:,:,:]'):

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -21,7 +21,7 @@ def test_numpy_bit_and(language):
             epyc_f = epyccel(f, language=language)
 
             z = f(x,y)
-            epyc_z = f(x,y)
+            epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
@@ -37,7 +37,7 @@ def test_numpy_bit_or(language):
             epyc_f = epyccel(f, language=language)
 
             z = f(x,y)
-            epyc_z = f(x,y)
+            epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
@@ -53,7 +53,7 @@ def test_numpy_bit_xor(language):
             epyc_f = epyccel(f, language=language)
 
             z = f(x,y)
-            epyc_z = f(x,y)
+            epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
@@ -69,7 +69,7 @@ def test_numpy_bit_lshift(language):
             epyc_f = epyccel(f, language=language)
 
             z = f(x,y)
-            epyc_z = f(x,y)
+            epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
@@ -85,7 +85,7 @@ def test_numpy_bit_rshift(language):
             epyc_f = epyccel(f, language=language)
 
             z = f(x,y)
-            epyc_z = f(x,y)
+            epyc_z = epyc_f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
 
@@ -99,6 +99,6 @@ def test_numpy_bit_invert(language):
         epyc_f = epyccel(f, language=language)
 
         z = f(x)
-        epyc_z = f(x)
+        epyc_z = epyc_f(x)
         assert np.array_equal(epyc_z, z)
         assert z.dtype is epyc_z.dtype

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -15,8 +15,8 @@ def test_numpy_bit_and(language):
 
     for t_x in int_types:
         for t_y in int_types:
-            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
-            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+            x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
 
@@ -31,8 +31,8 @@ def test_numpy_bit_or(language):
 
     for t_x in int_types:
         for t_y in int_types:
-            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
-            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+            x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
 
@@ -47,8 +47,8 @@ def test_numpy_bit_xor(language):
 
     for t_x in int_types:
         for t_y in int_types:
-            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
-            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+            x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
 
@@ -63,8 +63,8 @@ def test_numpy_bit_lshift(language):
 
     for t_x in int_types:
         for t_y in int_types:
-            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
-            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+            x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
 
@@ -79,8 +79,8 @@ def test_numpy_bit_rshift(language):
 
     for t_x in int_types:
         for t_y in int_types:
-            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
-            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+            x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
 

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -19,14 +19,14 @@ def test_numpy_bit_and(language):
     def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a & b
 
+    epyc_f = epyccel(f, language=language)
+    epyc_g = epyccel(g, language=language)
+    epyc_h = epyccel(h, language=language)
+
     for t_x in int_types:
         for t_y in int_types:
             x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
             y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
-
-            epyc_f = epyccel(f, language=language)
-            epyc_g = epyccel(g, language=language)
-            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
@@ -53,14 +53,14 @@ def test_numpy_bit_or(language):
     def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a | b
 
+    epyc_f = epyccel(f, language=language)
+    epyc_g = epyccel(g, language=language)
+    epyc_h = epyccel(h, language=language)
+
     for t_x in int_types:
         for t_y in int_types:
             x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
             y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
-
-            epyc_f = epyccel(f, language=language)
-            epyc_g = epyccel(g, language=language)
-            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
@@ -87,14 +87,14 @@ def test_numpy_bit_xor(language):
     def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a ^ b
 
+    epyc_f = epyccel(f, language=language)
+    epyc_g = epyccel(g, language=language)
+    epyc_h = epyccel(h, language=language)
+
     for t_x in int_types:
         for t_y in int_types:
             x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
             y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
-
-            epyc_f = epyccel(f, language=language)
-            epyc_g = epyccel(g, language=language)
-            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
@@ -121,14 +121,14 @@ def test_numpy_bit_lshift(language):
     def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a << b
 
+    epyc_f = epyccel(f, language=language)
+    epyc_g = epyccel(g, language=language)
+    epyc_h = epyccel(h, language=language)
+
     for t_x in int_types:
         for t_y in int_types:
             x = randint(2 if t_x is bool else 32, size=(2,3,4), dtype = t_x)
             y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
-
-            epyc_f = epyccel(f, language=language)
-            epyc_g = epyccel(g, language=language)
-            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
@@ -158,14 +158,14 @@ def test_numpy_bit_rshift(language):
     def h(a : 'IT', b : 'IT2[:,:,:]'):
         return a >> b
 
+    epyc_f = epyccel(f, language=language)
+    epyc_g = epyccel(g, language=language)
+    epyc_h = epyccel(h, language=language)
+
     for t_x in int_types:
         for t_y in int_types:
             x = randint(2 if t_x is bool else 32, size=(2,3,4), dtype = t_x)
             y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
-
-            epyc_f = epyccel(f, language=language)
-            epyc_g = epyccel(g, language=language)
-            epyc_h = epyccel(h, language=language)
 
             z = f(x,y)
             epyc_z = epyc_f(x,y)
@@ -193,10 +193,10 @@ def test_numpy_bit_invert(language):
     def f(a : 'IT[:,:,:]'):
         return ~a
 
+    epyc_f = epyccel(f, language=language)
+
     for t_x in int_types:
         x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
-
-        epyc_f = epyccel(f, language=language)
 
         z = f(x)
         epyc_z = epyc_f(x)

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
+import os
 from typing import TypeVar
 from numpy.random import randint
 import numpy as np
@@ -185,6 +186,8 @@ def test_numpy_bit_rshift(language):
             assert np.array_equal(epyc_z3, z3)
             assert z3.dtype is epyc_z3.dtype
 
+@pytest.mark.skipif(os.environ.get('PYCCEL_DEFAULT_COMPILER', 'GNU') == 'intel',
+        reason="Intel's invert implementation does not seem to match.")
 def test_numpy_bit_invert(language):
     def f(a : 'IT[:,:,:]'):
         return ~a

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -3,6 +3,7 @@ import os
 from typing import TypeVar
 from numpy.random import randint
 import numpy as np
+import pytest
 
 from pyccel import epyccel
 

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from pyccel import epyccel
 
-int_types = (bool, np.int8, np.int32, np.int64)
+int_types = (bool, np.int8, np.int64)
 IT = TypeVar('IT', *int_types)
 IT2 = TypeVar('IT2', *int_types)
 

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -88,3 +88,17 @@ def test_numpy_bit_rshift(language):
             epyc_z = f(x,y)
             assert np.array_equal(epyc_z, z)
             assert z.dtype is epyc_z.dtype
+
+def test_numpy_bit_invert(language):
+    def f(a : 'IT[:,:,:]'):
+        return ~a
+
+    for t_x in int_types:
+        x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
+
+        epyc_f = epyccel(f, language=language)
+
+        z = f(x)
+        epyc_z = f(x)
+        assert np.array_equal(epyc_z, z)
+        assert z.dtype is epyc_z.dtype

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from pyccel import epyccel
 
-int_types = (bool, int, np.int8, np.int16, np.int32, np.int64)
+int_types = (bool, np.int8, np.int32, np.int64)
 IT = TypeVar('IT', *int_types)
 IT2 = TypeVar('IT2', *int_types)
 

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -63,7 +63,7 @@ def test_numpy_bit_lshift(language):
 
     for t_x in int_types:
         for t_y in int_types:
-            x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
+            x = randint(2 if t_x is bool else 32, size=(2,3,4), dtype = t_x)
             y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
@@ -79,7 +79,7 @@ def test_numpy_bit_rshift(language):
 
     for t_x in int_types:
         for t_y in int_types:
-            x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
+            x = randint(2 if t_x is bool else 32, size=(2,3,4), dtype = t_x)
             y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -64,7 +64,7 @@ def test_numpy_bit_lshift(language):
     for t_x in int_types:
         for t_y in int_types:
             x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
-            y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
+            y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
 

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -80,7 +80,7 @@ def test_numpy_bit_rshift(language):
     for t_x in int_types:
         for t_y in int_types:
             x = randint(2 if t_x is bool else 127, size=(2,3,4), dtype = t_x)
-            y = randint(2 if t_y is bool else 127, size=(2,3,4), dtype = t_y)
+            y = randint(2 if t_y is bool else 5, size=(2,3,4), dtype = t_y)
 
             epyc_f = epyccel(f, language=language)
 

--- a/tests/epyccel/recognised_functions/test_numpy_operators.py
+++ b/tests/epyccel/recognised_functions/test_numpy_operators.py
@@ -1,0 +1,90 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+from typing import TypeVar
+from numpy.random import randint
+import numpy as np
+
+from pyccel import epyccel
+
+int_types = (bool, int, np.int8, np.int16, np.int32, np.int64)
+IT = TypeVar('IT', *int_types)
+IT2 = TypeVar('IT2', *int_types)
+
+def test_numpy_bit_and(language):
+    def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a & b
+
+    for t_x in int_types:
+        for t_y in int_types:
+            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+
+            epyc_f = epyccel(f, language=language)
+
+            z = f(x,y)
+            epyc_z = f(x,y)
+            assert np.array_equal(epyc_z, z)
+            assert z.dtype is epyc_z.dtype
+
+def test_numpy_bit_or(language):
+    def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a | b
+
+    for t_x in int_types:
+        for t_y in int_types:
+            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+
+            epyc_f = epyccel(f, language=language)
+
+            z = f(x,y)
+            epyc_z = f(x,y)
+            assert np.array_equal(epyc_z, z)
+            assert z.dtype is epyc_z.dtype
+
+def test_numpy_bit_xor(language):
+    def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a ^ b
+
+    for t_x in int_types:
+        for t_y in int_types:
+            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+
+            epyc_f = epyccel(f, language=language)
+
+            z = f(x,y)
+            epyc_z = f(x,y)
+            assert np.array_equal(epyc_z, z)
+            assert z.dtype is epyc_z.dtype
+
+def test_numpy_bit_lshift(language):
+    def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a << b
+
+    for t_x in int_types:
+        for t_y in int_types:
+            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+
+            epyc_f = epyccel(f, language=language)
+
+            z = f(x,y)
+            epyc_z = f(x,y)
+            assert np.array_equal(epyc_z, z)
+            assert z.dtype is epyc_z.dtype
+
+def test_numpy_bit_rshift(language):
+    def f(a : 'IT[:,:,:]', b : 'IT2[:,:,:]'):
+        return a >> b
+
+    for t_x in int_types:
+        for t_y in int_types:
+            x = randint(2 if t_x is bool else 255, size=(2,3,4), dtype = t_x)
+            y = randint(2 if t_y is bool else 255, size=(2,3,4), dtype = t_y)
+
+            epyc_f = epyccel(f, language=language)
+
+            z = f(x,y)
+            epyc_z = f(x,y)
+            assert np.array_equal(epyc_z, z)
+            assert z.dtype is epyc_z.dtype


### PR DESCRIPTION
Add support for bitwise operators with NumPy arrays. This improves coverage on sections that were introduced for this purpose but were never fully implemented and tested. This is necessary for the tests to pass on #2352