### PR TITLE
Use a consistent naming scheme for path variables. Part 1

### DIFF
--- a/pyccel/codegen/compiling/basic.py
+++ b/pyccel/codegen/compiling/basic.py
@@ -24,8 +24,8 @@ class CompileObj:
     file_name : str
         Name of file to be compiled.
 
-    folder : str
-        Name of the folder where the file is found.
+    dirpath : str
+        Path to the directory where the file is found.
 
     flags : str
         Any non-default flags passed to the compiler.
@@ -55,12 +55,12 @@ class CompileObj:
         name is used.
     """
     compilation_in_progress = FileLock('.lock_acquisition.lock')
-    __slots__ = ('_file','_folder','_module_name','_module_target','_prog_target',
+    __slots__ = ('_file_path','_dirpath','_module_name','_module_target','_prog_target',
                  '_lock_target','_lock_source','_flags','_include','_libs',
                  '_libdir','_accelerators','_dependencies','_has_target_file')
     def __init__(self,
                  file_name,
-                 folder,
+                 dirpath,
                  flags        = (),
                  include     = (),
                  libs         = (),
@@ -70,16 +70,16 @@ class CompileObj:
                  has_target_file = True,
                  prog_target  = None):
 
-        folder = Path(folder)
-        self._folder = folder
-        self._file = folder / file_name
+        dirpath = Path(dirpath)
+        self._dirpath = dirpath
+        self._file_path = dirpath / file_name
 
         self._module_name = Path(file_name).stem
-        rel_mod_name = folder / self._module_name
+        rel_mod_name = dirpath / self._module_name
         self._module_target = rel_mod_name.with_suffix('.o')
 
         if prog_target:
-            self._prog_target = folder / prog_target
+            self._prog_target = dirpath / prog_target
         else:
             self._prog_target = rel_mod_name
         if sys.platform == "win32":
@@ -91,40 +91,40 @@ class CompileObj:
                                             self.source.suffix + '.lock')))
 
         self._flags        = list(flags)
-        self._include     = {folder, *(Path(i) for i in include)}
+        self._include     = {dirpath, *(Path(i) for i in include)}
         self._libs         = list(libs)
         self._libdir      = set(libdir)
         self._accelerators = set(accelerators)
         self._dependencies = {a.module_target:a for a in dependencies}
         self._has_target_file = has_target_file
 
-    def reset_folder(self, folder):
+    def reset_dirpath(self, dirpath):
         """
-        Change the folder in which the source file is saved.
+        Change the dirpath in which the source file is saved.
 
-        Change the folder in which the source file is saved. Normally the location
+        Change the dirpath in which the source file is saved. Normally the location
         of the source file should not change during the execution, however when
-        working with the stdlib, the `CompileObj` is created with the folder set
+        working with the stdlib, the `CompileObj` is created with the dirpath set
         to the file's location in the Pyccel install directory. When the file is
-        used it is copied to the user's folder, at which point the folder of the
+        used it is copied to the user's dirpath, at which point the dirpath of the
         `CompileObj` must be updated.
 
         Parameters
         ----------
-        folder : str
-            The new folder where the source file can be found.
+        dirpath : str
+            The new dirpath where the source file can be found.
         """
-        folder = Path(folder)
-        self._include.remove(self._folder)
-        self._include.add(folder)
+        dirpath = Path(dirpath)
+        self._include.remove(self._dirpath)
+        self._include.add(dirpath)
 
-        self._file = folder / self._file.name
+        self._file_path = dirpath / self._file_path.name
         self._lock_source  = FileLock(self.source.with_suffix(
                                         self.source.suffix+'.lock'))
-        self._folder = folder
-        self._include.add(self._folder)
+        self._dirpath = dirpath
+        self._include.add(self._dirpath)
 
-        rel_mod_name = folder / self._module_name
+        rel_mod_name = dirpath / self._module_name
         self._module_target = rel_mod_name.with_suffix('.o')
 
         self._prog_target = rel_mod_name
@@ -138,13 +138,13 @@ class CompileObj:
     def source(self):
         """ Returns the file to be compiled
         """
-        return self._file
+        return self._file_path
 
     @property
-    def source_folder(self):
+    def source_dirpath(self):
         """ Returns the location of the file to be compiled
         """
-        return self._folder
+        return self._dirpath
 
     @property
     def python_module(self):

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -48,18 +48,18 @@ def get_condaless_search_path(conda_warnings = 'basic'):
     """
     path_sep = ';' if platform.system() == 'Windows' else ':'
     current_path = os.environ['PATH']
-    folders = {f: f.split(os.sep) for f in current_path.split(path_sep)}
-    conda_folder_names = ('conda', 'anaconda', 'miniconda',
+    dirpaths = {f: f.split(os.sep) for f in current_path.split(path_sep)}
+    conda_dirpath_names = ('conda', 'anaconda', 'miniconda',
                           'Conda', 'Anaconda', 'Miniconda')
-    conda_folders = [p for p,f in folders.items() if any(con in f for con in conda_folder_names)]
-    if conda_folders:
+    conda_dirpaths = [p for p,f in dirpaths.items() if any(con in f for con in conda_dirpath_names)]
+    if conda_dirpaths:
         if conda_warnings in ('basic', 'verbose'):
             message_warning = "Conda paths are ignored. See https://github.com/pyccel/pyccel/blob/devel/docs/compiler.md#utilising-pyccel-within-anaconda-environment for details"
             if conda_warnings == 'verbose':
                 message_warning = message_warning + "\nConda ignored PATH:\n"
-                message_warning = message_warning + ":".join(conda_folders)
+                message_warning = message_warning + ":".join(conda_dirpaths)
             warnings.warn(UserWarning(message_warning))
-    acceptable_search_paths = path_sep.join(p for p in folders.keys() if p not in conda_folders and os.path.exists(p))
+    acceptable_search_paths = path_sep.join(p for p in dirpaths.keys() if p not in conda_dirpaths and os.path.exists(p))
     return acceptable_search_paths
 
 #------------------------------------------------------------
@@ -179,7 +179,7 @@ class Compiler:
         """
         Collect necessary compile property.
 
-        Collect necessary compile properties such as include folders
+        Collect necessary compile properties such as include dirpaths
         or library directories.
 
         Parameters
@@ -237,7 +237,7 @@ class Compiler:
         Returns
         -------
         list[str]
-            A list of the include folders.
+            A list of the include dirpaths.
         """
         return self._get_property('include', include, accelerators)
 
@@ -279,7 +279,7 @@ class Compiler:
         Returns
         -------
         list[str]
-            A list of the folders containing libraries.
+            A list of the dirpaths containing libraries.
         """
         return self._get_property('libdir', libdir, accelerators)
 
@@ -366,7 +366,7 @@ class Compiler:
 
         return exec_cmd, inc_flags, libs_flags, libdir_flags, m_code
 
-    def compile_module(self, compile_obj, output_folder, language, verbose):
+    def compile_module(self, compile_obj, output_dirpath, language, verbose):
         """
         Compile a module.
 
@@ -377,8 +377,8 @@ class Compiler:
         compile_obj : CompileObj
             Object containing all information about the object to be compiled.
 
-        output_folder : str
-            The folder where the result should be saved.
+        output_dirpath : str
+            The dirpath where the result should be saved.
 
         language : str
             Language that we are compiling.
@@ -408,7 +408,7 @@ class Compiler:
         exec_cmd = self._get_exec(accelerators)
 
         if language == 'fortran':
-            j_code = (self._language_info['module_output_flag'], output_folder)
+            j_code = (self._language_info['module_output_flag'], output_dirpath)
         else:
             j_code = ()
 
@@ -421,7 +421,7 @@ class Compiler:
 
         self._language_info = None
 
-    def compile_program(self, compile_obj, output_folder, language, verbose):
+    def compile_program(self, compile_obj, output_dirpath, language, verbose):
         """
         Compile a program.
 
@@ -432,8 +432,8 @@ class Compiler:
         compile_obj : CompileObj
             Object containing all information about the object to be compiled.
 
-        output_folder : str
-            The folder where the result should be saved.
+        output_dirpath : str
+            The dirpath where the result should be saved.
 
         language : str
             Language that we are compiling.
@@ -462,7 +462,7 @@ class Compiler:
         linker_libdir_flags = ['-Wl,-rpath' if l == '-L' else l for l in libdir_flags]
 
         if language == 'fortran':
-            j_code = (self._language_info['module_output_flag'], output_folder)
+            j_code = (self._language_info['module_output_flag'], output_dirpath)
         else:
             j_code = ()
 
@@ -478,7 +478,7 @@ class Compiler:
 
         return compile_obj.program_target
 
-    def compile_shared_library(self, compile_obj, output_folder, language, verbose, sharedlib_modname=None):
+    def compile_shared_library(self, compile_obj, output_dirpath, language, verbose, sharedlib_modname=None):
         """
         Compile a module to a shared library.
 
@@ -490,8 +490,8 @@ class Compiler:
         compile_obj : CompileObj
             Object containing all information about the object to be compiled.
 
-        output_folder : str
-            The folder where the result should be saved.
+        output_dirpath : str
+            The dirpath where the result should be saved.
 
         language : str
             Language that we are compiling.
@@ -607,8 +607,8 @@ class Compiler:
             should be printed.
         """
         compiler_export_file = pathlib.Path(compiler_export_filename)
-        folder = compiler_export_file.parent
-        os.makedirs(folder, exist_ok=True)
+        dirpath = compiler_export_file.parent
+        os.makedirs(dirpath, exist_ok=True)
         with open(compiler_export_file,'w', encoding="utf-8") as out_file:
             print(json.dumps(self._compiler_info, indent=4),
                     file=out_file)

--- a/pyccel/codegen/compiling/compilers.py
+++ b/pyccel/codegen/compiling/compilers.py
@@ -530,7 +530,7 @@ class Compiler:
         # Get name of file
         ext_suffix = self._language_info['python']['shared_suffix']
         sharedlib_modname = sharedlib_modname or compile_obj.python_module
-        file_out = os.path.join(compile_obj.source_folder, sharedlib_modname+ext_suffix)
+        file_out = os.path.join(compile_obj.source_dirpath, sharedlib_modname+ext_suffix)
 
         if verbose:
             print(">> Compiling shared library :: ", file_out)

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -306,7 +306,7 @@ def execute_pyccel(fname, *,
     compile_libs.extend(libs)
 
     mod_obj = CompileObj(file_name = fname,
-            folder       = pyccel_dirpath,
+            dirpath      = pyccel_dirpath,
             flags        = flags,
             include      = include,
             libs         = compile_libs,
@@ -358,7 +358,7 @@ def execute_pyccel(fname, *,
     try:
         if codegen.is_program:
             prog_obj = CompileObj(file_name = prog_name,
-                    folder       = pyccel_dirpath,
+                    dirpath      = pyccel_dirpath,
                     dependencies = (mod_obj,),
                     prog_target  = module_name)
             generated_program_filepath = compiler.compile_program(compile_obj=prog_obj,

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -347,7 +347,7 @@ def execute_pyccel(fname, *,
     # Compile code to modules
     try:
         compiler.compile_module(compile_obj=mod_obj,
-                output_folder=pyccel_dirpath,
+                output_dirpath=pyccel_dirpath,
                 language=language,
                 verbose=verbose)
     except Exception:
@@ -362,7 +362,7 @@ def execute_pyccel(fname, *,
                     dependencies = (mod_obj,),
                     prog_target  = module_name)
             generated_program_filepath = compiler.compile_program(compile_obj=prog_obj,
-                    output_folder=pyccel_dirpath,
+                    output_dirpath=pyccel_dirpath,
                     language=language,
                     verbose=verbose)
 

--- a/pyccel/codegen/python_wrapper.py
+++ b/pyccel/codegen/python_wrapper.py
@@ -133,7 +133,7 @@ def create_shared_library(codegen,
                 dependencies = (main_obj,))
         wrapper_compile_obj.add_dependencies(bind_c_obj)
         compiler.compile_module(compile_obj=bind_c_obj,
-                output_folder=pyccel_dirpath,
+                output_dirpath=pyccel_dirpath,
                 language=language,
                 verbose=verbose)
         timings['Bind C wrapping'] = time.time() - start_bind_c_compiling
@@ -184,12 +184,12 @@ def create_shared_library(codegen,
     #---------------------------------------
     start_compile_wrapper = time.time()
     compiler.compile_module(wrapper_compile_obj,
-                            output_folder = pyccel_dirpath,
+                            output_dirpath = pyccel_dirpath,
                             language='c',
                             verbose = verbose)
 
     sharedlib_filepath = compiler.compile_shared_library(wrapper_compile_obj,
-                                                    output_folder = pyccel_dirpath,
+                                                    output_dirpath = pyccel_dirpath,
                                                     sharedlib_modname = sharedlib_modname,
                                                     language = language,
                                                     verbose = verbose)

--- a/pyccel/codegen/python_wrapper.py
+++ b/pyccel/codegen/python_wrapper.py
@@ -128,7 +128,7 @@ def create_shared_library(codegen,
 
         start_bind_c_compiling = time.time()
         bind_c_obj=CompileObj(file_name = bind_c_filename,
-                folder = pyccel_dirpath,
+                dirpath = pyccel_dirpath,
                 flags  = main_obj.flags,
                 dependencies = (main_obj,))
         wrapper_compile_obj.add_dependencies(bind_c_obj)

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -320,7 +320,7 @@ def recompile_object(compile_obj,
             outdated = True
     if outdated:
         compiler.compile_module(compile_obj=compile_obj,
-                output_folder=compile_obj.source_dirpath,
+                output_dirpath=compile_obj.source_dirpath,
                 language=language,
                 verbose=verbose)
 

--- a/pyccel/codegen/utilities.py
+++ b/pyccel/codegen/utilities.py
@@ -43,46 +43,46 @@ language_extension = {'fortran':'f90', 'c':'c', 'python':'py'}
 # map internal libraries to their folders inside pyccel/stdlib and their compile objects
 # The compile object folder will be in the pyccel dirpath
 internal_libs = {
-    "pyc_math_f90"     : (stdlib_path / "math", "math", CompileObj("pyc_math_f90.f90",folder="math", libs = ('m',))),
-    "pyc_math_c"       : (stdlib_path / "math", "math", CompileObj("pyc_math_c.c",folder="math")),
-    "pyc_tools_f90"    : (stdlib_path / "tools", "tools", CompileObj("pyc_tools_f90.f90",folder="tools")),
-    "cwrapper"         : (stdlib_path / "cwrapper", "cwrapper", CompileObj("cwrapper.c",folder="cwrapper", accelerators=('python',))),
-    "CSpan_extensions" : (stdlib_path / "STC_Extensions", "STC_Extensions", CompileObj("CSpan_extensions.h", folder="STC_Extensions", has_target_file = False)),
-    "stc" : (ext_path / "STC/include/stc", "STC/include/stc", CompileObj("stc", folder="STC/include", has_target_file = False)),
-    "gFTL" : (ext_path / "gFTL/install/GFTL-1.13/include/v2", "gFTL", CompileObj("gFTL", folder=".", has_target_file = False)),
+    "pyc_math_f90"     : (stdlib_path / "math", "math", CompileObj("pyc_math_f90.f90",dirpath="math", libs = ('m',))),
+    "pyc_math_c"       : (stdlib_path / "math", "math", CompileObj("pyc_math_c.c",dirpath="math")),
+    "pyc_tools_f90"    : (stdlib_path / "tools", "tools", CompileObj("pyc_tools_f90.f90",dirpath="tools")),
+    "cwrapper"         : (stdlib_path / "cwrapper", "cwrapper", CompileObj("cwrapper.c",dirpath="cwrapper", accelerators=('python',))),
+    "CSpan_extensions" : (stdlib_path / "STC_Extensions", "STC_Extensions", CompileObj("CSpan_extensions.h", dirpath="STC_Extensions", has_target_file = False)),
+    "stc" : (ext_path / "STC/include/stc", "STC/include/stc", CompileObj("stc", dirpath="STC/include", has_target_file = False)),
+    "gFTL" : (ext_path / "gFTL/install/GFTL-1.13/include/v2", "gFTL", CompileObj("gFTL", dirpath=".", has_target_file = False)),
 }
 internal_libs["STC_Extensions/Set_extensions"] = (stdlib_path / "STC_Extensions", "STC_Extensions", CompileObj("Set_Extensions.h",
-                                                      folder="STC_Extensions",
+                                                      dirpath="STC_Extensions",
                                                       has_target_file = False,
                                                       dependencies = (internal_libs['stc'][2],)))
 internal_libs["STC_Extensions/Dict_extensions"] = (stdlib_path / "STC_Extensions", "STC_Extensions", CompileObj("Dict_Extensions.h",
-                                                     folder="STC_Extensions",
+                                                     dirpath="STC_Extensions",
                                                      has_target_file=False,
                                                      dependencies=(internal_libs["stc"][2],)))
 internal_libs["STC_Extensions/List_extensions"] = (stdlib_path / "STC_Extensions", "STC_Extensions", CompileObj("List_Extensions.h",
-                                                      folder="STC_Extensions",
+                                                      dirpath="STC_Extensions",
                                                       has_target_file = False,
                                                       dependencies = (internal_libs['stc'][2],)))
 internal_libs["STC_Extensions/Common_extensions"] = (stdlib_path / "STC_Extensions", "STC_Extensions", CompileObj("Common_Extensions.h",
-                                                      folder="STC_Extensions",
+                                                      dirpath="STC_Extensions",
                                                       has_target_file = False,
                                                       dependencies = (internal_libs['stc'][2],)))
 internal_libs["gFTL_functions/Set_extensions"] = (stdlib_path / "gFTL_functions", "gFTL_functions", CompileObj("Set_Extensions.inc",
-                                                                     folder="gFTL_functions",
+                                                                     dirpath="gFTL_functions",
                                                                      has_target_file = False,
                                                                      dependencies = (internal_libs['gFTL'][2],)))
 internal_libs["gFTL_functions/Vector_extensions"] = (stdlib_path / "gFTL_functions", "gFTL_functions", CompileObj("Vector_Extensions.inc",
-                                                                     folder="gFTL_functions",
+                                                                     dirpath="gFTL_functions",
                                                                      has_target_file = False,
                                                                      dependencies = (internal_libs['gFTL'][2],)))
 internal_libs["gFTL_functions/Map_extensions"] = (stdlib_path / "gFTL_functions", "gFTL_functions", CompileObj("Map_Extensions.inc",
-                                                                     folder="gFTL_functions",
+                                                                     dirpath="gFTL_functions",
                                                                      has_target_file = False,
                                                                      dependencies = (internal_libs['gFTL'][2],)))
-internal_libs["stc/cstr"] = (ext_path / "STC/src", "STC/src", CompileObj("cstr_core.c", folder="STC/include", dependencies = (internal_libs['stc'][2],)))
-internal_libs["stc/cspan"] = (ext_path / "STC/src", "STC/src", CompileObj("cspan.c", folder="STC/include", dependencies = (internal_libs['stc'][2],)))
+internal_libs["stc/cstr"] = (ext_path / "STC/src", "STC/src", CompileObj("cstr_core.c", dirpath="STC/include", dependencies = (internal_libs['stc'][2],)))
+internal_libs["stc/cspan"] = (ext_path / "STC/src", "STC/src", CompileObj("cspan.c", dirpath="STC/include", dependencies = (internal_libs['stc'][2],)))
 internal_libs["stc/algorithm"] = (ext_path / "STC/include/stc/", "STC/include/stc/", CompileObj("algorithm.h",
-                                    folder="STC/include",
+                                    dirpath="STC/include",
                                     has_target_file = False,
                                     dependencies = (internal_libs['stc'][2],)))
 
@@ -273,7 +273,7 @@ def generate_extension_modules(import_key, import_node, pyccel_dirpath,
             with open(filename, 'w', encoding="utf-8") as f:
                 f.write(code)
 
-        new_dependencies.append(CompileObj(os.path.basename(filename), folder=folder,
+        new_dependencies.append(CompileObj(os.path.basename(filename), dirpath=folder,
                             include=include,
                             libs=libs, libdir=libdir,
                             dependencies=(*dependencies, internal_libs['gFTL'][2]),
@@ -320,7 +320,7 @@ def recompile_object(compile_obj,
             outdated = True
     if outdated:
         compiler.compile_module(compile_obj=compile_obj,
-                output_folder=compile_obj.source_folder,
+                output_folder=compile_obj.source_dirpath,
                 language=language,
                 verbose=verbose)
 
@@ -367,7 +367,7 @@ def manage_dependencies(pyccel_imports, compiler, pyccel_dirpath, mod_obj, langu
             # convert only
             if convert_only:
                 continue
-            stdlib.reset_folder(lib_dest_path) # pylint: disable=E1101
+            stdlib.reset_dirpath(lib_dest_path) # pylint: disable=E1101
 
             # get the include folder path and library files
             recompile_object(stdlib,
@@ -449,7 +449,7 @@ def get_module_and_compile_dependencies(parser, compile_libs = None, deps = None
             dep_compile_libs = [l for l in parser.metavars.get('libraries', '').split(',') if l]
             if not parser.metavars.get('ignore_at_import', False):
                 deps[dep_fname] = CompileObj(mod_base,
-                                    folder          = mod_folder,
+                                    dirpath         = mod_folder,
                                     libs            = dep_compile_libs,
                                     has_target_file = not parser.metavars.get('no_target', False))
             else:


### PR DESCRIPTION
Use a consistent naming scheme for path variables as suggested in #2333.