### PR TITLE
Fix extra tests due to bad autouse

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,10 @@ def skipif_by_language(request):
         reason    = mark.kwargs['reason']
 
         assert isinstance(condition, bool), preamble + "condition must be bool"
+        assert isinstance(language, str), preamble + "language must be str"
         assert isinstance(reason, str), preamble + "reason must be str"
+
+        assert 'language' in request.fixturenames, preamble + "test must depend on the language fixture"
 
         if condition and request.getfixturevalue('language') == language:
             pytest.skip(reason)


### PR DESCRIPTION
The new fixture `skipif_by_language` depends on `language` and uses `autouse=True`. This means that the fixture is automatically used by every test. These tests then depend on `language` even if this was not the case previously. This results in the same test running 3 times unnecessarily. The fix is to extract the language from the `request` parameter rather than adding it as a dependency.