### PR TITLE
Fix linux CI Python input

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,7 +44,7 @@ jobs:
     - id: dispatch-matrix
       if: github.event_name == 'workflow_dispatch'
       run: |
-        echo "matrix=[${{ inputs.python_version }}]" >> $GITHUB_ENV
+        echo "matrix=['${{ inputs.python_version }}']" >> $GITHUB_ENV
       shell: bash
     - id: set-matrix
       run: |

--- a/.github/workflows/linux_pyccel-test_cmd.yml
+++ b/.github/workflows/linux_pyccel-test_cmd.yml
@@ -40,7 +40,7 @@ jobs:
     - id: dispatch-matrix
       if: github.event_name == 'workflow_dispatch'
       run: |
-        echo "matrix=[${{ inputs.python_version }}]" >> $GITHUB_ENV
+        echo "matrix=['${{ inputs.python_version }}']" >> $GITHUB_ENV
       shell: bash
     - id: set-matrix
       run: |


### PR DESCRIPTION
All the workflow dispatch CIs handle the Python version as a string allowing `3.10` to be passed. For the linux CI there is an extra layer of obfuscation (due to the use of matrix). During this obfuscation the version is handled without specifying the type. This means that the string type is lost. As a result this workflow (and only this workflow) currently needs to be triggered with `'3.10'`. This also means that the linux tests run by the bot are also currently not working. This PR fixes this by quoting the received string to preserve the type.