### PR TITLE
Fix returning an empty tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 -   #2440 : Fix incorrect handling of shapes and strides of Fortran-order multi-dimensional array that is C contiguous.
 -   #2441 : Fix function call pointer result assignment in Fortran.
 -   #2452 : Fix default Pyccel compiler on command line to use `PYCCEL_DEFAULT_COMPILER` environment variable.
+-   #2447 : Fix returning an empty tuple.
 -   Rename `main` function when translating to C.
 
 ### Changed

--- a/pyccel/ast/builtins.py
+++ b/pyccel/ast/builtins.py
@@ -598,7 +598,7 @@ class PythonTuple(TypedAstNode):
             return
         elif len(args) == 0:
             if class_type is None:
-                self._class_type = HomogeneousTupleType(GenericType())
+                self._class_type = InhomogeneousTupleType()
                 self._is_homogeneous = False
             else:
                 self._class_type = class_type

--- a/pyccel/ast/datatypes.py
+++ b/pyccel/ast/datatypes.py
@@ -913,7 +913,11 @@ class InhomogeneousTupleType(ContainerType, TupleType, metaclass = ArgumentSingl
 
         # Determine datatype
         possible_types = set(t.datatype for t in self._element_types)
-        dtype = possible_types.pop()
+        try:
+            dtype = possible_types.pop()
+        except KeyError:
+            dtype = GenericType()
+
         self._datatype = dtype if all(d == dtype for d in possible_types) else self
 
         # Determine rank

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -653,9 +653,6 @@ class IndexedElement(TypedAstNode):
 
     def __init__(self, base, *indices):
 
-        if not indices:
-            raise IndexError('Indexed needs at least one index.')
-
         self._label = base
         self._shape = None
         if pyccel_stage == 'syntactic':

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -591,8 +591,11 @@ class CWrapperCodePrinter(CCodePrinter):
     def _print_PyTuple_Pack(self, expr):
         args = expr.args
         n = len(args)
-        args_code = ', '.join(self._print(a) for a in args)
-        return f'(*PyTuple_Pack( {n}, {args_code} ))'
+        if n:
+            args_code = ', '.join(self._print(a) for a in args)
+            return f'(*PyTuple_Pack( {n}, {args_code} ))'
+        else:
+            return f'(*PyTuple_Pack( {n} ))'
 
     def _print_PyList_Clear(self, expr):
         list_code = self._print(ObjectAddress(expr.list_obj))

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -668,7 +668,7 @@ class PythonCodePrinter(CodePrinter):
             if isinstance(return_var.class_type, InhomogeneousTupleType):
                 elem_code = [get_return_code(self.scope.collect_tuple_element(elem)) for elem in return_var]
                 return_expr = ', '.join(elem_code)
-                if len(elem_code) < 2:
+                if len(elem_code) == 1:
                     return_expr += ','
                 return f'({return_expr})'
             else:

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -502,6 +502,8 @@ class PythonCodePrinter(CodePrinter):
                 indices = indices[0]
 
             indices = ','.join(self._print(i) for i in indices)
+            if len(indices) == 0:
+                indices = '()'
         else:
             errors.report(PYCCEL_RESTRICTION_TODO, symbol=expr,
                 severity='fatal')

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -1094,14 +1094,17 @@ class PythonCodePrinter(CodePrinter):
 
     def _print_Allocate(self, expr):
         class_type = expr.variable.class_type
+        if isinstance(class_type, HomogeneousTupleType) and expr.shape[0] == 0:
+            var = self._print(expr.variable)
+            return f'{var} = ()\n'
         if expr.alloc_type == 'reserve':
             var = self._print(expr.variable)
             if isinstance(class_type, HomogeneousSetType):
                 return f'{var} = set()\n'
             elif isinstance(class_type, HomogeneousListType):
-                return f'{var} = list()\n'
+                return f'{var} = []\n'
             elif isinstance(class_type, DictType):
-                return f'{var} = dict()\n'
+                return f'{var} = {{}}\n'
 
         return ''
 

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -1681,7 +1681,10 @@ class PythonCodePrinter(CodePrinter):
 
     def _print_InhomogeneousTupleType(self, expr):
         args = ', '.join(self._print(t) for t in expr)
-        return f'tuple[{args}]'
+        if args:
+            return f'tuple[{args}]'
+        else:
+            return 'tuple[()]'
 
     def _print_HomogeneousTupleType(self, expr):
         return f'tuple[{self._print(expr.element_type)}, ...]'

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -2338,6 +2338,11 @@ class SemanticParser(BasicParser):
         elif isinstance(base, UnionTypeAnnotation):
             return UnionTypeAnnotation(*[self._get_indexed_type(t, args, expr) for t in base.type_list])
 
+        if len(args) == 0:
+            if not (isinstance(base, PyccelFunctionDef) and base.cls_name.static_type() is TupleType):
+                errors.report("Unrecognised type", severity='fatal', symbol=expr)
+            return UnionTypeAnnotation(VariableTypeAnnotation(InhomogeneousTupleType()))
+
         if all(isinstance(a, Slice) for a in args):
             rank = len(args)
             order = None if rank < 2 else 'C'

--- a/tests/epyccel/modules/tuples.py
+++ b/tests/epyccel/modules/tuples.py
@@ -82,6 +82,9 @@ __all__ = [
         'tuple_return_unknown_length',
         'tuple_assignment',
         'return_1_elem_inhomog_tuple',
+        'return_empty_tuple',
+        'return_empty_int_tuple',
+        'return_annotated_empty_tuple',
         ]
 
 def homogeneous_tuple_int():
@@ -537,3 +540,12 @@ def tuple_assignment():
 def return_1_elem_inhomog_tuple():
     a : 'tuple[int]' = (1,)
     return a
+
+def return_empty_tuple():
+    return ()
+
+def return_empty_int_tuple() -> tuple[int,...]:
+    return ()
+
+def return_annotated_empty_tuple() -> tuple[()]:
+    return ()


### PR DESCRIPTION
Fix returning an empty tuple by saving such objects as inhomogeneous tuples instead of homogeneous tuples of unknown type. Fixes #2447