### PR TITLE
Fix documentation deployment

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt install graphviz
     - name: Install Python dependencies
       run: |
-        pip3 install .
+        pip3 install -e .
         pip3 install -r docs/requirements.txt
     - name: Make the sphinx doc
       run: |


### PR DESCRIPTION
The documentation deployment was broken by #2602. In order to make `isort` happy `docs/source/conf.py` was modified to use a path to the docs relative to Pyccel's installation directory. This means that the documentation generation only works when using an editable installation as described in the docs. However the documentation deployment workflow was not updated to respect this restriction. As a result the docs are currently not deploying. This PR fixes the missing editable flag.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
