### PR TITLE
Add missing error for overwriting Constant objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 -   #2452 : Fix default Pyccel compiler on command line to use `PYCCEL_DEFAULT_COMPILER` environment variable.
 -   #2447 : Fix returning an empty tuple.
 -   #2456 : Fix Python reference counting when returning a boolean from a function.
--   #2460 : Fix missing error when overwriting constant variables (e.g. `np.pi`).
+-   #2460 : Fix missing error when overwriting a constant (e.g. `np.pi`).
 -   Rename `main` function when translating to C.
 
 ### Changed

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -1907,7 +1907,7 @@ class SemanticParser(BasicParser):
             # Variable already exists
             else:
                 if isinstance(var, Constant):
-                    errors.report(f"Attempting to overwrite constant variable {lhs}",
+                    errors.report(f"Attempting to overwrite the constant {lhs}",
                                   bounding_box=(self.current_ast_node.lineno, self.current_ast_node.col_offset),
                                   severity='error')
 

--- a/tests/errors/semantic/non_blocking/CONST_OVERWRITE.py
+++ b/tests/errors/semantic/non_blocking/CONST_OVERWRITE.py
@@ -1,4 +1,4 @@
-# Attempting to overwrite constant variable
+# Attempting to overwrite the constant
 # pylint: disable=missing-function-docstring, missing-module-docstring, missing-class-docstring
 
 def f1():


### PR DESCRIPTION
Add missing error when Constant objects (such as `np.pi`) are  overwritten.