### PR TITLE
Remove code associated with deprecated Python/NumPy versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ All notable changes to this project will be documented in this file.
 -   #2412 : Remove unused, undocumented obsolete decorator `bypass`.
 -   #2412 : Remove unused, undocumented obsolete decorator `sympy`.
 -   #2474 : Drop support for Python 3.9, test with Python 3.14.
+-   #2474 : Drop support for NumPy < v2.1.
 -   Remaining references to `.pyh` header files are removed. Please use `.pyi` stub files.
 -   \[INTERNALS\] Remove unused properties in `pyccel.codegen.Codegen` (`imports`, `variables`, `body`, `routines`, `classes`, `interfaces`, `modules`, `language`).
 -   \[INTERNALS\] Remove undocumented and untested `stdlib.parallel` folder.

--- a/pyccel/ast/utilities.py
+++ b/pyccel/ast/utilities.py
@@ -108,10 +108,7 @@ builtin_import_registry = Module(
         Import("typing", typing_mod),
     ],
 )
-if sys.version_info < (3, 10):
-    from .builtin_imports import python_builtin_libs
-else:
-    python_builtin_libs = set(sys.stdlib_module_names)  # pylint: disable=no-member
+python_builtin_libs = set(sys.stdlib_module_names)
 
 recognised_libs = python_builtin_libs | builtin_import_registry.keys()
 

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -10,7 +10,6 @@ strings of C code.
 
 import ast
 import functools
-import sys
 from itertools import chain, product
 
 import numpy as np

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -3773,12 +3773,7 @@ class CCodePrinter(CodePrinter):
 
     def _print_Assert(self, expr):
         if isinstance(expr.test, LiteralTrue):
-            if sys.version_info < (3, 9):
-                return ""
-            else:
-                return (
-                    "//" + ast.unparse(expr.python_ast) + "\n"
-                )  # pylint: disable=no-member
+            return "//" + ast.unparse(expr.python_ast) + "\n"
         condition = self._print(expr.test)
         self.add_import(c_imports["assert"])
         return f"assert({condition});\n"

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -3455,12 +3455,7 @@ class FCodePrinter(CodePrinter):
 
     def _print_Assert(self, expr):
         if isinstance(expr.test, LiteralTrue):
-            if sys.version_info < (3, 9):
-                return ""
-            else:
-                return (
-                    "!" + ast.unparse(expr.python_ast) + "\n"
-                )  # pylint: disable=no-member
+            return "!" + ast.unparse(expr.python_ast) + "\n"
         test_code = self._print(expr.test)
         return f"if ( .not. ({test_code})) then\n" "stop 1\n" "end if\n"
 

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -10,7 +10,6 @@ www.fortran90.org as much as possible."""
 import ast
 import re
 import string
-import sys
 from collections import OrderedDict
 from itertools import chain
 

--- a/tests/epyccel/recognised_functions/test_math_funcs.py
+++ b/tests/epyccel/recognised_functions/test_math_funcs.py
@@ -805,7 +805,6 @@ def test_ldexp_return_type(language):  # ldexp
 # --------------------------- remainder function ------------------------------#
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 @pytest.mark.parametrize(
     "language",
     (
@@ -838,7 +837,6 @@ def test_remainder_call(language):  # remainder
     assert isclose(remainder_call(-x, y), f1(-x, y), rtol=RTOL, atol=ATOL)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 @pytest.mark.parametrize(
     "language",
     (

--- a/tests/epyccel/recognised_functions/test_numpy_types.py
+++ b/tests/epyccel/recognised_functions/test_numpy_types.py
@@ -31,12 +31,6 @@ from test_numpy_funcs import (
 
 from pyccel import epyccel
 
-numpy_basic_types_deprecated = tuple(int(v) for v in np.version.version.split(".")) >= (
-    1,
-    24,
-    0,
-)
-
 NT1 = TypeVar("NT1", "int32", "int64", "float32", "float64", "complex64", "complex128")
 NT2 = TypeVar("NT2", "int32", "int64", "float32", "float64", "complex64", "complex128")
 T = TypeVar(
@@ -164,94 +158,6 @@ def test_numpy_scalar_promotion(language):
         assert isinstance(pyccel_result, type(python_result))
 
 
-@pytest.mark.skipif(numpy_basic_types_deprecated, reason="Can't import bool from numpy")
-def test_numpy_bool_scalar(language):
-
-    def get_bool(a: T):
-        from numpy import bool as NumpyBool
-
-        b = NumpyBool(a)
-        return b
-
-    integer8 = randint(min_int8, max_int8, dtype=np.int8)
-    integer16 = randint(min_int16, max_int16, dtype=np.int16)
-    integer = randint(min_int, max_int, dtype=int)
-    integer32 = randint(min_int32, max_int32, dtype=np.int32)
-    integer64 = randint(min_int64, max_int64, dtype=np.int64)
-
-    fl = uniform(min_float / 2, max_float / 2)
-    fl32 = uniform(min_float32 / 2, max_float32 / 2)
-    fl32 = np.float32(fl32)
-    fl64 = uniform(min_float64 / 2, max_float64 / 2)
-
-    epyccel_func = epyccel(get_bool, language=language)
-
-    f_bl_true_output = epyccel_func(True)
-    test_bool_true_output = get_bool(True)
-
-    f_bl_false_output = epyccel_func(False)
-    test_bool_false_output = get_bool(False)
-
-    assert f_bl_true_output == test_bool_true_output
-    assert f_bl_false_output == test_bool_false_output
-
-    assert matching_types(f_bl_true_output, test_bool_true_output)
-    assert matching_types(f_bl_false_output, test_bool_false_output)
-
-    f_integer_output = epyccel_func(integer)
-    test_int_output = get_bool(integer)
-
-    assert f_integer_output == test_int_output
-    assert matching_types(f_integer_output, test_int_output)
-
-    f_integer8_output = epyccel_func(integer8)
-    test_int8_output = get_bool(integer8)
-
-    assert f_integer8_output == test_int8_output
-    assert matching_types(f_integer8_output, test_int8_output)
-
-    f_integer16_output = epyccel_func(integer16)
-    test_int16_output = get_bool(integer16)
-
-    assert f_integer16_output == test_int16_output
-    assert matching_types(f_integer16_output, test_int16_output)
-
-    f_integer32_output = epyccel_func(integer32)
-    test_int32_output = get_bool(integer32)
-
-    assert f_integer32_output == test_int32_output
-    assert matching_types(f_integer32_output, test_int32_output)
-
-    f_integer64_output = epyccel_func(integer64)
-    test_int64_output = get_bool(integer64)
-
-    assert f_integer64_output == test_int64_output
-    assert matching_types(f_integer64_output, test_int64_output)
-
-    f_fl_output = epyccel_func(fl)
-    test_float_output = get_bool(fl)
-
-    assert f_fl_output == test_float_output
-    assert matching_types(f_fl_output, test_float_output)
-
-    f_fl32_output = epyccel_func(fl32)
-    test_float32_output = get_bool(fl32)
-
-    assert f_fl32_output == test_float32_output
-    assert matching_types(f_fl32_output, test_float32_output)
-
-    f_fl64_output = epyccel_func(fl64)
-    test_float64_output = get_bool(fl64)
-
-    assert f_fl64_output == test_float64_output
-    assert matching_types(f_fl64_output, test_float64_output)
-
-
-def get_int(a: T):
-    from numpy import int as Numpyint
-
-    b = Numpyint(a)
-    return b
 
 
 def get_int64(a: T):
@@ -282,21 +188,12 @@ def get_int8(a: T):
     return b
 
 
-if numpy_basic_types_deprecated:
-    int_functions_and_boundaries = [
-        (get_int64, min_int64, max_int64),
-        (get_int32, min_int32, max_int32),
-        (get_int16, min_int16, max_int16),
-        (get_int8, min_int8, max_int8),
-    ]
-else:
-    int_functions_and_boundaries = [
-        (get_int, min_int, max_int),
-        (get_int64, min_int64, max_int64),
-        (get_int32, min_int32, max_int32),
-        (get_int16, min_int16, max_int16),
-        (get_int8, min_int8, max_int8),
-    ]
+int_functions_and_boundaries = [
+    (get_int64, min_int64, max_int64),
+    (get_int32, min_int32, max_int32),
+    (get_int16, min_int16, max_int16),
+    (get_int8, min_int8, max_int8),
+]
 
 
 @pytest.mark.parametrize("function_boundaries", int_functions_and_boundaries)
@@ -539,13 +436,6 @@ def test_numpy_int_array_like_2d(language, function_boundaries):
     assert epyccel_func(fl32) == get_int(fl32)
 
 
-def get_float(a: T):
-    from numpy import float as NumpyFloat
-
-    b = NumpyFloat(a)
-    return b
-
-
 def get_float64(a: T):
     from numpy import float64
 
@@ -560,10 +450,7 @@ def get_float32(a: T):
     return b
 
 
-if numpy_basic_types_deprecated:
-    float_functions = [get_float64, get_float32]
-else:
-    float_functions = [get_float64, get_float32, get_float]
+float_functions = [get_float64, get_float32]
 
 
 @pytest.mark.parametrize("get_float", float_functions)

--- a/tests/epyccel/recognised_functions/test_numpy_types.py
+++ b/tests/epyccel/recognised_functions/test_numpy_types.py
@@ -158,8 +158,6 @@ def test_numpy_scalar_promotion(language):
         assert isinstance(pyccel_result, type(python_result))
 
 
-
-
 def get_int64(a: T):
     from numpy import int64
 

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
-import sys
 from typing import TypeVar
 
 import numpy as np

--- a/tests/epyccel/test_builtins.py
+++ b/tests/epyccel/test_builtins.py
@@ -861,9 +861,6 @@ def test_isinstance_tuple(language):
     assert f(1 + 2j) == isinstance_test(6.5 + 8.3j)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="Union of types implemented in Python 3.10"
-)
 def test_isinstance_union(language):
     def isinstance_test(
         a: bool | int | float | complex,

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -392,10 +392,6 @@ def test_decorator_f22(language):
     assert f(np.complex128(1 + 2.2j)) == f22(np.complex128(1 + 2.2j))
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="PEP604 (writing union types as X | Y) implemented in Python 3.10",
-)
 def test_union_type(language):
     def square(a: int | float):  # pylint: disable=unsupported-binary-operation
         return a * a

--- a/tests/epyccel/test_epyccel_functions.py
+++ b/tests/epyccel/test_epyccel_functions.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring
 # coding: utf-8
-import sys
 from typing import Final, TypeVar
 
 import numpy as np

--- a/tests/epyccel/test_epyccel_modules.py
+++ b/tests/epyccel/test_epyccel_modules.py
@@ -227,9 +227,6 @@ def test_awkward_names(language):
     assert mod.allocate(1) == modnew.allocate(1)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="PEP613 (TypeAlias) implemented in Python 3.10"
-)
 def test_module_type_alias(language):
     import modules.Module_9 as mod
 


### PR DESCRIPTION
Remove code associated with deprecated Python/NumPy versions. We support Python>=3.10, which means we also require NumPy>=v2.1 (the CHANGELOG is retroactively modified to indicate when support for NumPy v1 was dropped, even if the supported NumPy version is entirely dictated by the Python version). There are still multiple places in the code implementing different logic for some older versions. This is not necessary so it is removed.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
