### PR TITLE
Fix shape/stride calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 -   #2424 : Fix `isinstance` call testing class instance.
 -   #2248 : Fix wrapper bug when returning an instance of a class from the method of a preceding class.
 -   #2413 : Fix late name conflict detection bug.
+-   #2440 : Fix incorrect handling of shapes and strides of Fortran-order multi-dimensional array that is C contiguous.
 
 ### Changed
 

--- a/pyccel/ast/numpy_wrapper.py
+++ b/pyccel/ast/numpy_wrapper.py
@@ -155,7 +155,8 @@ get_strides_and_shape_from_numpy_array = FunctionDef(
         arguments = [
             FunctionDefArgument(Variable(PyccelPyObject(), 'arr', memory_handling='alias')),
             FunctionDefArgument(Variable(CStackArray(NumpyInt64Type()), 'shape', memory_handling='alias')),
-            FunctionDefArgument(Variable(CStackArray(NumpyInt64Type()), 'strides', memory_handling='alias'))
+            FunctionDefArgument(Variable(CStackArray(NumpyInt64Type()), 'strides', memory_handling='alias')),
+            FunctionDefArgument(Variable(PythonNativeBool(), 'c_order'))
             ],
         body = [])
 

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1145,7 +1145,8 @@ class CToPythonWrapper(Wrapper):
 
         get_data = AliasAssign(data_var, PyArray_DATA(ObjectAddress(pyarray_collect_arg)))
         get_strides_and_shape = get_strides_and_shape_from_numpy_array(
-                                        ObjectAddress(collect_arg), shape_var, stride_var)
+                                        ObjectAddress(collect_arg), shape_var, stride_var,
+                                        convert_to_literal(orig_var.order != 'F'))
 
         body = [get_data, get_strides_and_shape]
 

--- a/pyccel/stdlib/cwrapper/cwrapper.c
+++ b/pyccel/stdlib/cwrapper/cwrapper.c
@@ -137,7 +137,7 @@ PyObject	*Float_to_NumpyDouble(float *d)
  * Functions : Numpy array handling functions
  */
 
-void get_strides_and_shape_from_numpy_array(PyObject* arr, int64_t shape[], int64_t strides[])
+void get_strides_and_shape_from_numpy_array(PyObject* arr, int64_t shape[], int64_t strides[], bool c_order)
 {
     PyArrayObject* a = (PyArrayObject*)(arr);
     int nd = PyArray_NDIM(a);
@@ -155,7 +155,7 @@ void get_strides_and_shape_from_numpy_array(PyObject* arr, int64_t shape[], int6
         npy_intp current_stride = PyArray_ITEMSIZE(a);
         npy_intp* np_strides = PyArray_STRIDES(a);
         npy_intp* np_shape = PyArray_SHAPE(a);
-        if (PyArray_CHKFLAGS(a, NPY_ARRAY_C_CONTIGUOUS)) {
+        if (c_order) {
             for (int i = nd-1; i >= 0; --i) {
                 shape[i] = np_shape[i];
                 strides[i] = np_strides[i] / current_stride;

--- a/pyccel/stdlib/cwrapper/cwrapper.h
+++ b/pyccel/stdlib/cwrapper/cwrapper.h
@@ -231,6 +231,6 @@ bool	is_numpy_array(PyObject *o, int dtype, int rank, int flag, bool allow_empty
 /*
  * Functions : Numpy array handling functions
  */
-void get_strides_and_shape_from_numpy_array(PyObject* arr, int64_t shape[], int64_t strides[]);
+void get_strides_and_shape_from_numpy_array(PyObject* arr, int64_t shape[], int64_t strides[], bool c_order);
 
 #endif


### PR DESCRIPTION
Fix incorrect handling of shapes and strides of Fortran-order multi-dimensional array that is C contiguous. Fixes #2440 