### PR TITLE
Incorporate type modifiers into typing system

### DIFF
--- a/pyccel/ast/builtin_methods/dict_methods.py
+++ b/pyccel/ast/builtin_methods/dict_methods.py
@@ -141,7 +141,7 @@ class DictPopitem(DictMethod):
 
     def __init__(self, dict_obj):
         dict_type = dict_obj.class_type
-        self._class_type = InhomogeneousTupleType(dict_type.key_type, dict_type.value_type)
+        self._class_type = InhomogeneousTupleType.get_new(dict_type.key_type, dict_type.value_type)
         super().__init__(dict_obj)
 
     def __iter__(self):

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -594,7 +594,7 @@ class PythonTuple(TypedAstNode):
         if pyccel_stage == 'syntactic':
             return
         elif len(args) == 0:
-            self._class_type = HomogeneousTupleType(GenericType())
+            self._class_type = HomogeneousTupleType.get_new(GenericType())
             self._shape = (LiteralInteger(0),)
             self._is_homogeneous = False
             return
@@ -608,7 +608,7 @@ class PythonTuple(TypedAstNode):
         self._shape = (LiteralInteger(len(args)),)
 
         if any(isinstance(d, SymbolicType) for d in unique_element_types):
-            self._class_type = InhomogeneousTupleType(*[a.class_type for a in args])
+            self._class_type = InhomogeneousTupleType.get_new(*[a.class_type for a in args])
             self._is_homogeneous = False
             return
 
@@ -628,12 +628,12 @@ class PythonTuple(TypedAstNode):
         self._is_homogeneous = is_homogeneous
         if is_homogeneous:
             if contains_pointers:
-                self._class_type = InhomogeneousTupleType(*element_types)
+                self._class_type = InhomogeneousTupleType.get_new(*element_types)
             else:
-                self._class_type = HomogeneousTupleType(unique_element_types.popitem()[1])
+                self._class_type = HomogeneousTupleType.get_new(unique_element_types.popitem()[1])
 
         else:
-            self._class_type = InhomogeneousTupleType(*[a.class_type for a in args])
+            self._class_type = InhomogeneousTupleType.get_new(*[a.class_type for a in args])
 
         assert self._class_type.shape_is_compatible(self._shape)
 
@@ -769,7 +769,7 @@ class PythonList(TypedAstNode):
             return
         elif len(args) == 0:
             self._shape = (LiteralInteger(0),)
-            self._class_type = HomogeneousListType(GenericType())
+            self._class_type = HomogeneousListType.get_new(GenericType())
             return
         arg0 = args[0]
         is_homogeneous = arg0.class_type is not GenericType() and \
@@ -783,7 +783,7 @@ class PythonList(TypedAstNode):
         else:
             raise TypeError("Can't create an inhomogeneous list")
 
-        self._class_type = HomogeneousListType(dtype)
+        self._class_type = HomogeneousListType.get_new(dtype)
 
     def __iter__(self):
         return self._args.__iter__()
@@ -884,7 +884,7 @@ class PythonSet(TypedAstNode):
             return
         elif len(args) == 0:
             self._shape = (LiteralInteger(0),)
-            self._class_type = HomogeneousSetType(GenericType())
+            self._class_type = HomogeneousSetType.get_new(GenericType())
             return
 
         arg0 = args[0]
@@ -899,7 +899,7 @@ class PythonSet(TypedAstNode):
         else:
             raise TypeError("Can't create an inhomogeneous set")
 
-        self._class_type = HomogeneousSetType(elem_type)
+        self._class_type = HomogeneousSetType.get_new(elem_type)
 
     def __iter__(self):
         return self._args.__iter__()
@@ -987,7 +987,7 @@ class PythonDict(PyccelFunction):
             raise TypeError("Unpacking values in a dictionary is not yet supported.")
         elif len(keys) == 0:
             self._shape = (LiteralInteger(0),)
-            self._class_type = DictType(GenericType(), GenericType())
+            self._class_type = DictType.get_new(GenericType(), GenericType())
             return
 
         key0 = keys[0]
@@ -998,7 +998,7 @@ class PythonDict(PyccelFunction):
                            all(val0.class_type == v.class_type for v in values[1:])
 
         if homogeneous_keys and homogeneous_vals:
-            self._class_type = DictType(key0.class_type, val0.class_type)
+            self._class_type = DictType.get_new(key0.class_type, val0.class_type)
 
             self._shape = (LiteralInteger(len(keys)), )
         else:
@@ -1354,7 +1354,7 @@ class PythonZip(Iterable):
                 self._length = min(lengths)
             else:
                 self._length = PythonMin(*[PythonLen(a) for a in self.args])
-            self._class_type = InhomogeneousTupleType(*[a.class_type for a in args])
+            self._class_type = InhomogeneousTupleType.get_new(*[a.class_type for a in args])
         super().__init__(1)
 
     @property

--- a/pyccel/ast/c_concepts.py
+++ b/pyccel/ast/c_concepts.py
@@ -6,8 +6,9 @@
 """
 Module representing concepts that are only applicable to C code (e.g. ObjectAddress).
 """
+from functools import cache
 
-from pyccel.utilities.metaclasses import ArgumentSingleton
+from pyccel.utilities.metaclasses import Singleton
 from .basic     import TypedAstNode, PyccelAstNode
 from .datatypes import HomogeneousContainerType, FixedSizeType, FixedSizeNumericType, PrimitiveIntegerType
 from .datatypes import CharType
@@ -37,7 +38,7 @@ class CNativeInt(FixedSizeNumericType):
 
 #------------------------------------------------------------------------------
 
-class CStackArray(HomogeneousContainerType, metaclass=ArgumentSingleton):
+class CStackArray(HomogeneousContainerType, metaclass=Singleton):
     """
     A data type representing an array allocated on the stack.
 
@@ -54,10 +55,14 @@ class CStackArray(HomogeneousContainerType, metaclass=ArgumentSingleton):
     _container_rank = 1
     _order = None
 
-    def __init__(self, element_type):
-        assert isinstance(element_type, FixedSizeType)
-        self._element_type = element_type
-        super().__init__()
+    @classmethod
+    @cache
+    def get_new(cls, element_type):
+        def __init__(self):
+            self._element_type = element_type
+            HomogeneousContainerType.__init__(self)
+        return type(f'CStackArray{type(element_type).__name__}', (CStackArray,),
+                    {'__init__' : __init__})()
 
 #------------------------------------------------------------------------------
 class ObjectAddress(TypedAstNode):

--- a/pyccel/ast/cmathext.py
+++ b/pyccel/ast/cmathext.py
@@ -434,7 +434,7 @@ class CmathPolar(PyccelFunction):
     __slots__ = ()
     name = 'polar'
     _shape = (LiteralInteger(2),)
-    _class_type = HomogeneousTupleType(PythonNativeFloat())
+    _class_type = HomogeneousTupleType.get_new(PythonNativeFloat())
 
     def __init__(self, z):
         super().__init__(z)

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -17,7 +17,7 @@ from .bitwise_operators import PyccelBitOr, PyccelBitAnd, PyccelLShift, PyccelRS
 
 from .builtins  import PythonBool, PythonTuple
 
-from .datatypes import (PyccelType, CustomDataType,
+from .datatypes import (PyccelType, CustomDataType, FinalType,
                         PythonNativeBool, InhomogeneousTupleType, SymbolicType)
 
 from .internals import PyccelSymbol, PyccelFunction, Iterable
@@ -1550,7 +1550,7 @@ class FunctionDefArgument(TypedAstNode):
         if pyccel_stage != "syntactic":
             if isinstance(self.var, Variable):
                 self._inout = (self.var.rank > 0 or isinstance(self.var.class_type, CustomDataType)) \
-                        and not self.var.is_const
+                        and not isinstance(self.var.class_type, FinalType)
             else:
                 # If var is not a Variable it is a FunctionAddress
                 self._inout = False

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -215,10 +215,13 @@ class FinalType:
             return type_class.__hash__(underlying_type)
         def __eq__(self, other):
             return type_class.__eq__(underlying_type, other)
+        def get_underlying_type(self):
+            return self._underlying_type
         return type(f'Final{type_class.__name__}', (FinalType, type_class,),
                     {'__init__' : __init__,
                      '__hash__' : __hash__,
-                     '__eq__' : __eq__})()
+                     '__eq__' : __eq__,
+                     'underlying_type': property(get_underlying_type)})()
 
     def __str__(self):
         return f'Final[{self._underlying_type}]'

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -668,12 +668,6 @@ class HomogeneousContainerType(ContainerType):
         """
         return self._order # pylint: disable=no-member
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.element_type == other.element_type
-
-    def __hash__(self):
-        return hash((self.__class__, self.element_type))
-
 class StringType(ContainerType, metaclass = Singleton):
     """
     Class representing Python's native string type.
@@ -800,6 +794,12 @@ class HomogeneousTupleType(HomogeneousContainerType, TupleType, metaclass = Sing
         # TODO: Remove this specialisation if tuples are saved in lists instead of ndarrays
         return isinstance(shape, tuple) and len(shape) == self.rank
 
+    def __eq__(self, other):
+        return isinstance(other, HomogeneousTupleType) and self.element_type == other.element_type
+
+    def __hash__(self):
+        return hash((HomogeneousTupleType, self.element_type))
+
 class HomogeneousListType(HomogeneousContainerType, metaclass = Singleton):
     """
     Class representing the homogeneous list type.
@@ -828,11 +828,11 @@ class HomogeneousListType(HomogeneousContainerType, metaclass = Singleton):
                     {'__init__' : __init__})()
 
     def __eq__(self, other):
-        return isinstance(other, self.__class__) and self._element_type == other._element_type \
+        return isinstance(other, HomogeneousListType) and self._element_type == other._element_type \
                 and self._order == other._order
 
     def __hash__(self):
-        return hash((self.__class__, self._element_type, self._order))
+        return hash((HomogeneousListType, self._element_type, self._order))
 
 class HomogeneousSetType(HomogeneousContainerType, metaclass = Singleton):
     """
@@ -862,10 +862,10 @@ class HomogeneousSetType(HomogeneousContainerType, metaclass = Singleton):
                     {'__init__' : __init__})()
 
     def __eq__(self, other):
-        return isinstance(other, self.__class__) and self._element_type == other._element_type
+        return isinstance(other, HomogeneousSetType) and self._element_type == other._element_type
 
     def __hash__(self):
-        return hash((self.__class__, self._element_type))
+        return hash((HomogeneousSetType, self._element_type))
 
 #==============================================================================
 
@@ -1130,11 +1130,11 @@ class DictType(ContainerType, metaclass = Singleton):
         return None
 
     def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.key_type == other.key_type \
+        return isinstance(other, DictType) and self.key_type == other.key_type \
                 and self.value_type == other.value_type
 
     def __hash__(self):
-        return hash((self.__class__, self._key_type, self._value_type))
+        return hash((DictType, self._key_type, self._value_type))
 
 #==============================================================================
 

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -116,7 +116,7 @@ pyarray_to_ndarray = FunctionDef(
                 name      = 'pyarray_to_ndarray',
                 body      = [],
                 arguments = [FunctionDefArgument(Variable(PyccelPyObject(), 'a', memory_handling = 'alias'))],
-                results   = FunctionDefResult(Variable(NumpyNDArrayType(GenericType(), 1, None), 'array')))
+                results   = FunctionDefResult(Variable(NumpyNDArrayType.get_new(GenericType(), 1, None), 'array')))
 
 numpy_to_stc_strides = FunctionDef(
                 name      = 'numpy_to_stc_strides',

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -99,12 +99,12 @@ PyArray_BASE = FunctionDef(name = 'PyArray_BASE',
 PyArray_SHAPE = FunctionDef(name = 'PyArray_SHAPE',
                             body = [],
                             arguments = [FunctionDefArgument(Variable(PyccelPyArrayObject(), name = 'o', memory_handling='alias'))],
-                            results   = FunctionDefResult(Variable(CStackArray(NumpyInt32Type()), name='s', memory_handling='alias')))
+                            results   = FunctionDefResult(Variable(CStackArray.get_new(NumpyInt32Type()), name='s', memory_handling='alias')))
 
 PyArray_STRIDES = FunctionDef(name = 'PyArray_STRIDES',
                             body = [],
                             arguments = [FunctionDefArgument(Variable(PyccelPyArrayObject(), name = 'o', memory_handling='alias'))],
-                            results   = FunctionDefResult(Variable(CStackArray(NumpyInt32Type()), name='s', memory_handling='alias')))
+                            results   = FunctionDefResult(Variable(CStackArray.get_new(NumpyInt32Type()), name='s', memory_handling='alias')))
 
 PyArray_ITEMSIZE = FunctionDef(name = 'PyArray_ITEMSIZE',
                             body = [],
@@ -122,7 +122,7 @@ numpy_to_stc_strides = FunctionDef(
                 name      = 'numpy_to_stc_strides',
                 arguments = [FunctionDefArgument(Variable(PyccelPyArrayObject(), name = 'o', memory_handling='alias'))],
                 body      = [],
-                results   = FunctionDefResult(Variable(CStackArray(NumpyInt32Type()), 'strides')))
+                results   = FunctionDefResult(Variable(CStackArray.get_new(NumpyInt32Type()), 'strides')))
 
 # NumPy array check elements : function definition in pyccel/stdlib/cwrapper/cwrapper_ndarrays.c
 pyarray_check = FunctionDef(
@@ -154,8 +154,8 @@ get_strides_and_shape_from_numpy_array = FunctionDef(
         name = 'get_strides_and_shape_from_numpy_array',
         arguments = [
             FunctionDefArgument(Variable(PyccelPyObject(), 'arr', memory_handling='alias')),
-            FunctionDefArgument(Variable(CStackArray(NumpyInt64Type()), 'shape', memory_handling='alias')),
-            FunctionDefArgument(Variable(CStackArray(NumpyInt64Type()), 'strides', memory_handling='alias'))
+            FunctionDefArgument(Variable(CStackArray.get_new(NumpyInt64Type()), 'shape', memory_handling='alias')),
+            FunctionDefArgument(Variable(CStackArray.get_new(NumpyInt64Type()), 'strides', memory_handling='alias'))
             ],
         body = [])
 
@@ -175,7 +175,7 @@ to_pyarray = FunctionDef(name = 'to_pyarray',
                          arguments = [FunctionDefArgument(Variable(CNativeInt(), name = 'nd')),
                                       FunctionDefArgument(Variable(CNativeInt(), name = 'typenum')),
                                       FunctionDefArgument(Variable(VoidType(), name = 'data', memory_handling='alias')),
-                                      FunctionDefArgument(Variable(CStackArray(NumpyInt64Type()), 'shape')),
+                                      FunctionDefArgument(Variable(CStackArray.get_new(NumpyInt64Type()), 'shape')),
                                       FunctionDefArgument(Variable(PythonNativeBool(), 'c_order')),
                                       FunctionDefArgument(Variable(PythonNativeBool(), 'release_memory'))],
                          results = FunctionDefResult(Variable(PyccelPyObject(), name = 'arr', memory_handling='alias'))

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -243,7 +243,7 @@ class NumpyFloat(PythonFloat):
         self._shape = arg.shape
         rank  = arg.rank
         order = arg.order
-        self._class_type = NumpyNDArrayType(self.static_type(), rank, order) if rank else self.static_type()
+        self._class_type = NumpyNDArrayType.get_new(self.static_type(), rank, order)
         super().__init__(arg)
 
     @property
@@ -304,7 +304,7 @@ class NumpyBool(PythonBool):
         self._shape = arg.shape
         rank  = arg.rank
         order = arg.order
-        self._class_type = NumpyNDArrayType(self.static_type(), rank, order) if rank else self.static_type()
+        self._class_type = NumpyNDArrayType.get_new(self.static_type(), rank, order)
         super().__init__(arg)
 
     @property
@@ -343,7 +343,7 @@ class NumpyInt(PythonInt):
         self._shape = arg.shape
         rank  = arg.rank
         order = arg.order
-        self._class_type = NumpyNDArrayType(self.static_type(), rank, order) if rank else self.static_type()
+        self._class_type = NumpyNDArrayType.get_new(self.static_type(), rank, order)
         super().__init__(arg)
 
     @property
@@ -446,8 +446,8 @@ class NumpyReal(PythonReal):
         super().__init__(arg)
         rank  = arg.rank
         order = arg.order
-        dtype = arg.dtype.element_type
-        self._class_type = NumpyNDArrayType(dtype, rank, order) if rank else dtype
+        dtype = process_dtype(arg.dtype.element_type)
+        self._class_type = NumpyNDArrayType.get_new(dtype, rank, order)
         self._shape = process_shape(self.rank == 0, self.internal_var.shape)
 
     @property
@@ -489,8 +489,8 @@ class NumpyImag(PythonImag):
         super().__init__(arg)
         rank  = arg.rank
         order = arg.order
-        dtype = arg.dtype.element_type
-        self._class_type = NumpyNDArrayType(dtype, rank, order) if rank else dtype
+        dtype = process_dtype(arg.dtype.element_type)
+        self._class_type = NumpyNDArrayType.get_new(dtype, rank, order)
         self._shape = process_shape(self.rank == 0, self.internal_var.shape)
 
     @property
@@ -527,7 +527,7 @@ class NumpyComplex(PythonComplex):
         self._shape = arg0.shape
         rank  = arg0.rank
         order = arg0.order
-        self._class_type = NumpyNDArrayType(self.static_type(), rank, order) if rank else self.static_type()
+        self._class_type = NumpyNDArrayType.get_new(self.static_type(), rank, order)
         super().__init__(arg0)
 
     @property
@@ -795,7 +795,7 @@ class NumpyArray(NumpyNewArray):
 
         self._arg   = arg
         self._shape = shape
-        super().__init__(class_type = NumpyNDArrayType(dtype, rank, order), init_dtype = init_dtype)
+        super().__init__(class_type = NumpyNDArrayType.get_new(dtype, rank, order), init_dtype = init_dtype)
 
     def __str__(self):
         return str(self.arg)
@@ -853,7 +853,7 @@ class NumpyArange(NumpyNewArray):
         self._shape = (MathCeil(PyccelDiv(PyccelMinus(self._stop, self._start), self._step)))
         self._shape = process_shape(False, self._shape)
         dtype = process_dtype(dtype)
-        super().__init__(class_type = NumpyNDArrayType(dtype, 1, None), init_dtype = init_dtype)
+        super().__init__(class_type = NumpyNDArrayType.get_new(dtype, 1, None), init_dtype = init_dtype)
 
     @property
     def arg(self):
@@ -994,7 +994,7 @@ class NumpyMatmul(PyccelFunction):
         else:
             order = None if rank < 2 else 'C'
 
-        self._class_type = NumpyNDArrayType(dtype, rank, order) if rank else dtype
+        self._class_type = NumpyNDArrayType.get_new(dtype, rank, order)
 
     @property
     def a(self):
@@ -1117,7 +1117,7 @@ class NumpyLinspace(NumpyNewArray):
         else:
             self._step = PyccelDiv(PyccelMinus(self.stop, self.start), PyccelMinus(self.num, PythonInt(self.endpoint)))
 
-        class_type = NumpyNDArrayType(final_dtype, rank, order)
+        class_type = NumpyNDArrayType.get_new(final_dtype, rank, order)
 
         super().__init__(class_type = class_type, init_dtype = init_dtype)
 
@@ -1212,7 +1212,7 @@ class NumpyWhere(PyccelFunction):
         self._shape = process_shape(False, shape)
         rank  = len(shape)
         order = None if rank < 2 else 'C'
-        self._class_type = NumpyNDArrayType(process_dtype(type_info.dtype), rank, order)
+        self._class_type = NumpyNDArrayType.get_new(process_dtype(type_info.dtype), rank, order)
         super().__init__(condition, x, y)
 
     @property
@@ -1260,7 +1260,7 @@ class NumpyRand(PyccelFunction):
             self._class_type = PythonNativeFloat()
         else:
             order = None if rank < 2 else 'C'
-            self._class_type = NumpyNDArrayType(NumpyFloat64Type(), rank, order)
+            self._class_type = NumpyNDArrayType.get_new(NumpyFloat64Type(), rank, order)
 
 #==============================================================================
 class NumpyRandint(PyccelFunction):
@@ -1298,7 +1298,7 @@ class NumpyRandint(PyccelFunction):
         else:
             rank = len(self.shape)
             order = None if rank < 2 else 'C'
-            self._class_type = NumpyNDArrayType(NumpyInt64Type(), rank, order)
+            self._class_type = NumpyNDArrayType.get_new(NumpyInt64Type(), rank, order)
         self._rand    = NumpyRand() if size is None else NumpyRand(*size)
         self._low     = low
         self._high    = high
@@ -1369,7 +1369,7 @@ class NumpyFull(NumpyNewArray):
         rank  = len(self._shape)
         order = NumpyNewArray._process_order(rank, order)
 
-        class_type = NumpyNDArrayType(dtype, rank, order)
+        class_type = NumpyNDArrayType.get_new(dtype, rank, order)
 
         super().__init__(fill_value, class_type = class_type, init_dtype = init_dtype)
 
@@ -1694,7 +1694,7 @@ class NumpyNorm(PyccelFunction):
             self._shape = tuple(sh)
             rank = len(self._shape)
             order = None if rank < 2 else arg.order
-            self._class_type = NumpyNDArrayType(dtype, rank, order) if rank else dtype
+            self._class_type = NumpyNDArrayType.get_new(dtype, rank, order)
         else:
             self._shape = None
             self._class_type = dtype
@@ -1765,7 +1765,7 @@ class NumpyUfuncUnary(NumpyUfuncBase):
         dtype = self._get_dtype(x)
         self._shape, rank = self._get_shape_rank(x)
         order = self._get_order(x, rank)
-        self._class_type = NumpyNDArrayType(dtype, rank, order) if rank else dtype
+        self._class_type = NumpyNDArrayType.get_new(dtype, rank, order)
         super().__init__(x)
 
     def _get_shape_rank(self, x):
@@ -1866,7 +1866,7 @@ class NumpyUfuncBinary(NumpyUfuncBase):
         dtype = self._get_dtype(x1, x2)
         self._shape, rank = self._get_shape_rank(x1, x2)
         order = self._get_order(x1, x2, rank)
-        self._class_type = NumpyNDArrayType(dtype, rank, order) if rank else dtype
+        self._class_type = NumpyNDArrayType.get_new(dtype, rank, order)
 
     def _get_shape_rank(self, x1, x2):
         """
@@ -2424,7 +2424,7 @@ class NumpyConjugate(PythonConjugate):
         order = arg.order
         rank  = arg.rank
         self._shape = process_shape(rank == 0, arg.shape)
-        self._class_type = NumpyNDArrayType(arg.dtype, rank, order) if rank else arg.dtype
+        self._class_type = NumpyNDArrayType.get_new(arg.dtype, rank, order)
 
     @property
     def is_elemental(self):
@@ -2456,7 +2456,7 @@ class NumpyNonZeroElement(NumpyNewArray):
         self._dim = dim
 
         self._shape = (NumpyCountNonZero(a),)
-        super().__init__(a, class_type = NumpyNDArrayType(NumpyInt64Type(), 1, None))
+        super().__init__(a, class_type = NumpyNDArrayType.get_new(NumpyInt64Type(), 1, None))
 
     @property
     def array(self):
@@ -2491,7 +2491,7 @@ class NumpyNonZero(PyccelFunction):
     __slots__ = ('_elements','_arr','_shape')
     _attribute_nodes = ('_elements',)
     name = 'nonzero'
-    _class_type = HomogeneousTupleType.get_new(NumpyNDArrayType(NumpyInt64Type(), 1, None))
+    _class_type = HomogeneousTupleType.get_new(NumpyNDArrayType.get_new(NumpyInt64Type(), 1, None))
 
     def __init__(self, a):
         if (a.rank > 1):
@@ -2554,7 +2554,7 @@ class NumpyCountNonZero(PyccelFunction):
                 self._shape = tuple(shape)
             else:
                 self._shape = (LiteralInteger(1),)*rank
-            self._class_type = NumpyNDArrayType(dtype, rank, order)
+            self._class_type = NumpyNDArrayType.get_new(dtype, rank, order)
         else:
             if axis is not None:
                 dtype = NumpyInt64Type()
@@ -2563,7 +2563,7 @@ class NumpyCountNonZero(PyccelFunction):
                 self._shape = tuple(shape)
                 rank  = a.rank-1
                 order = a.order
-                self._class_type = NumpyNDArrayType(dtype, rank, order)
+                self._class_type = NumpyNDArrayType.get_new(dtype, rank, order)
             else:
                 self._shape = None
                 self._class_type = PythonNativeInt()

--- a/pyccel/ast/numpyext.py
+++ b/pyccel/ast/numpyext.py
@@ -2491,7 +2491,7 @@ class NumpyNonZero(PyccelFunction):
     __slots__ = ('_elements','_arr','_shape')
     _attribute_nodes = ('_elements',)
     name = 'nonzero'
-    _class_type = HomogeneousTupleType(NumpyNDArrayType(NumpyInt64Type(), 1, None))
+    _class_type = HomogeneousTupleType.get_new(NumpyNDArrayType(NumpyInt64Type(), 1, None))
 
     def __init__(self, a):
         if (a.rank > 1):

--- a/pyccel/ast/numpytypes.py
+++ b/pyccel/ast/numpytypes.py
@@ -16,7 +16,7 @@ from pyccel.utilities.stage   import PyccelStage
 
 from .datatypes import FixedSizeNumericType, HomogeneousContainerType, PythonNativeBool
 from .datatypes import PrimitiveBooleanType, PrimitiveIntegerType, PrimitiveFloatingPointType, PrimitiveComplexType
-from .datatypes import GenericType
+from .datatypes import GenericType, CharType
 from .datatypes import pyccel_type_to_original_type, original_type_to_pyccel_type
 
 __all__ = (
@@ -282,7 +282,7 @@ class NumpyNDArrayType(HomogeneousContainerType, metaclass = Singleton):
         assert isinstance(rank, int)
         assert order in (None, 'C', 'F')
         assert rank < 2 or order is not None
-        assert isinstance(dtype, (NumpyNumericType, PythonNativeBool, GenericType))
+        assert isinstance(dtype, (NumpyNumericType, PythonNativeBool, GenericType, CharType))
 
         if rank == 0:
             return dtype

--- a/pyccel/ast/type_annotations.py
+++ b/pyccel/ast/type_annotations.py
@@ -16,7 +16,7 @@ from .bitwise_operators import PyccelBitOr
 from .core import FunctionDefArgument, FunctionDefResult
 
 from .datatypes import PythonNativeBool, PythonNativeInt, PythonNativeFloat, PythonNativeComplex
-from .datatypes import VoidType, GenericType, StringType, PyccelType
+from .datatypes import VoidType, GenericType, StringType, PyccelType, FinalType
 
 from .variable import DottedName, AnnotatedPyccelSymbol, IndexedElement
 
@@ -43,15 +43,11 @@ class VariableTypeAnnotation(PyccelAstNode):
     ----------
     class_type : PyccelType
         The requested Python type of the variable.
-
-    is_const : bool, default=False
-        True if the variable cannot be modified, false otherwise.
     """
-    __slots__ = ('_class_type', '_is_const')
+    __slots__ = ('_class_type',)
     _attribute_nodes = ()
-    def __init__(self, class_type : PyccelType, is_const : bool = False):
+    def __init__(self, class_type : PyccelType):
         self._class_type = class_type
-        self._is_const = is_const
 
         super().__init__()
 
@@ -75,22 +71,6 @@ class VariableTypeAnnotation(PyccelAstNode):
         this is equal to 0.
         """
         return self.class_type.rank
-
-    @property
-    def is_const(self):
-        """
-        Indicates whether the object will remain constant.
-
-        Returns a boolean which is false if the value of the object can be
-        modified, and true otherwise.
-        """
-        return self._is_const
-
-    @is_const.setter
-    def is_const(self, val):
-        if not isinstance(val, bool):
-            raise TypeError("Is const value should be a boolean")
-        self._is_const = val
 
     def __hash__(self):
         return hash(self.class_type)

--- a/pyccel/ast/typingext.py
+++ b/pyccel/ast/typingext.py
@@ -9,7 +9,7 @@
 
 from .basic     import TypedAstNode
 from .core      import Module, PyccelFunctionDef
-from .datatypes import TypeAlias, GenericType
+from .datatypes import TypeAlias, GenericType, FinalType
 
 __all__ = (
     'TypingAny',
@@ -37,6 +37,7 @@ class TypingFinal(TypedAstNode):
     __slots__ = ('_arg',)
     _attribute_nodes = ('_arg',)
     name = 'Final'
+    _static_type = FinalType()
 
     def __init__(self, arg):
         self._arg = arg

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -55,9 +55,6 @@ class Variable(TypedAstNode):
         'stack' if memory should be allocated on the stack, represents stack arrays and scalars.
         'alias' if object allows access to memory stored in another variable.
 
-    is_const : bool, default: False
-        Indicates if object is a const argument of a function.
-
     is_target : bool, default: False
         Indicates if object is pointed to by another variable.
 
@@ -97,7 +94,7 @@ class Variable(TypedAstNode):
     >>> Variable(PythonNativeInt(), DottedName('matrix', 'n_rows'))
     matrix.n_rows
     """
-    __slots__ = ('_name', '_alloc_shape', '_memory_handling', '_is_const', '_is_target',
+    __slots__ = ('_name', '_alloc_shape', '_memory_handling', '_is_target',
             '_is_optional', '_allows_negative_indexes', '_cls_base', '_is_argument', '_is_temp',
             '_shape','_is_private','_class_type')
     _attribute_nodes = ()
@@ -108,7 +105,6 @@ class Variable(TypedAstNode):
         name,
         *,
         memory_handling='stack',
-        is_const=False,
         is_target=False,
         is_optional=False,
         is_private=False,
@@ -138,10 +134,6 @@ class Variable(TypedAstNode):
         if memory_handling not in ('heap', 'stack', 'alias'):
             raise ValueError("memory_handling must be 'heap', 'stack' or 'alias'")
         self._memory_handling = memory_handling
-
-        if not isinstance(is_const, bool):
-            raise TypeError('is_const must be a boolean.')
-        self._is_const = is_const
 
         if not isinstance(is_target, bool):
             raise TypeError('is_target must be a boolean.')
@@ -325,16 +317,6 @@ class Variable(TypedAstNode):
         """ Class from which the Variable inherits
         """
         return self._cls_base
-
-    @property
-    def is_const(self):
-        """
-        Indicates whether the Variable is constant within its context.
-
-        Indicates whether the Variable is constant within its context.
-        True if the Variable is constant, false if it can be modified.
-        """
-        return self._is_const
 
     @property
     def is_temp(self):
@@ -799,16 +781,6 @@ class IndexedElement(TypedAstNode):
             return IndexedElement(base, *new_indexes)
         else:
             return IndexedElement(self, *args)
-
-    @property
-    def is_const(self):
-        """
-        Indicates whether the Variable is constant within its context.
-
-        Indicates whether the Variable is constant within its context.
-        True if the Variable is constant, false if it can be modified.
-        """
-        return self.base.is_const
 
     @property
     def allows_negative_indexes(self):

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -15,6 +15,7 @@ from pyccel.ast.core       import Import, Module, Declare
 from pyccel.ast.cwrapper   import PyBuildValueNode, PyCapsule_New, PyCapsule_Import, PyModule_Create
 from pyccel.ast.cwrapper   import Py_None, WrapperCustomDataType, Py_ssize_t
 from pyccel.ast.cwrapper   import PyccelPyObject, PyccelPyTypeObject, PyTuple_Pack
+from pyccel.ast.datatypes  import FinalType
 from pyccel.ast.literals   import LiteralString, Nil, LiteralInteger
 from pyccel.ast.numpy_wrapper import PyccelPyArrayObject
 from pyccel.ast.c_concepts import ObjectAddress
@@ -156,13 +157,13 @@ class CWrapperCodePrinter(CCodePrinter):
         CCodePrinter.get_declare_type : The extended function.
         """
         if expr.dtype is BindCPointer():
-            if expr.is_const:
+            if isinstance(expr.class_type, FinalType):
                 return 'const void*'
             else:
                 return 'void*'
         if expr.dtype is Py_ssize_t():
             dtype =  'Py_ssize_t*' if self.is_c_pointer(expr) else 'Py_ssize_t'
-            if expr.is_const:
+            if isinstance(expr.class_type, FinalType):
                 return f'const {dtype}'
             else:
                 return dtype

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -45,7 +45,7 @@ from pyccel.ast.datatypes import PrimitiveBooleanType, PrimitiveIntegerType, Pri
 from pyccel.ast.datatypes import PrimitiveCharacterType
 from pyccel.ast.datatypes import SymbolicType, StringType, FixedSizeNumericType, HomogeneousContainerType
 from pyccel.ast.datatypes import HomogeneousTupleType, HomogeneousListType, HomogeneousSetType, DictType
-from pyccel.ast.datatypes import PythonNativeInt, PythonNativeBool, FixedSizeType
+from pyccel.ast.datatypes import PythonNativeInt, PythonNativeBool, FixedSizeType, FinalType
 from pyccel.ast.datatypes import CustomDataType, InhomogeneousTupleType, TupleType
 from pyccel.ast.datatypes import pyccel_type_to_original_type, PyccelType
 
@@ -1907,7 +1907,7 @@ class FCodePrinter(CodePrinter):
         dtype           = var.dtype
         rank            = var.rank
         shape           = var.alloc_shape
-        is_const        = var.is_const
+        is_const        = isinstance(expr_type, FinalType)
         is_optional     = var.is_optional
         is_private      = var.is_private
         is_alias        = var.is_alias and not isinstance(dtype, BindCPointer)

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -223,9 +223,6 @@ class PythonCodePrinter(CodePrinter):
                 return self._get_type_annotation(obj.var)
         elif isinstance(obj, Variable):
             type_annotation = self._print(obj.class_type)
-            if obj.is_const and not isinstance(obj.class_type, FixedSizeNumericType):
-                self.add_import(Import('typing', [AsName(TypingFinal, 'Final')]))
-                type_annotation = f'Final[{type_annotation}]'
             return f"'{type_annotation}'"
         elif isinstance(obj, FunctionAddress):
             args = ', '.join(self._get_type_annotation(a).strip("'") for a in obj.arguments)
@@ -1610,11 +1607,7 @@ class PythonCodePrinter(CodePrinter):
         return f"({results})({args})"
 
     def _print_VariableTypeAnnotation(self, expr):
-        dtype = self._print(expr.class_type)
-        if expr.is_const:
-            self.add_import(Import('typing', [AsName(TypingFinal, 'Final')]))
-            dtype = f'Final[{dtype}]'
-        return dtype
+        return self._print(expr.class_type)
 
     def _print_TypingFinal(self, expr):
         annotation = self._print(expr.arg)

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -51,6 +51,7 @@ from pyccel.ast.internals     import Slice
 from pyccel.ast.literals      import Nil, LiteralTrue, LiteralString, LiteralInteger
 from pyccel.ast.literals      import LiteralFalse, convert_to_literal
 from pyccel.ast.numpytypes    import NumpyNDArrayType, NumpyInt64Type, NumpyInt32Type
+from pyccel.ast.numpytypes    import numpy_precision_map
 from pyccel.ast.numpy_wrapper import PyArray_DATA
 from pyccel.ast.numpy_wrapper import get_strides_and_shape_from_numpy_array
 from pyccel.ast.numpy_wrapper import pyarray_to_ndarray, PyArray_SetBaseObject, import_array
@@ -2509,7 +2510,8 @@ class CToPythonWrapper(Wrapper):
         if is_bind_c_argument:
             element_type = orig_var.class_type.element_type
             #raise errors.report("Fortran set interface is not yet implemented", severity='fatal', symbol=orig_var)
-            arr_var = Variable(NumpyNDArrayType.get_new(element_type, 1, None), self.scope.get_expected_name(orig_var.name),
+            numpy_dtype = numpy_precision_map[(element_type.primitive_type, element_type.precision)]
+            arr_var = Variable(NumpyNDArrayType.get_new(numpy_dtype, 1, None), self.scope.get_expected_name(orig_var.name),
                                 shape = (size_var,), memory_handling = 'heap')
             self.scope.insert_variable(arr_var, orig_var.name)
             arg_var = Variable(BindCArrayType.get_new(1, False), self.scope.get_new_name(orig_var.name),
@@ -2588,9 +2590,10 @@ class CToPythonWrapper(Wrapper):
 
         if is_bind_c_argument:
             element_type = orig_var.class_type.element_type
-            #raise errors.report("Fortran set interface is not yet implemented", severity='fatal', symbol=orig_var)
-            arr_var = Variable(NumpyNDArrayType.get_new(element_type, 1, None), self.scope.get_expected_name(orig_var.name),
-                                shape = (size_var,), memory_handling = 'heap')
+            numpy_dtype = numpy_precision_map[(element_type.primitive_type, element_type.precision)]
+            arr_var = Variable(NumpyNDArrayType.get_new(numpy_dtype, 1, None),
+                               self.scope.get_expected_name(orig_var.name),
+                               shape = (size_var,), memory_handling = 'heap')
             self.scope.insert_variable(arr_var, orig_var.name)
             arg_var = Variable(BindCArrayType.get_new(1, False), self.scope.get_new_name(orig_var.name),
                         shape = (LiteralInteger(2),))

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -2358,7 +2358,7 @@ class CToPythonWrapper(Wrapper):
 
         if is_bind_c_argument:
             rank = orig_var.rank
-            arg_var = Variable(BindCArrayType(rank, True), self.scope.get_new_name(orig_var.name),
+            arg_var = Variable(BindCArrayType.get_new(rank, True), self.scope.get_new_name(orig_var.name),
                         shape = (LiteralInteger(rank*2+1),))
             self.scope.insert_symbolic_alias(IndexedElement(arg_var, LiteralInteger(0)), ObjectAddress(parts['data']))
             for i,s in enumerate(shape):
@@ -2451,7 +2451,7 @@ class CToPythonWrapper(Wrapper):
             data_var = Variable(CStackArray(orig_var.class_type.element_type), self.scope.get_new_name(orig_var.name + '_data'),
                                 memory_handling='alias')
             self.scope.insert_variable(data_var)
-            arg_var = Variable(BindCArrayType(1, False), self.scope.get_new_name(orig_var.name),
+            arg_var = Variable(BindCArrayType.get_new(1, False), self.scope.get_new_name(orig_var.name),
                         shape = (LiteralInteger(2),))
             self.scope.insert_symbolic_alias(IndexedElement(arg_var, LiteralInteger(0)), ObjectAddress(data_var))
             self.scope.insert_symbolic_alias(IndexedElement(arg_var, LiteralInteger(1)), size_var)
@@ -2506,7 +2506,7 @@ class CToPythonWrapper(Wrapper):
             arr_var = Variable(NumpyNDArrayType(element_type, 1, None), self.scope.get_expected_name(orig_var.name),
                                 shape = (size_var,), memory_handling = 'heap')
             self.scope.insert_variable(arr_var, orig_var.name)
-            arg_var = Variable(BindCArrayType(1, False), self.scope.get_new_name(orig_var.name),
+            arg_var = Variable(BindCArrayType.get_new(1, False), self.scope.get_new_name(orig_var.name),
                         shape = (LiteralInteger(2),))
             data = DottedVariable(VoidType(), 'data', lhs=arr_var)
             self.scope.insert_symbolic_alias(IndexedElement(arg_var, LiteralInteger(0)), data)
@@ -2583,7 +2583,7 @@ class CToPythonWrapper(Wrapper):
             arr_var = Variable(NumpyNDArrayType(element_type, 1, None), self.scope.get_expected_name(orig_var.name),
                                 shape = (size_var,), memory_handling = 'heap')
             self.scope.insert_variable(arr_var, orig_var.name)
-            arg_var = Variable(BindCArrayType(1, False), self.scope.get_new_name(orig_var.name),
+            arg_var = Variable(BindCArrayType.get_new(1, False), self.scope.get_new_name(orig_var.name),
                         shape = (LiteralInteger(2),))
             data = DottedVariable(VoidType(), 'data', lhs=arr_var)
             self.scope.insert_symbolic_alias(IndexedElement(arg_var, LiteralInteger(0)), data)
@@ -2685,7 +2685,7 @@ class CToPythonWrapper(Wrapper):
                 data_var = Variable(CStackArray(CharType()), self.scope.get_expected_name(orig_var.name),
                                     shape = (None,), memory_handling='alias', is_const = True)
                 size_var = Variable(PythonNativeInt(), self.scope.get_new_name(f'{data_var.name}_size'))
-                arg_var = Variable(BindCArrayType(1, False), self.scope.get_new_name(orig_var.name),
+                arg_var = Variable(BindCArrayType.get_new(1, False), self.scope.get_new_name(orig_var.name),
                                     shape = (LiteralInteger(2),))
                 self.scope.insert_variable(data_var, orig_var.name)
                 self.scope.insert_variable(size_var)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -41,7 +41,7 @@ from pyccel.ast.core import StarredArguments
 from pyccel.ast.core import CodeBlock
 from pyccel.ast.core import IndexedElement
 
-from pyccel.ast.datatypes import TypeAlias
+from pyccel.ast.datatypes import TypeAlias, FinalType
 
 from pyccel.ast.bitwise_operators import PyccelRShift, PyccelLShift, PyccelBitXor, PyccelBitOr, PyccelBitAnd, PyccelInvert
 from pyccel.ast.operators import PyccelPow, PyccelAdd, PyccelMul, PyccelDiv, PyccelMod, PyccelFloorDiv
@@ -1439,7 +1439,7 @@ class SyntaxParser(BasicParser):
         name = self._visit(stmt.name)
         self._in_lhs_assign = False
         rhs = self._treat_type_annotation(stmt.value, self._visit(stmt.value))
-        type_annotation = UnionTypeAnnotation(VariableTypeAnnotation(TypeAlias(), is_const = True))
+        type_annotation = UnionTypeAnnotation(VariableTypeAnnotation(FinalType.get_new(TypeAlias())))
         return Assign(AnnotatedPyccelSymbol(name, annotation=type_annotation), rhs)
 
 #==============================================================================

--- a/pyccel/utilities/metaclasses.py
+++ b/pyccel/utilities/metaclasses.py
@@ -37,7 +37,7 @@ class ArgumentSingleton(type):
 
     def __call__(cls, *args, **kwargs):
         index = (*args, *sorted(kwargs.items()))
-        existing_instance = cls._instances.get(index, None)
+        existing_instance = next((i for i in cls._instances if i is index), None)
         if existing_instance is None:
             new_instance = super().__call__(*args, **kwargs)
             cls._instances[index] = new_instance

--- a/tests/pyccel/scripts/runtest_stub.pyi
+++ b/tests/pyccel/scripts/runtest_stub.pyi
@@ -1,9 +1,9 @@
 from typing import Final, TypeVar
-from typing import Final, TypeVar, overload
+from typing import TypeVar, overload
 from numpy import float64
 
 T = TypeVar('T', 'int', 'float', 'complex')
-S = TypeVar('S', 'Final[int]', 'Final[float]', 'Final[complex]')
+S = TypeVar('S', 'int', 'float', 'complex')
 
 
 class A:
@@ -25,7 +25,7 @@ def f(a : 'int', b : 'float64[:]') -> 'tuple[int, float64]':
 def g() -> 'float':
     ...
 
-def h(arg : 'Final[list[int]]') -> None:
+def h(arg : 'list[int]') -> None:
     ...
 
 @overload
@@ -55,7 +55,7 @@ def l(a : 'complex') -> 'tuple[complex, ...]':
 def m(b : 'int') -> 'int':
     ...
 
-def n(arg : 'Final[list[int]]') -> None:
+def n(arg : 'list[int]') -> None:
     ...
 
 @overload


### PR DESCRIPTION
Some type information does not directly represent a type but simply how an object of this type behaves in certain circumstances. This is notably the case for `Final` and `Optional`. Currently this information is stored in the `Variable` class however this is not really sufficient (particularly for `Optional`) as printing of other objects may need this information (e.g. `dict.get` should be printed differently if `None` can be returned).

Incorporating this information into the datatype is therefore necessary for `Optional` but this is non-trivial as the code often relies on statements like `isinstance(dtype, NativeIntegerType)` which should return true if dtype is `Optional[NativeIntegerType]`. Many other changes are required to make `Optional` work as a general concept so in order to break up the work `Final` is first incorporated into the typing system to work as a prototype. `Optional` will then be implemented following this pattern.

In order to ensure that `isinstance(final_native_integer_type_obj, NativeIntegerType)` returns true, `FinalNativeIntegerType` must inherit from `NativeIntegerType`. In order for `FinalListNativeIntegerType` to follow a similar pattern and to know how to initialise itself it is simpler for all datatypes to be singletons. Previously things like `HomogeneousListType` were `ArgumentSingleton`s meaning that there was 1 instance for each possible argument type. In order to create a singleton with the correct inheritance a new class method `get_new` is added to build the necessary type on the fly. `@cache` is used to ensure we don't have multiple types representing the same concept.