### PR TITLE
Improve C speed on contiguous 1D arrays

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,10 @@ ignore=pyccel/extensions
 # regex matches against base names, not paths.
 ignore-patterns=.*.txt
 
-ignore-paths=docs/tutorials/*
+ignore-paths=docs/tutorials/*,
+       tests/pyccel/scripts/runtest_stub.fortran.pyi,
+       tests/pyccel/scripts/runtest_stub.c.pyi,
+       tests/pyccel/scripts/runtest_stub.python.pyi
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   #2309 : Fix crash when using `np.random.randint` with `size` argument for Fortran.
+-   #2558 : Fix performance issue in C when iterating over contiguous 1D data.
 
 ### Changed
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -424,6 +424,10 @@ class Variable(TypedAstNode):
         """
         return isinstance(self.class_type, NumpyNDArrayType)
 
+    @property
+    def is_contiguous(self):
+        return not self.is_ndarray or not self._is_argument
+
     def __str__(self):
         return str(self.name)
 

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -426,7 +426,7 @@ class Variable(TypedAstNode):
 
     @property
     def is_contiguous(self):
-        return not self.is_ndarray or not self._is_argument
+        return (not self.is_ndarray or not self._is_argument) and not self.is_alias
 
     def __str__(self):
         return str(self.name)

--- a/pyccel/ast/variable.py
+++ b/pyccel/ast/variable.py
@@ -426,7 +426,16 @@ class Variable(TypedAstNode):
 
     @property
     def is_contiguous(self):
-        return (not self.is_ndarray or not self._is_argument) and not self.is_alias
+        """
+        Check if the variable memory is contiguous.
+
+        Check if the memory used by a storage container is contiguous, this
+        allows for some optimisations.
+        """
+        return (
+            isinstance(self.class_type, (NumpyNDArrayType, HomogeneousTupleType))
+            and not self._is_argument
+        ) and not self.is_alias
 
     def __str__(self):
         return str(self.name)

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2271,7 +2271,9 @@ class CCodePrinter(CodePrinter):
         if isinstance(base.class_type, (NumpyNDArrayType, HomogeneousTupleType)):
             if base.rank == 1 and base.is_contiguous:
                 self.add_import(c_imports["CSpan_extensions"])
-                return f"(*contig_cspan_at({self._print(ObjectAddress(base))}, {indices}))"
+                return (
+                    f"(*contig_cspan_at({self._print(ObjectAddress(base))}, {indices}))"
+                )
             else:
                 return f"(*cspan_at({self._print(ObjectAddress(base))}, {indices}))"
         elif isinstance(base.class_type, CStackArray):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2269,13 +2269,9 @@ class CCodePrinter(CodePrinter):
 
         indices = ", ".join(self._print(i) for i in inds)
         if isinstance(base.class_type, (NumpyNDArrayType, HomogeneousTupleType)):
-            if base.rank == 1 and base.is_contiguous:
-                data_obj = ObjectAddress(
-                    DottedVariable(
-                        VoidType(), "data", lhs=base, memory_handling="alias"
-                    )
-                )
-                return f"{self._print(data_obj)}[{indices}]"
+            if base.is_contiguous:
+                self.add_import(c_imports["CSpan_extensions"])
+                return f"(*contig_cspan_at({self._print(ObjectAddress(base))}, {indices}))"
             else:
                 return f"(*cspan_at({self._print(ObjectAddress(base))}, {indices}))"
         elif isinstance(base.class_type, CStackArray):

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2269,7 +2269,15 @@ class CCodePrinter(CodePrinter):
 
         indices = ", ".join(self._print(i) for i in inds)
         if isinstance(base.class_type, (NumpyNDArrayType, HomogeneousTupleType)):
-            return f"(*cspan_at({self._print(ObjectAddress(base))}, {indices}))"
+            if base.rank == 1 and base.is_contiguous:
+                data_obj = ObjectAddress(
+                    DottedVariable(
+                        VoidType(), "data", lhs=base, memory_handling="alias"
+                    )
+                )
+                return f"{self._print(data_obj)}[{indices}]"
+            else:
+                return f"(*cspan_at({self._print(ObjectAddress(base))}, {indices}))"
         elif isinstance(base.class_type, CStackArray):
             return f"{self._print(ObjectAddress(base))}[{indices}]"
         else:

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2269,7 +2269,7 @@ class CCodePrinter(CodePrinter):
 
         indices = ", ".join(self._print(i) for i in inds)
         if isinstance(base.class_type, (NumpyNDArrayType, HomogeneousTupleType)):
-            if base.is_contiguous:
+            if base.rank == 1 and base.is_contiguous:
                 self.add_import(c_imports["CSpan_extensions"])
                 return f"(*contig_cspan_at({self._print(ObjectAddress(base))}, {indices}))"
             else:

--- a/pyccel/stdlib/STC_Extensions/CMakeLists.txt
+++ b/pyccel/stdlib/STC_Extensions/CMakeLists.txt
@@ -5,3 +5,10 @@ target_include_directories(STC_Extensions
     "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
 
+
+add_library(CSpan_extensions INTERFACE)
+target_include_directories(CSpan_extensions
+    INTERFACE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+

--- a/pyccel/stdlib/STC_Extensions/CSpan_extensions.h
+++ b/pyccel/stdlib/STC_Extensions/CSpan_extensions.h
@@ -13,3 +13,25 @@
     }
 
 #endif
+
+#define contig_cspan_at(self, ...) ((self)->data + contig_cspan_index(self, __VA_ARGS__))
+
+#define contig_cspan_index(...) contig_cspan_index_fn(__VA_ARGS__, c_COMMA_N(contig_cspan_index_3d), c_COMMA_N(contig_cspan_index_2d), \
+                                                     c_COMMA_N(contig_cspan_index_1d),)(__VA_ARGS__)
+#define contig_cspan_index_fn(self, i,j,k,n, ...) c_TUPLE_AT_1(n, contig_cspan_index_nd,)
+#define contig_cspan_index_1d(self, i)     (c_static_assert(cspan_rank(self) == 1), \
+                                     c_assert((i) < (self)->shape[0]), \
+                                     i)
+#define contig_cspan_index_2d(self, i,j)   (c_static_assert(cspan_rank(self) == 2), \
+                                     c_assert((i) < (self)->shape[0] && (j) < (self)->shape[1]), \
+                                     (i)*(self)->stride.d[0] + j)
+#define contig_cspan_index_3d(self, i,j,k) (c_static_assert(cspan_rank(self) == 3), \
+                                     c_assert((i) < (self)->shape[0] && (j) < (self)->shape[1] && (k) < (self)->shape[2]), \
+                                     (i)*(self)->stride.d[0] + (j)*(self)->stride.d[1] + k)
+#define contig_cspan_index_nd(self, ...) _cspan_index((self)->shape, (self)->stride.d, c_make_array(isize, {__VA_ARGS__}), \
+                                               (c_static_assert(cspan_rank(self) == c_NUMARGS(__VA_ARGS__)), cspan_rank(self)))
+
+
+#define cspan_contig_index_1d(self, i)  (c_static_assert(cspan_rank(self) == 1), \
+                                         c_assert((i) < (self)->shape[0]), \
+                                         i)

--- a/pyccel/stdlib/STC_Extensions/CSpan_extensions.h
+++ b/pyccel/stdlib/STC_Extensions/CSpan_extensions.h
@@ -12,8 +12,6 @@
         } \
     }
 
-#endif
-
 #define contig_cspan_at(self, ...) ((self)->data + contig_cspan_index(self, __VA_ARGS__))
 
 #define contig_cspan_index(...) cspan_index_fn(__VA_ARGS__, c_COMMA_N(cspan_index_3d), c_COMMA_N(cspan_index_2d), \
@@ -21,3 +19,5 @@
 #define contig_cspan_index_1d(self, i)     (c_static_assert(cspan_rank(self) == 1), \
                                      c_assert((i) < (self)->shape[0]), \
                                      i)
+
+#endif

--- a/pyccel/stdlib/STC_Extensions/CSpan_extensions.h
+++ b/pyccel/stdlib/STC_Extensions/CSpan_extensions.h
@@ -16,22 +16,8 @@
 
 #define contig_cspan_at(self, ...) ((self)->data + contig_cspan_index(self, __VA_ARGS__))
 
-#define contig_cspan_index(...) contig_cspan_index_fn(__VA_ARGS__, c_COMMA_N(contig_cspan_index_3d), c_COMMA_N(contig_cspan_index_2d), \
+#define contig_cspan_index(...) cspan_index_fn(__VA_ARGS__, c_COMMA_N(cspan_index_3d), c_COMMA_N(cspan_index_2d), \
                                                      c_COMMA_N(contig_cspan_index_1d),)(__VA_ARGS__)
-#define contig_cspan_index_fn(self, i,j,k,n, ...) c_TUPLE_AT_1(n, contig_cspan_index_nd,)
 #define contig_cspan_index_1d(self, i)     (c_static_assert(cspan_rank(self) == 1), \
                                      c_assert((i) < (self)->shape[0]), \
                                      i)
-#define contig_cspan_index_2d(self, i,j)   (c_static_assert(cspan_rank(self) == 2), \
-                                     c_assert((i) < (self)->shape[0] && (j) < (self)->shape[1]), \
-                                     (i)*(self)->stride.d[0] + j)
-#define contig_cspan_index_3d(self, i,j,k) (c_static_assert(cspan_rank(self) == 3), \
-                                     c_assert((i) < (self)->shape[0] && (j) < (self)->shape[1] && (k) < (self)->shape[2]), \
-                                     (i)*(self)->stride.d[0] + (j)*(self)->stride.d[1] + k)
-#define contig_cspan_index_nd(self, ...) _cspan_index((self)->shape, (self)->stride.d, c_make_array(isize, {__VA_ARGS__}), \
-                                               (c_static_assert(cspan_rank(self) == c_NUMARGS(__VA_ARGS__)), cspan_rank(self)))
-
-
-#define cspan_contig_index_1d(self, i)  (c_static_assert(cspan_rank(self) == 1), \
-                                         c_assert((i) < (self)->shape[0]), \
-                                         i)

--- a/pyccel/stdlib/STC_Extensions/meson.build
+++ b/pyccel/stdlib/STC_Extensions/meson.build
@@ -1,2 +1,3 @@
 
 STC_Extensions_dep = declare_dependency(include_directories: '..')
+CSpan_extensions_dep = declare_dependency(include_directories: '.')

--- a/tests/pyccel/scripts/runtest_stub.c.pyi
+++ b/tests/pyccel/scripts/runtest_stub.c.pyi
@@ -1,4 +1,4 @@
-#$ header metavar printer_imports="stdlib, stdint, complex, stc/cspan, stdio, inttypes, stc/vec, stdbool, STC_Extensions/List_extensions"
+#$ header metavar printer_imports="stdlib, stdint, complex, stc/cspan, CSpan_extensions, stdio, inttypes, stc/vec, stdbool, STC_Extensions/List_extensions"
 from typing import Final, TypeVar, overload
 from pyccel.decorators import low_level
 from numpy import float64


### PR DESCRIPTION
Improve C speed when iterating over contiguous 1D arrays by avoiding the use of the stride. This allows the compiler to vectorise expressions. Fixes #2558 

We can see the impact of this change by comparing the benchmarking results from devel:
![performance on devel](https://raw.githubusercontent.com/pyccel/pyccel-benchmarks/main/version_specific_results/devel_performance_312_execution.svg)
to the benchmarking results from this branch:
![performance on devel-issue2558 with a jump in C performance for the FD cases](https://raw.githubusercontent.com/pyccel/pyccel-benchmarks/4dc824a31e809e2b6f375925b3353c7da8b6b2e2/version_specific_results/devel_performance_312_execution.svg)

In particular improvements are seen in the finite difference cases.

**Commit Summary**
- Add `is_contiguous` property to variables. This property will be useful for #2559 but local arrays can already be identified as contiguous data
- Add `contig_cspan_index_1d` to supplement `cspan_index_1d` for contiguous arrays.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
