### PR TITLE
Add support for `np.true_divide`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 -   #1741 : Add support for set method `difference()`.
 -   #1742 : Add support for set method `difference_update()`.
+-   #1585 : Add support for `np.divide` and its alias `np.true_divide`.
 
 ### Fixed
 

--- a/docs/numpy-functions.md
+++ b/docs/numpy-functions.md
@@ -433,7 +433,7 @@ In Pyccel we try to support the NumPy functions which developers use the most.. 
 -   Supported [math functions](https://numpy.org/doc/stable/reference/routines.math.html) (optional parameters are not supported):
 
     `sqrt`, `abs`, `sin`, `cos`, `exp`, `log`, `tan`, `arcsin`, `arccos`, `arctan`, `arctan2`, `sinh`, `cosh`, `tanh`, `arcsinh`, `arccosh` and
-    `arctanh`.
+    `arctanh`, `true_divide`, `divide`.
 
 -   Supported [logic functions](https://numpy.org/doc/stable/reference/routines.logic.html) (optional parameters are not supported):
 

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -2763,7 +2763,35 @@ class NumpyNDArray(PyccelFunction):
         return NumpyArray(*args, **kwargs)
 
 #==============================================================================
+class NumpyDivide(PyccelFunction):
+    """
+    Class representing a class to numpy.divide or numpy.true_divide in the user code.
 
+    Class representing a class to numpy.divide or numpy.true_divide in the user code.
+
+    Parameters
+    ----------
+    x1 : TypedAstNode
+        The dividend.
+    x2 : TypedAstNode
+        The divisor.
+    """
+    __slots__ = ()
+    name = 'divide'
+    def __new__(cls, x1, x2):
+        if x1.rank == 0:
+            x1_type = x1.class_type
+            x1_np_type = process_dtype(x1_type)
+            if x1_type != x1_np_type:
+                x1 = DtypePrecisionToCastFunction[x1_np_type](x1)
+        if x2.rank == 0:
+            x2_type = x2.class_type
+            x2_np_type = process_dtype(x2_type)
+            if x2_type != x2_np_type:
+                x2 = DtypePrecisionToCastFunction[x2_np_type](x2)
+        return PyccelDiv(x1, x2)
+
+#==============================================================================
 DtypePrecisionToCastFunction.update({
     PythonNativeBool()    : NumpyBool,
     NumpyInt8Type()       : NumpyInt8,
@@ -2837,6 +2865,8 @@ numpy_funcs = {
     'product'   : PyccelFunctionDef('product'   , NumpyProduct),
     'linspace'  : PyccelFunctionDef('linspace'  , NumpyLinspace),
     'where'     : PyccelFunctionDef('where'     , NumpyWhere),
+    'divide'    : PyccelFunctionDef('divide'    , NumpyDivide),
+    'true_divide' : PyccelFunctionDef('true_divide', NumpyDivide),
     # ---
     'isnan'     : PyccelFunctionDef('isnan'     , NumpyIsNan),
     'isinf'     : PyccelFunctionDef('isinf'     , NumpyIsInf),

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -6111,16 +6111,6 @@ def test_copy(language):
         assert res_3d_pyt.flags.c_contiguous == res_3d_pyc.flags.c_contiguous
         assert res_3d_pyt.flags.f_contiguous == res_3d_pyc.flags.f_contiguous
 
-@pytest.mark.parametrize( 'language', (
-        pytest.param("fortran", marks = pytest.mark.fortran),
-        pytest.param("c", marks = pytest.mark.c),
-        pytest.param("python", marks = [
-            pytest.mark.skip("NumpyDivide handles types in __new__ so it "
-                "cannot be used in a translated interface in python"),
-            pytest.mark.python]
-        ),
-    )
-)
 def test_true_divide(language):
     def basic_division(a : 'int | float | complex', b : 'int | float | complex'):
         from numpy import true_divide
@@ -6157,4 +6147,5 @@ def test_true_divide(language):
     assert np.allclose(basic_array_division(f_arr_1d,i), epyccel_basic_array_division(f_arr_1d,i), rtol=RTOL, atol=ATOL)
     assert np.allclose(basic_array_division(f_arr_1d,f), epyccel_basic_array_division(f_arr_1d,f), rtol=RTOL, atol=ATOL)
     assert np.allclose(basic_array_division(f_arr_1d,c), epyccel_basic_array_division(f_arr_1d,c), rtol=RTOL, atol=ATOL)
-    assert np.isclose(basic_division(f,0), epyccel_basic_division(f,0), rtol=RTOL, atol=ATOL)
+    if language != 'python':
+        assert np.isclose(basic_division(f,0), epyccel_basic_division(f,0), rtol=RTOL, atol=ATOL)

--- a/tests/epyccel/recognised_functions/test_numpy_funcs.py
+++ b/tests/epyccel/recognised_functions/test_numpy_funcs.py
@@ -6110,3 +6110,51 @@ def test_copy(language):
         assert res_3d_pyt.dtype is res_3d_pyc.dtype
         assert res_3d_pyt.flags.c_contiguous == res_3d_pyc.flags.c_contiguous
         assert res_3d_pyt.flags.f_contiguous == res_3d_pyc.flags.f_contiguous
+
+@pytest.mark.parametrize( 'language', (
+        pytest.param("fortran", marks = pytest.mark.fortran),
+        pytest.param("c", marks = pytest.mark.c),
+        pytest.param("python", marks = [
+            pytest.mark.skip("NumpyDivide handles types in __new__ so it "
+                "cannot be used in a translated interface in python"),
+            pytest.mark.python]
+        ),
+    )
+)
+def test_true_divide(language):
+    def basic_division(a : 'int | float | complex', b : 'int | float | complex'):
+        from numpy import true_divide
+        return true_divide(a,b)
+    def basic_array_division(a : 'int[:] | float[:]', b : 'int | float | complex | int[:] | float[:]'):
+        from numpy import true_divide
+        return true_divide(a,b)
+
+    i = randint(1e6)
+    f = uniform(min_float/2, max_float/2)
+    c = uniform(min_float/2, max_float/2)+1j*uniform(min_float/2, max_float/2)
+    i_arr_1d = randint(min_int, max_int, size=5)
+    f_arr_1d = uniform(min_float/2, max_float/2, size=5)
+
+    epyccel_basic_division = epyccel(basic_division, language=language)
+    epyccel_basic_array_division = epyccel(basic_array_division, language=language)
+
+    assert np.isclose(basic_division(i,i), epyccel_basic_division(i,i), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(i,f), epyccel_basic_division(i,f), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(i,c), epyccel_basic_division(i,c), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(f,i), epyccel_basic_division(f,i), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(f,f), epyccel_basic_division(f,f), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(f,c), epyccel_basic_division(f,c), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(c,i), epyccel_basic_division(c,i), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(c,f), epyccel_basic_division(c,f), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(c,c), epyccel_basic_division(c,c), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(i_arr_1d,i_arr_1d), epyccel_basic_array_division(i_arr_1d,i_arr_1d), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(i_arr_1d,f_arr_1d), epyccel_basic_array_division(i_arr_1d,f_arr_1d), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(i_arr_1d,i), epyccel_basic_array_division(i_arr_1d,i), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(i_arr_1d,f), epyccel_basic_array_division(i_arr_1d,f), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(i_arr_1d,c), epyccel_basic_array_division(i_arr_1d,c), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(f_arr_1d,i_arr_1d), epyccel_basic_array_division(f_arr_1d,i_arr_1d), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(f_arr_1d,f_arr_1d), epyccel_basic_array_division(f_arr_1d,f_arr_1d), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(f_arr_1d,i), epyccel_basic_array_division(f_arr_1d,i), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(f_arr_1d,f), epyccel_basic_array_division(f_arr_1d,f), rtol=RTOL, atol=ATOL)
+    assert np.allclose(basic_array_division(f_arr_1d,c), epyccel_basic_array_division(f_arr_1d,c), rtol=RTOL, atol=ATOL)
+    assert np.isclose(basic_division(f,0), epyccel_basic_division(f,0), rtol=RTOL, atol=ATOL)


### PR DESCRIPTION
Add support for `np.divide` and its alias `np.true_divide`. These methods are equivalent to the `/` operator but do not crash when dividing by 0. The translation is therefore just a use of `PyccelDiv`. Fixes #1585 