### PR TITLE
Clean up multi-line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 -   #2558 : Fix performance issue in C when iterating over contiguous 1D data.
 -   #2618 : Fix unnecessary stack memory allocation for variables storing temporary slices.
 -   #2618 : Fix unnecessary slicing returning the whole array.
+-   #2620 : Fix strange indenting in Fortran when a comment line begins with a dollar sign.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 -   #2595 : Make `#$` and `# $` interchangeable so OpenMP can be used in codes using black.
 -   #2618 : Use `cspan_submd<RANK>` instead of `cspan_slice` for improved performance.
+-   #2620 : Improve formatting of comment blocks in Fortran and C.
 -   \[DEVELOPER\] Require black formatting.
 
 ### Deprecated

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -3754,20 +3754,22 @@ class CCodePrinter(CodePrinter):
         header = expr.header
         header_size = len(expr.header)
 
-        ln = max(len(i) for i in txts)
+        ln = max(len(i) for i in txts) + 2
         if ln < max(20, header_size + 4):
             ln = 20
+        if ln % 2 == 1:
+            ln += 1
         top = (
             "/*"
             + "_" * int((ln - header_size) / 2)
             + header
             + "_" * int((ln - header_size) / 2)
-            + "*/\n"
+            + "\n"
         )
-        ln = len(top) - 4
-        bottom = "/*" + "_" * ln + "*/\n"
+        ln = len(top) - 2
+        bottom = " *" + "_" * ln + "*/\n"
 
-        txts = ["/*" + t + " " * (ln - len(t)) + "*/\n" for t in txts]
+        txts = [" * " + t + "\n" for t in txts]
 
         body = "".join(i for i in txts)
 
@@ -4183,8 +4185,6 @@ class CCodePrinter(CodePrinter):
             return "".join(code_lines)
 
         tab = " " * self._default_settings["tabwidth"]
-
-        code = [line.lstrip(" \t") for line in code]
 
         increase = [int(line.endswith("{\n")) for line in code]
         decrease = [int(any(map(line.startswith, "}\n"))) for line in code]

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1350,8 +1350,6 @@ class FCodePrinter(CodePrinter):
             ln = 20
         if ln % 2 == 1:
             ln += 1
-        print(ln)
-        print(int((ln - header_size) / 2))
         top = (
             "!_"
             + "_" * ((ln - header_size) // 2)

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1360,7 +1360,7 @@ class FCodePrinter(CodePrinter):
             + "_!"
         )
         ln = len(top) - 3
-        bottom = "!" + "_" * (ln+1) + "!"
+        bottom = "!" + "_" * (ln + 1) + "!"
 
         txts = ["! " + txt + " " * (ln - len(txt)) + "!" for txt in txts]
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1346,7 +1346,7 @@ class FCodePrinter(CodePrinter):
         header_size = len(expr.header)
 
         ln = max(len(i) for i in txts)
-        if ln < max(20, header_size + 2):
+        if ln < max(20, header_size + 4):
             ln = 20
         top = (
             "!"
@@ -1358,7 +1358,7 @@ class FCodePrinter(CodePrinter):
         ln = len(top) - 2
         bottom = "!" + "_" * ln + "!"
 
-        txts = ["! " + txt + " " * (ln - len(txt)) + "!" for txt in txts]
+        txts = ["! " + txt + " " * (ln - len(txt)-1) + "!" for txt in txts]
 
         body = "\n".join(i for i in txts)
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1338,7 +1338,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_Comment(self, expr):
         comments = self._print(expr.text)
-        return "!" + comments + "\n"
+        return "! " + comments + "\n"
 
     def _print_CommentBlock(self, expr):
         txts = expr.comments
@@ -1358,11 +1358,11 @@ class FCodePrinter(CodePrinter):
         ln = len(top) - 2
         bottom = "!" + "_" * ln + "!"
 
-        txts = ["!" + txt + " " * (ln - len(txt)) + "!" for txt in txts]
+        txts = ["! " + txt + " " * (ln - len(txt)) + "!" for txt in txts]
 
         body = "\n".join(i for i in txts)
 
-        return ("{0}\n" "{1}\n" "{2}\n").format(top, body, bottom)
+        return f"{top}\n{body}\n{bottom}\n"
 
     def _print_EmptyNode(self, expr):
         return ""

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1352,9 +1352,9 @@ class FCodePrinter(CodePrinter):
             ln += 1
         top = (
             "!_"
-            + "_" * ((ln - header_size) // 2)
+            + "_" * int((ln - header_size) / 2)
             + header
-            + "_" * ((ln - header_size) // 2)
+            + "_" * int((ln - header_size) / 2)
             + "_!"
         )
         ln = len(top) - 3

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -1345,20 +1345,24 @@ class FCodePrinter(CodePrinter):
         header = expr.header
         header_size = len(expr.header)
 
-        ln = max(len(i) for i in txts)
+        ln = max(len(i) for i in txts) + 2
         if ln < max(20, header_size + 4):
             ln = 20
+        if ln % 2 == 1:
+            ln += 1
+        print(ln)
+        print(int((ln - header_size) / 2))
         top = (
-            "!"
-            + "_" * int((ln - header_size) / 2)
+            "!_"
+            + "_" * ((ln - header_size) // 2)
             + header
-            + "_" * int((ln - header_size) / 2)
-            + "!"
+            + "_" * ((ln - header_size) // 2)
+            + "_!"
         )
-        ln = len(top) - 2
-        bottom = "!" + "_" * ln + "!"
+        ln = len(top) - 3
+        bottom = "!" + "_" * (ln+1) + "!"
 
-        txts = ["! " + txt + " " * (ln - len(txt)-1) + "!" for txt in txts]
+        txts = ["! " + txt + " " * (ln - len(txt)) + "!" for txt in txts]
 
         body = "\n".join(i for i in txts)
 


### PR DESCRIPTION
Fix strange indenting in Fortran when a comment begins with a dollar sign. This arose due to `!$` being the signifier for a compile pragma in Fortran. Spaces are also added at the beginning of comment blocks in Fortran and C to improve readability.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
