### PR TITLE
Fix Python containers as arguments to interface functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   #2364 : Fix the use of the `--export-compiler-config` flag.
+-   #2306 : Fix Python containers as arguments to interface functions.
 -   \[INTERNALS\] Fix unsorted `__all__` variables.
 -   \[INTERNALS\] Allow CI scripts `check_pyccel_conventions.py`, `check_pylint_commands.py`, and `ci_tools/check_python_capitalisation.py` to be called easily locally.
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -487,8 +487,10 @@ class PythonCodePrinter(CodePrinter):
                             check_option.append(f'{a}.ndim == {t.rank}')
                             if t.order:
                                 check_option.append(f"{a}.flags['{t.order}_CONTIGUOUS']")
-                        else:
+                        elif isinstance(t, FixedSizeNumericType):
                             check_option.append(f'isinstance({a}, {self._get_numpy_name(DtypePrecisionToCastFunction[t])})')
+                        else:
+                            raise NotImplementedError(f"Can't print a Python interface for type {t}")
                     checks.append(' and '.join(check_option))
                 if len(checks) > 1:
                     code += ' or '.join(f'({c})' for c in checks)

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -469,17 +469,15 @@ class CToPythonWrapper(Wrapper):
         for i, py_arg in enumerate(args):
             # Get the relevant typed arguments from the original functions
             interface_args = [func.arguments[i].var for func in orig_funcs]
-            # Get the type key
-            interface_types = [(str(a.dtype), a.rank, a.order) for a in interface_args]
             # Get a dictionary mapping each unique type key to an example argument
-            type_to_example_arg = dict(zip(interface_types, interface_args))
+            type_to_example_arg = {a.class_type : a for a in interface_args}
             # Get a list of unique keys
             possible_types = list(type_to_example_arg.keys())
 
             n_possible_types = len(possible_types)
             if n_possible_types != 1:
                 # Update argument_type_flags with the index of the type key
-                for func, t in zip(funcs, interface_types):
+                for func, t in zip(funcs, type_to_example_arg):
                     index = possible_types.index(t)*step
                     argument_type_flags[func] += index
 

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -447,6 +447,14 @@ def test_wrong_argument_combination_in_interface(language):
     with pytest.raises(TypeError):
         epyc_f(3.5, 4)
 
+@pytest.mark.parametrize('language', (
+    pytest.param('fortran', marks = pytest.mark.fortran),
+    pytest.param("c", marks = pytest.mark.c),
+    pytest.param('python', marks = [
+        pytest.mark.skip(reason="Cannot differentiate between list/set in Python as dtype cannot be checked"),
+        pytest.mark.python]
+    ))
+)
 def test_container_interface(language):
     T = TypeVar('T', 'int[:]', list[int], set[int])
 

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 # coding: utf-8
 import sys
-from typing import TypeVar
+from typing import TypeVar, Final
 
 import pytest
 import numpy as np
@@ -447,9 +447,13 @@ def test_wrong_argument_combination_in_interface(language):
     with pytest.raises(TypeError):
         epyc_f(3.5, 4)
 
-##==============================================================================
-## CLEAN UP GENERATED FILES AFTER RUNNING TESTS
-##==============================================================================
-#
-#def teardown_module():
-#    clean_test()
+def test_container_interface(language):
+    T = TypeVar('T', 'int[:]', list[int], set[int])
+
+    def f(a : Final[T]):
+        return len(a)
+
+    epyc_f = epyccel(f, language=language)
+    assert f([1,2]) == f([1,2])
+    assert f({1,2}) == f({1,2})
+    assert f(np.array([1,2])) == f(np.array([1,2]))


### PR DESCRIPTION
Fix Python containers as arguments to interface functions. The key for the different functions was `(str(a.dtype), a.rank, a.order)` as this test was older than our cleaned up typing system. With the new typing system the key is simply `a.class_type` and the classes are no longer seen as equivalent. Fixes #2306 