### PR TITLE
Stop `pr_clean_up` workflow triggering when `pr_tests` is skipped

### DIFF
--- a/.github/actions/update_review_label/action.yml
+++ b/.github/actions/update_review_label/action.yml
@@ -20,6 +20,14 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Remove pre-existing labels
+      run: |
+        gh pr edit $PR_NUMBER --remove-label needs_initial_review
+        gh pr edit $PR_NUMBER --remove-label Ready_for_review
+        gh pr edit $PR_NUMBER --remove-label Ready_to_merge
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
     - name: Compute and apply label
       id: compute
       run: |

--- a/.github/workflows/pr_clean_up.yml
+++ b/.github/workflows/pr_clean_up.yml
@@ -14,6 +14,8 @@ jobs:
   update_status:
     name: Update PR status
     runs-on: ubuntu-latest
+    # Possible conclusions : ~action_required~, cancelled, failure, ~neutral~, skipped, stale, success, timed_out, startup_failure, null
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion != 'failure' }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr_clean_up.yml
+++ b/.github/workflows/pr_clean_up.yml
@@ -15,7 +15,7 @@ jobs:
     name: Update PR status
     runs-on: ubuntu-latest
     # Possible conclusions : ~action_required~, cancelled, failure, ~neutral~, skipped, stale, success, timed_out, startup_failure, null
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion != 'failure' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Stop `pr_clean_up` workflow triggering when `pr_tests` is skipped. When the workflow is skipped everything that ran passed so the PR may be marked as `needs_initial_review` even if the PR is in draft.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
