### PR TITLE
Fix the use of the `--export-compiler-config` flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+-   #2364 : Fix the use of the `--export-compiler-config` flag.
+
 ### Changed
 
 ### Deprecated

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -9,6 +9,7 @@ Module handling everything related to the compilers used to compile the various 
 """
 import json
 import os
+import pathlib
 import shutil
 import subprocess
 import platform
@@ -589,7 +590,7 @@ class Compiler:
 
         return cmd
 
-    def export_compiler_info(self, compiler_export_file):
+    def export_compiler_info(self, compiler_export_filename):
         """
         Export the compiler configuration to a json file.
 
@@ -601,10 +602,13 @@ class Compiler:
 
         Parameters
         ----------
-        compiler_export_file : str
+        compiler_export_filename : str | Path
             The name of the file where the compiler configuration
             should be printed.
         """
+        compiler_export_file = pathlib.Path(compiler_export_filename)
+        folder = compiler_export_file.parent
+        os.makedirs(folder, exist_ok=True)
         with open(compiler_export_file,'w', encoding="utf-8") as out_file:
             print(json.dumps(self._compiler_info, indent=4),
                     file=out_file)

--- a/pyccel/commands/console.py
+++ b/pyccel/commands/console.py
@@ -190,7 +190,9 @@ def pyccel() -> None:
             errors.check()
             sys.exit(1)
 
-        execute_pyccel('', compiler_export_file = filename)
+        execute_pyccel('',
+                       compiler_family = str(compiler) if compiler is not None else None,
+                       compiler_export_file = filename)
         sys.exit(0)
 
     # ...

--- a/pyccel/commands/console.py
+++ b/pyccel/commands/console.py
@@ -264,7 +264,6 @@ def pyccel() -> None:
                        debug           = args.debug,
                        accelerators    = accelerators,
                        folder          = str(output) if output is not None else None,
-                       compiler_export_file = compiler_export_file,
                        conda_warnings  = args.conda_warnings)
     except PyccelError:
         sys.exit(1)

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -1129,7 +1129,7 @@ def test_json():
     print(output_dir)
     cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json']
     subprocess.run(cmd, check=True)
-    with open(get_abs_path(f'{output_dir}/test.json'), 'r') as f:
+    with open(get_abs_path(f'{output_dir}/test.json'), 'r', encoding='utf-8') as f:
         dict_1 = json.load(f)
     cmd = [shutil.which("pyccel"),
            '--compiler-config',
@@ -1137,7 +1137,7 @@ def test_json():
            '--export-compiler-config',
            f'{output_dir}/test2.json']
     subprocess.run(cmd, check=True)
-    with open(get_abs_path(f'{output_dir}/test2.json'), 'r') as f:
+    with open(get_abs_path(f'{output_dir}/test2.json'), 'r', encoding='utf-8') as f:
         dict_2 = json.load(f)
 
     assert dict_1 == dict_2

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -1126,10 +1126,11 @@ def test_inline_import(language):
 #------------------------------------------------------------------------------
 def test_json():
     output_dir = get_abs_path(insert_pyccel_folder('scripts/'))
-    cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json']
+    cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json', '--compiler-family', 'intel']
     subprocess.run(cmd, check=True)
     with open(get_abs_path(f'{output_dir}/test.json'), 'r', encoding='utf-8') as f:
         dict_1 = json.load(f)
+    assert dict_1['c']['exec'] == 'icx'
     cmd = [shutil.which("pyccel"),
            '--compiler-config',
            f'{output_dir}/test.json',

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -1124,15 +1124,20 @@ def test_inline_import(language):
                 language = language)
 
 #------------------------------------------------------------------------------
-@pytest.mark.xdist_incompatible
 def test_json():
-    pyccel_test("scripts/runtest_funcs.py", language = 'fortran',
-            pyccel_commands='--export-compiler-config test.json')
-    with open(get_abs_path('scripts/test.json'), 'r') as f:
+    output_dir = insert_pyccel_folder('scripts/')
+    print(output_dir)
+    cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json']
+    subprocess.run(cmd, check=True)
+    with open(get_abs_path(f'{output_dir}/test.json'), 'r') as f:
         dict_1 = json.load(f)
-    pyccel_test("scripts/runtest_funcs.py", language = 'fortran',
-        pyccel_commands='--compiler-config test.json --export-compiler-config test2.json')
-    with open(get_abs_path('scripts/test2.json'), 'r') as f:
+    cmd = [shutil.which("pyccel"),
+           '--compiler-config',
+           f'{output_dir}/test.json',
+           '--export-compiler-config',
+           f'{output_dir}/test2.json']
+    subprocess.run(cmd, check=True)
+    with open(get_abs_path(f'{output_dir}/test2.json'), 'r') as f:
         dict_2 = json.load(f)
 
     assert dict_1 == dict_2

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -1141,6 +1141,24 @@ def test_json():
 
     assert dict_1 == dict_2
 
+#------------------------------------------------------------------------------
+def test_ambiguous_json():
+    output_dir = get_abs_path(insert_pyccel_folder('scripts/'))
+    cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test']
+    subprocess.run(cmd, check=True)
+    with open(get_abs_path(f'{output_dir}/test.json'), 'r', encoding='utf-8') as f:
+        dict_1 = json.load(f)
+    cmd = [shutil.which("pyccel"),
+           '--compiler-config',
+           f'{output_dir}/test.json',
+           '--export-compiler-config',
+           f'{output_dir}/test2']
+    subprocess.run(cmd, check=True)
+    with open(get_abs_path(f'{output_dir}/test2.json'), 'r', encoding='utf-8') as f:
+        dict_2 = json.load(f)
+
+    assert dict_1 == dict_2
+
 @pytest.mark.xdist_incompatible
 def test_json_relative_path():
     output_dir = get_abs_path(insert_pyccel_folder('scripts/'))

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -1126,7 +1126,6 @@ def test_inline_import(language):
 #------------------------------------------------------------------------------
 def test_json():
     output_dir = insert_pyccel_folder('scripts/')
-    print(output_dir)
     cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json']
     subprocess.run(cmd, check=True)
     with open(get_abs_path(f'{output_dir}/test.json'), 'r', encoding='utf-8') as f:
@@ -1144,9 +1143,10 @@ def test_json():
 
 @pytest.mark.xdist_incompatible
 def test_json_relative_path():
-    pyccel_test("scripts/runtest_funcs.py", language = 'fortran',
-            pyccel_commands='--export-compiler-config test.json')
-    shutil.move(get_abs_path('scripts/test.json'), get_abs_path('scripts/hope_benchmarks/test.json'))
+    output_dir = insert_pyccel_folder('scripts/')
+    cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json']
+    subprocess.run(cmd, check=True)
+    shutil.move(get_abs_path('{output_dir}/test.json'), get_abs_path('scripts/hope_benchmarks/test.json'))
     compile_pyccel(get_abs_path('scripts/hope_benchmarks'), "../runtest_funcs.py", '--compiler-config test.json')
 
 #------------------------------------------------------------------------------

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -1146,7 +1146,7 @@ def test_json_relative_path():
     output_dir = insert_pyccel_folder('scripts/')
     cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json']
     subprocess.run(cmd, check=True)
-    shutil.move(get_abs_path('{output_dir}/test.json'), get_abs_path('scripts/hope_benchmarks/test.json'))
+    shutil.move(get_abs_path(f'{output_dir}/test.json'), get_abs_path('scripts/hope_benchmarks/test.json'))
     compile_pyccel(get_abs_path('scripts/hope_benchmarks'), "../runtest_funcs.py", '--compiler-config test.json')
 
 #------------------------------------------------------------------------------

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -1125,7 +1125,7 @@ def test_inline_import(language):
 
 #------------------------------------------------------------------------------
 def test_json():
-    output_dir = insert_pyccel_folder('scripts/')
+    output_dir = get_abs_path(insert_pyccel_folder('scripts/'))
     cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json']
     subprocess.run(cmd, check=True)
     with open(get_abs_path(f'{output_dir}/test.json'), 'r', encoding='utf-8') as f:
@@ -1143,7 +1143,7 @@ def test_json():
 
 @pytest.mark.xdist_incompatible
 def test_json_relative_path():
-    output_dir = insert_pyccel_folder('scripts/')
+    output_dir = get_abs_path(insert_pyccel_folder('scripts/'))
     cmd = [shutil.which("pyccel"), '--export-compiler-config', f'{output_dir}/test.json']
     subprocess.run(cmd, check=True)
     shutil.move(get_abs_path(f'{output_dir}/test.json'), get_abs_path('scripts/hope_benchmarks/test.json'))


### PR DESCRIPTION
Fix the use of the `--export-compiler-config` flag. Fixes #2364