### PR TITLE
Ensure test files are generated in `__pyccel__` subfolders

### DIFF
--- a/pyccel/codegen/make_pipeline.py
+++ b/pyccel/codegen/make_pipeline.py
@@ -224,6 +224,7 @@ def execute_pyccel_make(
             new_location = folder / f
             if verbose:
                 print(f"cp {fname} {new_location}")
+            os.makedirs(new_location.parent, exist_ok = True)
             shutil.copyfile(fname, new_location)
         else:
             start_wrapper_creation = time.time()

--- a/pyccel/commands/pyccel_make.py
+++ b/pyccel/commands/pyccel_make.py
@@ -208,7 +208,7 @@ def setup_pyccel_make_parser(parser):
     )
 
 
-def pyccel_make(*, language, **kwargs) -> None:
+def pyccel_make(*, language, folder, **kwargs) -> None:
     """
     Call the `pyccel make` pipeline.
 
@@ -218,10 +218,21 @@ def pyccel_make(*, language, **kwargs) -> None:
     ----------
     language : str
         The target language Pyccel is translating to.
+    folder : str
+        Path to the directory where output files are created. Generated files are created
+        following the same folder structure as found in the folder where the command line
+        tool is called. Default is the folder where the command line tool is called.
+        The __pyccel__ directory is created inside this folder.
     **kwargs : dict
         See execute_pyccel_make.
     """
 
     from pyccel.codegen.make_pipeline import execute_pyccel_make
 
-    execute_pyccel_make(language=language.lower(), **kwargs)
+    if language == "Python" and folder == "":
+        errors.report(
+            "Cannot output Python file to same folder as this would overwrite the original file. Please specify --output",
+            severity="error",
+        )
+
+    execute_pyccel_make(language=language.lower(), folder=folder, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,20 +117,15 @@ def pytest_runtest_teardown(item, nextitem):
 
     config = item.config
     xdist_plugin = config.pluginmanager.getplugin("xdist")
-    if (
-        xdist_plugin is None
-        or "PYTEST_XDIST_WORKER_COUNT" not in os.environ
-        or os.getenv("PYTEST_XDIST_WORKER_COUNT") == 1
-    ):
-        marks = [m.name for m in item.own_markers]
-        if "mpi" not in marks:
+    marks = [m.name for m in item.own_markers]
+    if "mpi" not in marks:
+        pyccel_clean(path_dir, remove_shared_libs=True)
+    else:
+        comm = MPI.COMM_WORLD
+        comm.Barrier()
+        if comm.rank == 0:
             pyccel_clean(path_dir, remove_shared_libs=True)
-        else:
-            comm = MPI.COMM_WORLD
-            comm.Barrier()
-            if comm.rank == 0:
-                pyccel_clean(path_dir, remove_shared_libs=True)
-            comm.Barrier()
+        comm.Barrier()
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,14 +117,19 @@ def pytest_runtest_teardown(item, nextitem):
 
     config = item.config
     xdist_plugin = config.pluginmanager.getplugin("xdist")
+    using_xdist = (
+        xdist_plugin is None
+        or "PYTEST_XDIST_WORKER_COUNT" not in os.environ
+        or os.getenv("PYTEST_XDIST_WORKER_COUNT") == 1
+    )
     marks = [m.name for m in item.own_markers]
     if "mpi" not in marks:
-        pyccel_clean(path_dir, remove_shared_libs=True)
+        pyccel_clean(path_dir, remove_shared_libs=not using_xdist)
     else:
         comm = MPI.COMM_WORLD
         comm.Barrier()
         if comm.rank == 0:
-            pyccel_clean(path_dir, remove_shared_libs=True)
+            pyccel_clean(path_dir, remove_shared_libs=not using_xdist)
         comm.Barrier()
 
 

--- a/tests/pyccel/test_pyccel.py
+++ b/tests/pyccel/test_pyccel.py
@@ -415,7 +415,7 @@ def pyccel_test(
 
     if output_dir is None:
         if language == "python":
-            output_dir = os.path.join(get_abs_path(rel_test_dir), "__pyccel__")
+            output_dir = os.path.join(get_abs_path(rel_test_dir), "__pyccel__" + os.environ.get("PYTEST_XDIST_WORKER", ""))
 
     if dependencies:
         if isinstance(dependencies, str):

--- a/tests/pyccel/test_pyccel_make.py
+++ b/tests/pyccel/test_pyccel_make.py
@@ -51,16 +51,17 @@ def pyccel_make_test(
     python_output = get_python_output(folder / main_file, cwd=folder)
 
     cmd = [
-            shutil.which("pyccel"),
-            "make",
-            *args,
-            f"--language={language}",
-            f"--build-system={build_system}",
-        ]
+        shutil.which("pyccel"),
+        "make",
+        *args,
+        f"--language={language}",
+        f"--build-system={build_system}",
+    ]
 
     if language == "python":
-        cmd.append(f'--output={folder / "__pyccel__" + os.environ.get("PYTEST_XDIST_WORKER", "")}')
-
+        cmd.append(
+            f'--output={folder / ("__pyccel__" + os.environ.get("PYTEST_XDIST_WORKER", ""))}'
+        )
 
     p = subprocess.run(
         cmd,

--- a/tests/pyccel/test_pyccel_make.py
+++ b/tests/pyccel/test_pyccel_make.py
@@ -49,14 +49,20 @@ def pyccel_make_test(
     """
     python_output = get_python_output(folder / main_file, cwd=folder)
 
-    p = subprocess.run(
-        [
+    cmd = [
             shutil.which("pyccel"),
             "make",
             *args,
             f"--language={language}",
             f"--build-system={build_system}",
-        ],
+        ]
+
+    if language == "python":
+        cmd.append(f'--output={folder / "__pyccel__" + os.environ.get("PYTEST_XDIST_WORKER", "")}')
+
+
+    p = subprocess.run(
+        cmd,
         cwd=folder,
         check=True,
     )

--- a/tests/pyccel/test_pyccel_make.py
+++ b/tests/pyccel/test_pyccel_make.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
+import os
 import shutil
 import subprocess
 import sys


### PR DESCRIPTION
When translating to Python the `--output` flag was not passed to the `pyccel make` command. This means that files are created in the test folder but outside a `__pyccel__` folder. This PR fixes this and ensures an error is raised when files will be overwritten due to default values.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [ ] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
