### PR TITLE
Fix missing call to Py_INCREF

### DIFF
--- a/pyccel/stdlib/cwrapper/cwrapper.c
+++ b/pyccel/stdlib/cwrapper/cwrapper.c
@@ -84,7 +84,9 @@ PyObject	*Complex64_to_NumpyComplex(float complex *c)
 //-----------------------------------------------------//
 PyObject	*Bool_to_PyBool(bool *b)
 {
-	return (*b) ? Py_True : Py_False;
+    PyObject* result = (*b) ? Py_True : Py_False;
+    Py_INCREF(result);
+    return result;
 }
 //-----------------------------------------------------//
 PyObject	*Int64_to_PyLong(int64_t *i)

--- a/tests/epyccel/test_epyccel_garbage_collection.py
+++ b/tests/epyccel/test_epyccel_garbage_collection.py
@@ -2,6 +2,7 @@
 import gc
 import sys
 import numpy as np
+import pytest
 from pyccel import epyccel
 
 def test_return_pointer(language):
@@ -314,3 +315,16 @@ def test_setter(language):
 
     assert ref_count_target1 == start_ref_count_target
     assert ref_count_target2 == start_ref_count_target
+
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="PEP-0683 introduced immortal objects")
+def test_return_bool(language):
+    def get_true():
+        return True
+
+    f = epyccel(get_true, language=language)
+
+    a = True
+    ref_count_1 = sys.getrefcount(a)
+    b = f()
+    ref_count_2 = sys.getrefcount(a)
+    assert ref_count_1 != ref_count_2


### PR DESCRIPTION
Calls to `Py_INCREF` are usually not needed as most methods of creating Python objects take care of reference counting internally. However we are currently stealing a reference to `Py_True` or `Py_False`. This can lead to bad deallocation. The missing call is added in this PR