### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -113,6 +113,10 @@ jobs:
           python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
           export PYTHONPATH=ci_tools
+          ls
+          git status
+          python3 -m numpydoc validate ci_tools.bot_tools.github_api_interactions.GitHubAPIInteractions
+          python -m numpydoc validate ci_tools.bot_tools.github_api_interactions.GitHubAPIInteractions
           while read line; do
             echo "python -m numpydoc validate $line"
             python -m numpydoc validate $line 2>&1 | tee -a report.txt || true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Documentation (docs, ${{ inputs.python_version || '3.10' }})
-    #if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
     steps:
       - id: duplicate_check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ on:
       - ready_for_review
 
 env:
-  COMMIT: ${{ inputs.ref || github.event.pull_request.head.sha }}
+  COMMIT: ${{ inputs.ref || github.event.ref }}
   PEM: ${{ secrets.BOT_PEM }}
   GITHUB_RUN_ID: ${{ github.run_id }}
   GITHUB_CHECK_RUN_ID: ${{ inputs.check_run_id }}
@@ -68,14 +68,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: "Setup check run"
-        if: github.event_name != 'pull_request'
-        id: token
-        run: |
-          pip install jwt requests
-          cd compare
-          python ../base/ci_tools/setup_check_run.py docs
-          cd ..
       - name: Install python CI dependencies
         if: steps.duplicate_check.outputs.should_skip != 'true'
         run: |
@@ -83,7 +75,15 @@ jobs:
           python -m pip install docstr-coverage
           python -m pip install numpydoc
           python -m pip install defusedxml # All imported modules must be available for numpydoc
+          python -m pip install jwt requests # Required to parse ci_tools folder
         shell: bash
+      - name: "Setup check run"
+        if: github.event_name != 'pull_request'
+        id: token
+        run: |
+          cd compare
+          python ../base/ci_tools/setup_check_run.py docs
+          cd ..
       - name: Install dependencies
         if: steps.duplicate_check.outputs.should_skip != 'true'
         uses: ./compare/.github/actions/linux_install
@@ -113,13 +113,6 @@ jobs:
           python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
           export PYTHONPATH=ci_tools
-          git status
-          ls
-          ls ci_tools
-          ls ci_tools/bot_tools
-          python3 -c "from ci_tools.bot_tools import github_api_interactions"
-          python3 -m numpydoc validate ci_tools.bot_tools.github_api_interactions.GitHubAPIInteractions
-          python -m numpydoc validate ci_tools.bot_tools.github_api_interactions.GitHubAPIInteractions
           while read line; do
             echo "python -m numpydoc validate $line"
             python -m numpydoc validate $line 2>&1 | tee -a report.txt || true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -113,8 +113,11 @@ jobs:
           python ci_tools/list_docs_tovalidate.py pull_diff.txt objects.txt
           touch report.txt
           export PYTHONPATH=ci_tools
-          ls
           git status
+          ls
+          ls ci_tools
+          ls ci_tools/bot_tools
+          python3 -c "from ci_tools.bot_tools import github_api_interactions"
           python3 -m numpydoc validate ci_tools.bot_tools.github_api_interactions.GitHubAPIInteractions
           python -m numpydoc validate ci_tools.bot_tools.github_api_interactions.GitHubAPIInteractions
           while read line; do

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Documentation (docs, ${{ inputs.python_version || '3.10' }})
-    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    #if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
     steps:
       - id: duplicate_check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ on:
       - ready_for_review
 
 env:
-  COMMIT: ${{ inputs.ref || github.event.ref }}
+  COMMIT: ${{ inputs.ref || github.event.pull_request.head.sha }}
   PEM: ${{ secrets.BOT_PEM }}
   GITHUB_RUN_ID: ${{ github.run_id }}
   GITHUB_CHECK_RUN_ID: ${{ inputs.check_run_id }}

--- a/.github/workflows/linux_pyccel-test_cmd.yml
+++ b/.github/workflows/linux_pyccel-test_cmd.yml
@@ -80,6 +80,7 @@ jobs:
         id: token
         run: |
           pip install jwt requests
+          python ci_tools/setup_check_run.py linux_pyccel-test_cmd
       - name: Install dependencies
         if: steps.duplicate_check.outputs.should_skip != 'true'
         uses: ./.github/actions/linux_install
@@ -96,3 +97,11 @@ jobs:
         run: |
           pyccel-test
         shell: bash
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip != 'true'
+        run:
+          python ci_tools/complete_check_run.py ${{ steps.pyccel-test.outcome }}
+      - name: "Post completed"
+        if: always() && github.event_name != 'push' && steps.duplicate_check.outputs.should_skip == 'true'
+        run:
+          python ci_tools/complete_check_run.py 'success'

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -53,8 +53,9 @@ jobs:
         id: token
         run: |
           pip install jwt requests
-          python ci_tools/setup_check_run.py markdownlint
+          python ci_tools/setup_check_run.py markdown_lint
       - name: Markdownlint
+        id: md_test
         uses: DavidAnson/markdownlint-cli2-action@v19
         with:
           config: './.markdownlint.json'
@@ -62,4 +63,4 @@ jobs:
       - name: "Post completed"
         if: always() && github.event_name != 'pull_request'
         run:
-          python ci_tools/complete_check_run.py ${{ steps.spelling.outcome }} ${{ steps.manual_spelling.outcome }}
+          python ci_tools/complete_check_run.py ${{ steps.md_test.outcome }}

--- a/ci_tools/bot_tools/github_api_interactions.py
+++ b/ci_tools/bot_tools/github_api_interactions.py
@@ -64,6 +64,12 @@ class GitHubAPIInteractions:
 
     A helper class which exposes the GitHub API in a readable
     manner.
+
+    Parameters
+    ----------
+    repo : str
+        A string which identifies the repository where the requests
+        should be made (e.g. 'pyccel/pyccel').
     """
     def __init__(self, repo):
         repo = repo or os.environ["GITHUB_REPOSITORY"]

--- a/pyccel/ast/bind_c.py
+++ b/pyccel/ast/bind_c.py
@@ -16,7 +16,6 @@ from pyccel.ast.datatypes import FixedSizeType, PythonNativeInt, InhomogeneousTu
 from pyccel.ast.datatypes import StringType
 from pyccel.ast.internals import PyccelFunction
 from pyccel.ast.literals import LiteralInteger
-from pyccel.ast.numpytypes import NumpyNDArrayType
 from pyccel.ast.variable import Variable
 from pyccel.errors.errors     import Errors
 from pyccel.utilities.metaclasses import Singleton

--- a/pyccel/ast/bitwise_operators.py
+++ b/pyccel/ast/bitwise_operators.py
@@ -13,7 +13,7 @@ import numpy
 
 from .builtins     import DtypePrecisionToCastFunction
 from .datatypes    import PrimitiveBooleanType, PrimitiveIntegerType
-from .datatypes    import PythonNativeBool, PythonNativeInt
+from .datatypes    import PythonNativeInt
 from .operators    import PyccelUnaryOperator, PyccelBinaryOperator
 from .numpytypes   import NumpyInt8Type
 

--- a/pyccel/ast/builtin_methods/set_methods.py
+++ b/pyccel/ast/builtin_methods/set_methods.py
@@ -11,7 +11,6 @@ This module contains objects which describe these methods within Pyccel's AST.
 """
 from pyccel.ast.datatypes import VoidType, PythonNativeBool
 from pyccel.ast.internals import PyccelFunction
-from pyccel.ast.basic import TypedAstNode
 
 __all__ = (
     'SetAdd',

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -15,14 +15,14 @@ from .basic     import PyccelAstNode, TypedAstNode, iterable, ScopedAstNode
 
 from .bitwise_operators import PyccelBitOr, PyccelBitAnd, PyccelLShift, PyccelRShift
 
-from .builtins  import PythonBool, PythonTuple, PythonList
+from .builtins  import PythonBool, PythonTuple
 
-from .datatypes import (PyccelType, HomogeneousTupleType, VoidType, CustomDataType,
-                        PythonNativeBool, InhomogeneousTupleType, TupleType, SymbolicType)
+from .datatypes import (PyccelType, CustomDataType,
+                        PythonNativeBool, InhomogeneousTupleType, SymbolicType)
 
 from .internals import PyccelSymbol, PyccelFunction, Iterable
 
-from .literals  import Nil, LiteralFalse, LiteralInteger, LiteralString
+from .literals  import Nil, LiteralFalse, LiteralString
 from .literals  import NilArgument, LiteralTrue
 
 from .operators import PyccelAdd, PyccelMinus, PyccelMul, PyccelDiv, PyccelMod

--- a/pyccel/ast/cwrapper.py
+++ b/pyccel/ast/cwrapper.py
@@ -35,7 +35,7 @@ from .c_concepts import ObjectAddress, CNativeInt
 
 from .internals import PyccelFunction
 
-from .literals  import LiteralString, LiteralInteger, Nil
+from .literals  import LiteralInteger, Nil
 
 from .variable  import Variable
 

--- a/pyccel/ast/headers.py
+++ b/pyccel/ast/headers.py
@@ -5,13 +5,7 @@
 #------------------------------------------------------------------------------------------#
 
 from ..errors.errors    import Errors
-from .basic             import PyccelAstNode, iterable
-from .core              import Assign, FunctionCallArgument
-from .core              import FunctionCall
-from .internals         import PyccelSymbol, Slice
-from .type_annotations  import SyntacticTypeAnnotation, UnionTypeAnnotation
-from .variable          import DottedName, DottedVariable
-from .variable          import Variable
+from .basic             import PyccelAstNode
 
 __all__ = (
     'Header',

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -9,8 +9,6 @@ Handling the transitions between Python code and C code using (Numpy/C Api).
 
 import numpy as np
 
-from .bind_c            import BindCPointer
-
 from .datatypes         import PythonNativeBool, GenericType, VoidType, FixedSizeType, CharType
 
 from .cwrapper          import PyccelPyObject, check_type_registry, c_to_py_registry, pytype_parse_registry

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -24,7 +24,7 @@ from .core           import Module, Import, PyccelFunctionDef, FunctionCall
 
 from .datatypes      import PythonNativeBool, PythonNativeInt, PythonNativeFloat
 from .datatypes      import PrimitiveBooleanType, PrimitiveIntegerType, PrimitiveFloatingPointType, PrimitiveComplexType
-from .datatypes      import HomogeneousTupleType, FixedSizeNumericType, GenericType, HomogeneousContainerType
+from .datatypes      import HomogeneousTupleType, FixedSizeNumericType, GenericType
 from .datatypes      import InhomogeneousTupleType, ContainerType, SymbolicType
 
 from .internals      import PyccelFunction, Slice

--- a/pyccel/ast/operators.py
+++ b/pyccel/ast/operators.py
@@ -16,7 +16,7 @@ from ..errors.errors        import Errors, PyccelSemanticError
 from .basic                 import TypedAstNode
 
 from .datatypes             import PythonNativeBool, PythonNativeFloat
-from .datatypes             import StringType, FixedSizeNumericType, ContainerType
+from .datatypes             import StringType, FixedSizeNumericType
 from .datatypes             import PrimitiveBooleanType, PrimitiveIntegerType
 
 from .literals              import Literal, LiteralInteger, LiteralFloat, LiteralComplex

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -18,7 +18,6 @@ from .core          import (AsName, Import, FunctionCall,
 
 from .builtins      import (builtin_functions_dict,
                             PythonRange, PythonList, PythonTuple, PythonSet)
-from .bind_c        import BindCVariable
 from .cmathext      import cmath_mod
 from .datatypes     import HomogeneousTupleType, InhomogeneousTupleType, PythonNativeInt
 from .datatypes     import StringType

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -23,7 +23,7 @@ from pyccel.ast.builtins  import PythonList, PythonTuple, PythonSet, PythonDict,
 
 from pyccel.ast.builtin_methods.dict_methods  import DictItems, DictKeys, DictValues, DictPopitem
 
-from pyccel.ast.core      import Declare, For, CodeBlock, ClassDef
+from pyccel.ast.core      import Declare, For, CodeBlock
 from pyccel.ast.core      import FunctionCall, FunctionCallArgument
 from pyccel.ast.core      import Deallocate, If, IfSection
 from pyccel.ast.core      import FunctionAddress
@@ -31,7 +31,7 @@ from pyccel.ast.core      import Assign, Import, AugAssign, AliasAssign
 from pyccel.ast.core      import SeparatorComment
 from pyccel.ast.core      import Module, AsName, FunctionDef, Return
 
-from pyccel.ast.c_concepts import ObjectAddress, CMacro, CStringExpression, PointerCast, CNativeInt
+from pyccel.ast.c_concepts import ObjectAddress, CMacro, CStringExpression, PointerCast
 from pyccel.ast.c_concepts import CStackArray, CStrStr
 
 from pyccel.ast.datatypes import PythonNativeInt, PythonNativeBool, VoidType
@@ -41,7 +41,7 @@ from pyccel.ast.datatypes import InhomogeneousTupleType, HomogeneousListType, Ho
 from pyccel.ast.datatypes import PrimitiveBooleanType, PrimitiveIntegerType, PrimitiveFloatingPointType, PrimitiveComplexType
 from pyccel.ast.datatypes import HomogeneousContainerType, DictType, FixedSizeType
 
-from pyccel.ast.internals import Slice, PrecomputedCode, PyccelArrayShapeElement
+from pyccel.ast.internals import Slice, PyccelArrayShapeElement
 from pyccel.ast.internals import PyccelFunction
 
 from pyccel.ast.literals  import LiteralTrue, LiteralFalse, LiteralImaginaryUnit, LiteralFloat
@@ -57,7 +57,6 @@ from pyccel.ast.numpyext import NumpyReal, NumpyImag, NumpyFloat
 from pyccel.ast.numpyext import NumpyAmin, NumpyAmax
 from pyccel.ast.numpyext import get_shape_of_multi_level_container
 
-from pyccel.ast.numpytypes import NumpyInt8Type, NumpyInt16Type, NumpyInt32Type, NumpyInt64Type
 from pyccel.ast.numpytypes import NumpyFloat32Type, NumpyFloat64Type, NumpyFloat128Type
 from pyccel.ast.numpytypes import NumpyNDArrayType, numpy_precision_map
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -7,7 +7,6 @@
 www.fortran90.org as much as possible."""
 
 import ast
-import functools
 import string
 import sys
 import re
@@ -34,10 +33,10 @@ from pyccel.ast.builtin_methods.set_methods import SetUnion
 
 from pyccel.ast.core import FunctionDef, FunctionDefArgument, FunctionDefResult
 from pyccel.ast.core import SeparatorComment, Comment
-from pyccel.ast.core import ConstructorCall, ClassDef
+from pyccel.ast.core import ConstructorCall
 from pyccel.ast.core import FunctionCallArgument
-from pyccel.ast.core import FunctionAddress, Interface
-from pyccel.ast.core import Return, Module, For, If, IfSection
+from pyccel.ast.core import FunctionAddress
+from pyccel.ast.core import Module, For, If, IfSection
 from pyccel.ast.core import Import, CodeBlock, AsName, EmptyNode
 from pyccel.ast.core import Assign, AliasAssign, Declare, Deallocate
 from pyccel.ast.core import FunctionCall, PyccelFunctionDef
@@ -1973,7 +1972,6 @@ class FCodePrinter(CodePrinter):
         optionalstr    = ''
         privatestr     = ''
         externalstr    = ''
-        is_string = isinstance(var.class_type, StringType)
 
         # Compute intent string
         if intent:

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1504,7 +1504,7 @@ class CToPythonWrapper(Wrapper):
             body.append(AliasAssign(res, func_args[0].var))
             body.append(Py_INCREF(res))
         else:
-            wrapped_results = self._extract_FunctionDefResult(expr.results.var, is_bind_c_function_def, expr)
+            wrapped_results = self._extract_FunctionDefResult(python_results.var, is_bind_c_function_def, expr)
 
         # Get the arguments and results which should be used to call the c-compatible function
         func_call_args = [ca for a in wrapped_args for ca in a['args']]

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -24,7 +24,7 @@ from pyccel.ast.core import If, IfSection, Import, Interface, FunctionDefArgumen
 from pyccel.ast.core import AsName, Module, AliasAssign, FunctionDefResult
 from pyccel.ast.core import For
 from pyccel.ast.datatypes import CustomDataType, FixedSizeNumericType
-from pyccel.ast.datatypes import HomogeneousTupleType, TupleType
+from pyccel.ast.datatypes import TupleType
 from pyccel.ast.datatypes import PythonNativeInt, CharType
 from pyccel.ast.datatypes import InhomogeneousTupleType
 from pyccel.ast.internals import Slice

--- a/pyccel/commands/pyccel_test.py
+++ b/pyccel/commands/pyccel_test.py
@@ -179,21 +179,6 @@ def pyccel_test(*, folder, dry_run, verbose, language, run_mpi):
     # Set the return code to OK by default
     retcode = pytest.ExitCode.OK
 
-    # Run the tests in the specified order
-    for desc, cmd in zip(descriptions, commands):
-        print()
-        print(desc)
-        print(f'> pytest {" ".join(cmd)}')
-        if dry_run:
-            print("Dry run, not executing the tests.")
-            retcode = pytest.ExitCode.OK
-        else:
-            retcode = pytest.main(cmd)
-            print(f"\nPytest return code: {retcode.name}")
-            if retcode == pytest.ExitCode.INTERRUPTED:
-                print("\nTest execution was interrupted by the user, exiting...\n")
-                return retcode
-
     if run_mpi:
         # Run the parallel tests
         import subprocess
@@ -211,11 +196,27 @@ def pyccel_test(*, folder, dry_run, verbose, language, run_mpi):
             print("Dry run, not executing the parallel tests.")
             retcode = pytest.ExitCode.OK
         else:
-            p = subprocess.run(cmd_mpi, check=False, stderr=subprocess.PIPE)
+            p = subprocess.run(cmd_mpi, check=False, capture_output=True, universal_newlines=True)
+            print(p.stdout)
             if p.returncode != 0:
-                print("Error running parallel tests")
+                print(f"Error running parallel tests. Failed with error code {p.returncode}")
                 print(p.stderr)
                 retcode = pytest.ExitCode.TESTS_FAILED
+
+    # Run the tests in the specified order
+    for desc, cmd in zip(descriptions, commands):
+        print()
+        print(desc)
+        print(f'> pytest {" ".join(cmd)}')
+        if dry_run:
+            print("Dry run, not executing the tests.")
+            retcode = pytest.ExitCode.OK
+        else:
+            retcode = pytest.main(cmd)
+            print(f"\nPytest return code: {retcode.name}")
+            if retcode == pytest.ExitCode.INTERRUPTED:
+                print("\nTest execution was interrupted by the user, exiting...\n")
+                return retcode
 
     # Return the final return code
     return retcode

--- a/pyccel/parser/extend_tree.py
+++ b/pyccel/parser/extend_tree.py
@@ -7,12 +7,13 @@
 ===========================================================
 
 """
-from io import StringIO
+from ast import AST, If as IfNode, parse
 
 from numpy import array, logical_and, where
-from ast   import AST, If as IfNode, parse
-from pyccel.errors.errors import Errors
+
+from pyccel.errors.errors   import Errors
 from pyccel.errors.messages import INVALID_PYTHON_SYNTAX
+
 
 class CommentLine(AST):
     """"New AST node representing a comment line"""

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -10,7 +10,6 @@ See the developer docs for more details
 from itertools import chain, product
 import os
 from types import ModuleType, BuiltinFunctionType
-import sys
 import typing
 import warnings
 
@@ -26,13 +25,12 @@ from sympy import ceiling
 from textx.exceptions import TextXSyntaxError
 
 #==============================================================================
-from pyccel.utilities.strings import random_string
-from pyccel.ast.basic         import PyccelAstNode, TypedAstNode, ScopedAstNode, iterable
+from pyccel.ast.basic import PyccelAstNode, TypedAstNode, ScopedAstNode, iterable
 
 from pyccel.ast.bitwise_operators import PyccelBitOr, PyccelLShift, PyccelRShift, PyccelBitAnd
 
 from pyccel.ast.builtins import PythonPrint, PythonTupleFunction, PythonSetFunction
-from pyccel.ast.builtins import PythonComplex, PythonDict, PythonDictFunction, PythonListFunction
+from pyccel.ast.builtins import PythonComplex, PythonDict, PythonListFunction
 from pyccel.ast.builtins import builtin_functions_dict, PythonImag, PythonReal
 from pyccel.ast.builtins import PythonList, PythonConjugate , PythonSet, VariableIterator
 from pyccel.ast.builtins import PythonRange, PythonZip, PythonEnumerate, PythonTuple
@@ -160,8 +158,6 @@ from pyccel.utilities.stage import PyccelStage
 
 import pyccel.decorators as def_decorators
 
-if sys.version_info >= (3, 10):
-    from types import UnionType
 #==============================================================================
 
 errors = Errors()
@@ -3866,7 +3862,7 @@ class SemanticParser(BasicParser):
             elif expr.lhs.is_temp:
                 return rhs
             else:
-                errors.report("Cannot assign result of a function without a return",
+                raise errors.report("Cannot assign result of a function without a return",
                         severity='fatal', symbol=expr)
 
             if isinstance(results.class_type, NumpyNDArrayType) and isinstance(lhs, IndexedElement):

--- a/pyccel/parser/syntax/headers.py
+++ b/pyccel/parser/syntax/headers.py
@@ -15,7 +15,7 @@ from pyccel.ast.headers   import MetaVariable
 from pyccel.ast.core      import FunctionDefArgument, EmptyNode
 from pyccel.ast.variable  import DottedName
 from pyccel.ast.literals  import LiteralString, LiteralInteger, LiteralFloat
-from pyccel.ast.literals  import LiteralTrue, LiteralFalse, LiteralEllipsis, Nil
+from pyccel.ast.literals  import LiteralEllipsis, Nil
 from pyccel.ast.internals import PyccelSymbol, Slice
 from pyccel.ast.variable  import AnnotatedPyccelSymbol, IndexedElement
 from pyccel.ast.type_annotations import SyntacticTypeAnnotation, FunctionTypeAnnotation, UnionTypeAnnotation

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "2.0.0"
+__version__ = "1.12.1"

--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "1.12.1"
+__version__ = "2.0.0"


### PR DESCRIPTION
Fix errors in the CI detected on the release branch.

**Commit Summary**
- Add missing package dependence to parse `ci_tools` docs
- Ensure `linux_pyccel-test_cmd` workflow reports its result when run by a workflow dispatch
- Ensure `markdown_lint` workflow reports the correct result when run by a workflow dispatch
- Fix badly formatted docstrings (merged in the 2-3 days when the doc CI was down)
- Fix pylint errors
    - Unused import
    - Unnecessary `.keys()`
    - Unclear execution path (possibly undefined variable etc)
- Run MPI tests first in `pyccel-test` to avoid undiagnosed failures