### PR TITLE
Improve slicing performance in C code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   #2309 : Fix crash when using `np.random.randint` with `size` argument for Fortran.
+-   #2618 : Fix unnecessary stack memory allocation for variables storing temporary slices.
+-   #2618 : Fix unnecessary slicing returning the whole array.
 
 ### Changed
 
 -   #2595 : Make `#$` and `# $` interchangeable so OpenMP can be used in codes using black.
+-   #2618 : Use `cspan_submd<RANK>` instead of `cspan_slice` for improved performance.
 -   \[DEVELOPER\] Require black formatting.
 
 ### Deprecated

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2227,7 +2227,7 @@ class CCodePrinter(CodePrinter):
                     and expr.rank < base.rank
                     and all(isinstance(i, Slice) for i in inds[expr.rank :])
                 ):
-                    indices_code = ", ".join(indices[: expr.rank])
+                    indices_code = ", ".join(indices[: -expr.rank])
                     return (
                         f"({c_type})cspan_submd{base.rank}({base_code}, {indices_code})"
                     )

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2221,15 +2221,24 @@ class CCodePrinter(CodePrinter):
                         )
                     indices.append(self._print(idx))
                 base_code = self._print(ObjectAddress(base))
-                if expr.rank < 4 and base.rank < 5 and expr.rank < base.rank and all(isinstance(i, Slice) for i in inds[expr.rank:]):
-                    indices_code = ", ".join(indices[:expr.rank])
-                    return f"({c_type})cspan_submd{base.rank}({base_code}, {indices_code})"
+                if (
+                    expr.rank < 4
+                    and base.rank < 5
+                    and expr.rank < base.rank
+                    and all(isinstance(i, Slice) for i in inds[expr.rank :])
+                ):
+                    indices_code = ", ".join(indices[: expr.rank])
+                    return (
+                        f"({c_type})cspan_submd{base.rank}({base_code}, {indices_code})"
+                    )
                 else:
                     indices_code = ", ".join(f"{{{i}}}" for i in indices)
                     return f"cspan_slice({base_code}, {c_type}, {indices_code})"
             else:
                 new_type = base.class_type.switch_rank(expr.rank, expr.order)
-                tmp_var = self.scope.get_temporary_variable(new_type, shape=expr.shape, memory_handling='alias')
+                tmp_var = self.scope.get_temporary_variable(
+                    new_type, shape=expr.shape, memory_handling="alias"
+                )
                 assign = AliasAssign(tmp_var, expr)
                 code = self._print(assign)
                 self._additional_code += code

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2225,7 +2225,13 @@ class CCodePrinter(CodePrinter):
                     expr.rank < 4
                     and base.rank < 5
                     and expr.rank < base.rank
-                    and all(isinstance(i, Slice) for i in inds[expr.rank :])
+                    and all(
+                        isinstance(i, Slice)
+                        and i.start is None
+                        and i.stop is None
+                        and i.step is None
+                        for i in inds[expr.rank :]
+                    )
                 ):
                     indices_code = ", ".join(indices[: -expr.rank])
                     return (

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2219,13 +2219,17 @@ class CCodePrinter(CodePrinter):
                             PyccelArrayShapeElement(base, i),
                             allow_negative_indexes,
                         )
-                    indices.append("{" + self._print(idx) + "}")
-                indices_code = ", ".join(indices)
+                    indices.append(self._print(idx))
                 base_code = self._print(ObjectAddress(base))
-                return f"cspan_slice({base_code}, {c_type}, {indices_code})"
+                if expr.rank < 4 and base.rank < 5 and expr.rank < base.rank and all(isinstance(i, Slice) for i in inds[expr.rank:]):
+                    indices_code = ", ".join(indices[:expr.rank])
+                    return f"({c_type})cspan_submd{base.rank}({base_code}, {indices_code})"
+                else:
+                    indices_code = ", ".join(f"{{{i}}}" for i in indices)
+                    return f"cspan_slice({base_code}, {c_type}, {indices_code})"
             else:
                 new_type = base.class_type.switch_rank(expr.rank, expr.order)
-                tmp_var = self.scope.get_temporary_variable(new_type, shape=expr.shape)
+                tmp_var = self.scope.get_temporary_variable(new_type, shape=expr.shape, memory_handling='alias')
                 assign = AliasAssign(tmp_var, expr)
                 code = self._print(assign)
                 self._additional_code += code

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -2222,6 +2222,8 @@ class CCodePrinter(CodePrinter):
                     indices.append(self._print(idx))
                 base_code = self._print(ObjectAddress(base))
                 if (
+                    # cspan_submd{N} exists only for N = 2, 3, 4,
+                    # where N is the rank of the array to be sliced
                     expr.rank < 4
                     and base.rank < 5
                     and expr.rank < base.rank

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4266,7 +4266,8 @@ class SemanticParser(BasicParser):
             args = [self._visit(idx) for idx in expr.indices]
 
             if all(
-                isinstance(a, Slice)
+                not isinstance(class_type, HomogeneousListType)
+                and isinstance(a, Slice)
                 and a.start is None
                 and a.stop is None
                 and a.step is None

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4270,6 +4270,8 @@ class SemanticParser(BasicParser):
                     isinstance(expr.current_user_node, Assign)
                     and expr.current_user_node.lhs is expr
                 )
+            # The property `current_user_node` of `PyccelAstNode`
+            # works for objects with only one user node
             except AssertionError:
                 in_lhs_assign = False
 

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4265,7 +4265,10 @@ class SemanticParser(BasicParser):
             # TODO check consistency of indices with shape/rank
             args = [self._visit(idx) for idx in expr.indices]
 
-            if len(args) == 1 and isinstance(
+            if all(isinstance(a, Slice) for a in args):
+                return var
+
+            elif len(args) == 1 and isinstance(
                 getattr(args[0], "class_type", None), TupleType
             ):
                 args = args[0]

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4281,6 +4281,8 @@ class SemanticParser(BasicParser):
                 and a.step is None
                 for a in args
             ):
+                # Replace a[:] with a to avoid printing
+                # unnecessary slicing in generated code
                 return var
 
             elif len(args) == 1 and isinstance(

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4265,7 +4265,13 @@ class SemanticParser(BasicParser):
             # TODO check consistency of indices with shape/rank
             args = [self._visit(idx) for idx in expr.indices]
 
-            if all(isinstance(a, Slice) for a in args):
+            if all(
+                isinstance(a, Slice)
+                and a.start is None
+                and a.stop is None
+                and a.step is None
+                for a in args
+            ):
                 return var
 
             elif len(args) == 1 and isinstance(

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4265,10 +4265,15 @@ class SemanticParser(BasicParser):
             # TODO check consistency of indices with shape/rank
             args = [self._visit(idx) for idx in expr.indices]
 
-            if not (
-                isinstance(expr.current_user_node, Assign)
-                and expr.current_user_node.lhs is expr
-            ) and all(
+            try:
+                in_lhs_assign = (
+                    isinstance(expr.current_user_node, Assign)
+                    and expr.current_user_node.lhs is expr
+                )
+            except AssertionError:
+                in_lhs_assign = False
+
+            if not in_lhs_assign and all(
                 not isinstance(class_type, HomogeneousListType)
                 and isinstance(a, Slice)
                 and a.start is None

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -4265,7 +4265,10 @@ class SemanticParser(BasicParser):
             # TODO check consistency of indices with shape/rank
             args = [self._visit(idx) for idx in expr.indices]
 
-            if all(
+            if not (
+                isinstance(expr.current_user_node, Assign)
+                and expr.current_user_node.lhs is expr
+            ) and all(
                 not isinstance(class_type, HomogeneousListType)
                 and isinstance(a, Slice)
                 and a.start is None


### PR DESCRIPTION
Slicing in C involves a call to a `cspan_slice`. This external function has a cost which makes it hard for the compiler to optimise this and surrounding code. Cspan provides `cspan_submd<RANK>` functions to construct a lower rank submd spans. This is equivalent to `cspan_slice` but faster as it is based on a macro design. Additionally minor slice related bug fixes are incorporated which also improve speed.

**Commit summary**
- Use calls to `cspan_submd<RANK>` when possible
- Ensure the variable generated to save a temporary slice is marked as an alias (prevents unnecessary stack memory allocation)
- Translate expressions such as `a[:]` to `a` to avoid printing unnecessary slicing in the generated code

---

We can see the impact of this change by comparing the benchmarking results from devel:
![performance on devel](https://raw.githubusercontent.com/pyccel/pyccel-benchmarks/5d56b8d9dac45dc056754ce666c632d97f345661/version_specific_results/devel_performance_312_execution.svg)
to the benchmarking results from this branch:
![performance on ebourne_c_slicing_performance with a jump in C performance for the time stepping cases](
https://raw.githubusercontent.com/pyccel/pyccel-benchmarks/4081a754a66fffff68803971d62def004e70a3d0/version_specific_results/devel_performance_312_execution.svg)

In particular, improvements can be seen for the time stepping methods.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
