### PR TITLE
Fix minor pylint errors

### DIFF
--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -810,8 +810,6 @@ class IndexedElement(TypedAstNode):
             j = 0
             base = self.base
 
-            negative_idxs_possible = getattr(base, 'allows_negative_indexes', False)
-
             for i, idx in enumerate(self.indices):
                 if isinstance(idx, Slice) and j<len(args):
                     current_arg = args[j]

--- a/pyccel/codegen/make_pipeline.py
+++ b/pyccel/codegen/make_pipeline.py
@@ -13,9 +13,8 @@ import sys
 import time
 from pathlib import Path
 
-from pyccel.errors.errors          import Errors, PyccelError
+from pyccel.errors.errors          import Errors
 from pyccel.errors.errors          import PyccelSyntaxError, PyccelSemanticError, PyccelCodegenError
-from pyccel.errors.messages        import PYCCEL_RESTRICTION_TODO
 from pyccel.parser.parser          import Parser
 from pyccel.codegen.build_generation.cmake_gen import CMakeHandler
 from pyccel.codegen.build_generation.meson_gen import MesonHandler

--- a/pyccel/codegen/wrap_pipeline.py
+++ b/pyccel/codegen/wrap_pipeline.py
@@ -11,7 +11,7 @@ import os
 import sys
 import time
 
-from pyccel.errors.errors          import Errors, PyccelError
+from pyccel.errors.errors          import Errors
 from pyccel.errors.errors          import PyccelSyntaxError, PyccelSemanticError, PyccelCodegenError
 from pyccel.parser.parser          import Parser
 from pyccel.codegen.codegen        import Codegen

--- a/pyccel/commands/pyccel_make.py
+++ b/pyccel/commands/pyccel_make.py
@@ -8,7 +8,6 @@ File containing the `pyccel make` command line interface.
 
 import argparse
 import glob
-import sys
 from pathlib import Path
 
 from .argparse_helpers import add_compiler_selection, add_accelerator_selection

--- a/pyccel/commands/pyccel_wrap.py
+++ b/pyccel/commands/pyccel_wrap.py
@@ -7,7 +7,6 @@ File containing the `pyccel wrap` command line interface.
 """
 
 import sys
-import os
 import argparse
 import pathlib
 


### PR DESCRIPTION
Codacy uses a diff to report only relevant pylint errors, however this sometimes results in errors being missed. 6 issues are reported in #2527 which are fixed here.