### PR TITLE
Fix links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Pyccel's acceleration capabilities lead to much faster code. Comparisons of Pyth
 The results for the `devel` branch currently show the following performance on Python 3.10:
 ![Pyccel execution times for devel branch](https://raw.githubusercontent.com/pyccel/pyccel-benchmarks/main/version_specific_results/devel_performance_310_execution.svg)
 
-If you are eager to try Pyccel out, we recommend reading our [quick-start guide](https://github.com/pyccel/pyccel/blob/devel/docs/quickstart.md).
+If you are eager to try Pyccel out, we recommend reading our [quick-start guide](https://pyccel.github.io/pyccel/docs/quickstart.html).
 
 ## Citing Pyccel
 
@@ -36,7 +36,7 @@ The associated bibtex can be found [here](https://github.com/pyccel/pyccel/blob/
 ## Installation
 
 Pyccel has a few system requirements to ensure that the system where it is installed is capable of compiling Fortran code.
-These requirements are detailed in the [documentation](https://github.com/pyccel/pyccel/blob/devel/docs/installation.md).
+These requirements are detailed in the [documentation](https://pyccel.github.io/pyccel/docs/installation.html).
 Once all requirements are satisfied, we recommend installing Pyccel into a Python virtual environment, which can be created with [venv](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment).
 Once the Python virtual environment is ready and activated, Pyccel can be easily installed using [pip](https://github.com/pypa/pip?tab=readme-ov-file#pip---the-python-package-installer), the Python package installer.
 The simple command
@@ -46,7 +46,7 @@ pip install pyccel
 ```
 
 will download the latest release of Pyccel from [PyPI](https://pypi.org/project/pyccel/), the Python package index.
-Alternative installation methods such as installing from source, or installing with a docker, are described in the [documentation](https://github.com/pyccel/pyccel/blob/devel/docs/installation.md).
+Alternative installation methods such as installing from source, or installing with a docker, are described in the [documentation](https://pyccel.github.io/pyccel/docs/installation.html).
 
 ## Testing
 
@@ -69,52 +69,13 @@ This installs a few additional Python packages which are necessary for running t
 The recommended way of running the unit tests is simply using the command line tool `pyccel-test` which is installed with Pyccel.
 This runs all unit tests using Pytest under the hood.
 
-Alternatively, if more fine-grained control over which tests are run is desired, e.g. for debugging local modifications to Pyccel, Pytest can be called directly using the commands provided in the [documentation](https://github.com/pyccel/pyccel/blob/devel/docs/testing.md).
+Alternatively, if more fine-grained control over which tests are run is desired, e.g. for debugging local modifications to Pyccel, Pytest can be called directly using the commands provided in the [documentation](https://pyccel.github.io/pyccel/docs/testing.html).
 
 ## Contributing
 
 We welcome any and all contributions.
 
 There are many ways to help with the Pyccel project which are more or less involved.
-A summary can be found in the [documentation](https://github.com/pyccel/pyccel/blob/devel/docs/CONTRIBUTING.md).
+A summary can be found in the [documentation](https://pyccel.github.io/pyccel/docs/CONTRIBUTING.html).
 
 We can also be contacted via the [Pyccel Discord Server](https://discord.gg/2Q6hwjfFVb).
-
-## User Documentation
-
--   [Quick-start Guide](https://github.com/pyccel/pyccel/blob/devel/docs/quickstart.md)
-
--   [Installation](https://github.com/pyccel/pyccel/blob/devel/docs/installation.md)
-
--   [Testing](https://github.com/pyccel/pyccel/blob/devel/docs/testing.md)
-
--   [Contributing](https://github.com/pyccel/pyccel/blob/devel/docs/CONTRIBUTING.md)
-
--   [C/Fortran Compilers](https://github.com/pyccel/pyccel/blob/devel/docs/compiler.md)
-
--   [Decorators](https://github.com/pyccel/pyccel/blob/devel/docs/decorators.md)
-
--   [Header Files](https://github.com/pyccel/pyccel/blob/devel/docs/header-files.md)
-
--   [Templates](https://github.com/pyccel/pyccel/blob/devel/docs/templates.md)
-
--   [N-dimensional Arrays](https://github.com/pyccel/pyccel/blob/devel/docs/ndarrays.md)
-
--   [Function-pointers as arguments](https://github.com/pyccel/pyccel/blob/devel/docs/function-pointers-as-arguments.md)
-
--   [Const keyword](https://github.com/pyccel/pyccel/blob/devel/docs/const_keyword.md)
-
--   Supported libraries/APIs
-    -   [OpenMP](https://github.com/pyccel/pyccel/blob/devel/docs/openmp.md)
-    -   [NumPy](https://github.com/pyccel/pyccel/blob/devel/docs/numpy-functions.md)
-
-## Developer Documentation
-
--   [Overview](https://github.com/pyccel/pyccel/blob/devel/developer_docs/overview.md)
--   [How to solve an issue](https://github.com/pyccel/pyccel/blob/devel/developer_docs/how_to_solve_an_issue.md)
--   [Review Process](https://github.com/pyccel/pyccel/blob/devel/developer_docs/review_process.md)
--   [Development Conventions](https://github.com/pyccel/pyccel/blob/devel/developer_docs/development_conventions.md)
--   [Tips and Tricks](https://github.com/pyccel/pyccel/blob/devel/developer_docs/tips_and_tricks.md)
--   [Scope](https://github.com/pyccel/pyccel/blob/devel/developer_docs/scope.md)
--   [Type Inference](https://github.com/pyccel/pyccel/blob/devel/developer_docs/type_inference.md)
--   [Array Ordering](https://github.com/pyccel/pyccel/blob/devel/developer_docs/order_docs.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,10 +42,10 @@ There are many pull requests and reviewing them is a great way to help things ge
 This is also a really good way to get to grips with the code base as you will see examples of many different areas of the code.
 It's incredibly helpful to have pull requests go through as many reviews as possible, to make sure the code change makes sense, is documented, and is efficient and clear.
 As the clarity is subjective, more eyes can only improve the code base.
-The review process is described in the [developer docs](https://github.com/pyccel/pyccel/blob/devel/developer_docs/review_process.md), keep an eye out for pull requests tagged `needs_initial_review`.
+The review process is described in the [developer docs](../developer_docs/review_process.md), keep an eye out for pull requests tagged `needs_initial_review`.
 
 ## Contributing code
 
 Before contributing we strongly recommend you check out the [developer docs](https://github.com/pyccel/pyccel/tree/devel/developer_docs).
 We try to flag `good-first-issue`s.
-These are either issues which can be fixed by following the example provided by a similar solution which is already implemented, or issues which only concern one of the Pyccel [stages](https://github.com/pyccel/pyccel/blob/devel/developer_docs/overview.md).
+These are either issues which can be fixed by following the example provided by a similar solution which is already implemented, or issues which only concern one of the Pyccel [stages](../developer_docs/overview.md).

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -632,13 +632,3 @@ Traceback (most recent call last):
   File "<string>", line 1, in <module>
 ImportError: cannot import name 'get_val' from 'boo' (/home/__init__.py)
 ```
-
-## Getting Help
-
-If you face problems with Pyccel, please take the following steps:
-
-1.  Consult our documentation in the tutorial directory;
-2.  Send an email message to <pyccel@googlegroups.com>;
-3.  Open an issue on GitHub.
-
-Thank you!

--- a/docs/function-pointers-as-arguments.md
+++ b/docs/function-pointers-as-arguments.md
@@ -1,7 +1,5 @@
 # Function-pointers as arguments
 
-Note: before reading this you should have read [Installation and Command Line Usage](https://github.com/pyccel/pyccel/blob/devel/docs/quickstart.md#installation)
-
 In order to support passing [function-pointers](https://en.wikipedia.org/wiki/Function_pointer) as arguments, Pyccel needs the user to define the type of the passed function-pointers. This can be done by using the syntax `def function_name(func1_name : '(func1_return_type)(func1_arguments_types)', func2_name : '(func2_return_type)(func2_arguments_types)', ..., arg1, arg2, ...)` or using a function-header `#$ header function function_name((func1_return_type)(func1_arguments), (func2_return_type)(func2_arguments), ..., var1_type, var2_type, ...)`. Here is how Pyccel converts that feature:
 
 In this example we will use short syntax for this feature:
@@ -421,8 +419,7 @@ end program prog_prog_boo
 
 If you face problems with Pyccel, please take the following steps:
 
-1.  Consult our documentation in the  [`docs/`](https://github.com/pyccel/pyccel/blob/devel/docs) directory;
-2.  Send an email message to <pyccel@googlegroups.com>;
-3.  Open an issue on GitHub.
+1.  Consult our documentation at <https://pyccel.github.io/pyccel>;
+2.  Open an issue on GitHub.
 
 Thank you!

--- a/docs/function-pointers-as-arguments.md
+++ b/docs/function-pointers-as-arguments.md
@@ -414,12 +414,3 @@ program prog_prog_boo
 
 end program prog_prog_boo
 ```
-
-## Getting Help
-
-If you face problems with Pyccel, please take the following steps:
-
-1.  Consult our documentation at <https://pyccel.github.io/pyccel>;
-2.  Open an issue on GitHub.
-
-Thank you!

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -133,7 +133,7 @@ Such type annotations are compatible with mypy and as such are recommended for u
 
 Pyccel's official releases can be downloaded and installed from PyPI (the Python Package Index) using `pip`.
 To get the latest (trunk) version of Pyccel, one can clone the `git` repository from GitHub and checkout the `devel` branch.
-Detailed installation instructions are found [here](https://github.com/pyccel/pyccel/blob/devel/docs/installation.md).
+Detailed installation instructions are found [here](installation.md).
 
 ### Command Line Usage
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -554,8 +554,7 @@ This tool removes all folders whose name begins with `__pyccel__` or `__epyccel_
 
 If you face problems with Pyccel, please take the following steps:
 
-1.  Consult our documentation in the  [`docs/`](https://github.com/pyccel/pyccel/blob/devel/docs) directory;
-2.  Send an email message to <pyccel@googlegroups.com>;
-3.  Open an issue on GitHub.
+1.  Consult our documentation at <https://pyccel.github.io/pyccel>;
+2.  Open an issue on GitHub.
 
 Thank you!


### PR DESCRIPTION
Fix links in docs. Absolute links should be used in `README.md` as this file is used as-is on PyPI. Everywhere else relative links should be used. These are resolved to url links by sphinx.