### PR TITLE
Add support for a comment block in C++

### DIFF
--- a/pyccel/codegen/printing/cppcode.py
+++ b/pyccel/codegen/printing/cppcode.py
@@ -833,6 +833,31 @@ class CppCodePrinter(CodePrinter):
 
         return f"//{comments}\n"
 
+    def _print_CommentBlock(self, expr):
+        txts = expr.comments
+        header = expr.header
+        header_size = len(expr.header)
+
+        ln = max(len(i) for i in txts)
+        if ln < max(20, header_size + 4):
+            ln = 20
+        if ln % 2 == 1:
+            ln += 1
+        top = (
+            "/*"
+            + "*" * int((ln - header_size) / 2)
+            + f" {header} "
+            + "*" * int((ln - header_size) / 2)
+            + "\n"
+        )
+        bottom = " *" + "*" * ln + "*/\n"
+
+        txts = [" * " + t + " " * (ln - len(t)) + "*\n" for t in txts]
+
+        body = "".join(i for i in txts)
+
+        return "".join([top, body, bottom])
+
     def _print_Import(self, expr):
         if expr.ignore:
             return ""

--- a/pyccel/codegen/printing/pybindcode.py
+++ b/pyccel/codegen/printing/pybindcode.py
@@ -82,13 +82,12 @@ class PyBindCodePrinter(CppCodePrinter):
             )
             docstring = f"{mod_code}.doc() = {docstring_code};"
 
-        parts = [
-            f"PYBIND11_MODULE({expr.name}, {mod_code})\n",
-            "{\n",
-            docstring,
-            self._print(expr.body),
-            "}\n",
-        ]
-
-        code = "".join(p for p in parts if p)
-        return code
+        return "".join(
+            [
+                f"PYBIND11_MODULE({expr.name}, {mod_code})\n",
+                "{\n",
+                docstring,
+                self._print(expr.body),
+                "}\n",
+            ]
+        )

--- a/pyccel/codegen/printing/pybindcode.py
+++ b/pyccel/codegen/printing/pybindcode.py
@@ -6,6 +6,7 @@
 """Functions for printing PyBind11 code."""
 
 from pyccel.ast.core import Import, Module, SeparatorComment
+from pyccel.ast.literals import LiteralString
 from pyccel.codegen.printing.cppcode import CppCodePrinter
 
 __all__ = ("PyBindCodePrinter",)
@@ -69,13 +70,25 @@ class PyBindCodePrinter(CppCodePrinter):
     def _print_PyModInitFunc(self, expr):
         my_vars = expr.scope.variables
         assert len(my_vars) == 1
-        mod = next(iter(my_vars.values()))
-        code = "".join(
-            (
-                f"PYBIND11_MODULE({expr.name}, {self._print(mod)})\n",
-                "{\n",
-                self._print(expr.body),
-                "}\n",
+        mod_var = next(iter(my_vars.values()))
+        mod_code = self._print(mod_var)
+
+        mod = expr.current_user_node
+
+        docstring = ''
+        if mod.docstring:
+            docstring_code = self._print(
+                LiteralString("\n".join(mod.docstring.comments))
             )
-        )
+            docstring = f'{mod_code}.doc() = {docstring_code};'
+
+        parts = [
+            f"PYBIND11_MODULE({expr.name}, {mod_code})\n",
+            "{\n",
+            docstring,
+            self._print(expr.body),
+            "}\n",
+        ]
+
+        code = "".join(p for p in parts if p)
         return code

--- a/pyccel/codegen/printing/pybindcode.py
+++ b/pyccel/codegen/printing/pybindcode.py
@@ -75,12 +75,12 @@ class PyBindCodePrinter(CppCodePrinter):
 
         mod = expr.current_user_node
 
-        docstring = ''
+        docstring = ""
         if mod.docstring:
             docstring_code = self._print(
                 LiteralString("\n".join(mod.docstring.comments))
             )
-            docstring = f'{mod_code}.doc() = {docstring_code};'
+            docstring = f"{mod_code}.doc() = {docstring_code};"
 
         parts = [
             f"PYBIND11_MODULE({expr.name}, {mod_code})\n",

--- a/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
@@ -8,7 +8,7 @@ Module describing the code-wrapping class : CppToPythonWrapper
 which creates an interface exposing C++ code to Python using pybind11.
 """
 
-from pyccel.ast.core import Import, CommentBlock
+from pyccel.ast.core import CommentBlock, Import
 from pyccel.ast.cwrapper import PyccelPyObject, PyModInitFunc, PyModule
 from pyccel.ast.literals import Nil
 from pyccel.ast.variable import Variable

--- a/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
@@ -143,10 +143,18 @@ class CppToPythonWrapper(Wrapper):
 
         imports = [Import(mod_scope.get_python_name(expr.name), expr)]
         original_mod_name = expr.scope.get_python_name(name)
+
+        docstring = (
+            next(d for d in original_mod.docstring.body if isinstance(d, CommentBlock))
+            if original_mod.docstring
+            else None
+        )
+
         return PyModule(
             original_mod_name,
             [],
             (),
+            docstring=docstring,
             imports=imports,
             interfaces=(),
             classes=(),

--- a/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
@@ -8,7 +8,7 @@ Module describing the code-wrapping class : CppToPythonWrapper
 which creates an interface exposing C++ code to Python using pybind11.
 """
 
-from pyccel.ast.core import Import
+from pyccel.ast.core import Import, CommentBlock
 from pyccel.ast.cwrapper import PyccelPyObject, PyModInitFunc, PyModule
 from pyccel.ast.literals import Nil
 from pyccel.ast.variable import Variable

--- a/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
@@ -145,8 +145,8 @@ class CppToPythonWrapper(Wrapper):
         original_mod_name = expr.scope.get_python_name(name)
 
         docstring = (
-            next(d for d in original_mod.docstring.body if isinstance(d, CommentBlock))
-            if original_mod.docstring
+            next(d for d in expr.docstring.body if isinstance(d, CommentBlock))
+            if expr.docstring
             else None
         )
 

--- a/tests/epyccel/test_docstrings.py
+++ b/tests/epyccel/test_docstrings.py
@@ -95,6 +95,6 @@ def test_property_docstring(language):
 def test_module_docstring(experimental_language):
     from modules import Module_docstring as mod
 
-    epyc_mod = epyccel(mod, language=language)
+    epyc_mod = epyccel(mod, language=experimental_language)
     python_doc, pyccel_doc = pad_docstrings(mod.__doc__, epyc_mod.__doc__)
     assert python_doc == pyccel_doc

--- a/tests/epyccel/test_docstrings.py
+++ b/tests/epyccel/test_docstrings.py
@@ -92,7 +92,7 @@ def test_property_docstring(language):
     assert python_doc == pyccel_doc
 
 
-def test_module_docstring(language):
+def test_module_docstring(experimental_language):
     from modules import Module_docstring as mod
 
     epyc_mod = epyccel(mod, language=language)


### PR DESCRIPTION
Add support for a comment block in C++. Comment blocks are used to print module docstrings so this PR also adds C++ support for module docstrings.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
