### PR TITLE
Fix Intel CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 -   #2401 : Fix an unreported, undetected race condition when running 2 Pyccel instances which install the same library to different folders.
 -   #2440 : Fix incorrect handling of shapes and strides of Fortran-order multi-dimensional array that is C contiguous.
 -   #2441 : Fix function call pointer result assignment in Fortran.
+-   #2452 : Fix default Pyccel compiler on command line to use `PYCCEL_DEFAULT_COMPILER` environment variable.
 -   Rename `main` function when translating to C.
 
 ### Changed

--- a/pyccel/commands/console.py
+++ b/pyccel/commands/console.py
@@ -87,7 +87,7 @@ def pyccel() -> None:
     compiler_group = group.add_mutually_exclusive_group(required=False)
     compiler_group.add_argument('--compiler-family',
                                 type=str,
-                                default='GNU',
+                                default=os.environ.get('PYCCEL_DEFAULT_COMPILER', 'GNU'),
                                 metavar='FAMILY',
                                 help='Compiler family {GNU,intel,PGI,nvidia,LLVM} (default: GNU).')
     compiler_group.add_argument('--compiler-config',

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -211,8 +211,9 @@ def compile_fortran_or_c(compiler_info, extension, path_dir, test_file, dependen
     else:
         command.append(test_file[:-3])
 
-    command.append(compiler_info['module_output_flag'])
-    command.append(base_dir)
+    if 'module_output_flag' in compiler_info:
+        command.append(compiler_info['module_output_flag'])
+        command.append(base_dir)
 
     with subprocess.Popen(command, universal_newlines=True, cwd=path_dir) as p:
         p.wait()

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -498,7 +498,6 @@ def test_imports_in_folder(language):
             compile_with_pyccel = False, language = language)
 
 #------------------------------------------------------------------------------
-@pytest.mark.skip_llvm
 @pytest.mark.xdist_incompatible
 def test_imports(language):
     pyccel_test("scripts/runtest_imports.py", "scripts/funcs.py",


### PR DESCRIPTION
Fix default Pyccel compiler (broken in v2.0.0) for command-line interface. This means the command line interface was not correctly tested for Intel and LLVM. Fixes #2452