### PR TITLE
Fix Scope thread safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 -   #2618 : Fix unnecessary stack memory allocation for variables storing temporary slices.
 -   #2618 : Fix unnecessary slicing returning the whole array.
 -   #2620 : Fix strange indenting in Fortran when a comment line begins with a dollar sign.
+-   #2629 : Fix race condition due to class variables in `Scope`.
 
 ### Changed
 

--- a/pyccel/codegen/make_pipeline.py
+++ b/pyccel/codegen/make_pipeline.py
@@ -156,8 +156,14 @@ def execute_pyccel_make(
     cwd = os.getcwd()
     files = [f.relative_to(cwd) if f.is_absolute() else f for f in files]
 
-    parsers = {f: Parser(f.absolute(), output_folder=folder,
-                         name_clash_checker=name_clash_checkers[language]) for f in files}
+    parsers = {
+        f: Parser(
+            f.absolute(),
+            output_folder=folder,
+            name_clash_checker=name_clash_checkers[language],
+        )
+        for f in files
+    }
 
     to_remove = []
     for f, p in parsers.items():

--- a/pyccel/codegen/make_pipeline.py
+++ b/pyccel/codegen/make_pipeline.py
@@ -28,7 +28,6 @@ from pyccel.errors.errors import (
 )
 from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
-from pyccel.parser.scope import Scope
 from pyccel.utilities.stage import PyccelStage
 
 from .compiling.compilers import Compiler, get_condaless_search_path
@@ -144,9 +143,6 @@ def execute_pyccel_make(
     Compiler.acceptable_bin_paths = get_condaless_search_path(conda_warnings)
     compiler = Compiler(compiler_family, debug)
 
-    # Get compiler object
-    Scope.name_clash_checker = name_clash_checkers[language]
-
     start_syntax = time.time()
     timers["Initialisation"] = start_syntax - start
 
@@ -160,7 +156,8 @@ def execute_pyccel_make(
     cwd = os.getcwd()
     files = [f.relative_to(cwd) if f.is_absolute() else f for f in files]
 
-    parsers = {f: Parser(f.absolute(), output_folder=folder) for f in files}
+    parsers = {f: Parser(f.absolute(), output_folder=folder,
+                         name_clash_checker=name_clash_checkers[language]) for f in files}
 
     to_remove = []
     for f, p in parsers.items():

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -29,7 +29,6 @@ from pyccel.errors.errors import (
 )
 from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
-from pyccel.parser.scope import Scope
 from pyccel.utilities.stage import PyccelStage
 
 from .compiling.basic import CompileObj

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -211,12 +211,11 @@ def execute_pyccel(
         if not fname:
             return
 
-    Scope.name_clash_checker = name_clash_checkers[language]
-
     start_syntax = time.time()
     timers["Initialisation"] = start_syntax - start
     # Parse Python file
-    parser = Parser(pymod_filepath, output_folder=folder, context_dict=context_dict)
+    parser = Parser(pymod_filepath, output_folder=folder, context_dict=context_dict,
+                    name_clash_checker = name_clash_checkers[language])
     parser.parse(verbose=verbose)
     if errors.has_errors():
         raise PyccelSyntaxError("Syntax step failed")

--- a/pyccel/codegen/pipeline.py
+++ b/pyccel/codegen/pipeline.py
@@ -214,8 +214,12 @@ def execute_pyccel(
     start_syntax = time.time()
     timers["Initialisation"] = start_syntax - start
     # Parse Python file
-    parser = Parser(pymod_filepath, output_folder=folder, context_dict=context_dict,
-                    name_clash_checker = name_clash_checkers[language])
+    parser = Parser(
+        pymod_filepath,
+        output_folder=folder,
+        context_dict=context_dict,
+        name_clash_checker=name_clash_checkers[language],
+    )
     parser.parse(verbose=verbose)
     if errors.has_errors():
         raise PyccelSyntaxError("Syntax step failed")

--- a/pyccel/codegen/printing/ccode.py
+++ b/pyccel/codegen/printing/ccode.py
@@ -154,6 +154,7 @@ from pyccel.errors.messages import (
     PYCCEL_RESTRICTION_IS_ISNOT,
     PYCCEL_RESTRICTION_TODO,
 )
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.scope import Scope
 
 errors = Errors()
@@ -3915,6 +3916,7 @@ class CCodePrinter(CodePrinter):
             scope_type="class",
             used_symbols=expr.scope.local_used_symbols.copy(),
             original_symbols=expr.scope.python_names.copy(),
+            name_clash_checker=name_clash_checkers["c"],
         )
 
         # Generate safe C names for function pointer members and store on cls_name

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -658,8 +658,11 @@ class FCodePrinter(CodePrinter):
                 mod_name,
                 (),
                 (),
-                scope=Scope(name=mod_name, scope_type="module",
-                            name_clash_checker=name_clash_checkers["fortran"]),
+                scope=Scope(
+                    name=mod_name,
+                    scope_type="module",
+                    name_clash_checker=name_clash_checkers["fortran"],
+                ),
                 imports=imports_and_macros,
                 is_external=True,
             )
@@ -773,8 +776,11 @@ class FCodePrinter(CodePrinter):
                 mod_name,
                 (),
                 (),
-                scope=Scope(name=mod_name, scope_type="module",
-                            name_clash_checker=name_clash_checkers["fortran"]),
+                scope=Scope(
+                    name=mod_name,
+                    scope_type="module",
+                    name_clash_checker=name_clash_checkers["fortran"],
+                ),
                 imports=imports_and_macros,
                 is_external=True,
             )

--- a/pyccel/codegen/printing/fcode.py
+++ b/pyccel/codegen/printing/fcode.py
@@ -162,6 +162,7 @@ from pyccel.errors.messages import (
     PYCCEL_RESTRICTION_IS_ISNOT,
     PYCCEL_RESTRICTION_TODO,
 )
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.scope import Scope
 
 # TODO: add examples
@@ -657,7 +658,8 @@ class FCodePrinter(CodePrinter):
                 mod_name,
                 (),
                 (),
-                scope=Scope(name=mod_name, scope_type="module"),
+                scope=Scope(name=mod_name, scope_type="module",
+                            name_clash_checker=name_clash_checkers["fortran"]),
                 imports=imports_and_macros,
                 is_external=True,
             )
@@ -771,7 +773,8 @@ class FCodePrinter(CodePrinter):
                 mod_name,
                 (),
                 (),
-                scope=Scope(name=mod_name, scope_type="module"),
+                scope=Scope(name=mod_name, scope_type="module",
+                            name_clash_checker=name_clash_checkers["fortran"]),
                 imports=imports_and_macros,
                 is_external=True,
             )

--- a/pyccel/codegen/wrap_pipeline.py
+++ b/pyccel/codegen/wrap_pipeline.py
@@ -142,8 +142,12 @@ def execute_pyccel_wrap(
     start_syntax = time.time()
     timers["Initialisation"] = start_syntax - start
     # Parse Python file
-    parser = Parser(pymod_filepath, output_folder=folder, context_dict={},
-                    name_clash_checker = name_clash_checkers[language])
+    parser = Parser(
+        pymod_filepath,
+        output_folder=folder,
+        context_dict={},
+        name_clash_checker=name_clash_checkers[language],
+    )
     parser.parse(verbose=verbose)
 
     if errors.has_errors():

--- a/pyccel/codegen/wrap_pipeline.py
+++ b/pyccel/codegen/wrap_pipeline.py
@@ -25,7 +25,6 @@ from pyccel.errors.errors import (
 )
 from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
-from pyccel.parser.scope import Scope
 from pyccel.utilities.stage import PyccelStage
 
 from .compiling.basic import CompileObj
@@ -140,12 +139,11 @@ def execute_pyccel_wrap(
     Compiler.acceptable_bin_paths = get_condaless_search_path(conda_warnings)
     compiler = Compiler(compiler_family, debug)
 
-    Scope.name_clash_checker = name_clash_checkers[language]
-
     start_syntax = time.time()
     timers["Initialisation"] = start_syntax - start
     # Parse Python file
-    parser = Parser(pymod_filepath, output_folder=folder, context_dict={})
+    parser = Parser(pymod_filepath, output_folder=folder, context_dict={},
+                    name_clash_checker = name_clash_checkers[language])
     parser.parse(verbose=verbose)
 
     if errors.has_errors():

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -183,6 +183,7 @@ from pyccel.ast.operators import (
 from pyccel.ast.variable import DottedVariable, IndexedElement, Variable
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import PYCCEL_RESTRICTION_TODO
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.scope import Scope
 
 from .wrapper import Wrapper
@@ -1751,6 +1752,7 @@ class CToPythonWrapper(Wrapper):
             used_symbols=scope.local_used_symbols.copy(),
             original_symbols=scope.python_names.copy(),
             scope_type="module",
+            name_clash_checker=name_clash_checkers["c"],
         )
         self.scope = mod_scope
 
@@ -2952,6 +2954,7 @@ class CToPythonWrapper(Wrapper):
                         used_symbols=expr.source_module.scope.local_used_symbols.copy(),
                         original_symbols=expr.source_module.scope.python_names.copy(),
                         scope_type="module",
+                        name_clash_checker=name_clash_checkers["c"],
                     )
                 name = t.scope.get_python_name(t.name)
                 struct_name = import_scope.get_new_name(f"Py{name}Object")
@@ -2963,7 +2966,8 @@ class CToPythonWrapper(Wrapper):
                     t,
                     struct_name,
                     type_name,
-                    Scope(name=name, scope_type="class"),
+                    Scope(name=name, scope_type="class",
+                          name_clash_checker=name_clash_checkers["c"]),
                     class_type=dtype,
                 )
                 self._python_object_map[t] = wrapped_class
@@ -2973,7 +2977,8 @@ class CToPythonWrapper(Wrapper):
 
         if import_wrapper:
             wrapper_name = f"{expr.source}_wrapper"
-            mod_spoof_scope = Scope(name=expr.source_module.name, scope_type="module")
+            mod_spoof_scope = Scope(name=expr.source_module.name, scope_type="module",
+                                     name_clash_checker=name_clash_checkers["c"])
             mod_import_func = FunctionDef(
                 mod_spoof_scope.get_new_name("import"),
                 (),

--- a/pyccel/codegen/wrapper/c_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/c_to_python_wrapper.py
@@ -2966,8 +2966,11 @@ class CToPythonWrapper(Wrapper):
                     t,
                     struct_name,
                     type_name,
-                    Scope(name=name, scope_type="class",
-                          name_clash_checker=name_clash_checkers["c"]),
+                    Scope(
+                        name=name,
+                        scope_type="class",
+                        name_clash_checker=name_clash_checkers["c"],
+                    ),
                     class_type=dtype,
                 )
                 self._python_object_map[t] = wrapped_class
@@ -2977,8 +2980,11 @@ class CToPythonWrapper(Wrapper):
 
         if import_wrapper:
             wrapper_name = f"{expr.source}_wrapper"
-            mod_spoof_scope = Scope(name=expr.source_module.name, scope_type="module",
-                                     name_clash_checker=name_clash_checkers["c"])
+            mod_spoof_scope = Scope(
+                name=expr.source_module.name,
+                scope_type="module",
+                name_clash_checker=name_clash_checkers["c"],
+            )
             mod_import_func = FunctionDef(
                 mod_spoof_scope.get_new_name("import"),
                 (),

--- a/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
+++ b/pyccel/codegen/wrapper/cpp_to_python_wrapper.py
@@ -13,6 +13,7 @@ from pyccel.ast.cwrapper import PyccelPyObject, PyModInitFunc, PyModule
 from pyccel.ast.literals import Nil
 from pyccel.ast.variable import Variable
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.scope import Scope
 
 from .wrapper import Wrapper
@@ -126,6 +127,7 @@ class CppToPythonWrapper(Wrapper):
             used_symbols=scope.local_used_symbols.copy(),
             original_symbols=scope.python_names.copy(),
             scope_type="module",
+            name_clash_checker=name_clash_checkers["c++"],
         )
         self.scope = mod_scope
 

--- a/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
+++ b/pyccel/codegen/wrapper/fortran_to_c_wrapper.py
@@ -71,6 +71,7 @@ from pyccel.ast.operators import PyccelAdd, PyccelIsNot, PyccelMul
 from pyccel.ast.variable import DottedVariable, IndexedElement, Variable
 from pyccel.errors.errors import Errors
 from pyccel.errors.messages import PYCCEL_RESTRICTION_TODO
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.scope import Scope
 
 from .wrapper import Wrapper
@@ -203,6 +204,7 @@ class FortranToCWrapper(Wrapper):
             used_symbols=scope.local_used_symbols.copy(),
             original_symbols=scope.python_names.copy(),
             scope_type="module",
+            name_clash_checker=name_clash_checkers["fortran"],
         )
         name = mod_scope.get_new_name(f"bind_c_{expr.name}")
         self.scope = mod_scope

--- a/pyccel/codegen/wrappergen.py
+++ b/pyccel/codegen/wrappergen.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 from ..ast.core import ModuleHeader
 from ..errors.errors import Errors
-from ..naming import name_clash_checkers
-from ..parser.scope import Scope
 from ..utilities.stage import PyccelStage
 from .codegen import _extension_registry, _header_extension_registry
 from .printing.cwrappercode import CWrapperCodePrinter
@@ -83,7 +81,6 @@ class Wrappergen:
         sharedlib_dirpath : str
             The folder where the generated .so file will be located.
         """
-        current_name_clash_checker = Scope.name_clash_checker
         ast = self._ast
         for Wrapper in self._wrapper_types:
             if self._verbose:
@@ -92,9 +89,6 @@ class Wrappergen:
                     self._name,
                 )
 
-            Scope.name_clash_checker = name_clash_checkers[
-                Wrapper.start_language.lower()
-            ]
             wrapper = Wrapper(sharedlib_dirpath, verbose=self._verbose)
 
             ast = wrapper.wrap(ast)
@@ -102,8 +96,6 @@ class Wrappergen:
 
             if errors.has_errors():
                 break
-
-        Scope.name_clash_checker = current_name_clash_checker
 
     def print(self, dirpath):
         """

--- a/pyccel/complexity/basic.py
+++ b/pyccel/complexity/basic.py
@@ -33,8 +33,11 @@ class Complexity:
     """
 
     def __init__(self, filename_or_text):
-        pyccel = Parser(filename_or_text, output_folder=os.getcwd(),
-                        name_clash_checker=name_clash_checkers["python"])
+        pyccel = Parser(
+            filename_or_text,
+            output_folder=os.getcwd(),
+            name_clash_checker=name_clash_checkers["python"],
+        )
         self._ast = pyccel.parse(verbose=0)
         self._ast = pyccel.annotate(verbose=0).ast
 

--- a/pyccel/complexity/basic.py
+++ b/pyccel/complexity/basic.py
@@ -12,6 +12,7 @@ or the memory/space complexity.
 
 import os
 
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 __all__ = ["Complexity"]
@@ -32,7 +33,8 @@ class Complexity:
     """
 
     def __init__(self, filename_or_text):
-        pyccel = Parser(filename_or_text, output_folder=os.getcwd())
+        pyccel = Parser(filename_or_text, output_folder=os.getcwd(),
+                        name_clash_checker=name_clash_checkers["python"])
         self._ast = pyccel.parse(verbose=0)
         self._ast = pyccel.annotate(verbose=0).ast
 

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -57,6 +57,7 @@ class Parser:
         output_folder,
         context_dict=None,
         original_filename=None,
+        name_clash_checker,
         **kwargs,
     ):
 
@@ -77,6 +78,8 @@ class Parser:
         self._compile_obj = None
 
         self._context_dict = context_dict
+
+        self._name_clash_checker = name_clash_checker
 
         self._original_filename = Path(original_filename or filename)
 
@@ -198,7 +201,8 @@ class Parser:
             print(">> Parsing :: ", self._filename)
 
         parser = SyntaxParser(
-            self._filename, verbose=verbose, context_dict=self._context_dict
+            self._filename, verbose=verbose, context_dict=self._context_dict,
+            name_clash_checker = self._name_clash_checker
         )
         self.syntax_parser = parser
 

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -358,6 +358,7 @@ class Parser:
                     stashed_filename,
                     output_folder=q_output_folder,
                     original_filename=filename,
+                    name_clash_checker=self._name_clash_checker,
                 )
             q.parse(d_parsers_by_filename=d_parsers_by_filename, verbose=verbose)
             d_parsers_by_filename[filename] = q

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -46,6 +46,10 @@ class Parser:
         filename is a .pyi file in a __pyccel__ folder (i.e. a .pyi file that was
         auto-generated to describe the prototypes of the methods).
 
+    name_clash_checker : LanguageNameClashChecker
+        The class which allows new names to be defined, preventing clashes with existing
+        names and language-specific keywords.
+
     **kwargs : dict
         Any keyword arguments for BasicParser.
     """

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -47,7 +47,7 @@ class Parser:
         auto-generated to describe the prototypes of the methods).
 
     name_clash_checker : LanguageNameClashChecker
-        The class which allows new names to be defined, preventing clashes with existing
+        The object which allows new names to be defined, preventing clashes with existing
         names and language-specific keywords.
 
    **kwargs : dict

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -50,8 +50,8 @@ class Parser:
         The class which allows new names to be defined, preventing clashes with existing
         names and language-specific keywords.
 
-    **kwargs : dict
-        Any keyword arguments for BasicParser.
+   **kwargs : dict
+       Any additional keyword arguments for BasicParser.
     """
 
     def __init__(

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -50,8 +50,8 @@ class Parser:
         The object which allows new names to be defined, preventing clashes with existing
         names and language-specific keywords.
 
-   **kwargs : dict
-       Any additional keyword arguments for BasicParser.
+    **kwargs : dict
+        Any additional keyword arguments for BasicParser.
     """
 
     def __init__(

--- a/pyccel/parser/parser.py
+++ b/pyccel/parser/parser.py
@@ -201,8 +201,10 @@ class Parser:
             print(">> Parsing :: ", self._filename)
 
         parser = SyntaxParser(
-            self._filename, verbose=verbose, context_dict=self._context_dict,
-            name_clash_checker = self._name_clash_checker
+            self._filename,
+            verbose=verbose,
+            context_dict=self._context_dict,
+            name_clash_checker=self._name_clash_checker,
         )
         self.syntax_parser = parser
 

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -67,8 +67,6 @@ class Scope:
         The type of the scope being created [module, function, class, loop, program].
     """
 
-    allow_loop_scoping = False
-    name_clash_checker = PythonNameClashChecker()
     __slots__ = (
         "_name",
         "_imports",
@@ -84,6 +82,8 @@ class Scope:
         "_dotted_symbols",
         "_symbol_prefix",
         "_scope_type",
+        "_name_clash_checker",
+        "_allow_loop_scoping",
     )
 
     categories = (
@@ -107,10 +107,14 @@ class Scope:
         original_symbols=None,
         symbolic_aliases=None,
         scope_type,
+        name_clash_checker,
+        allow_loop_scoping = False
     ):
 
         assert (name is None) != (not is_loop)
         assert scope_type in ("module", "function", "class", "loop", "program")
+
+        self._name_clash_checker = name_clash_checker
 
         self._name = name
         self._scope_type = scope_type
@@ -148,6 +152,7 @@ class Scope:
         self._is_loop = is_loop
         # scoping for loops
         self._loops = []
+        self._allow_loop_scoping = allow_loop_scoping
 
         self._dotted_symbols = []
 
@@ -177,7 +182,8 @@ class Scope:
         if ps is not self:
             raise ValueError(f"A child of {self} cannot have a parent {ps}")
 
-        child = Scope(name=name, **kwargs, parent_scope=self, scope_type=scope_type)
+        child = Scope(name=name, **kwargs, parent_scope=self, scope_type=scope_type,
+                      name_clash_checker = self._name_clash_checker)
 
         self.add_son(name, child)
 
@@ -410,7 +416,7 @@ class Scope:
         if name is None:
             name = self.get_python_name(var.name)
 
-        if not self.allow_loop_scoping and self.is_loop:
+        if not self._allow_loop_scoping and self.is_loop:
             self.parent_scope.insert_variable(var, name)
         else:
             if name in self._locals["variables"]:
@@ -598,10 +604,10 @@ class Scope:
             self._dotted_symbols.append(symbol)
             return symbol
         else:
-            if not self.allow_loop_scoping and self.is_loop:
+            if not self._allow_loop_scoping and self.is_loop:
                 return self.parent_scope.insert_symbol(symbol)
             elif symbol not in self._used_symbols:
-                collisionless_name = self.name_clash_checker.get_collisionless_name(
+                collisionless_name = self._name_clash_checker.get_collisionless_name(
                     symbol,
                     self.all_used_symbols,
                     prefix=self._symbol_prefix,
@@ -635,12 +641,12 @@ class Scope:
         if isinstance(python_symbol, AnnotatedPyccelSymbol):
             python_symbol = python_symbol.name
 
-        if not self.allow_loop_scoping and self.is_loop:
+        if not self._allow_loop_scoping and self.is_loop:
             self.parent_scope.insert_low_level_symbol(python_symbol, low_level_symbol)
 
         assert python_symbol not in self._used_symbols
 
-        if self.name_clash_checker.has_clash(low_level_symbol, self.all_used_symbols):
+        if self._name_clash_checker.has_clash(low_level_symbol, self.all_used_symbols):
             errors.report(
                 "Low-level name conflicts with name already in use.",
                 severity="error",
@@ -680,7 +686,7 @@ class Scope:
         alias : pyccel.ast.basic.Basic
             The object which will be represented by the symbol.
         """
-        if not self.allow_loop_scoping and self.is_loop:
+        if not self._allow_loop_scoping and self.is_loop:
             self.parent_scope.insert_symbolic_alias(symbol, alias)
         else:
             symbolic_aliases = self._locals["symbolic_aliases"]
@@ -801,7 +807,7 @@ class Scope:
             self.local_used_symbols.values(),
             prefix=prefix,
             counter=counter,
-            name_clash_checker=self.name_clash_checker,
+            name_clash_checker=self._name_clash_checker,
         )
 
         chosen_new_symbol = PyccelSymbol(new_name, is_temp=True)
@@ -840,7 +846,7 @@ class Scope:
         PyccelSymbol
             The new name which will be printed in the code.
         """
-        if current_name is not None and not self.name_clash_checker.has_clash(
+        if current_name is not None and not self._name_clash_checker.has_clash(
             current_name, self.all_python_symbols
         ):
             new_name = PyccelSymbol(current_name, is_temp=is_temp)
@@ -854,7 +860,7 @@ class Scope:
                 self.all_used_symbols,
                 prefix=current_name,
                 counter=self._dummy_counter,
-                name_clash_checker=self.name_clash_checker,
+                name_clash_checker=self._name_clash_checker,
             )
         else:
             if is_temp is None:
@@ -864,7 +870,7 @@ class Scope:
                 self.all_used_symbols, prefix=current_name
             )
 
-        collisionless_name = self.name_clash_checker.get_collisionless_name(
+        collisionless_name = self._name_clash_checker.get_collisionless_name(
             new_name,
             self.all_used_symbols,
             prefix=self._symbol_prefix,

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -21,7 +21,6 @@ from pyccel.ast.variable import (
     Variable,
 )
 from pyccel.errors.errors import Errors
-from pyccel.naming.pythonnameclashchecker import PythonNameClashChecker
 from pyccel.utilities.strings import create_incremented_string
 
 errors = Errors()

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -65,6 +65,15 @@ class Scope:
 
     scope_type : str
         The type of the scope being created [module, function, class, loop, program].
+
+    name_clash_checker : LanguageNameClashChecker
+        The class which allows new names to be defined, preventing clashes with existing
+        names and language-specific keywords.
+
+    allow_loop_scoping : bool, default=False
+        Indicates whether variables are allowed to be defined local to a loop scope.
+        This is forbidden in Python and Fortran, but can be useful for temporary
+        variables added for other languages.
     """
 
     __slots__ = (

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -384,6 +384,7 @@ class Scope:
             is_loop=True,
             parent_scope=self,
             scope_type="loop",
+            name_clash_checker=self._name_clash_checker,
         )
         self.add_loop(new_scope)
         return new_scope

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -66,7 +66,7 @@ class Scope:
         The type of the scope being created [module, function, class, loop, program].
 
     name_clash_checker : LanguageNameClashChecker
-        The class which allows new names to be defined, preventing clashes with existing
+        The object which allows new names to be defined, preventing clashes with existing
         names and language-specific keywords.
 
     allow_loop_scoping : bool, default=False

--- a/pyccel/parser/scope.py
+++ b/pyccel/parser/scope.py
@@ -108,7 +108,7 @@ class Scope:
         symbolic_aliases=None,
         scope_type,
         name_clash_checker,
-        allow_loop_scoping = False
+        allow_loop_scoping=False,
     ):
 
         assert (name is None) != (not is_loop)
@@ -182,8 +182,13 @@ class Scope:
         if ps is not self:
             raise ValueError(f"A child of {self} cannot have a parent {ps}")
 
-        child = Scope(name=name, **kwargs, parent_scope=self, scope_type=scope_type,
-                      name_clash_checker = self._name_clash_checker)
+        child = Scope(
+            name=name,
+            **kwargs,
+            parent_scope=self,
+            scope_type=scope_type,
+            name_clash_checker=self._name_clash_checker,
+        )
 
         self.add_son(name, child)
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -213,8 +213,9 @@ class SyntaxParser(BasicParser):
 
             scope_name = inputs.stem
 
-        self._scope = Scope(name=scope_name, scope_type="module",
-                            name_clash_checker = name_clash_checker)
+        self._scope = Scope(
+            name=scope_name, scope_type="module", name_clash_checker=name_clash_checker
+        )
 
         self._code = code
         self._context = []

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -190,6 +190,10 @@ class SyntaxParser(BasicParser):
         A dictionary describing any variables in the context where the translated
         objected was defined.
 
+    name_clash_checker : LanguageNameClashChecker
+        The class which allows new names to be defined, preventing clashes with existing
+        names and language-specific keywords.
+
     **kwargs : dict
         Additional keyword arguments for BasicParser.
     """

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -191,7 +191,7 @@ class SyntaxParser(BasicParser):
         objected was defined.
 
     name_clash_checker : LanguageNameClashChecker
-        The class which allows new names to be defined, preventing clashes with existing
+        The object which allows new names to be defined, preventing clashes with existing
         names and language-specific keywords.
 
     **kwargs : dict

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1773,18 +1773,3 @@ class SyntaxParser(BasicParser):
             VariableTypeAnnotation(FinalType.get_new(TypeAlias()))
         )
         return Assign(AnnotatedPyccelSymbol(name, annotation=type_annotation), rhs)
-
-
-# ==============================================================================
-
-
-if __name__ == "__main__":
-    import sys
-
-    try:
-        filename = sys.argv[1]
-    except IndexError:
-        raise ValueError("Expecting an argument for filename")
-
-    parser = SyntaxParser(filename)
-    print(parser.ast)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -194,11 +194,12 @@ class SyntaxParser(BasicParser):
         Additional keyword arguments for BasicParser.
     """
 
-    def __init__(self, inputs, *, context_dict=None, **kwargs):
+    def __init__(self, inputs, *, context_dict=None, name_clash_checker, **kwargs):
         BasicParser.__init__(self, **kwargs)
 
         # check if inputs is a file
         code = inputs
+        scope_name = ""
         if os.path.isfile(inputs):
 
             self._filename = inputs
@@ -210,9 +211,10 @@ class SyntaxParser(BasicParser):
             with open(inputs, "r", encoding="utf-8") as file:
                 code = file.read()
 
-            self._scope = Scope(name=inputs.stem, scope_type="module")
-        else:
-            self._scope = Scope(name="", scope_type="module")
+            scope_name = inputs.stem
+
+        self._scope = Scope(name=scope_name, scope_type="module",
+                            name_clash_checker = name_clash_checker)
 
         self._code = code
         self._context = []

--- a/tests/ast/test_basic.py
+++ b/tests/ast/test_basic.py
@@ -18,8 +18,11 @@ path_dir = os.path.join(base_dir, "scripts")
 
 
 def get_functions(filename):
-    pyccel = Parser(filename, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        filename,
+        output_folder=os.getcwd(),
+        name_clash_checker=name_clash_checkers["python"],
+    )
     errors = Errors()
 
     ast = pyccel.parse(verbose=0)

--- a/tests/ast/test_basic.py
+++ b/tests/ast/test_basic.py
@@ -10,6 +10,7 @@ from pyccel.ast.literals import LiteralInteger
 from pyccel.ast.operators import PyccelAdd, PyccelMinus, PyccelMul, PyccelOperator
 from pyccel.ast.variable import Variable
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -17,7 +18,8 @@ path_dir = os.path.join(base_dir, "scripts")
 
 
 def get_functions(filename):
-    pyccel = Parser(filename, output_folder=os.getcwd())
+    pyccel = Parser(filename, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     errors = Errors()
 
     ast = pyccel.parse(verbose=0)

--- a/tests/codegen/ccode/test_ccode_codegen.py
+++ b/tests/codegen/ccode/test_ccode_codegen.py
@@ -10,6 +10,7 @@ import pytest
 
 from pyccel.codegen.codegen import Codegen
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -38,7 +39,8 @@ def test_codegen(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["c"])
     ast = pyccel.parse(verbose=0)
 
     # Assert syntactic success

--- a/tests/codegen/ccode/test_ccode_codegen.py
+++ b/tests/codegen/ccode/test_ccode_codegen.py
@@ -39,8 +39,9 @@ def test_codegen(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["c"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["c"]
+    )
     ast = pyccel.parse(verbose=0)
 
     # Assert syntactic success

--- a/tests/codegen/fcode/test_fcode_codegen.py
+++ b/tests/codegen/fcode/test_fcode_codegen.py
@@ -41,8 +41,9 @@ def test_codegen(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["fortran"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["fortran"]
+    )
     ast = pyccel.parse(verbose=0)
 
     # Assert syntactic success

--- a/tests/codegen/fcode/test_fcode_codegen.py
+++ b/tests/codegen/fcode/test_fcode_codegen.py
@@ -10,6 +10,7 @@ import pytest
 
 from pyccel.codegen.codegen import Codegen
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -40,7 +41,8 @@ def test_codegen(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["fortran"])
     ast = pyccel.parse(verbose=0)
 
     # Assert syntactic success

--- a/tests/codegen/pycode/test_pycode_codegen.py
+++ b/tests/codegen/pycode/test_pycode_codegen.py
@@ -24,8 +24,9 @@ files = [os.path.join(path_dir, f) for f in files if (f.endswith(".py"))]
 @pytest.mark.parametrize("f", files)
 def test_codegen(f):
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
     ast = pyccel.parse(verbose=0)
 
     ast = pyccel.annotate(verbose=0)

--- a/tests/codegen/pycode/test_pycode_codegen.py
+++ b/tests/codegen/pycode/test_pycode_codegen.py
@@ -10,6 +10,7 @@ import pytest
 
 from pyccel.codegen.codegen import Codegen
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -23,7 +24,8 @@ files = [os.path.join(path_dir, f) for f in files if (f.endswith(".py"))]
 @pytest.mark.parametrize("f", files)
 def test_codegen(f):
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     ast = pyccel.parse(verbose=0)
 
     ast = pyccel.annotate(verbose=0)

--- a/tests/errors/test_errors.py
+++ b/tests/errors/test_errors.py
@@ -23,7 +23,6 @@ from pyccel.errors.errors import (
 )
 from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
-from pyccel.parser.scope import Scope
 
 error_mode = ErrorsMode()
 
@@ -47,7 +46,8 @@ def test_syntax_blockers(f):
     with open(f, encoding="utf-8") as fl:
         expected_error_msg = fl.readlines()[0][1:].strip()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
 
     with pytest.raises(PyccelSyntaxError):
         pyccel.parse(verbose=0)
@@ -69,7 +69,8 @@ def test_syntax_errors(f):
     with open(f, encoding="utf-8") as fl:
         expected_error_msg = fl.readlines()[0][1:].strip()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
 
     pyccel.parse(verbose=0)
 
@@ -92,8 +93,8 @@ def test_semantic_blocking_errors(f):
     errors = Errors()
     errors.reset()
 
-    Scope.name_clash_checker = name_clash_checkers["fortran"]
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["fortran"])
     pyccel.parse(verbose=0)
 
     with pytest.raises(PyccelSemanticError):
@@ -118,7 +119,8 @@ def test_traceback():
     errors.reset()
     error_mode.set_mode("developer")
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     pyccel.parse(verbose=0)
 
     try:
@@ -149,7 +151,8 @@ def test_semantic_non_blocking_errors(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     pyccel.parse(verbose=0)
 
     pyccel.annotate(verbose=0)
@@ -172,7 +175,8 @@ def test_semantic_non_blocking_developer_errors(f):
     errors.reset()
     error_mode.set_mode("developer")
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     pyccel.parse(verbose=0)
 
     with pytest.raises(PyccelSemanticError):
@@ -192,7 +196,8 @@ def test_codegen_blocking_errors(f):
     with open(f, encoding="utf-8") as fl:
         expected_error_msg = fl.readlines()[0][1:].strip()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["fortran"])
     pyccel.parse(verbose=0)
 
     ast = pyccel.annotate(verbose=0)
@@ -221,7 +226,8 @@ def test_codegen_non_blocking_errors(f):
     with open(f, encoding="utf-8") as fl:
         expected_error_msg = fl.readlines()[0][1:].strip()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["fortran"])
     pyccel.parse(verbose=0)
 
     ast = pyccel.annotate(verbose=0)

--- a/tests/errors/test_errors.py
+++ b/tests/errors/test_errors.py
@@ -46,8 +46,9 @@ def test_syntax_blockers(f):
     with open(f, encoding="utf-8") as fl:
         expected_error_msg = fl.readlines()[0][1:].strip()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
 
     with pytest.raises(PyccelSyntaxError):
         pyccel.parse(verbose=0)
@@ -69,8 +70,9 @@ def test_syntax_errors(f):
     with open(f, encoding="utf-8") as fl:
         expected_error_msg = fl.readlines()[0][1:].strip()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
 
     pyccel.parse(verbose=0)
 
@@ -93,8 +95,9 @@ def test_semantic_blocking_errors(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["fortran"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["fortran"]
+    )
     pyccel.parse(verbose=0)
 
     with pytest.raises(PyccelSemanticError):
@@ -119,8 +122,9 @@ def test_traceback():
     errors.reset()
     error_mode.set_mode("developer")
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
     pyccel.parse(verbose=0)
 
     try:
@@ -151,8 +155,9 @@ def test_semantic_non_blocking_errors(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
     pyccel.parse(verbose=0)
 
     pyccel.annotate(verbose=0)
@@ -175,8 +180,9 @@ def test_semantic_non_blocking_developer_errors(f):
     errors.reset()
     error_mode.set_mode("developer")
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
     pyccel.parse(verbose=0)
 
     with pytest.raises(PyccelSemanticError):
@@ -196,8 +202,9 @@ def test_codegen_blocking_errors(f):
     with open(f, encoding="utf-8") as fl:
         expected_error_msg = fl.readlines()[0][1:].strip()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["fortran"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["fortran"]
+    )
     pyccel.parse(verbose=0)
 
     ast = pyccel.annotate(verbose=0)
@@ -226,8 +233,9 @@ def test_codegen_non_blocking_errors(f):
     with open(f, encoding="utf-8") as fl:
         expected_error_msg = fl.readlines()[0][1:].strip()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["fortran"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["fortran"]
+    )
     pyccel.parse(verbose=0)
 
     ast = pyccel.annotate(verbose=0)

--- a/tests/parser/test_comments.py
+++ b/tests/parser/test_comments.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.syntactic import SyntaxParser
 
 
@@ -63,7 +64,8 @@ def test_parse(f):
     with open(f) as infile:
         orig = infile.read().strip()
 
-    pyccel = SyntaxParser(Path(f), verbose=0)
+    pyccel = SyntaxParser(Path(f), verbose=0,
+                          name_clash_checker=name_clash_checkers["python"])
     unparser = Unparser()
     copy = unparser.visit(pyccel.fst)
 

--- a/tests/parser/test_comments.py
+++ b/tests/parser/test_comments.py
@@ -64,8 +64,9 @@ def test_parse(f):
     with open(f) as infile:
         orig = infile.read().strip()
 
-    pyccel = SyntaxParser(Path(f), verbose=0,
-                          name_clash_checker=name_clash_checkers["python"])
+    pyccel = SyntaxParser(
+        Path(f), verbose=0, name_clash_checker=name_clash_checkers["python"]
+    )
     unparser = Unparser()
     copy = unparser.visit(pyccel.fst)
 

--- a/tests/parser/test_comments.py
+++ b/tests/parser/test_comments.py
@@ -61,7 +61,7 @@ def test_parse(f):
     errors = Errors()
     errors.reset()
 
-    with open(f) as infile:
+    with open(f, encoding="utf-8") as infile:
         orig = infile.read().strip()
 
     pyccel = SyntaxParser(

--- a/tests/preprocess/test_preprocess.py
+++ b/tests/preprocess/test_preprocess.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -18,7 +19,8 @@ files = [os.path.join(path_dir, f) for f in files if (f.endswith(".py"))]
 @pytest.mark.language_agnostic
 @pytest.mark.parametrize("f", files)
 def test_preprocess(f):
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     pyccel.parse(verbose=0)
     print(pyccel.fst)
 

--- a/tests/preprocess/test_preprocess.py
+++ b/tests/preprocess/test_preprocess.py
@@ -19,8 +19,9 @@ files = [os.path.join(path_dir, f) for f in files if (f.endswith(".py"))]
 @pytest.mark.language_agnostic
 @pytest.mark.parametrize("f", files)
 def test_preprocess(f):
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
     pyccel.parse(verbose=0)
     print(pyccel.fst)
 

--- a/tests/semantic/test_semantic.py
+++ b/tests/semantic/test_semantic.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -19,7 +20,8 @@ files = [os.path.join(path_dir, f) for f in files if (f.endswith(".py"))]
 @pytest.mark.parametrize("f", files)
 def test_semantic(f):
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     pyccel.parse(verbose=0)
 
     pyccel.annotate(verbose=0)

--- a/tests/semantic/test_semantic.py
+++ b/tests/semantic/test_semantic.py
@@ -20,8 +20,9 @@ files = [os.path.join(path_dir, f) for f in files if (f.endswith(".py"))]
 @pytest.mark.parametrize("f", files)
 def test_semantic(f):
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
     pyccel.parse(verbose=0)
 
     pyccel.annotate(verbose=0)

--- a/tests/symbolic/test_symbolic.py
+++ b/tests/symbolic/test_symbolic.py
@@ -12,6 +12,7 @@ import sympy as sp
 from pyccel import lambdify as pyc_lambdify
 from pyccel.codegen.codegen import Codegen
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 RTOL = 1e-13
@@ -29,7 +30,8 @@ T = TypeVar("T", "float[:]", "float[:,:]")
 @pytest.mark.skip(reason="Broken symbolic function support, see issue #330")
 def test_symbolic(f, language):
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers[language])
     pyccel.parse()
 
     settings = {}

--- a/tests/symbolic/test_symbolic.py
+++ b/tests/symbolic/test_symbolic.py
@@ -30,8 +30,9 @@ T = TypeVar("T", "float[:]", "float[:,:]")
 @pytest.mark.skip(reason="Broken symbolic function support, see issue #330")
 def test_symbolic(f, language):
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers[language])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers[language]
+    )
     pyccel.parse()
 
     settings = {}

--- a/tests/symbolic/test_symbolic.py
+++ b/tests/symbolic/test_symbolic.py
@@ -33,7 +33,7 @@ def test_symbolic(f, language):
     pyccel = Parser(
         f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers[language]
     )
-    pyccel.parse()
+    pyccel.parse(verbose=0)
 
     settings = {}
     ast = pyccel.annotate(**settings)

--- a/tests/syntax/test_syntax.py
+++ b/tests/syntax/test_syntax.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 base_dir = os.path.dirname(os.path.realpath(__file__))
@@ -22,7 +23,8 @@ def test_syntax(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     pyccel.parse(verbose=0)
 
     # Assert syntactic success

--- a/tests/syntax/test_syntax.py
+++ b/tests/syntax/test_syntax.py
@@ -23,8 +23,9 @@ def test_syntax(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
     pyccel.parse(verbose=0)
 
     # Assert syntactic success

--- a/tests/warnings/test_warnings.py
+++ b/tests/warnings/test_warnings.py
@@ -13,6 +13,7 @@ from wrapper import HIGH_ORDER_FUNCTIONS_IN_CLASS_FUNCS
 
 from pyccel import epyccel
 from pyccel.errors.errors import Errors
+from pyccel.naming import name_clash_checkers
 from pyccel.parser.parser import Parser
 
 
@@ -49,7 +50,8 @@ def test_semantic_warnings(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd())
+    pyccel = Parser(f, output_folder=os.getcwd(),
+                    name_clash_checker=name_clash_checkers["python"])
     pyccel.parse(verbose=0)
 
     pyccel.annotate(verbose=0)

--- a/tests/warnings/test_warnings.py
+++ b/tests/warnings/test_warnings.py
@@ -50,8 +50,9 @@ def test_semantic_warnings(f):
     errors = Errors()
     errors.reset()
 
-    pyccel = Parser(f, output_folder=os.getcwd(),
-                    name_clash_checker=name_clash_checkers["python"])
+    pyccel = Parser(
+        f, output_folder=os.getcwd(), name_clash_checker=name_clash_checkers["python"]
+    )
     pyccel.parse(verbose=0)
 
     pyccel.annotate(verbose=0)


### PR DESCRIPTION
The class `pyccel.parser.scope.Scope` contains 2 class variables. These are common to all open instances of Pyccel which makes them a source of race conditions. In particular this prevents tests translating to different languages from being run simultaneously. This PR adds `name_clash_checker` to the arguments of `Scope` to remove this race condition.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
