### PR TITLE
Fix epyccel path

### DIFF
--- a/pyccel/commands/epyccel.py
+++ b/pyccel/commands/epyccel.py
@@ -327,7 +327,7 @@ def epyccel_seq(function_class_or_module, *,
 
     # Try is necessary to ensure lock is released
     try:
-        pymod_filename = f'{module_name}.py'
+        pymod_filename = os.path.join(epyccel_dirpath, f'{module_name}.py')
         # ...
 
         # Create new directories if not existing


### PR DESCRIPTION
Following #2476 one path was forgotten. As a result the temporary files created by epyccel were printed locally instead of inside the `__epyccel__` folder. This PR fixes this oversight.