### PR TITLE
Update Pyccel version to 2.0.1

### DIFF
--- a/pyccel/version.py
+++ b/pyccel/version.py
@@ -1,4 +1,4 @@
 """
 Module specifying the current version string for pyccel
 """
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
Pyccel v2.0.1 was released on June 27, 2025. Probably because of a bad merge, file `version.py` has never been updated in `devel`, where it mistakenly read `2.0.0`. This is now fixed.