### PR TITLE
Add support for module docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 -   #2309 : Add support for `dtype` and tuple `size` arguments of `np.random.randint`.
 -   #2525 : Add preliminary support for C++ translations.
+-   #2621 : Add support for module docstrings.
 
 ### Fixed
 

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -949,7 +949,7 @@ class Module(ScopedAstNode):
         The doc string of the function. This is a CodeBlock containing
         a CommentBlock or the CommentBlock itself.
         Note that in the subclass PyModule this should always be a
-        CommentBlock as comments preceeding module docstrings (e.g.
+        CommentBlock as comments preceding module docstrings (e.g.
         licence information) are not used by the Python interface.
 
     init_func : FunctionDef, default: None

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -945,6 +945,9 @@ class Module(ScopedAstNode):
     funcs : list
         A list of FunctionDef instances.
 
+    docstring : str
+        The doc string of the function.
+
     init_func : FunctionDef, default: None
         The function which initialises the module (expressions in the
         python module which are executed on import).
@@ -1002,6 +1005,7 @@ class Module(ScopedAstNode):
         "_name",
         "_variables",
         "_funcs",
+        "_docstring",
         "_interfaces",
         "_classes",
         "_imports",
@@ -1015,6 +1019,7 @@ class Module(ScopedAstNode):
     _attribute_nodes = (
         "_variables",
         "_funcs",
+        "_docstring",
         "_interfaces",
         "_classes",
         "_imports",
@@ -1029,6 +1034,8 @@ class Module(ScopedAstNode):
         name,
         variables,
         funcs,
+        *,
+        docstring=None,
         init_func=None,
         free_func=None,
         program=None,
@@ -1093,6 +1100,7 @@ class Module(ScopedAstNode):
         self._variables = variables
         self._variable_inits = [None] * len(variables)
         self._funcs = funcs
+        self._docstring = docstring
         self._init_func = init_func
         self._free_func = free_func
         self._program = program
@@ -1145,6 +1153,15 @@ class Module(ScopedAstNode):
     def variables(self):
         """Module global variables"""
         return self._variables
+
+    @property
+    def docstring(self):
+        """
+        The docstring of the module.
+
+        The docstring of the module.
+        """
+        return self._docstring
 
     @property
     def init_func(self):

--- a/pyccel/ast/core.py
+++ b/pyccel/ast/core.py
@@ -945,8 +945,12 @@ class Module(ScopedAstNode):
     funcs : list
         A list of FunctionDef instances.
 
-    docstring : str
-        The doc string of the function.
+    docstring : CodeBlock | CommentBlock, default=None
+        The doc string of the function. This is a CodeBlock containing
+        a CommentBlock or the CommentBlock itself.
+        Note that in the subclass PyModule this should always be a
+        CommentBlock as comments preceeding module docstrings (e.g.
+        licence information) are not used by the Python interface.
 
     init_func : FunctionDef, default: None
         The function which initialises the module (expressions in the

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1251,6 +1251,11 @@ class CCodePrinter(CodePrinter):
         imports = self.sort_imports(imports)
         imports = "".join(self._print(i) for i in imports)
 
+        if expr.module.docstring:
+            docstring = self._print(expr.module.docstring)
+        else:
+            docstring = ''
+
         self._in_header = False
         self.exit_scope()
         body = "\n".join(
@@ -1258,13 +1263,15 @@ class CCodePrinter(CodePrinter):
             for info_block in (imports, global_variables, classes, funcs)
             if info_block
         )
-        return f"#ifndef {name.upper()}_H\n \
-                #define {name.upper()}_H\n\n \
-                {body}\n \
-                #endif // {name}_H\n"
+        return "\n".join((f"#ifndef {name.upper()}_H",
+                f"#define {name.upper()}_H",
+                docstring,
+                body,
+                f"#endif // {name}_H\n"))
 
     def _print_Module(self, expr):
         self.set_scope(expr.scope)
+
         body = "\n".join(self._print(i) for i in expr.body)
 
         global_variables = "".join([self._print(d) for d in expr.declarations])
@@ -1276,6 +1283,10 @@ class CCodePrinter(CodePrinter):
         imports = self._print(imports)
 
         code = "\n".join((imports, global_variables, body))
+
+        if expr.docstring:
+            docstring = self._print(expr.docstring)
+            code = f"{docstring}\n{code}"
 
         self.exit_scope()
         return code

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -1254,7 +1254,7 @@ class CCodePrinter(CodePrinter):
         if expr.module.docstring:
             docstring = self._print(expr.module.docstring)
         else:
-            docstring = ''
+            docstring = ""
 
         self._in_header = False
         self.exit_scope()
@@ -1263,11 +1263,15 @@ class CCodePrinter(CodePrinter):
             for info_block in (imports, global_variables, classes, funcs)
             if info_block
         )
-        return "\n".join((f"#ifndef {name.upper()}_H",
+        return "\n".join(
+            (
+                f"#ifndef {name.upper()}_H",
                 f"#define {name.upper()}_H",
                 docstring,
                 body,
-                f"#endif // {name}_H\n"))
+                f"#endif // {name}_H\n",
+            )
+        )
 
     def _print_Module(self, expr):
         self.set_scope(expr.scope)

--- a/pyccel/codegen/printing/cppcode.py
+++ b/pyccel/codegen/printing/cppcode.py
@@ -348,7 +348,7 @@ class CppCodePrinter(CodePrinter):
         if expr.module.docstring:
             docstring = self._print(expr.module.docstring)
         else:
-            docstring = ''
+            docstring = ""
 
         self.exit_scope()
         self._in_header = False
@@ -383,12 +383,18 @@ class CppCodePrinter(CodePrinter):
 
         docstring = self._print(expr.docstring) if expr.docstring else ""
 
-        parts = [docstring, imports_code, f"namespace {name} {{\n\n", global_variables, body, "\n}\n"]
+        parts = [
+            docstring,
+            imports_code,
+            f"namespace {name} {{\n\n",
+            global_variables,
+            body,
+            "\n}\n",
+        ]
 
         self.exit_scope()
 
-        return "".join(p for p in parts if p
-        )
+        return "".join(p for p in parts if p)
 
     def _print_Program(self, expr):
         mod = expr.get_direct_user_nodes(lambda x: isinstance(x, Module))[0]

--- a/pyccel/codegen/printing/cppcode.py
+++ b/pyccel/codegen/printing/cppcode.py
@@ -345,11 +345,17 @@ class CppCodePrinter(CodePrinter):
         # imports = self.sort_imports(imports)
         imports = "".join(self._print(i) for i in imports)
 
+        if expr.module.docstring:
+            docstring = self._print(expr.module.docstring)
+        else:
+            docstring = ''
+
         self.exit_scope()
         self._in_header = False
 
         sections = (
             "#pragma once\n",
+            docstring,
             imports,
             f"namespace {name} {{\n",
             global_variables,
@@ -375,10 +381,13 @@ class CppCodePrinter(CodePrinter):
         if "complex" in self._additional_imports:
             imports_code += "using namespace std::complex_literals;\n"
 
+        docstring = self._print(expr.docstring) if expr.docstring else ""
+
+        parts = [docstring, imports_code, f"namespace {name} {{\n\n", global_variables, body, "\n}\n"]
+
         self.exit_scope()
 
-        return "".join(
-            (imports_code, f"namespace {name} {{\n\n", global_variables, body, "\n}\n")
+        return "".join(p for p in parts if p
         )
 
     def _print_Program(self, expr):

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -425,13 +425,18 @@ class CWrapperCodePrinter(CCodePrinter):
             "};\n"
         )
 
+        if expr.docstring:
+            module_docstring = self._print(CStrStr(LiteralString('\n'.join(expr.docstring.comments))))
+        else:
+            module_docstring = "NULL"
+
         module_def = (
             f"static struct PyModuleDef {expr.module_def_name} = {{\n"
             "PyModuleDef_HEAD_INIT,\n"
             "/* name of module */\n"
             f'"{self._module_name}",\n'
             "/* module documentation, may be NULL */\n"
-            "NULL,\n"  # TODO: Add documentation
+            f"{module_docstring},\n"
             "/* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */\n"
             "0,\n"
             f"{method_def_name},\n"

--- a/pyccel/codegen/printing/cwrappercode.py
+++ b/pyccel/codegen/printing/cwrappercode.py
@@ -426,7 +426,9 @@ class CWrapperCodePrinter(CCodePrinter):
         )
 
         if expr.docstring:
-            module_docstring = self._print(CStrStr(LiteralString('\n'.join(expr.docstring.comments))))
+            module_docstring = self._print(
+                CStrStr(LiteralString("\n".join(expr.docstring.comments)))
+            )
         else:
             module_docstring = "NULL"
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -939,7 +939,7 @@ class FCodePrinter(CodePrinter):
         if expr.docstring:
             docstring = self._print(expr.docstring)
         else:
-            docstring = ''
+            docstring = ""
 
         parts = [
             docstring,

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -936,7 +936,13 @@ class FCodePrinter(CodePrinter):
         imports = self.print_constant_imports() + imports
         implicit_none = "" if expr.is_external else "implicit none\n"
 
+        if expr.docstring:
+            docstring = self._print(expr.docstring)
+        else:
+            docstring = ''
+
         parts = [
+            docstring,
             f"module {name}\n",
             imports,
             implicit_none,

--- a/pyccel/codegen/printing/pycode.py
+++ b/pyccel/codegen/printing/pycode.py
@@ -1805,10 +1805,13 @@ class PythonCodePrinter(CodePrinter):
         else:
             prog = ""
 
+        if expr.docstring:
+            docstring = self._print(expr.docstring)
+        else:
+            docstring = ""
+
         self.exit_scope()
-        return ("{imports}\n" "{body}" "{prog}").format(
-            imports=imports, body=body, prog=prog
-        )
+        return f"{docstring}{imports}\n{body}{prog}"
 
     def _print_ModuleHeader(self, expr):
         self._in_header = True

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1816,7 +1816,11 @@ class CToPythonWrapper(Wrapper):
             imports.append(Import(mod_scope.get_python_name(expr.name), expr))
         original_mod_name = mod_scope.get_python_name(original_mod.name)
 
-        docstring = next(d for d in original_mod.docstring.body if isinstance(d, CommentBlock)) if original_mod.docstring else None
+        docstring = (
+            next(d for d in original_mod.docstring.body if isinstance(d, CommentBlock))
+            if original_mod.docstring
+            else None
+        )
 
         return PyModule(
             original_mod_name,

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -1815,10 +1815,14 @@ class CToPythonWrapper(Wrapper):
         if not isinstance(expr, BindCModule):
             imports.append(Import(mod_scope.get_python_name(expr.name), expr))
         original_mod_name = mod_scope.get_python_name(original_mod.name)
+
+        docstring = next(d for d in original_mod.docstring.body if isinstance(d, CommentBlock)) if original_mod.docstring else None
+
         return PyModule(
             original_mod_name,
             [API_var],
             funcs,
+            docstring=docstring,
             imports=imports,
             interfaces=interfaces,
             classes=classes,

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -250,6 +250,7 @@ class FortranToCWrapper(Wrapper):
             name,
             variables,
             funcs,
+            docstring=expr.docstring,
             variable_wrappers=variable_getters,
             init_func=init_func,
             free_func=free_func,

--- a/pyccel/parser/semantic.py
+++ b/pyccel/parser/semantic.py
@@ -3897,6 +3897,7 @@ class SemanticParser(BasicParser):
             mod_name,
             variables,
             funcs,
+            docstring=expr.docstring,
             init_func=init_func,
             free_func=free_func,
             interfaces=interfaces,

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -589,6 +589,17 @@ class SyntaxParser(BasicParser):
             if not isinstance(v, (ast.FunctionDef, ast.ClassDef))
         ]
 
+        body = [l for b in body for l in (b.body if isinstance(b, CodeBlock) else [b])]
+
+        docstring = [b for b in body if isinstance(b, (Comment, CommentBlock))]
+        docstring_idx = next(i for i, l in enumerate(docstring) if isinstance(l, CommentBlock))
+        if docstring_idx:
+            docstring_idx += 1
+            docstring = CodeBlock(docstring[:docstring_idx])
+            body = body[docstring_idx:]
+        else:
+            docstring = None
+
         functions = [self._visit(f) for f in ast_functions]
         classes = [self._visit(c) for c in ast_classes]
         imports = [i for i in body if isinstance(i, Import)]
@@ -618,6 +629,7 @@ class SyntaxParser(BasicParser):
             name,
             [],
             functions,
+            docstring=docstring,
             init_func=CodeBlock(body),
             scope=self.scope,
             classes=classes,

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -593,7 +593,7 @@ class SyntaxParser(BasicParser):
 
         docstring = [b for b in body if isinstance(b, (Comment, CommentBlock))]
         docstring_idx = next(
-            i for i, l in enumerate(docstring) if isinstance(l, CommentBlock)
+            (i for i, l in enumerate(docstring) if isinstance(l, CommentBlock)), None
         )
         if docstring_idx:
             docstring_idx += 1

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -592,7 +592,9 @@ class SyntaxParser(BasicParser):
         body = [l for b in body for l in (b.body if isinstance(b, CodeBlock) else [b])]
 
         docstring = [b for b in body if isinstance(b, (Comment, CommentBlock))]
-        docstring_idx = next(i for i, l in enumerate(docstring) if isinstance(l, CommentBlock))
+        docstring_idx = next(
+            i for i, l in enumerate(docstring) if isinstance(l, CommentBlock)
+        )
         if docstring_idx:
             docstring_idx += 1
             docstring = CodeBlock(docstring[:docstring_idx])

--- a/tests/epyccel/modules/Module_docstring.py
+++ b/tests/epyccel/modules/Module_docstring.py
@@ -1,0 +1,12 @@
+# Licence info line 1
+# Licence info line 2
+"""
+This is a module to test that module docstrings are correctly detected.
+"""
+
+# a = 4
+a = 4
+
+"""
+Multi-line comment is not in module docstring.
+"""

--- a/tests/epyccel/test_docstrings.py
+++ b/tests/epyccel/test_docstrings.py
@@ -91,6 +91,7 @@ def test_property_docstring(language):
     python_doc, pyccel_doc = pad_docstrings(MyA.x.__doc__, B.x.__doc__)
     assert python_doc == pyccel_doc
 
+
 def test_module_docstring(language):
     from modules import Module_docstring as mod
 

--- a/tests/epyccel/test_docstrings.py
+++ b/tests/epyccel/test_docstrings.py
@@ -90,3 +90,10 @@ def test_property_docstring(language):
     assert python_doc == pyccel_doc
     python_doc, pyccel_doc = pad_docstrings(MyA.x.__doc__, B.x.__doc__)
     assert python_doc == pyccel_doc
+
+def test_module_docstring(language):
+    from modules import Module_docstring as mod
+
+    epyc_mod = epyccel(mod, language=language)
+    python_doc, pyccel_doc = pad_docstrings(mod.__doc__, epyc_mod.__doc__)
+    assert python_doc == pyccel_doc


### PR DESCRIPTION
Add support for module docstrings for C, Fortran and Python. Fixes #2621.

**Commit Summary**
- Add `docstring` property to `ast.core.Module`
- Print the docstring at the top of `.h` and `.c` files in C
- Print the docstring before the `module` declaration in Fortran
- Print the docstring in Python at the top of the file
- Ensure the docstring is passed through to the wrapper
- Ensure the docstring is exposed back to Python
- Add a test to ensure that the docstring is parsed correctly.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing