### PR TITLE
Put back support for lambda functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 -   #1741 : Add support for set method `difference()`.
 -   #1742 : Add support for set method `difference_update()`.
+-   #1849 : Add support for lambda functions by treating them as inline functions.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 -   #1741 : Add support for set method `difference()`.
 -   #1742 : Add support for set method `difference_update()`.
--   #1849 : Add support for lambda functions by treating them as inline functions.
+-   #1849 : Add support for lambda functions in assign statements by treating them as inline functions.
 
 ### Fixed
 

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -41,6 +41,7 @@ Python contains a limited number of builtin functions defined [here](https://doc
 | **`isinstance`** | **Yes** |
 | `issubclass` | No |
 | `iter` | No |
+| **`lambda`** | **Yes** |
 | **`len`** | **Yes** |
 | *`list`* | Python-only |
 | `locals` | No |

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -41,7 +41,7 @@ Python contains a limited number of builtin functions defined [here](https://doc
 | **`isinstance`** | **Yes** |
 | `issubclass` | No |
 | `iter` | No |
-| **`lambda`** | **Yes** |
+| **`lambda`** | Yes (but not as function arguments) |
 | **`len`** | **Yes** |
 | *`list`* | Python-only |
 | `locals` | No |

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -34,7 +34,6 @@ from .variable  import IndexedElement, Variable
 pyccel_stage = PyccelStage()
 
 __all__ = (
-    'Lambda',
     'PythonAbs',
     'PythonBool',
     'PythonComplex',
@@ -1543,51 +1542,6 @@ class PythonMin(PyccelFunction):
         else:
             self._class_type = sum(x.class_type, start=GenericType())
         super().__init__(x)
-
-#==============================================================================
-class Lambda(PyccelAstNode):
-    """
-    Represents a call to Python's lambda for temporary functions.
-
-    Represents a call to Python's built-in function `lambda` for temporary functions.
-
-    Parameters
-    ----------
-    variables : tuple of symbols
-        The arguments to the lambda expression.
-    expr : TypedAstNode
-        The expression carried out when the lambda function is called.
-    """
-    __slots__ = ('_variables', '_expr')
-    _attribute_nodes = ('_variables', '_expr')
-    def __init__(self, variables, expr):
-        if not isinstance(variables, (list, tuple)):
-            raise TypeError("Lambda arguments must be a tuple or list")
-        self._variables = tuple(variables)
-        self._expr = expr
-        super().__init__()
-
-    @property
-    def variables(self):
-        """ The arguments to the lambda function
-        """
-        return self._variables
-
-    @property
-    def expr(self):
-        """ The expression carried out when the lambda function is called
-        """
-        return self._expr
-
-    def __call__(self, *args):
-        """ Returns the expression with the arguments replaced with
-        the calling arguments
-        """
-        assert len(args) == len(self.variables)
-        return self.expr.subs(self.variables, args)
-
-    def __str__(self):
-        return f"{self.variables} -> {self.expr}"
 
 #==============================================================================
 class PythonType(PyccelFunction):

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -594,9 +594,12 @@ class PythonCodePrinter(CodePrinter):
 
     def _print_Return(self, expr):
 
+        result_vars = [expr.expr] if isinstance(expr.expr, Variable) else expr.expr.get_attribute_nodes(Variable)
+
         if expr.stmt:
-            to_print = [l for l in expr.stmt.body if not ((isinstance(l, Assign) and isinstance(l.lhs, Variable))
-                                                        or isinstance(l, UnpackManagedMemory))]
+            to_print = [l for l in expr.stmt.body \
+                            if not ((isinstance(l, Assign) and isinstance(l.lhs, Variable) and l.lhs in result_vars)
+                                     or isinstance(l, UnpackManagedMemory))]
             assigns = {a.lhs: a.rhs for a in expr.stmt.body if (isinstance(a, Assign) and isinstance(a.lhs, Variable))}
             assigns.update({a.out_ptr: a.managed_object for a in expr.stmt.body if isinstance(a, UnpackManagedMemory)})
             prelude = ''.join(self._print(l) for l in to_print)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -594,7 +594,7 @@ class PythonCodePrinter(CodePrinter):
 
     def _print_Return(self, expr):
 
-        result_vars = [expr.expr] if isinstance(expr.expr, Variable) else expr.expr.get_attribute_nodes(Variable)
+        result_vars = self.scope.collect_all_tuple_elements(expr.expr)
 
         if expr.stmt:
             to_print = [l for l in expr.stmt.body \

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -617,7 +617,7 @@ class PythonCodePrinter(CodePrinter):
         def get_return_code(return_var):
             """ Recursive method which replaces any variables in a return statement whose
             definition is known (via the assigns dict) with the definition. A function is
-            required to handle the recursivity implied by an unknown depth of inhomogenous
+            required to handle the recursivity implied by an unknown depth of inhomogeneous
             tuples.
             """
             if isinstance(return_var.class_type, InhomogeneousTupleType):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -34,7 +34,7 @@ from pyccel.ast.builtins import PythonComplex, PythonDict, PythonListFunction
 from pyccel.ast.builtins import builtin_functions_dict, PythonImag, PythonReal
 from pyccel.ast.builtins import PythonList, PythonConjugate , PythonSet, VariableIterator
 from pyccel.ast.builtins import PythonRange, PythonZip, PythonEnumerate, PythonTuple
-from pyccel.ast.builtins import Lambda, PythonMap, PythonBool
+from pyccel.ast.builtins import PythonMap, PythonBool
 
 from pyccel.ast.builtin_methods.dict_methods import DictKeys
 from pyccel.ast.builtin_methods.list_methods import ListAppend, ListPop, ListInsert
@@ -3505,31 +3505,6 @@ class SemanticParser(BasicParser):
         else:
             raise errors.report(f"In operator is not yet implemented for type {container_type}",
                     severity='fatal', symbol=expr)
-
-    def _visit_Lambda(self, expr):
-        errors.report("Lambda functions are not currently supported",
-                symbol=expr, severity='fatal')
-        expr_names = set(str(a) for a in expr.expr.get_attribute_nodes(PyccelSymbol))
-        var_names = map(str, expr.variables)
-        missing_vars = expr_names.difference(var_names)
-        if len(missing_vars) > 0:
-            errors.report(UNDEFINED_LAMBDA_VARIABLE, symbol = missing_vars,
-                bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
-                severity='fatal')
-        funcs = expr.expr.get_attribute_nodes(FunctionCall)
-        for func in funcs:
-            name = _get_name(func)
-            f = self.scope.find(name, 'symbolic_functions')
-            if f is None:
-                errors.report(UNDEFINED_LAMBDA_FUNCTION, symbol=name,
-                    bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
-                    severity='fatal')
-            else:
-
-                f = f(*func.args)
-                expr_new = expr.expr.subs(func, f)
-                expr = Lambda(tuple(expr.variables), expr_new)
-        return expr
 
     def _visit_FunctionCall(self, expr):
         name     = expr.funcdef

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2973,6 +2973,9 @@ class SemanticParser(BasicParser):
         for b in expr.body:
             if isinstance(b, EmptyNode):
                 continue
+            if isinstance(b, InlineFunctionDef):
+                self.insert_function(b)
+                continue
             # Save parsed code
             line = self._visit(b)
             ls.extend(self._additional_exprs[-1])

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1379,7 +1379,7 @@ class SyntaxParser(BasicParser):
 
     def _visit_Lambda(self, stmt):
         assign_node = self._context[-2]
-        if not isinstance(assign_node, Assign):
+        if not isinstance(assign_node, ast.Assign):
             errors.report("Lambda functions are only supported in assign statements currently.",
                           severity='fatal', symbol=stmt)
         name_lst = self._visit(assign_node.targets)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1321,7 +1321,15 @@ class SyntaxParser(BasicParser):
             self.exit_function_scope()
 
             imports = [i for i in body if isinstance(i, Import)]
-            body = [l for l in body if not isinstance(l, (FunctionDef, ClassDef, Import))]
+            functions = [l for l in body if isinstance(l, FunctionDef) and not l.is_inline]
+            classes = [l for l in body if isinstance(l, ClassDef)]
+            if classes:
+                errors.report("Classes should be declared in the module not in the program body",
+                              symbol = stmt, severity = 'error')
+            if any(not f.is_inline for f in functions):
+                errors.report("Functions should be declared in the module not in the program body",
+                              symbol = stmt, severity = 'error')
+            body = [l for l in body if l not in (imports, functions, classes)]
 
             return Program('__main__', (), CodeBlock(body), imports=imports, scope = scope)
         else:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -54,7 +54,7 @@ from pyccel.ast.operators import IfTernaryOperator
 from pyccel.ast.numpyext  import NumpyMatmul
 
 from pyccel.ast.builtins import PythonTuple, PythonList, PythonSet, PythonDict
-from pyccel.ast.builtins import PythonPrint, Lambda
+from pyccel.ast.builtins import PythonPrint
 from pyccel.ast.headers  import MetaVariable
 from pyccel.ast.literals import LiteralInteger, LiteralFloat, LiteralComplex
 from pyccel.ast.literals import LiteralFalse, LiteralTrue, LiteralString

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -3,7 +3,7 @@
 # This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
 # go to https://github.com/pyccel/pyccel/blob/devel/LICENSE for full license details.      #
 #------------------------------------------------------------------------------------------#
-
+from itertools import chain
 import os
 import re
 
@@ -1329,7 +1329,7 @@ class SyntaxParser(BasicParser):
             if any(not f.is_inline for f in functions):
                 errors.report("Functions should be declared in the module not in the program body",
                               symbol = stmt, severity = 'error')
-            body = [l for l in body if l not in (imports, functions, classes)]
+            body = [l for l in body if l not in chain(imports, functions, classes)]
 
             return Program('__main__', (), CodeBlock(body), imports=imports, scope = scope)
         else:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1379,6 +1379,9 @@ class SyntaxParser(BasicParser):
 
     def _visit_Lambda(self, stmt):
         assign_node = self._context[-2]
+        if not isinstance(assign_node, Assign):
+            errors.report("Lambda functions are only supported in assign statements currently.",
+                          severity='fatal', symbol=stmt)
         name_lst = self._visit(assign_node.targets)
 
         assert len(name_lst) == 1

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -461,8 +461,8 @@ def test_container_interface(language):
 
 def test_lambda(language):
     def f(a : int):
-        f1 = lambda x: x**2 + 1
-        g1 = lambda x: f1(x)**2 + 1
+        f1 = lambda x: x**2 + 1 # pylint: disable=unnecessary-lambda-assignment
+        g1 = lambda x: f1(x)**2 + 1 # pylint: disable=unnecessary-lambda-assignment
         return g1(a)
 
     epyc_f = epyccel(f, language=language)
@@ -472,7 +472,7 @@ def test_lambda(language):
 
 def test_lambda_2(language):
     def f(a : int):
-        f2 = lambda x,y: x**2 + y**2 + 1
+        f2 = lambda x,y: x**2 + y**2 + 1 # pylint: disable=unnecessary-lambda-assignment
         return f2(a, 3*a)
 
     epyc_f = epyccel(f, language=language)

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -5,6 +5,7 @@ from typing import TypeVar, Final
 
 import pytest
 import numpy as np
+from numpy.random import randint
 
 from pyccel import epyccel
 
@@ -457,3 +458,24 @@ def test_container_interface(language):
     assert f([1,2]) == epyc_f([1,2])
     assert f({1,2}) == epyc_f({1,2})
     assert f(np.array([1,2])) == epyc_f(np.array([1,2]))
+
+def test_lambda(language):
+    def f(a : int):
+        f1 = lambda x: x**2 + 1
+        g1 = lambda x: f1(x)**2 + 1
+        return g1(a)
+
+    epyc_f = epyccel(f, language=language)
+    val = randint(20)
+    assert f(val) == epyc_f(val)
+    assert isinstance(epyc_f(val), type(epyc_f(val)))
+
+def test_lambda_2(language):
+    def f(a : int):
+        f2 = lambda x,y: x**2 + y**2 + 1
+        return f2(a, 3*a)
+
+    epyc_f = epyccel(f, language=language)
+    val = randint(20)
+    assert f(val) == epyc_f(val)
+    assert isinstance(epyc_f(val), type(epyc_f(val)))

--- a/tests/errors/known_bugs/lambdas.py
+++ b/tests/errors/known_bugs/lambdas.py
@@ -1,8 +1,0 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring
-# coding: utf-8
-
-f1 = lambda x: x**2 + 1
-f2 = lambda x,y: x**2 + y**2 + 1
-g1 = lambda x: f1(x)**2 + 1
-
-f1(3)

--- a/tests/errors/semantic/blocking/UNDEFINED_LAMBDA_FUNCTION.py
+++ b/tests/errors/semantic/blocking/UNDEFINED_LAMBDA_FUNCTION.py
@@ -1,3 +1,0 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring
-a = lambda x: 1+b()
-

--- a/tests/errors/semantic/blocking/UNDEFINED_LAMBDA_VARIABLE.py
+++ b/tests/errors/semantic/blocking/UNDEFINED_LAMBDA_VARIABLE.py
@@ -1,2 +1,0 @@
-# pylint: disable=missing-function-docstring, missing-module-docstring
-a = lambda x: 1+b

--- a/tests/pyccel/scripts/runtest_funcs.py
+++ b/tests/pyccel/scripts/runtest_funcs.py
@@ -15,6 +15,6 @@ def sum_to_n(n : 'int'):
 if __name__ == '__main__':
     print(sum_to_n(4))
 
-    f = lambda x: x+3
+    f = lambda x: x+3 #pylint: disable=unnecessary-lambda-assignment
 
     print(f(5))

--- a/tests/pyccel/scripts/runtest_funcs.py
+++ b/tests/pyccel/scripts/runtest_funcs.py
@@ -14,3 +14,7 @@ def sum_to_n(n : 'int'):
 
 if __name__ == '__main__':
     print(sum_to_n(4))
+
+    f = lambda x: x+3
+
+    print(f(5))


### PR DESCRIPTION
Support for lambdas existed in 2018 (d712ada707b2b8735d58a647c1c087e7adc0d1ed) but it was never tested (tests did not call the function) and testing in 2020 (d712ada707b2b8735d58a647c1c087e7adc0d1ed) showed that the existing implementation did not work. Now that inline functions no longer need type specification for their arguments lambda functions can be supported in a much simpler way. The syntactic stage simply builds an `InlineFunctionDef` node which is handled in the semantic stage using existing code.

**Commit Summary**
- Remove old unnecessary classes originally designed to handle lambda functions
- Fix a small bug in `PythonCodePrinter._print_Return` when a return statement contains a temporary variable that is not the returned variable
- Build an `InlineFunctionDef` node in the semantic step to represent lambdas. Fixes #1849
- Add tests
- Remove tests checking for failures