### PR TITLE
Remove dead code

### DIFF
--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -86,7 +86,6 @@ __all__ = (
     'Return',
     'SeparatorComment',
     'StarredArguments',
-    'SympyFunction',
     'While',
     'With',
 )
@@ -3095,12 +3094,6 @@ class FunctionAddress(FunctionDef):
         kwargs['is_optional'] = self.is_optional
         kwargs['memory_handling'] = self.memory_handling
         return args, kwargs
-
-class SympyFunction(FunctionDef):
-
-    """Represents a function definition."""
-    __slots__ = ()
-
 
 
 class ClassDef(ScopedAstNode):

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -21,12 +21,6 @@ __all__ = (
 )
 
 
-def sympy(f):
-    return f
-
-def bypass(f):
-    return f
-
 def pure(f):
     return f
 

--- a/pyccel/decorators.py
+++ b/pyccel/decorators.py
@@ -10,13 +10,11 @@ import warnings
 
 __all__ = (
     'allow_negative_index',
-    'bypass',
     'elemental',
     'inline',
     'private',
     'pure',
     'stack_array',
-    'sympy',
     'types',
 )
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -18,7 +18,6 @@ import warnings
 from pyccel.version import __version__
 
 from pyccel.ast.core import FunctionDef, Interface, FunctionAddress
-from pyccel.ast.core import SympyFunction
 from pyccel.ast.core import Import, AsName
 
 from pyccel.ast.variable import DottedName
@@ -338,36 +337,23 @@ class BasicParser(object):
 
         Parameters
         ----------
-        func : FunctionDef | SympyFunction | Interface | FunctionAddress
+        func : FunctionDef | Interface | FunctionAddress
             The function to be inserted into the scope.
 
         scope : Scope, optional
             The scope where the function should be inserted.
         """
 
-        if isinstance(func, SympyFunction):
-            self.insert_symbolic_function(func)
-        elif isinstance(func, (FunctionDef, Interface, FunctionAddress)):
-            scope = scope or self.scope
-            container = scope.functions
-            if func.pyccel_staging == 'syntactic':
-                container[self.scope.get_expected_name(func.name)] = func
-            else:
-                name = func.name
-                container[name] = func
-                if self._current_function_name and name == self._current_function_name[-1]:
-                    self._current_function.append(func)
+        assert isinstance(func, (FunctionDef, Interface, FunctionAddress)):
+        scope = scope or self.scope
+        container = scope.functions
+        if func.pyccel_staging == 'syntactic':
+            container[self.scope.get_expected_name(func.name)] = func
         else:
-            raise TypeError('Expected a Function definition')
-
-    def insert_symbolic_function(self, func):
-        """."""
-
-        container = self.scope.symbolic_functions
-        if isinstance(func, SympyFunction):
-            container[func.name] = func
-        else:
-            raise TypeError('Expected a symbolic_function')
+            name = func.name
+            container[name] = func
+            if self._current_function_name and name == self._current_function_name[-1]:
+                self._current_function.append(func)
 
     def exit_function_scope(self):
         """

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -344,7 +344,7 @@ class BasicParser(object):
             The scope where the function should be inserted.
         """
 
-        assert isinstance(func, (FunctionDef, Interface, FunctionAddress)):
+        assert isinstance(func, (FunctionDef, Interface, FunctionAddress))
         scope = scope or self.scope
         container = scope.functions
         if func.pyccel_staging == 'syntactic':

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -65,7 +65,7 @@ class Scope(object):
             '_dummy_counter','_original_symbol', '_dotted_symbols')
 
     categories = ('functions','variables','classes',
-            'imports','symbolic_functions', 'symbolic_aliases',
+            'imports', 'symbolic_aliases',
             'decorators', 'cls_constructs')
 
     def __init__(self, *, name=None, decorators = (), is_loop = False,
@@ -194,12 +194,6 @@ class Scope(object):
         to a constant object. E.g. a symbol which represents a type.
         """
         return self._locals['symbolic_aliases']
-
-    @property
-    def symbolic_functions(self):
-        """ A dictionary of symbolic functions defined in this scope
-        """
-        return self._locals['symbolic_functions']
 
     def find(self, name, category = None, local_only = False, raise_if_missing = False):
         """

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3567,9 +3567,6 @@ class SemanticParser(BasicParser):
                             for a in func_args]
             args      = self._sort_function_call_args(func_args, args)
 
-        if name == 'lambdify':
-            args = self.scope.find(str(expr.args[0]), 'symbolic_functions')
-
         if self.scope.find(name, 'cls_constructs'):
 
             # TODO improve the test

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -23,7 +23,6 @@ from pyccel.ast.core import AugAssign
 from pyccel.ast.core import Return
 from pyccel.ast.core import Pass
 from pyccel.ast.core import FunctionDef, InlineFunctionDef
-from pyccel.ast.core import SympyFunction
 from pyccel.ast.core import ClassDef
 from pyccel.ast.core import For
 from pyccel.ast.core import If, IfSection
@@ -925,17 +924,7 @@ class SyntaxParser(BasicParser):
         argument_names = {a.var.name for a in arguments}
 
         body = stmt.body
-
-        if 'sympy' in decorators:
-            # TODO maybe we should run pylint here
-            stmt.decorators.pop()
-            func = SympyFunction(name, arguments, [], [str(stmt)])
-            func.set_current_ast(stmt)
-            self.insert_function(func)
-            return EmptyNode()
-
-        else:
-            body = self._visit(body)
+        body = self._visit(body)
 
         # Collect docstring
         if len(body) > 0 and isinstance(body[0], CommentBlock):


### PR DESCRIPTION
Remove unused undocumented decorators:
- `sympy`
- `bypass`

Remove code associated with the `sympy` decorator. This code populates `SympyFunction` objects which then remain unused. The class is therefore removed along with the code that creates these objects.