### PR TITLE
Fix missing undef in `Managed_memory.h`

### DIFF
--- a/.github/actions/valgrind_run/action.yml
+++ b/.github/actions/valgrind_run/action.yml
@@ -5,20 +5,20 @@ runs:
   steps:
     - name: Test with valgrind for memory leaks in ndarrays
       run: |
-        pyccel --language=c --flags="-g -O0" leaks_check.py
+        pyccel --language=c --debug leaks_check.py
         valgrind --leak-check=full --error-exitcode=1 ./leaks_check
       shell: bash
       working-directory: ./tests/ndarrays
     
     - name: Test with valgrind for memory leaks in built-in containers
       run: |
-        pyccel --language=c --flags="-g -O0" leaks_check.py
+        pyccel --language=c --debug leaks_check.py
         valgrind --leak-check=full --error-exitcode=1 ./leaks_check
         pyccel-clean -p
-        pyccel --language=fortran --flags="-g -O0" leaks_check.py
+        pyccel --language=fortran --debug leaks_check.py
         valgrind --leak-check=full --error-exitcode=1 ./leaks_check
         pyccel-clean -p
-        pyccel --language=c --flags="-g -O0" nested_leaks_check.py
+        pyccel --language=c --debug nested_leaks_check.py
         valgrind --leak-check=full --error-exitcode=1 ./nested_leaks_check
       shell: bash
       working-directory: ./tests/stc_containers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   #2306 : Fix Python containers as arguments to interface functions.
+-   #2407 : Fix bad memory handling for multi-level containers.
 
 ### Changed
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -787,7 +787,7 @@ class CCodePrinter(CodePrinter):
             decl_line = f'#define i_{tag}pro cstr\n'
         elif isinstance(element_type, (HomogeneousListType, HomogeneousSetType, DictType)):
             type_decl = self.get_c_type(element_type, not in_arc)
-            decl_line = f'#define i_{tag}class {type_decl}\n'
+            decl_line = f'#define i_{tag} {type_decl}\n#define i_{tag}drop {type_decl}_drop\n#define i_{tag}clone {type_decl}_steal\n'
         else:
             decl_line = ''
             errors.report(f"The declaration of type {element_type} is not yet implemented for containers.",

--- a/pyccel/stdlib/STC_Extensions/Managed_memory.h
+++ b/pyccel/stdlib/STC_Extensions/Managed_memory.h
@@ -65,5 +65,6 @@ STC_INLINE _m_value _c_MEMB(_release)(Self self) {
     return out;
 }
 
+#undef _i_is_arc
 #include <stc/priv/linkage2.h>
 #include <stc/priv/template2.h>

--- a/pyccel/stdlib/STC_Extensions/Managed_memory.h
+++ b/pyccel/stdlib/STC_Extensions/Managed_memory.h
@@ -1,4 +1,3 @@
-
 #include <stc/priv/linkage.h>
 
 #ifndef PYCCEL_MANAGED_MEM_H_INCLUDED
@@ -44,6 +43,10 @@ STC_INLINE Self _c_MEMB(_from_ptr)(_m_value* ptr) {
 
 STC_INLINE Self _c_MEMB(_clone)(const Self self) {
     return _c_MEMB(_from_ptr)(self.get);
+}
+
+STC_INLINE Self _c_MEMB(_steal)(const Self self) {
+    return self;
 }
 
 STC_INLINE void _c_MEMB(_drop)(const Self* self) {


### PR DESCRIPTION
The file `Managed_memory.h` defined the macro `i_is_arc` which affects STC's internals but it forgot to undefine this macro at the end of the file. This is easy to fix but the errant `i_is_arc` in the program lead to multi-level containers stealing references as they did not create copy methods. This is the desired behaviour as we write our code in such a way that the initialiser is passed a Managed_memory object with the correct ownership. However undefining the macro meant that we retrieved the default behaviour where `_clone` is called for class arguments of containers. This PR therefore additionally defines a `_steal` method which is used by containers to steal references to arguments. It is then the responsibility of the printer to ensure that the reference count is accurate.