### PR TITLE
Add a `Wrappergen` class to reduce code duplication

### DIFF
--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -55,9 +55,8 @@ class CWrapperCodePrinter(CCodePrinter):
                       PyccelPyTypeObject() : 'PyTypeObject',
                       BindCPointer()  : 'void'}
 
-    def __init__(self, filename, target_language, **settings):
+    def __init__(self, filename, **settings):
         CCodePrinter.__init__(self, filename, **settings)
-        self._target_language = target_language
         self._to_free_PyObject_list = []
         self._function_wrapper_names = dict()
         self._module_name = None

--- a/pyccel/codegen/python_wrapper.py
+++ b/pyccel/codegen/python_wrapper.py
@@ -13,6 +13,7 @@ from pyccel.codegen.printing.cwrappercode        import CWrapperCodePrinter
 from pyccel.codegen.printing.fcode               import FCodePrinter
 from pyccel.codegen.wrapper.fortran_to_c_wrapper import FortranToCWrapper
 from pyccel.codegen.wrapper.c_to_python_wrapper  import CToPythonWrapper
+from pyccel.codegen.wrappergen  import Wrappergen
 from pyccel.codegen.utilities                    import manage_dependencies
 from pyccel.errors.errors                        import Errors
 from pyccel.naming                               import name_clash_checkers
@@ -98,101 +99,63 @@ def create_shared_library(codegen,
     if sharedlib_modname is None:
         sharedlib_modname = module_name
 
-    wrapper_filename_root = f'{module_name}_wrapper'
-    wrapper_header_filename = f'{wrapper_filename_root}.h'
-    wrapper_filename = f'{wrapper_filename_root}.c'
-    wrapper_compile_obj = CompileObj(wrapper_filename,
-            pyccel_dirpath,
-            flags        = wrapper_flags,
-            dependencies = (main_obj,),
-            accelerators = ('python',))
+    gen = Wrappergen(codegen, module_name, language, verbose)
 
-    if language == 'fortran':
-        start_bind_c_wrapping = time.time()
-        if verbose:
-            print(">> Building Fortran-C interface :: ", module_name)
-        # Construct static interface for passing array shapes and write it to file bind_c_MOD.f90
-        wrapper = FortranToCWrapper(verbose)
-        bind_c_mod = wrapper.wrap(codegen.ast)
-        timings['Bind C wrapping'] = time.time() - start_bind_c_wrapping
+    #-------------------------------------------
+    #               Wrap code
+    #-------------------------------------------
 
-        bind_c_filename = f'{bind_c_mod.name}.f90'
-        if verbose:
-            print(">> Printing :: ", bind_c_filename)
-        start_bind_c_printing = time.time()
-        bind_c_code = FCodePrinter(bind_c_mod.name, verbose=verbose).doprint(bind_c_mod)
+    start_wrapper_creation = time.time()
+    gen.wrap(pyccel_dirpath)
+    timings['Wrapper creation'] = time.time() - start_wrapper_creation
 
-        with open(bind_c_filename, 'w') as f:
-            f.writelines(bind_c_code)
-        timings['Bind C printing'] = time.time() - start_bind_c_printing
+    #-------------------------------------------
+    #           Print wrapper code
+    #-------------------------------------------
 
-        start_bind_c_compiling = time.time()
-        bind_c_obj=CompileObj(file_name = bind_c_filename,
-                folder = pyccel_dirpath,
-                flags  = main_obj.flags,
-                dependencies = (main_obj,))
-        wrapper_compile_obj.add_dependencies(bind_c_obj)
-        compiler.compile_module(compile_obj=bind_c_obj,
+    start_wrapper_printing = time.time()
+    wrapper_files = gen.print(pyccel_dirpath)
+    timings['Wrapper printing'] = time.time() - start_wrapper_printing
+
+    printed_languages = gen.printed_languages
+
+    #-------------------------------------------
+    #         Prepare the compile objects
+    #-------------------------------------------
+
+    wrapper_compile_objs = [CompileObj(filepath,
+                                       pyccel_dirpath,
+                                       flags        = wrapper_flags,
+                                       dependencies = (main_obj,))
+                            for filepath in wrapper_files[:-1]] + \
+                           [CompileObj(wrapper_files[-1],
+                                       pyccel_dirpath,
+                                       flags        = wrapper_flags,
+                                       dependencies = (main_obj,),
+                                       accelerators = ('python',))]
+
+    for i, (obj, lang, imports) in enumerate(zip(wrapper_compile_objs, printed_languages, gen.get_additional_imports())):
+        obj.add_dependencies(*wrapper_compile_objs[:i])
+        manage_dependencies(imports, compiler,
+                pyccel_dirpath, obj, lang, verbose)
+
+    #-------------------------------------------
+    #               Compile code
+    #-------------------------------------------
+
+    start_compile_wrapper = time.time()
+    for obj in wrapper_compile_objs:
+        compiler.compile_module(compile_obj=obj,
                 output_folder=pyccel_dirpath,
                 language=language,
                 verbose=verbose)
-        timings['Bind C wrapping'] = time.time() - start_bind_c_compiling
-        c_ast = bind_c_mod
-    else:
-        c_ast = codegen.ast
 
-    #---------------------------------------
-    #      Print code specific cwrapper
-    #---------------------------------------
-    wrapper_codegen = CWrapperCodePrinter(codegen.parser.filename, language, verbose=verbose)
-    Scope.name_clash_checker = name_clash_checkers['c']
-    wrapper = CToPythonWrapper(base_dirpath, verbose)
-
-    if verbose:
-        print(">> Building C-Python interface :: ", c_ast.name)
-    start_wrapper_creation = time.time()
-    cwrap_ast = wrapper.wrap(c_ast)
-    timings['Wrapper creation'] = time.time() - start_wrapper_creation
-
-    if verbose:
-        print(">> Printing :: ", wrapper_filename)
-    start_print_cwrapper = time.time()
-    wrapper_code = wrapper_codegen.doprint(cwrap_ast)
-    #wrapper_code = wrapper_codegen.doprint(c_ast)
-    if errors.has_errors():
-        return
-
-    with open(wrapper_filename, 'w', encoding="utf-8") as f:
-        f.writelines(wrapper_code)
-    timings['Wrapper printing'] = time.time() - start_print_cwrapper
-
-    wrapper_header_code = wrapper_codegen.doprint(ModuleHeader(cwrap_ast))
-
-    with open(wrapper_header_filename, 'w', encoding="utf-8") as f:
-        f.writelines(wrapper_header_code)
-
-    #--------------------------------------------------------
-    #  Compile cwrapper_ndarrays from stdlib (if necessary)
-    #--------------------------------------------------------
-    start_compile_libs = time.time()
-    manage_dependencies(wrapper_codegen.get_additional_imports(), compiler,
-            pyccel_dirpath, wrapper_compile_obj, 'c', verbose)
-    timings['Dependency compilation'] = (time.time() - start_compile_libs)
-
-    #---------------------------------------
-    #         Compile code
-    #---------------------------------------
-    start_compile_wrapper = time.time()
-    compiler.compile_module(wrapper_compile_obj,
-                            output_folder = pyccel_dirpath,
-                            language='c',
-                            verbose = verbose)
-
-    sharedlib_filepath = compiler.compile_shared_library(wrapper_compile_obj,
+    sharedlib_filepath = compiler.compile_shared_library(wrapper_compile_objs[-1],
                                                     output_folder = pyccel_dirpath,
                                                     sharedlib_modname = sharedlib_modname,
                                                     language = language,
                                                     verbose = verbose)
+
     timings['Wrapper compilation'] = time.time() - start_compile_wrapper
 
     # Change working directory back to starting point

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -101,19 +101,22 @@ class CToPythonWrapper(Wrapper):
 
     Parameters
     ----------
-    file_location : str
+    pyccel_folder_path : str
         The folder where the translated code is located and where the generated .so file will
         be located.
     verbose : int
         The level of verbosity.
     """
-    def __init__(self, file_location, verbose):
+    target_language = 'Python'
+    start_language = 'C'
+
+    def __init__(self, pyccel_folder_path, verbose):
         # A map used to find the Python-compatible Variable equivalent to an object in the AST
         self._python_object_map = {}
         # The object that should be returned to indicate an error
         self._error_exit_code = Nil()
 
-        self._file_location = file_location
+        self._pyccel_folder_path = pyccel_folder_path
         super().__init__(verbose)
 
     def get_new_PyObject(self, name, dtype = None, is_temp = False):
@@ -837,7 +840,7 @@ class CToPythonWrapper(Wrapper):
                 AliasAssign(stash_path, PyList_GetItem(current_path, LiteralInteger(0, dtype=CNativeInt()))),
                 Py_INCREF(stash_path),
                 If(IfSection(PyccelEq(PyList_SetItem(current_path, LiteralInteger(0, dtype=CNativeInt()),
-                                                PyUnicode_FromString(CStrStr(LiteralString(self._file_location)))),
+                                                PyUnicode_FromString(CStrStr(LiteralString(self._pyccel_folder_path)))),
                                       PyccelUnarySub(LiteralInteger(1))),
                              [Return(self._error_exit_code)])),
                 AliasAssign(API_var, PyCapsule_Import(self.scope.get_python_name(mod_name))),

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -49,12 +49,19 @@ class FortranToCWrapper(Wrapper):
 
     Parameters
     ----------
+    pyccel_folder_path : str
+        The folder where the translated code is located and where the generated .so file will
+        be located.
     verbose : int
         The level of verbosity.
     """
-    def __init__(self, verbose):
+    target_language = 'C'
+    start_language = 'Fortran'
+
+    def __init__(self, pyccel_folder_path, verbose):
         self._additional_exprs = []
         self._wrapper_names_dict = {}
+        self._pyccel_folder_path = pyccel_folder_path
         super().__init__(verbose)
 
     def _get_function_def_body(self, func, wrapped_args, results, handled = ()):

--- a/pyccel/codegen/wrappergen.py
+++ b/pyccel/codegen/wrappergen.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/devel/LICENSE for full license details.      #
+#------------------------------------------------------------------------------------------#
+from pathlib import Path
+
+from .codegen import _extension_registry, _header_extension_registry
+from .printing.fcode  import FCodePrinter
+from .printing.ccode  import CCodePrinter
+from .printing.cwrappercode  import CWrapperCodePrinter
+from .wrapper.fortran_to_c_wrapper import FortranToCWrapper
+from .wrapper.c_to_python_wrapper import CToPythonWrapper
+from ..ast.core import ModuleHeader
+from ..naming import name_clash_checkers
+from ..parser.scope import Scope
+from ..utilities.stage import PyccelStage
+
+wrapper_registry = {
+        'fortran' : [FortranToCWrapper, CToPythonWrapper],
+        'c' : [CToPythonWrapper],
+        'python' : [],
+        }
+
+printer_registry = {
+        FortranToCWrapper : FCodePrinter,
+        CToPythonWrapper : CWrapperCodePrinter,
+        }
+
+pyccel_stage = PyccelStage()
+
+class Wrappergen:
+    """
+    """
+    def __init__(self, codegen, name, language, verbose):
+        pyccel_stage.set_stage('cwrapper')
+        self._ast      = codegen.ast
+        self._name     = name
+        self._language = language
+        self._verbose  = verbose
+        self._wrapper_ast = []
+
+        self._wrapper_types = wrapper_registry[language]
+        self._printer_types = [printer_registry[w] for w in self._wrapper_types]
+        self._additional_imports = [{} for _ in self._wrapper_types]
+
+    def wrap(self, dirpath):
+        current_name_clash_checker = Scope.name_clash_checker
+        ast = self._ast
+        for Wrapper in self._wrapper_types:
+            if self._verbose:
+                print(f">> Building {Wrapper.start_language}-{Wrapper.target_language} interface :: ", self._name)
+
+            Scope.name_clash_checker = name_clash_checkers[Wrapper.start_language.lower()]
+            wrapper = Wrapper(dirpath, verbose = self._verbose)
+
+            ast = wrapper.wrap(ast)
+            self._wrapper_ast.append(ast)
+
+        Scope.name_clash_checker = current_name_clash_checker
+
+    def print(self, dirpath):
+        dirpath = Path(dirpath)
+        files = [dirpath / f'{ast.name}_wrapper.{_extension_registry[Wrapper.start_language.lower()]}'
+                 for ast, Wrapper in zip(self._wrapper_ast, self._wrapper_types)]
+        for i, (filepath, ast, Printer) in enumerate(zip(files, self._wrapper_ast, self._printer_types)):
+            header_ext = _header_extension_registry[Printer.language.lower()]
+
+            if self._verbose:
+                print ('>>> Printing :: ', filepath)
+            printer = Printer(ast.name, verbose=self._verbose)
+
+            # print module
+            code = printer.doprint(ast)
+
+            with open(filepath, 'w', encoding="utf-8") as f:
+                f.write(code)
+
+            # print module header
+            if header_ext is not None:
+                header_filename = f'{ast.name}_wrapper.{header_ext}'
+                module_header = ModuleHeader(ast)
+                if self._verbose:
+                    print ('>>> Printing :: ', header_filename)
+                code = printer.doprint(module_header)
+                with open(header_filename, 'w', encoding="utf-8") as f:
+                    f.write(code)
+
+            self._additional_imports[i] = printer.get_additional_imports().copy()
+
+        return files
+
+    def get_additional_imports(self):
+        return self._additional_imports
+
+    @property
+    def printed_languages(self):
+        return [Printer.language.lower() for Printer in self._printer_types]


### PR DESCRIPTION
Add a `Wrappergen` class. This homogenises the treatment of the wrapper stage. It is important to reduce code duplication when adding new printers (e.g. a C++ printer which will not need to use C for the interface) or when adding new compilation methods (see #221).