### PR TITLE
Quality: Duplicate docstring content in BasicStmt class

### DIFF
--- a/pyccel/parser/syntax/basic.py
+++ b/pyccel/parser/syntax/basic.py
@@ -24,14 +24,6 @@ class BasicStmt:
     statement, like the index of a For statement.
     4) Every extension must implement the update function. This function is
     called to prepare for the applied property (for example the expr
-    1) Every extension class must provide the properties stmt_vars and
-    local_vars.
-    2) stmt_vars describes the list of all variables that are
-    created by the statement.
-    3) local_vars describes the list of all local variables to the
-    statement, like the index of a For statement.
-    4) Every extension must implement the update function. This function is
-    called to prepare for the applied property (for example the expr
     property).
 
     Parameters


### PR DESCRIPTION
## Summary

Quality: Duplicate docstring content in BasicStmt class

## Problem

**Severity**: `Low` | **File**: `pyccel/parser/syntax/basic.py:L21`

The docstring for the `BasicStmt` class contains duplicated conventions (items 1-4 are repeated). This appears to be a copy-paste error which reduces readability and maintainability.

## Solution

Remove the duplicated text in the docstring so the conventions list (items 1-4) only appears once.

## Changes

- `pyccel/parser/syntax/basic.py` (modified)

---

## Pull request checklist

Please tick off items when you have completed them or determined that they are not necessary for this pull request:

- [x] Write a clear PR description
- [ ] Ensure you appear in the AUTHORS file
- [x] Add tests to check your code works as expected
- [x] Update documentation if necessary
- [x] Update CHANGELOG.md
- [x] Ensure any relevant issues are linked
- [x] Ensure new tests are passing