### PR TITLE
Document and uniformise scope keys

### DIFF
--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1570,7 +1570,7 @@ class CToPythonWrapper(Wrapper):
         function = PyFunctionDef(func_name, func_args, body, func_results, scope=func_scope,
                 docstring = expr.docstring, original_function = original_func)
 
-        self.scope.functions[func_name] = function
+        self.scope.insert_function(function, func_name)
         self._python_object_map[expr] = function
 
         if 'property' in original_func.decorators:

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -252,7 +252,7 @@ class FortranToCWrapper(Wrapper):
         func = BindCFunctionDef(name, func_arguments, body, FunctionDefResult(func_results), scope=func_scope, original_function = expr,
                 docstring = expr.docstring, result_pointer_map = expr.result_pointer_map)
 
-        self.scope.functions[name] = func
+        self.scope.insert_function(func, name)
 
         return func
 

--- a/pyccel/parser/base.py
+++ b/pyccel/parser/base.py
@@ -346,12 +346,11 @@ class BasicParser(object):
 
         assert isinstance(func, (FunctionDef, Interface, FunctionAddress))
         scope = scope or self.scope
-        container = scope.functions
         if func.pyccel_staging == 'syntactic':
-            container[self.scope.get_expected_name(func.name)] = func
+            scope.insert_function(func, self.scope.get_expected_name(func.name))
         else:
             name = func.name
-            container[name] = func
+            scope.insert_function(func, name)
             if self._current_function_name and name == self._current_function_name[-1]:
                 self._current_function.append(func)
 

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -164,7 +164,7 @@ class Scope(object):
     def functions(self):
         """ A dictionary of functions defined in this scope
         """
-        return self._locals['functions']
+        return ReadOnlyDict(self._locals['functions'])
 
     @property
     def decorators(self):
@@ -458,6 +458,21 @@ class Scope(object):
         name = class_type.name
         assert name in self._used_symbols
         self._locals['cls_constructs'][name] = class_type
+
+    def insert_function(self, func, name):
+        """
+        Add a function to the scope.
+
+        Add a function to the scope. The key will be the low-level name of the
+        function. This should be changed before merging this PR.
+
+        Parameters
+        ----------
+        func : FunctionDef
+            The function to be inserted.
+        """
+        assert name in self._original_symbol
+        self._locals['functions'][name] = func
 
     def insert_symbol(self, symbol):
         """

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -177,7 +177,7 @@ class Scope(object):
         """ A dictionary of datatypes for the classes defined in
         this scope
         """
-        return self._locals['cls_constructs']
+        return ReadOnlyDict(self._locals['cls_constructs'])
 
     @property
     def sons_scopes(self):
@@ -448,6 +448,22 @@ class Scope(object):
             if not name_found:
                 raise RuntimeError('Class not found in scope')
             self._locals['classes'][name] = cls
+
+    def insert_cls_construct(self, class_type):
+        """
+        Add a class construct to the scope.
+
+        Add a class construct to the scope. A class construct is a type inheriting from
+        PyccelType which describes the type of a class.
+
+        Parameters
+        ----------
+        class_type : PyccelType
+            The construct to be inserted.
+        """
+        name = class_type.name
+        assert name in self._used_symbols
+        self._locals['cls_constructs'][name] = class_type
 
     def insert_symbol(self, symbol):
         """

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -370,6 +370,26 @@ class Scope(object):
         else:
             raise RuntimeError("Variable not found in scope")
 
+    def inline_variable_definition(self, var_value, name):
+        """
+        Add the definition of a variable inline.
+
+        Add an object to the variables dictionary. This object will
+        be returned when the variable is collected but may not be
+        itself a variable. This is important when translating inlined
+        functions. To ensure that when searching for the variables
+        representing the arguments, the value is used directly.
+
+        Parameters
+        ----------
+        var_value : TypedAstNode
+            The value of the variable.
+        name : str
+            The name of the variable.
+        """
+        self._locals['variables'][name] = var_value
+        self._used_symbols[name] = name
+
     def insert_class(self, cls, name = None):
         """
         Add a class to the current scope.

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -158,7 +158,7 @@ class Scope(object):
     def classes(self):
         """ A dictionary of classes defined in this scope
         """
-        return self._locals['classes']
+        return ReadOnlyDict(self._locals['classes'])
 
     @property
     def functions(self):

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -194,7 +194,7 @@ class Scope(object):
         A symbolic alias is a symbol declared in the scope which is mapped
         to a constant object. E.g. a symbol which represents a type.
         """
-        return self._locals['symbolic_aliases']
+        return ReadOnlyDict(self._locals['symbolic_aliases'])
 
     @property
     def symbolic_functions(self):

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -437,6 +437,8 @@ class Scope(object):
             raise TypeError('class must be of type ClassDef')
 
         name = cls.name
+        if cls.pyccel_staging != 'syntactic':
+            name = self.get_python_name(name)
 
         name_found = name in self._locals['classes']
 

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -19,6 +19,7 @@ from pyccel.errors.errors import Errors
 from pyccel.naming.pythonnameclashchecker import PythonNameClashChecker
 
 from pyccel.utilities.strings import create_incremented_string
+from pyccel.utilities.tools import ReadOnlyDict
 
 errors = Errors()
 
@@ -151,7 +152,7 @@ class Scope(object):
     def variables(self):
         """ A dictionary of variables defined in this scope
         """
-        return self._locals['variables']
+        return ReadOnlyDict(self._locals['variables'])
 
     @property
     def classes(self):

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -170,7 +170,7 @@ class Scope(object):
     def decorators(self):
         """Dictionary of Pyccel decorators which may be
         applied to a function definition in this scope."""
-        return self._locals['decorators']
+        return ReadOnlyDict(self._locals['decorators'])
 
     @property
     def cls_constructs(self):

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -404,17 +404,18 @@ class Scope(object):
 
         name : str, optional
             The name under which the classes should be indexed in the scope.
-            This defaults to the name of the class.
+            This defaults to the name of the class in Python.
         """
         if not isinstance(cls, ClassDef):
             raise TypeError('class must be of type ClassDef')
 
-        if name is None:
-            name = cls.name
-
         if self.is_loop:
-            self.parent_scope.insert_class(cls)
+            self.parent_scope.insert_class(cls, name)
         else:
+            if name is None:
+                name = cls.name
+                if cls.pyccel_staging != 'syntactic':
+                    name = self.get_python_name(name)
             if name in self._locals['classes']:
                 raise RuntimeError(f"A class with name '{name}' already exists in the scope")
             self._locals['classes'][name] = cls

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5080,8 +5080,7 @@ class SemanticParser(BasicParser):
                 # Otherwise the symbol used for the function arguments should be mapped
                 # to the call argument
                 func_a_name = replace_map.get(func_a, func_a)
-                self.scope.variables[func_a_name] = call_a
-                self.scope.local_used_symbols[func_a_name] = func_a_name
+                self.scope.inline_variable_definition(call_a, func_a_name)
 
         # Map local keyword call arguments to function arguments
         nargs = len(positional_call_args)
@@ -5097,8 +5096,7 @@ class SemanticParser(BasicParser):
                 # Otherwise the symbol used for the function arguments should be mapped
                 # to the call argument
                 used_func_a_name = replace_map.get(func_a_name, func_a_name)
-                self.scope.variables[used_func_a_name] = call_a
-                self.scope.local_used_symbols[func_a_name] = func_a_name
+                self.scope.inline_variable_definition(call_a, used_func_a_name)
 
         to_replace = list(replace_map.keys())
         local_var = list(replace_map.values())

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -5210,7 +5210,7 @@ class SemanticParser(BasicParser):
         #  create a new Datatype for the current class
         dtype = DataTypeFactory(name)()
         typenames_to_dtypes[name] = dtype
-        self.scope.cls_constructs[name] = dtype
+        self.scope.insert_cls_construct(dtype)
 
         parent = self._find_superclasses(expr)
 

--- a/pyccel/utilities/tools.py
+++ b/pyccel/utilities/tools.py
@@ -1,0 +1,22 @@
+#------------------------------------------------------------------------------------------#
+# This file is part of Pyccel which is released under MIT License. See the LICENSE file or #
+# go to https://github.com/pyccel/pyccel/blob/devel/LICENSE for full license details.      #
+#------------------------------------------------------------------------------------------#
+"""
+File containing basic tools.
+"""
+
+__all__ = (
+        'ReadOnlyDict',
+        )
+
+class ReadOnlyDict(dict):
+    """
+    A read-only version of a dictionary.
+
+    A read-only version of a dictionary. This is useful to prevent objects
+    being used in a way which was not intended.
+    """
+    def __setitem__(self, key, value):
+        raise TypeError("Can't modify read-only dictionary")
+        return super().__setitem__(key, value)


### PR DESCRIPTION
It is not immediately apparent whether the keys for the dictionaries in the scope are names of the Python objects or names of the low-level objects. As a result it is easy to make mistakes when handling objects that have been renamed (as seen in #2410). This PR aims to improve this situation by giving `Scope` complete control over its contents. Objects are always inserted using an `insert_X` function which chooses the appropriate name (Python or low-level). A class `ReadOnlyDict` is introduced to prevent bypassing these `insert_X` methods.