### PR TITLE
Stop combining single line comments into a `CommentMultiLine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 -   #2522 : Remove command-line tools: `pyccel-clean`, `pyccel-test`, `pyccel-wrap` in favour of sub-commands of the `pyccel` tool.
 -   \[DEVELOPER\] Remove unused method `FCodePrinter.set_current_class` and the associated property.
 -   \[DEVELOPER\] Remove unused methods `FCodePrinter.get_method` and `FCodePrinter.get_function`.
+-   \[DEVELOPER\] Removed unhelpful class `pyccel.parser.extend_tree.CommentMultiLine`.
 
 ## \[2.2.3\] - 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 -   #2621 : Add support for module docstrings.
 -   #2611 : Add a plugin framework.
 -   #2611 : Add `pluggy` as an installation dependency.
+-   #2632 : Allow `\\` to be used as a comment continuation character in OpenMP pragmas.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project will be documented in this file.
 
 ### Deprecated
 
+-   #2632 : Deprecate the use of `&` as a comment continuation character in OpenMP pragmas.
+
 ### Removed
 
 -   #2522 : Remove use of `pyccel` without sub-command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 -   #2621 : Add support for module docstrings.
 -   #2611 : Add a plugin framework.
 -   #2611 : Add `pluggy` as an installation dependency.
--   #2632 : Allow `\\` to be used as a comment continuation character in OpenMP pragmas.
+-   #2632 : Allow `\` to be used as a comment continuation character in OpenMP pragmas.
 
 ### Fixed
 

--- a/pyccel/commands/pyccel_compile.py
+++ b/pyccel/commands/pyccel_compile.py
@@ -148,7 +148,7 @@ def pyccel_compile(*, filename, language, output, plugin_manager, **kwargs):
     """
     Call the pyccel pipeline.
 
-    Handle the deprecated --export-compiler-config command and call the pyccel pipeline.
+    Call the pyccel pipeline.
 
     Parameters
     ----------

--- a/pyccel/parser/extend_tree.py
+++ b/pyccel/parser/extend_tree.py
@@ -41,7 +41,7 @@ def get_comments(code):
         c = line.strip()
         if c.startswith("#"):
             comments.append(CommentLine(c, index + 1, line.index("#")))
-            lineno_comments.append(index+1)
+            lineno_comments.append(index + 1)
         elif c.startswith("else"):
             if c[4:].strip().startswith(":"):
                 else_no.append(index + 1)

--- a/pyccel/parser/extend_tree.py
+++ b/pyccel/parser/extend_tree.py
@@ -32,6 +32,22 @@ class CommentLine(AST):
 
 
 def get_comments(code):
+    """
+    Find all one-line comments in the code.
+
+    Find all one-line comments in the code and save them in a CommentLine
+    object.
+
+    Parameters
+    ----------
+    code : str
+        The original code being parsed.
+
+    Results
+    -------
+    list[CommentLine]
+        The comments found in the code.
+    """
     lines = code.split("\n")
     comments = []
     lineno_comments = []

--- a/pyccel/parser/extend_tree.py
+++ b/pyccel/parser/extend_tree.py
@@ -43,7 +43,7 @@ def get_comments(code):
     code : str
         The original code being parsed.
 
-    Results
+    Returns
     -------
     list[CommentLine]
         The comments found in the code.

--- a/pyccel/parser/extend_tree.py
+++ b/pyccel/parser/extend_tree.py
@@ -4,7 +4,7 @@
 # for full license details.                                                 #
 # ------------------------------------------------------------------------- #
 
-"""Extended AST with CommentLine and CommentMultiLine nodes
+"""Extended AST with CommentLine nodes
 ===========================================================
 
 """
@@ -31,10 +31,6 @@ class CommentLine(AST):
         self.col_offset = col_offset
 
 
-class CommentMultiLine(CommentLine):
-    """ "New AST node representing a multi-line comment"""
-
-
 def get_comments(code):
     lines = code.split("\n")
     comments = []
@@ -44,42 +40,11 @@ def get_comments(code):
     for index, line in enumerate(lines):
         c = line.strip()
         if c.startswith("#"):
-            comments.append((c, index + 1, line.index("#")))
+            comments.append(CommentLine(c, index + 1, line.index("#")))
+            lineno_comments.append(index+1)
         elif c.startswith("else"):
             if c[4:].strip().startswith(":"):
                 else_no.append(index + 1)
-
-    if comments:
-        new_comments = [[comments[0]]]
-        for index in range(1, len(comments)):
-            if (
-                comments[index][1] == comments[index - 1][1] + 1
-                and comments[index][2] == comments[index - 1][2]
-            ):
-                new_comments[-1].append(comments[index])
-            else:
-                new_comments.append([comments[index]])
-
-        comments = []
-        for comm in new_comments:
-            lineno_comments.append(comm[0][1])
-
-            if len(comm) == 1:
-                comments.append(CommentLine(*comm[0]))
-            elif len(comm) > 1:
-                lineno = comm[0][1]
-                col_offset = comm[0][2]
-                comm = [lc[0] for lc in comm]
-                txt = comm[0]
-                for i, s in enumerate(comm[1:]):
-                    s_prev = comm[i]
-                    if s_prev.startswith("#$") and s_prev.rstrip().endswith("&"):
-                        assert s.startswith("#$")
-                        txt = txt.rstrip()[:-1] + s[2:]
-                    else:
-                        txt = txt + "\n" + s
-
-                comments.append(CommentMultiLine(txt, lineno, col_offset))
 
     assert len(lineno_comments) == len(comments)
     return array(lineno_comments), array(comments), array(else_no)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -323,7 +323,7 @@ class SyntaxParser(BasicParser):
         if txt.startswith("$"):
             env = txt[1:].strip()
             if env.startswith("omp"):
-                if line.rstrip().endswith('&'):
+                if line.rstrip().endswith("&"):
                     if self._multiline_comment_in_progress:
                         self._multiline_comment_in_progress.append(env[3:-1])
                     else:
@@ -331,7 +331,9 @@ class SyntaxParser(BasicParser):
                     return EmptyNode()
                 else:
                     if self._multiline_comment_in_progress:
-                        to_parse = ' '.join(["#$", *self._multiline_comment_in_progress, env[3:]])
+                        to_parse = " ".join(
+                            ["#$", *self._multiline_comment_in_progress, env[3:]]
+                        )
                         self._multiline_comment_in_progress = []
                     else:
                         to_parse = line

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -1672,15 +1672,6 @@ class SyntaxParser(BasicParser):
         test = self._visit(stmt.test)
         return Assert(test)
 
-    def _visit_CommentMultiLine(self, stmt):
-
-        exprs = [self._treat_comment_line(com, stmt) for com in stmt.s.split("\n")]
-
-        if len(exprs) == 1:
-            return exprs[0]
-        else:
-            return CodeBlock(exprs)
-
     def _visit_CommentLine(self, stmt):
         return self._treat_comment_line(stmt.s, stmt)
 

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -231,6 +231,8 @@ class SyntaxParser(BasicParser):
         self._fst = tree
         self._in_lhs_assign = False
 
+        self._multiline_comment_in_progress = []
+
         self.parse()
 
     def parse(self):
@@ -319,18 +321,29 @@ class SyntaxParser(BasicParser):
         """
         txt = line[1:].lstrip()
         if txt.startswith("$"):
-            env = txt[1:].lstrip()
+            env = txt[1:].strip()
             if env.startswith("omp"):
-                expr = omp_parse(stmts=line)
-                try:
-                    expr = omp_parse(stmts=line)
-                except TextXSyntaxError as e:
-                    errors.report(
-                        f"Invalid OpenMP header. {e.message}",
-                        symbol=stmt,
-                        column=e.col,
-                        severity="fatal",
-                    )
+                if line.rstrip().endswith('&'):
+                    if self._multiline_comment_in_progress:
+                        self._multiline_comment_in_progress.append(env[3:-1])
+                    else:
+                        self._multiline_comment_in_progress.append(env[:-1])
+                    return EmptyNode()
+                else:
+                    if self._multiline_comment_in_progress:
+                        to_parse = ' '.join(["#$", *self._multiline_comment_in_progress, env[3:]])
+                        self._multiline_comment_in_progress = []
+                    else:
+                        to_parse = line
+                    try:
+                        expr = omp_parse(stmts=to_parse)
+                    except TextXSyntaxError as e:
+                        errors.report(
+                            f"Invalid OpenMP header. {e.message}",
+                            symbol=stmt,
+                            column=e.col,
+                            severity="fatal",
+                        )
             elif env.startswith("acc"):
                 try:
                     expr = acc_parse(stmts=line)

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -323,7 +323,7 @@ class SyntaxParser(BasicParser):
         if txt.startswith("$"):
             env = txt[1:].strip()
             if env.startswith("omp"):
-                if line.rstrip().endswith("&"):
+                if env.endswith("&") or env.endswith(r"\"):
                     if self._multiline_comment_in_progress:
                         self._multiline_comment_in_progress.append(env[3:-1])
                     else:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -325,8 +325,11 @@ class SyntaxParser(BasicParser):
             if env.startswith("omp"):
                 if env.endswith("&") or env.endswith("\\"):
                     if env.endswith("&"):
-                        errors.report("Using & as an OpenMP continuation character is deprecated and will be removed in v2.5.",
-                                      severity="warning", symbol=stmt)
+                        errors.report(
+                            "Using & as an OpenMP continuation character is deprecated and will be removed in v2.5.",
+                            severity="warning",
+                            symbol=stmt,
+                        )
                     if self._multiline_comment_in_progress:
                         self._multiline_comment_in_progress.append(env[3:-1])
                     else:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -231,7 +231,7 @@ class SyntaxParser(BasicParser):
         self._fst = tree
         self._in_lhs_assign = False
 
-        self._multiline_comment_in_progress = []
+        self._multiline_directive_in_progress = []
 
         self.parse()
 
@@ -330,17 +330,17 @@ class SyntaxParser(BasicParser):
                             severity="warning",
                             symbol=stmt,
                         )
-                    if self._multiline_comment_in_progress:
-                        self._multiline_comment_in_progress.append(env[3:-1])
+                    if self._multiline_directive_in_progress:
+                        self._multiline_directive_in_progress.append(env[3:-1])
                     else:
-                        self._multiline_comment_in_progress.append(env[:-1])
+                        self._multiline_directive_in_progress.append(env[:-1])
                     return EmptyNode()
                 else:
-                    if self._multiline_comment_in_progress:
+                    if self._multiline_directive_in_progress:
                         to_parse = " ".join(
-                            ["#$", *self._multiline_comment_in_progress, env[3:]]
+                            ["#$", *self._multiline_directive_in_progress, env[3:]]
                         )
-                        self._multiline_comment_in_progress = []
+                        self._multiline_directive_in_progress = []
                     else:
                         to_parse = line
                     try:

--- a/pyccel/parser/syntactic.py
+++ b/pyccel/parser/syntactic.py
@@ -323,7 +323,10 @@ class SyntaxParser(BasicParser):
         if txt.startswith("$"):
             env = txt[1:].strip()
             if env.startswith("omp"):
-                if env.endswith("&") or env.endswith(r"\"):
+                if env.endswith("&") or env.endswith("\\"):
+                    if env.endswith("&"):
+                        errors.report("Using & as an OpenMP continuation character is deprecated and will be removed in v2.5.",
+                                      severity="warning", symbol=stmt)
                     if self._multiline_comment_in_progress:
                         self._multiline_comment_in_progress.append(env[3:-1])
                     else:

--- a/tests/epyccel/modules/openmp.py
+++ b/tests/epyccel/modules/openmp.py
@@ -606,7 +606,7 @@ def omp_long_multi_line(
     n4 = long_variable_4_oiweaxaijaqedqd34023423.shape[0]
     n5 = long_variable_5_oiwed423rnoic3242ewdx35.shape[0]
 
-    # $ omp parallel private(i1, i2, i3, i4, i5) &
+    # $ omp parallel private(i1, i2, i3, i4, i5) \
     # $ shared(long_variable_1_oiwed423rnoij21d4kojklm, long_variable_2_oiwedqwrnoij2asxaxnjkna, long_variable_3_oiweqxhnoijaqed34023423, long_variable_4_oiweaxaijaqedqd34023423, long_variable_5_oiwed423rnoic3242ewdx35, n1, n2, n3, n4, n5)
 
     # $ omp for reduction (+:func_result)

--- a/tests/epyccel/modules/openmp.py
+++ b/tests/epyccel/modules/openmp.py
@@ -607,7 +607,7 @@ def omp_long_multi_line(
     n5 = long_variable_5_oiwed423rnoic3242ewdx35.shape[0]
 
     # $ omp parallel private(i1, i2, i3, i4, i5) \
-    # $ shared(long_variable_1_oiwed423rnoij21d4kojklm, long_variable_2_oiwedqwrnoij2asxaxnjkna, long_variable_3_oiweqxhnoijaqed34023423, long_variable_4_oiweaxaijaqedqd34023423, long_variable_5_oiwed423rnoic3242ewdx35, n1, n2, n3, n4, n5)
+    # $ omp shared(long_variable_1_oiwed423rnoij21d4kojklm, long_variable_2_oiwedqwrnoij2asxaxnjkna, long_variable_3_oiweqxhnoijaqed34023423, long_variable_4_oiweaxaijaqedqd34023423, long_variable_5_oiwed423rnoic3242ewdx35, n1, n2, n3, n4, n5)
 
     # $ omp for reduction (+:func_result)
     for i1 in range(0, n1):

--- a/tests/epyccel/modules/openmp.py
+++ b/tests/epyccel/modules/openmp.py
@@ -590,3 +590,44 @@ def omp_long_line(
 
     # $ omp end parallel
     return func_result
+
+
+def omp_long_multi_line(
+    long_variable_1_oiwed423rnoij21d4kojklm: "int[:]",
+    long_variable_2_oiwedqwrnoij2asxaxnjkna: "int[:]",
+    long_variable_3_oiweqxhnoijaqed34023423: "int[:]",
+    long_variable_4_oiweaxaijaqedqd34023423: "int[:]",
+    long_variable_5_oiwed423rnoic3242ewdx35: "int[:]",
+):
+    func_result = 0
+    n1 = long_variable_1_oiwed423rnoij21d4kojklm.shape[0]
+    n2 = long_variable_2_oiwedqwrnoij2asxaxnjkna.shape[0]
+    n3 = long_variable_3_oiweqxhnoijaqed34023423.shape[0]
+    n4 = long_variable_4_oiweaxaijaqedqd34023423.shape[0]
+    n5 = long_variable_5_oiwed423rnoic3242ewdx35.shape[0]
+
+    # $ omp parallel private(i1, i2, i3, i4, i5) &
+    # $ shared(long_variable_1_oiwed423rnoij21d4kojklm, long_variable_2_oiwedqwrnoij2asxaxnjkna, long_variable_3_oiweqxhnoijaqed34023423, long_variable_4_oiweaxaijaqedqd34023423, long_variable_5_oiwed423rnoic3242ewdx35, n1, n2, n3, n4, n5)
+
+    # $ omp for reduction (+:func_result)
+    for i1 in range(0, n1):
+        func_result += long_variable_1_oiwed423rnoij21d4kojklm[i1]
+
+    # $ omp for reduction (+:func_result)
+    for i2 in range(0, n2):
+        func_result += long_variable_2_oiwedqwrnoij2asxaxnjkna[i2]
+
+    # $ omp for reduction (+:func_result)
+    for i3 in range(0, n3):
+        func_result += long_variable_3_oiweqxhnoijaqed34023423[i3]
+
+    # $ omp for reduction (+:func_result)
+    for i4 in range(0, n4):
+        func_result += long_variable_4_oiweaxaijaqedqd34023423[i4]
+
+    # $ omp for reduction (+:func_result)
+    for i5 in range(0, n5):
+        func_result += long_variable_5_oiwed423rnoic3242ewdx35[i5]
+
+    # $ omp end parallel
+    return func_result

--- a/tests/epyccel/test_epyccel_openmp.py
+++ b/tests/epyccel/test_epyccel_openmp.py
@@ -728,7 +728,9 @@ def test_omp_long_line(language):
 @pytest.mark.external
 def test_omp_long_multi_line(language):
     flags = get_wall_flag(language)
-    f1 = epyccel(openmp.omp_long_multi_line, flags=flags, openmp=True, language=language)
+    f1 = epyccel(
+        openmp.omp_long_multi_line, flags=flags, openmp=True, language=language
+    )
     set_num_threads = epyccel(
         openmp.set_num_threads, flags=flags, openmp=True, language=language
     )

--- a/tests/epyccel/test_epyccel_openmp.py
+++ b/tests/epyccel/test_epyccel_openmp.py
@@ -725,6 +725,23 @@ def test_omp_long_line(language):
     assert f1(x1, x2, x3, x4, x5) == np.sum(x1 + x2 + x3 + x4 + x5)
 
 
+@pytest.mark.external
+def test_omp_long_multi_line(language):
+    flags = get_wall_flag(language)
+    f1 = epyccel(openmp.omp_long_multi_line, flags=flags, openmp=True, language=language)
+    set_num_threads = epyccel(
+        openmp.set_num_threads, flags=flags, openmp=True, language=language
+    )
+    set_num_threads(4)
+    x1 = np.array(random.randint(20, size=(5)), dtype=int)
+    x2 = np.array(random.randint(20, size=(5)), dtype=int)
+    x3 = np.array(random.randint(20, size=(5)), dtype=int)
+    x4 = np.array(random.randint(20, size=(5)), dtype=int)
+    x5 = np.array(random.randint(20, size=(5)), dtype=int)
+
+    assert f1(x1, x2, x3, x4, x5) == np.sum(x1 + x2 + x3 + x4 + x5)
+
+
 @pytest.mark.parametrize(
     "language",
     (


### PR DESCRIPTION
Stop combining single line comments into a `CommentMultiLine`. Keep the combining of OpenMP comments via a trailing `&`. Also add support for a `\` continuation character. Support for `&` is deprecated. Add a test for a multi-line pragma.

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [x] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing
