### PR TITLE
Fix bug when inlining a call to a function with no return, via a dotted function call

### DIFF
--- a/.dict_custom.txt
+++ b/.dict_custom.txt
@@ -130,3 +130,4 @@ pythonic
 pre
 LLVM
 linter
+inlining

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 -   #2306 : Fix Python containers as arguments to interface functions.
 -   #2407 : Fix bad memory handling for multi-level containers.
+-   #2408 : Fix bug when inlining a call to a function with no return, via a dotted function call.
 
 ### Changed
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3356,6 +3356,7 @@ class SemanticParser(BasicParser):
                             func  = func.clone(new_name)
                     pyccel_stage.set_stage('syntactic')
                     syntactic_call = FunctionCall(func, args)
+                    syntactic_call.set_current_user_node(expr.current_user_node)
                     pyccel_stage.set_stage('semantic')
                     if first.__module__.startswith('pyccel.'):
                         self.insert_import(first.name, AsName(func, func.name), _get_name(lhs))
@@ -5148,6 +5149,7 @@ class SemanticParser(BasicParser):
         if assign:
             return body
         else:
+            assert expr.results
             self._additional_exprs[-1].append(body)
             return self._visit(lhs)
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3360,6 +3360,9 @@ class SemanticParser(BasicParser):
                     if len(current_user_nodes) == 1:
                         syntactic_call.set_current_user_node(current_user_nodes[0])
                     else:
+                        # If the DottedName has multiple users look for the relevant Assign
+                        # This happens if an Assign node was created to handle the expression
+                        # E.g. when the statement is found in a Return node.
                         syntactic_call.set_current_user_node(next(u for u in current_user_nodes if isinstance(u, Assign)))
                     pyccel_stage.set_stage('semantic')
                     if first.__module__.startswith('pyccel.'):

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3356,7 +3356,11 @@ class SemanticParser(BasicParser):
                             func  = func.clone(new_name)
                     pyccel_stage.set_stage('syntactic')
                     syntactic_call = FunctionCall(func, args)
-                    syntactic_call.set_current_user_node(expr.current_user_node)
+                    current_user_nodes = expr.get_all_user_nodes()
+                    if len(current_user_nodes) == 1:
+                        syntactic_call.set_current_user_node(current_user_nodes[0])
+                    else:
+                        syntactic_call.set_current_user_node(next(u for u in current_user_nodes if isinstance(u, Assign)))
                     pyccel_stage.set_stage('semantic')
                     if first.__module__.startswith('pyccel.'):
                         self.insert_import(first.name, AsName(func, func.name), _get_name(lhs))

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -920,13 +920,9 @@ class SyntaxParser(BasicParser):
             is_inline = True
 
 
-        argument_annotations = [a.annotation for a in arguments]
         result_annotation = self._treat_type_annotation(stmt, self._visit(stmt.returns))
 
         argument_names = {a.var.name for a in arguments}
-        # Repack AnnotatedPyccelSymbols to insert argument_annotations from headers or types decorators
-        arguments = [FunctionDefArgument(AnnotatedPyccelSymbol(a.var.name, annot), annotation=annot, value=a.value, kwonly=a.is_kwonly)
-                           for a, annot in zip(arguments, argument_annotations)]
 
         body = stmt.body
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1401,9 +1401,11 @@ class SyntaxParser(BasicParser):
         return_expr = Return(self._visit(stmt.body))
         return_expr.set_current_ast(stmt)
 
+        results = FunctionDefResult(self.scope.get_new_name())
+
         self.exit_function_scope()
 
-        return InlineFunctionDef(name, args, CodeBlock([return_expr]), scope = scope)
+        return InlineFunctionDef(name, args, CodeBlock([return_expr]), results, scope = scope)
 
     def _visit_withitem(self, stmt):
         # stmt.optional_vars

--- a/tests/pyccel/scripts/runtest_decorators_inline.py
+++ b/tests/pyccel/scripts/runtest_decorators_inline.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 import numpy as np
 from decorators_inline import power_4, get_powers, f, sin_base_1, fill_pi, positron_charge
+import decorators_inline
 
 def g(s : int):
     return f(s)/3
@@ -14,3 +15,12 @@ if __name__ == '__main__':
     fill_pi(arr)
     print(arr)
     print(positron_charge())
+
+    print(decorators_inline.get_powers(5))
+    print(decorators_inline.power_4(5))
+    print(decorators_inline.f(4))
+    print(decorators_inline.sin_base_1(0.25))
+    arr = np.empty(4)
+    decorators_inline.fill_pi(arr)
+    print(arr)
+    print(decorators_inline.positron_charge())


### PR DESCRIPTION
The method `_visit_InlineFunctionCall` assumes that a `FunctionCall` is either in an `Assign` node due to the anonymous assign nodes created here:
https://github.com/pyccel/pyccel/blob/55adae9a4c0ae39f75392b16cc5be34d815bef83/pyccel/parser/syntactic.py#L489-L495

or is in a statement (e.g. `f() + 3`). In the second case the function must return something. This means that `_visit_InlineFunctionCall` assumes that the function always returns something if there is no assign node.

This assumption is violated in the case of a dotted function call as the code creates a temporary node for the function call here:
https://github.com/pyccel/pyccel/blob/6e00555d2b3d3a5fc06ec248579bb88f027de018/pyccel/parser/semantic.py#L3358
This node has no parents and is therefore not found in an `Assign` node. The easy fix for this problem is to add the missing parent. Fixes #2408 

**Commit Summary**
- Add "inlining" to dictionary
- Ensure `FunctionCall` has user nodes
- Remove dead code in syntactic stage which leads to annotations having multiple user nodes
- Add missing `FunctionDefResult` variable to `InlineFunctionDef` created to represent a lambda function.
- Add tests for bug