### PR TITLE
Improve Windows installation and fix CI

### DIFF
--- a/.dict_custom.txt
+++ b/.dict_custom.txt
@@ -134,3 +134,5 @@ inlining
 inlined
 discoverable
 MinGW
+Makefile
+Makefiles

--- a/.dict_custom.txt
+++ b/.dict_custom.txt
@@ -133,3 +133,4 @@ linter
 inlining
 inlined
 discoverable
+MinGW

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -121,4 +121,6 @@ runs:
         $GFORTRAN_EXE=((Get-Command gfortran).Path -replace '\\', '/')
         echo "CC=$GCC_EXE" >> $env:GITHUB_ENV
         echo "FC=$GFORTRAN_EXE" >> $env:GITHUB_ENV
+        echo "CC=$GCC_EXE"
+        echo "FC=$GFORTRAN_EXE"
       shell: powershell

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -55,6 +55,8 @@ runs:
         cd lapack-3.12.1
         $GCC_EXE=((Get-Command gcc).Path -replace '\\', '/')
         $GFORTRAN_EXE=((Get-Command gfortran).Path -replace '\\', '/')
+        echo "CC=$GCC_EXE" >> $env:GITHUB_ENV
+        echo "FC=$GFORTRAN_EXE" >> $env:GITHUB_ENV
         cmake  -G "MinGW Makefiles" -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="$GCC_EXE" -D CMAKE_Fortran_COMPILER="$GFORTRAN_EXE" -D BUILD_SHARED_LIBS=ON -B build -S .
         cmake --build build -j 4 --target install
         ls ${Env:MINGW_DIR}/lib

--- a/.github/actions/windows_install/action.yml
+++ b/.github/actions/windows_install/action.yml
@@ -55,8 +55,6 @@ runs:
         cd lapack-3.12.1
         $GCC_EXE=((Get-Command gcc).Path -replace '\\', '/')
         $GFORTRAN_EXE=((Get-Command gfortran).Path -replace '\\', '/')
-        echo "CC=$GCC_EXE" >> $env:GITHUB_ENV
-        echo "FC=$GFORTRAN_EXE" >> $env:GITHUB_ENV
         cmake  -G "MinGW Makefiles" -D CMAKE_INSTALL_PREFIX="${Env:MINGW_DIR}" -D CMAKE_C_COMPILER="$GCC_EXE" -D CMAKE_Fortran_COMPILER="$GFORTRAN_EXE" -D BUILD_SHARED_LIBS=ON -B build -S .
         cmake --build build -j 4 --target install
         ls ${Env:MINGW_DIR}/lib
@@ -116,4 +114,11 @@ runs:
         dlltool -d msmpi.def -l libmsmpi.a -D msmpi.dll
         popd
         echo "MS MPI set up for use"
+      shell: powershell
+    - name: Add CC and FC to environment
+      run: |
+        $GCC_EXE=((Get-Command gcc).Path -replace '\\', '/')
+        $GFORTRAN_EXE=((Get-Command gfortran).Path -replace '\\', '/')
+        echo "CC=$GCC_EXE" >> $env:GITHUB_ENV
+        echo "FC=$GFORTRAN_EXE" >> $env:GITHUB_ENV
       shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
         if: steps.duplicate_check.outputs.should_skip != 'true'
         run: |
             python -m pip install --upgrade pip
-            python -m pip install .[test]
+            python -m pip install .[test] --verbose
         shell: bash
       - name: Fortran/C tests with pytest
         if: steps.duplicate_check.outputs.should_skip != 'true'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,7 +87,7 @@ jobs:
         if: steps.duplicate_check.outputs.should_skip != 'true'
         run: |
             python -m pip install --upgrade pip
-            python -m pip install .[test] --verbose
+            python -m pip install .[test]
         shell: bash
       - name: Fortran/C tests with pytest
         if: steps.duplicate_check.outputs.should_skip != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 -   #2414 : Ensure printing of imports from Fortran intrinsic libraries is done in a reproducible way (by sorting).
 -   Install STC to use it as a library instead of selectively compiling.
 -   #2450 : Use `type(ClassName)` rather than `class(ClassName)` whenever possible for improved performance.
+-   #2451 : Use MinGW Makefiles to install gFTL on Windows when using a MinGW Fortran compiler.
 -   \[INTERNALS\] Rename `SetMethod.set_variable` -> `SetMethod.set_obj` as this object is not necessarily a `Variable`.
 -   \[INTERNALS\] Rename `accelerators` variables and arguments to more accurate `extra_compilation_tools` where appropriate.
 -   \[INTERNALS\] Interface functions are no longer stored in `Module.functions`.

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 import shutil
 import subprocess
-import sys
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -52,7 +52,8 @@ class CustomBuildHook(BuildHookInterface):
         shutil.rmtree(gFTL_folder / 'install', ignore_errors = True)
         cmake_cmd = [shutil.which('cmake'), '-S', str(gFTL_folder), '-B', str(gFTL_folder / 'build'),
                         f'-DCMAKE_INSTALL_PREFIX={gFTL_folder / "install"}']
-        if sys.platform == 'win32':
+        gfortran = shutil.which('gfortran')
+        if 'mingw64' in gfortran:
             cmake_cmd.extend(('-G', '"MinGW Makefiles"'))
         subprocess.run(cmake_cmd, cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--build', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -54,7 +54,7 @@ class CustomBuildHook(BuildHookInterface):
                         f'-DCMAKE_INSTALL_PREFIX={gFTL_folder / "install"}']
         gfortran = shutil.which('gfortran')
         if 'mingw64' in gfortran:
-            cmake_cmd.extend(('-G', '"MinGW Makefiles"'))
+            cmake_cmd.extend(('-G', 'MinGW Makefiles'))
         subprocess.run(cmake_cmd, cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--build', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--install', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 

--- a/install_scripts/hook.py
+++ b/install_scripts/hook.py
@@ -49,8 +49,11 @@ class CustomBuildHook(BuildHookInterface):
                 raise RuntimeError("Trying to build in an isolated environment but submodules are not available. Please call 'git submodule update --init'") from e
         shutil.rmtree(gFTL_folder / 'build', ignore_errors = True)
         shutil.rmtree(gFTL_folder / 'install', ignore_errors = True)
-        subprocess.run([shutil.which('cmake'), '-S', str(gFTL_folder), '-B', str(gFTL_folder / 'build'),
-                        f'-DCMAKE_INSTALL_PREFIX={gFTL_folder / "install"}'], cwd = gFTL_folder, check=True)
+        cmake_cmd = [shutil.which('cmake'), '-S', str(gFTL_folder), '-B', str(gFTL_folder / 'build'),
+                        f'-DCMAKE_INSTALL_PREFIX={gFTL_folder / "install"}']
+        if sys.platform == 'win32':
+            cmake_cmd.extend(('-G', '"MinGW Makefiles"'))
+        subprocess.run(cmake_cmd, cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--build', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
         subprocess.run([shutil.which('cmake'), '--install', str(gFTL_folder / 'build')], cwd = gFTL_folder, check=True)
 

--- a/tests/epyccel/test_epyccel_openmp.py
+++ b/tests/epyccel/test_epyccel_openmp.py
@@ -487,6 +487,7 @@ def test_omp_sections(language):
     f2 = openmp.omp_sections
     assert f1() == f2()
 
+@pytest.mark.skipif(sys.platform == 'win32', reason="Type mismatch warning is an error on Windows")
 @pytest.mark.external
 def test_omp_get_set_schedule(language):
     set_num_threads = epyccel(openmp.set_num_threads, flags = '-Wall', openmp=True, language=language)

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -766,7 +766,7 @@ def test_c_arrays(language):
 def test_arrays_view(language):
     types = [int] * 10 + [int] * 10 + [int] * 4 + [int] * 4 + [int] * 10 + \
             [int] * 6 + [int] * 10 + [int] * 10 + [int] * 25 + [int] * 60
-    if platform.system() == 'Darwin' and language=='fortran':
+    if platform.system() in ('Darwin', 'Windows') and language=='fortran':
         # MacOS compiler incorrectly reports
         # Fortran runtime error: Index '4378074096' of dimension 2 of array 'a' outside of expected range (0:2)
         # At line 208 of file /Users/runner/work/pyccel/pyccel/tests/pyccel/scripts/__pyccel__/arrays_view.f90

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -1250,6 +1250,7 @@ def test_module_name_containing_conflict(language):
     assert out1 == out2
 
 #------------------------------------------------------------------------------
+@pytest.mark.skipif(sys.platform == 'win32' and not np.__version__.startswith('2.'), reason="Integer mismatch with numpy 1.*")
 def test_stubs(language):
     """
     This tests that a stub file is generated and ensures the stub files are


### PR DESCRIPTION
Use MinGW Makefiles to install gFTL on Windows when using a MinGW Fortran compiler to avoid CMake sticking during installation.

Skip problematic tests on Windows. Stub test errors for old Python versions as there is an integer mismatch between linux and windows. OpenMP test fails following windows update as warning has become an error.

