### PR TITLE
Fix "Update review label" action

### DIFF
--- a/.github/actions/update_review_label/action.yml
+++ b/.github/actions/update_review_label/action.yml
@@ -22,9 +22,9 @@ runs:
   steps:
     - name: Remove pre-existing labels
       run: |
-        gh pr edit $PR_NUMBER --remove-label needs_initial_review
-        gh pr edit $PR_NUMBER --remove-label Ready_for_review
-        gh pr edit $PR_NUMBER --remove-label Ready_to_merge
+        gh pr edit ${{ inputs.pr_number }} --remove-label needs_initial_review
+        gh pr edit ${{ inputs.pr_number }} --remove-label Ready_for_review
+        gh pr edit ${{ inputs.pr_number }} --remove-label Ready_to_merge
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The "Update review label" action uses `$PR_NUMBER` but this environment variable is not available. Instead the input should be used to get this information.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
