### PR TITLE
Include AUTHORS file in source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ logging.level = "INFO"
 sdist.cmake = true
 
 sdist.include = [
-  "AUTHOR",
+  "AUTHORS",
   "CHANGELOG.md",
   "CITATION.cff",
   "LICENSE",


### PR DESCRIPTION
Fix a typo in `pyproject.toml`, which caused the `AUTHORS` file to not be included in the source distribution.